### PR TITLE
perf(chat): load citations panel on first open

### DIFF
--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -1,6 +1,5 @@
 import { Checkbox, ConfirmDialog } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
-import CitationsPanel from '@renderer/components/chat/citations/CitationsPanel'
 import { ChatLayoutModeProvider } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import {
   type ResourcePaneConfig,
@@ -41,7 +40,7 @@ import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
 import type { ReactNode } from 'react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import AgentChatMain from './AgentChatMain'
@@ -53,6 +52,8 @@ import { locateAgentMessageInList } from './messages/agentMessageListAdapter'
 import type { CreateAgentSessionDefaults } from './types'
 import { type AgentChatRuntimeState, useAgentChatRuntimeState } from './useAgentChatRuntimeState'
 import type { AgentConversationBootstrap } from './useAgentConversationBootstrap'
+
+const CitationsPanel = lazy(() => import('@renderer/components/chat/citations/CitationsPanel'))
 
 const EMPTY_MESSAGES: CherryUIMessage[] = []
 const EMPTY_PARTS: Record<string, CherryMessagePart[]> = {}
@@ -191,6 +192,7 @@ const AgentChat = ({
   )
   const currentSessionId = conversationBootstrap.session?.id
   const [citationPanelState, setCitationPanelState] = useState<CitationPanelState | null>(null)
+  const [shouldMountCitationsPanel, setShouldMountCitationsPanel] = useState(false)
   const [modelSwitchTarget, setModelSwitchTarget] = useState<ModelSwitchTarget>()
   const [modelSwitchConfirmOpen, setModelSwitchConfirmOpen] = useState(false)
   const [skipModelSwitchConfirmation, setSkipModelSwitchConfirmation] = useState(false)
@@ -231,6 +233,7 @@ const AgentChat = ({
   const handleOpenCitationsPanel = useCallback(
     ({ citations }: { citations: Citation[] }) => {
       if (!currentSessionId) return
+      setShouldMountCitationsPanel(true)
       setCitationPanelState({ sessionId: currentSessionId, citations })
     },
     [currentSessionId]
@@ -464,13 +467,15 @@ const AgentChat = ({
         onSidebarToggle={onSidebarToggle}
       />
     )
-    sidePanel = (
-      <CitationsPanel
-        open={citationsPanelOpen}
-        onClose={() => setCitationPanelState(null)}
-        citations={citationPanelCitations ?? []}
-      />
-    )
+    sidePanel = shouldMountCitationsPanel ? (
+      <Suspense fallback={null}>
+        <CitationsPanel
+          open={citationsPanelOpen}
+          onClose={() => setCitationPanelState(null)}
+          citations={citationPanelCitations ?? []}
+        />
+      </Suspense>
+    ) : undefined
     centerClassName = 'transform-[translateZ(0)] relative justify-between'
     center = (
       <AgentChatSessionCenter

--- a/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
@@ -50,6 +50,7 @@ const conversationShellPropsMock = vi.hoisted(() => ({
 }))
 const toolApprovalRespondMock = vi.hoisted(() => vi.fn())
 const agentSessionRefreshMock = vi.hoisted(() => vi.fn())
+const citationsPanelModuleLoads = vi.hoisted(() => ({ value: 0 }))
 
 // Tool-approval responses now go through ipcApi.request('ai.tool.respond_approval', …).
 vi.mock('@renderer/ipc', () => ({
@@ -306,26 +307,30 @@ vi.mock('../components/AgentSessionMessages', () => ({
   )
 }))
 
-vi.mock('@renderer/components/chat/citations/CitationsPanel', () => ({
-  default: ({
-    open,
-    onClose,
-    citations
-  }: {
-    open: boolean
-    onClose: () => void
-    citations: Array<{ number: number; url: string }>
-  }) => (
-    <div data-testid="citations-panel" data-open={String(open)} data-count={citations.length}>
-      {open && citations.map((citation) => <span key={citation.number}>{citation.url}</span>)}
-      {open && (
-        <button type="button" onClick={onClose}>
-          close citations
-        </button>
-      )}
-    </div>
-  )
-}))
+vi.mock('@renderer/components/chat/citations/CitationsPanel', () => {
+  citationsPanelModuleLoads.value += 1
+
+  return {
+    default: ({
+      open,
+      onClose,
+      citations
+    }: {
+      open: boolean
+      onClose: () => void
+      citations: Array<{ number: number; url: string }>
+    }) => (
+      <div data-testid="citations-panel" data-open={String(open)} data-count={citations.length}>
+        {open && citations.map((citation) => <span key={citation.number}>{citation.url}</span>)}
+        {open && (
+          <button type="button" onClick={onClose}>
+            close citations
+          </button>
+        )}
+      </div>
+    )
+  }
+})
 
 describe('AgentChat settings panel', () => {
   const defaultSession = { id: 'session-1', agentId: 'agent-1', accessiblePaths: [] } as any
@@ -379,16 +384,19 @@ describe('AgentChat settings panel', () => {
     })
   })
 
-  it('opens and closes the citations panel from agent messages', () => {
+  it('loads citations on first open and keeps the panel mounted while closing', async () => {
+    const user = userEvent.setup()
     renderAgentChat()
 
-    expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'false')
+    expect(citationsPanelModuleLoads.value).toBe(0)
+    expect(screen.queryByTestId('citations-panel')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'open citations' }))
-    expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'true')
+    await user.click(screen.getByRole('button', { name: 'open citations' }))
+    expect(await screen.findByTestId('citations-panel')).toHaveAttribute('data-open', 'true')
     expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-count', '1')
+    expect(citationsPanelModuleLoads.value).toBe(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'close citations' }))
+    await user.click(screen.getByRole('button', { name: 'close citations' }))
     expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'false')
   })
 

--- a/src/renderer/pages/home/Chat.tsx
+++ b/src/renderer/pages/home/Chat.tsx
@@ -1,5 +1,4 @@
 import { usePreference } from '@data/hooks/usePreference'
-import CitationsPanel from '@renderer/components/chat/citations/CitationsPanel'
 import { ChatLayoutModeProvider } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import { ResourcePaneCountButton, type ResourcePaneCountButtonProps } from '@renderer/components/chat/panes/Shell'
 import ConversationCenterState from '@renderer/components/chat/shell/ConversationCenterState'
@@ -33,6 +32,8 @@ import ChatContent from './ChatContent'
 import ChatNavbar from './components/ChatNavbar'
 import { TopicRightPane, useTopicBranchLiveStateSetter } from './components/TopicRightPane'
 import type { AddNewTopicPayload } from './types'
+
+const CitationsPanel = React.lazy(() => import('@renderer/components/chat/citations/CitationsPanel'))
 
 const EMPTY_MODELS: ChatConversationControlsSnapshot['mentionedModels'] = []
 const NOOP_MODEL_SELECT: ChatConversationControlsSnapshot['onModelSelect'] = () => undefined
@@ -82,6 +83,7 @@ const Chat: FC<Props> = (props) => {
   const [messageStyle] = usePreference('chat.message.style')
   const [topicDisplayMode] = usePreference('topic.tab.display_mode')
   const [citationPanelState, setCitationPanelState] = useState<CitationPanelState | null>(null)
+  const [shouldMountCitationsPanel, setShouldMountCitationsPanel] = useState(false)
   const [branchLocateMessageId, setBranchLocateMessageId] = useState<string | undefined>()
   const setTopicBranchLiveState = useTopicBranchLiveStateSetter()
 
@@ -173,6 +175,7 @@ const Chat: FC<Props> = (props) => {
   const handleOpenCitationsPanel = useCallback(
     ({ citations }: { citations: Citation[] }) => {
       if (!activeTopicId) return
+      setShouldMountCitationsPanel(true)
       setCitationPanelState({ topicId: activeTopicId, citations })
     },
     [activeTopicId]
@@ -299,12 +302,14 @@ const Chat: FC<Props> = (props) => {
       }
       showTopRightToolWhenPaneOpen
       sidePanel={
-        showConversation ? (
-          <CitationsPanel
-            open={citationsPanelOpen}
-            onClose={() => setCitationPanelState(null)}
-            citations={citationPanelCitations ?? []}
-          />
+        showConversation && shouldMountCitationsPanel ? (
+          <React.Suspense fallback={null}>
+            <CitationsPanel
+              open={citationsPanelOpen}
+              onClose={() => setCitationPanelState(null)}
+              citations={citationPanelCitations ?? []}
+            />
+          </React.Suspense>
         ) : undefined
       }
       center={center}

--- a/src/renderer/pages/home/__tests__/Chat.test.tsx
+++ b/src/renderer/pages/home/__tests__/Chat.test.tsx
@@ -22,6 +22,7 @@ const commandHandlers = vi.hoisted(() => new Map<string, () => void | Promise<vo
 const eventEmitMock = vi.hoisted(() => vi.fn())
 const clearTopicMessagesMock = vi.hoisted(() => vi.fn(async () => undefined))
 const activeTabMock = vi.hoisted(() => ({ current: true }))
+const citationsPanelModuleLoads = vi.hoisted(() => ({ value: 0 }))
 
 const topic: Topic = {
   id: 'topic-1',
@@ -54,6 +55,7 @@ vi.mock('@renderer/components/chat/shell/ConversationShell', () => ({
       <div data-testid="conversation-shell">
         <div data-testid="conversation-top-bar">{props.topBar}</div>
         {props.topRightTool}
+        {props.sidePanel}
         {props.center}
         {props.centerOverlay}
         {props.rightPane}
@@ -62,9 +64,21 @@ vi.mock('@renderer/components/chat/shell/ConversationShell', () => ({
   }
 }))
 
-vi.mock('@renderer/components/chat/citations/CitationsPanel', () => ({
-  default: () => <div data-testid="citations-panel" />
-}))
+vi.mock('@renderer/components/chat/citations/CitationsPanel', () => {
+  citationsPanelModuleLoads.value += 1
+
+  return {
+    default: ({ open, onClose }: { open: boolean; onClose: () => void }) => (
+      <div data-testid="citations-panel" data-open={String(open)}>
+        {open ? (
+          <button type="button" onClick={onClose}>
+            close citations
+          </button>
+        ) : null}
+      </div>
+    )
+  }
+})
 
 vi.mock('@renderer/components/chat/shell/ConversationCenterState', () => ({
   default: ({ state }: { state: string }) => <div data-testid="conversation-center-state">{state}</div>
@@ -173,6 +187,9 @@ vi.mock('../ChatContent', async () => {
     return (
       <div data-testid="chat-content">
         <output aria-label="rail gutter">{railGutterPx}</output>
+        <button type="button" onClick={() => props.onOpenCitationsPanel({ citations: [{ number: 1 }] })}>
+          open citations
+        </button>
         <button type="button" onClick={() => setRailGutterPx(24)}>
           reserve rail gutter
         </button>
@@ -221,6 +238,23 @@ describe('Chat', () => {
     assistantContextMock.isModelPending = false
     commandHandlers.clear()
     activeTabMock.current = true
+  })
+
+  it('loads citations on first open and keeps the panel mounted while closing', async () => {
+    const user = userEvent.setup()
+    render(<Chat activeTopic={topic} />)
+
+    expect(citationsPanelModuleLoads.value).toBe(0)
+    expect(screen.queryByTestId('citations-panel')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'open citations' }))
+
+    expect(await screen.findByTestId('citations-panel')).toHaveAttribute('data-open', 'true')
+    expect(citationsPanelModuleLoads.value).toBe(1)
+
+    await user.click(screen.getByRole('button', { name: 'close citations' }))
+
+    expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'false')
   })
 
   it('clears the active topic once the confirmation is accepted', async () => {

--- a/src/renderer/pages/home/__tests__/Chat.test.tsx
+++ b/src/renderer/pages/home/__tests__/Chat.test.tsx
@@ -22,7 +22,6 @@ const commandHandlers = vi.hoisted(() => new Map<string, () => void | Promise<vo
 const eventEmitMock = vi.hoisted(() => vi.fn())
 const clearTopicMessagesMock = vi.hoisted(() => vi.fn(async () => undefined))
 const activeTabMock = vi.hoisted(() => ({ current: true }))
-const citationsPanelModuleLoads = vi.hoisted(() => ({ value: 0 }))
 
 const topic: Topic = {
   id: 'topic-1',
@@ -55,7 +54,6 @@ vi.mock('@renderer/components/chat/shell/ConversationShell', () => ({
       <div data-testid="conversation-shell">
         <div data-testid="conversation-top-bar">{props.topBar}</div>
         {props.topRightTool}
-        {props.sidePanel}
         {props.center}
         {props.centerOverlay}
         {props.rightPane}
@@ -64,21 +62,9 @@ vi.mock('@renderer/components/chat/shell/ConversationShell', () => ({
   }
 }))
 
-vi.mock('@renderer/components/chat/citations/CitationsPanel', () => {
-  citationsPanelModuleLoads.value += 1
-
-  return {
-    default: ({ open, onClose }: { open: boolean; onClose: () => void }) => (
-      <div data-testid="citations-panel" data-open={String(open)}>
-        {open ? (
-          <button type="button" onClick={onClose}>
-            close citations
-          </button>
-        ) : null}
-      </div>
-    )
-  }
-})
+vi.mock('@renderer/components/chat/citations/CitationsPanel', () => ({
+  default: () => <div data-testid="citations-panel" />
+}))
 
 vi.mock('@renderer/components/chat/shell/ConversationCenterState', () => ({
   default: ({ state }: { state: string }) => <div data-testid="conversation-center-state">{state}</div>
@@ -187,9 +173,6 @@ vi.mock('../ChatContent', async () => {
     return (
       <div data-testid="chat-content">
         <output aria-label="rail gutter">{railGutterPx}</output>
-        <button type="button" onClick={() => props.onOpenCitationsPanel({ citations: [{ number: 1 }] })}>
-          open citations
-        </button>
         <button type="button" onClick={() => setRailGutterPx(24)}>
           reserve rail gutter
         </button>
@@ -238,23 +221,6 @@ describe('Chat', () => {
     assistantContextMock.isModelPending = false
     commandHandlers.clear()
     activeTabMock.current = true
-  })
-
-  it('loads citations on first open and keeps the panel mounted while closing', async () => {
-    const user = userEvent.setup()
-    render(<Chat activeTopic={topic} />)
-
-    expect(citationsPanelModuleLoads.value).toBe(0)
-    expect(screen.queryByTestId('citations-panel')).not.toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: 'open citations' }))
-
-    expect(await screen.findByTestId('citations-panel')).toHaveAttribute('data-open', 'true')
-    expect(citationsPanelModuleLoads.value).toBe(1)
-
-    await user.click(screen.getByRole('button', { name: 'close citations' }))
-
-    expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'false')
   })
 
   it('clears the active topic once the confirmation is accepted', async () => {

--- a/src/renderer/pages/home/__tests__/ChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatSettingsPanel.test.tsx
@@ -13,6 +13,7 @@ const renderCounters = vi.hoisted(() => ({
   eventEmit: vi.fn(),
   setBranchLiveState: vi.fn()
 }))
+const citationsPanelModuleLoads = vi.hoisted(() => ({ value: 0 }))
 
 vi.mock('@data/hooks/usePreference', () => ({
   usePreference: (key: string) => {
@@ -169,26 +170,30 @@ vi.mock('../ChatContent', () => ({
   }
 }))
 
-vi.mock('@renderer/components/chat/citations/CitationsPanel', () => ({
-  default: ({
-    open,
-    onClose,
-    citations
-  }: {
-    open: boolean
-    onClose: () => void
-    citations: Array<{ number: number; url: string }>
-  }) => (
-    <div data-testid="citations-panel" data-open={String(open)} data-count={citations.length}>
-      {open && citations.map((citation) => <span key={citation.number}>{citation.url}</span>)}
-      {open && (
-        <button type="button" onClick={onClose}>
-          close citations
-        </button>
-      )}
-    </div>
-  )
-}))
+vi.mock('@renderer/components/chat/citations/CitationsPanel', () => {
+  citationsPanelModuleLoads.value += 1
+
+  return {
+    default: ({
+      open,
+      onClose,
+      citations
+    }: {
+      open: boolean
+      onClose: () => void
+      citations: Array<{ number: number; url: string }>
+    }) => (
+      <div data-testid="citations-panel" data-open={String(open)} data-count={citations.length}>
+        {open && citations.map((citation) => <span key={citation.number}>{citation.url}</span>)}
+        {open && (
+          <button type="button" onClick={onClose}>
+            close citations
+          </button>
+        )}
+      </div>
+    )
+  }
+})
 
 function renderChat(activeTopic: Topic) {
   return render(<Chat activeTopic={activeTopic} />)
@@ -212,19 +217,22 @@ describe('Chat panels', () => {
     renderCounters.setBranchLiveState.mockReset()
   })
 
-  it('opens and closes the citations panel from chat content', () => {
+  it('loads citations on first open and keeps the panel mounted while closing', async () => {
+    const user = userEvent.setup()
     renderChat(activeTopic)
 
-    expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'false')
+    expect(citationsPanelModuleLoads.value).toBe(0)
+    expect(screen.queryByTestId('citations-panel')).not.toBeInTheDocument()
     expect(screen.getByTestId('chat-navbar')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'branch shortcuts' })).toBeInTheDocument()
     expect(screen.getByTestId('topic-right-pane-viewport')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'open citations' }))
-    expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'true')
+    await user.click(screen.getByRole('button', { name: 'open citations' }))
+    expect(await screen.findByTestId('citations-panel')).toHaveAttribute('data-open', 'true')
     expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-count', '1')
+    expect(citationsPanelModuleLoads.value).toBe(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'close citations' }))
+    await user.click(screen.getByRole('button', { name: 'close citations' }))
     expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'false')
   })
 
@@ -233,7 +241,7 @@ describe('Chat panels', () => {
     const view = renderChat(activeTopic)
 
     await user.click(screen.getByRole('button', { name: 'open citations' }))
-    expect(screen.getByText('https://topic-1.example')).toBeInTheDocument()
+    expect(await screen.findByText('https://topic-1.example')).toBeInTheDocument()
 
     view.rerender(<Chat activeTopic={{ ...activeTopic, id: 'topic-2' }} />)
     expect(screen.queryByText('https://topic-1.example')).not.toBeInTheDocument()


### PR DESCRIPTION
### What this PR does

Before this PR:

The citations panel module was imported and mounted as soon as either chat shell rendered, even if the user never opened citations.

After this PR:

The Home Chat and Agent Chat shells load the citations panel module on first open. Once opened, the panel stays mounted while it is closed so its existing local state and close behavior remain intact.

Fixes #19672

### Why we need it and why it was done in this way

The citations panel is not part of the initial chat path for most sessions, so loading it eagerly adds avoidable renderer startup work. The change keeps the lazy-loading boundary directly in the two shell owners that already control panel visibility.

The following tradeoffs were made:

A small per-shell boolean is retained after the first open so closing the panel does not unmount it.

The following alternatives were considered:

Unmounting the panel on close would save more memory, but it would change the existing mounted lifecycle and could discard local panel state.

Links to places where the discussion took place: #19672

### Breaking changes

None.

### Special notes for your reviewer

Focused renderer coverage verifies that both shells avoid loading the module before first open, load it once on demand, and keep the closed panel mounted.

**UI evidence (exact PR head `5ad62b0`):**

This PR changes the panel's loading time, not its visual design. The first image shows the real Home Chat result before the panel's first open; the second shows the existing References panel after clicking the `2 citations` control.

Before first open:

![Home Chat with a two-citation result before the panel is opened](https://github.com/user-attachments/assets/8fb634e6-7c3d-4659-a5cc-0ffb13f5fc38)

After first open:

![Home Chat References panel after first open](https://github.com/user-attachments/assets/99606948-7649-4f85-8fbd-cb8dd4af62a7)

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets main
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [ ] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and is not applicable
- [ ] Documentation: A user-guide update was considered and is present or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer-only lazy-loading and mount gating with unchanged open/close UX; risk is limited to a brief Suspense gap on first open.
> 
> **Overview**
> **Home Chat** and **Agent Chat** no longer eagerly import or mount `CitationsPanel` when the shell renders. The panel is loaded with `React.lazy` / `Suspense` only after the user opens citations (`shouldMountCitationsPanel` flips on first open).
> 
> Closing the panel still clears citation state but **keeps the lazy chunk mounted** so reopen behavior and any in-panel state match the previous lifecycle without paying the bundle cost on every chat load.
> 
> Tests for both shells now assert the citations module is not evaluated until first open, loads once, and remains in the tree with `data-open="false"` after close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad62b021fad7f6b4b95bc0489b6419f70e20dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->