### PR TITLE
perf(provider-settings): lazy-load low-frequency editors

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderList.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderList/ProviderList.tsx
@@ -13,11 +13,10 @@ import { toast } from '@renderer/services/toast'
 import type { Provider } from '@shared/data/types/provider'
 import { canManageProvider } from '@shared/utils/provider'
 import { Plus } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useOvmsSupport } from '../hooks/useOvmsSupport'
-import ProviderEditorDrawer from './ProviderEditorDrawer'
 import type { ProviderFilterMode } from './providerFilterMode'
 import { getGroupedPresetIds } from './providerGrouping'
 import ProviderListContent, { type ProviderListContentItemState } from './ProviderListContent'
@@ -26,6 +25,8 @@ import ProviderListItemWithContextMenu from './ProviderListItemWithContextMenu'
 import ProviderListSearchField from './ProviderListSearchField'
 import { useProviderDelete } from './useProviderDelete'
 import { type ProviderCreationContext, type SubmitProviderEditorParams, useProviderEditor } from './useProviderEditor'
+
+const ProviderEditorDrawer = lazy(() => import('./ProviderEditorDrawer'))
 
 export interface ProviderListProps {
   selectedProviderId?: string
@@ -78,6 +79,25 @@ export default function ProviderList({
     cancel: cancelEditor,
     submit: submitEditor
   } = useProviderEditor({ onProviderCreated: handleProviderCreated })
+  const [editorActivated, setEditorActivated] = useState(false)
+  const openProviderEditor = useCallback(() => {
+    setEditorActivated(true)
+    startAdd()
+  }, [startAdd])
+  const openProviderEditorFrom = useCallback(
+    (provider: Provider) => {
+      setEditorActivated(true)
+      startAddFrom(provider)
+    },
+    [startAddFrom]
+  )
+  const openProviderEditorForEdit = useCallback(
+    (provider: Provider) => {
+      setEditorActivated(true)
+      startEdit(provider)
+    },
+    [startEdit]
+  )
 
   const { deleteProvider } = useProviderDelete()
 
@@ -272,11 +292,11 @@ export default function ProviderList({
         contextOpen={contextProviderId === provider.id}
         onContextOpenChange={(open) => setContextProviderId(open ? provider.id : null)}
         onSelect={() => onSelectProvider(provider.id)}
-        onEdit={() => startEdit(provider)}
+        onEdit={() => openProviderEditorForEdit(provider)}
         onDelete={() => handleDeleteProvider(provider.id)}
         onDuplicate={
           provider.presetProviderId && !groupedPresetIds.has(provider.presetProviderId)
-            ? () => startAddFrom(provider)
+            ? () => openProviderEditorFrom(provider)
             : undefined
         }
         showManagementActions={showManagementActions}
@@ -286,13 +306,13 @@ export default function ProviderList({
     )
   }
 
-  const handleAddAnother = useCallback((template: Provider) => startAddFrom(template), [startAddFrom])
+  const handleAddAnother = openProviderEditorFrom
   const addProviderButton = (
     <button
       type="button"
       aria-label={t('settings.provider.add.button_title')}
       disabled={dragging}
-      onClick={startAdd}
+      onClick={openProviderEditor}
       className={providerListClasses.addButton}>
       <Plus size={14} strokeWidth={2.5} />
       <span>{t('settings.provider.add.button_title')}</span>
@@ -330,15 +350,19 @@ export default function ProviderList({
         renderItem={renderProviderItem}
       />
       <div className={providerListClasses.addFooter}>{addProviderButton}</div>
-      <ProviderEditorDrawer
-        open={editorOpen}
-        mode={editorMode}
-        initialLogo={initialLogo}
-        presetSources={presetSources}
-        onClose={cancelEditor}
-        onSelectPreset={startAddFrom}
-        onSubmit={handleSubmitEditor}
-      />
+      {editorActivated ? (
+        <Suspense fallback={null}>
+          <ProviderEditorDrawer
+            open={editorOpen}
+            mode={editorMode}
+            initialLogo={initialLogo}
+            presetSources={presetSources}
+            onClose={cancelEditor}
+            onSelectPreset={startAddFrom}
+            onSubmit={handleSubmitEditor}
+          />
+        </Suspense>
+      ) : null}
     </aside>
   )
 }

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -3,15 +3,17 @@ import { useProvider } from '@renderer/hooks/useProvider'
 import { useTheme } from '@renderer/hooks/useTheme'
 import { cn } from '@renderer/utils/style'
 import { isLoginBasedProvider } from '@shared/utils/provider'
-import { useCallback, useState } from 'react'
+import { lazy, Suspense, useCallback, useState } from 'react'
 
 import ProviderHeader from './components/ProviderHeader'
 import AuthenticationSection from './ConnectionSettings/AuthenticationSection'
-import ProviderApiSetupDialog, { type ProviderApiSetupInitialStep } from './ConnectionSettings/ProviderApiSetupDialog'
+import type { ProviderApiSetupInitialStep } from './ConnectionSettings/ProviderApiSetupDialog'
 import { ApiKeyProvider } from './hooks/providerSetting/useAuthenticationApiKey'
 import { useProviderApiKey } from './hooks/providerSetting/useProviderApiKey'
 import { ModelList, ModelListHealthProvider } from './ModelList'
 import { providerDetailColumnClasses, ProviderSettingsContainer } from './primitives/ProviderSettingsPrimitives'
+
+const ProviderApiSetupDialog = lazy(() => import('./ConnectionSettings/ProviderApiSetupDialog'))
 
 interface ProviderSettingProps {
   providerId: string
@@ -61,7 +63,9 @@ function ProviderSettingSections({
         </div>
       </Scrollbar>
       {apiSetupStep ? (
-        <ProviderApiSetupDialog providerId={providerId} initialStep={apiSetupStep} onClose={closeApiSetup} />
+        <Suspense fallback={null}>
+          <ProviderApiSetupDialog providerId={providerId} initialStep={apiSetupStep} onClose={closeApiSetup} />
+        </Suspense>
       ) : null}
     </>
   )

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderList.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderList.test.tsx
@@ -15,8 +15,9 @@ const useReorderMock = vi.fn()
 const useOvmsSupportMock = vi.fn()
 const deleteProviderMock = vi.fn()
 const scrollIntoViewMock = vi.fn()
-const { providerEditorDrawerSpy } = vi.hoisted(() => ({
-  providerEditorDrawerSpy: vi.fn()
+const { providerEditorDrawerSpy, providerEditorModuleState } = vi.hoisted(() => ({
+  providerEditorDrawerSpy: vi.fn(),
+  providerEditorModuleState: { loaded: false }
 }))
 let providerItemRects: Record<string, { bottom: number; top: number }> = {}
 let scrollerRect = { bottom: 100, top: 0 }
@@ -119,12 +120,22 @@ vi.mock('../ProviderList/ProviderListItemWithContextMenu', () => ({
   )
 }))
 
-vi.mock('../ProviderList/ProviderEditorDrawer', () => ({
-  default: (props: any) => {
-    providerEditorDrawerSpy(props)
-    return <div data-testid="provider-editor-drawer" data-open={props.open ? 'true' : 'false'} />
+vi.mock('../ProviderList/ProviderEditorDrawer', () => {
+  providerEditorModuleState.loaded = true
+
+  return {
+    default: (props: any) => {
+      providerEditorDrawerSpy(props)
+      return (
+        <div data-testid="provider-editor-drawer" data-open={props.open ? 'true' : 'false'}>
+          <button type="button" onClick={props.onClose}>
+            close-provider-editor
+          </button>
+        </div>
+      )
+    }
   }
-}))
+})
 
 // The confirm-and-run dialog itself is covered by its own unit test; here we just let it run
 // the gated action (as if the user confirmed) and assert the delete flow.
@@ -198,6 +209,23 @@ describe('ProviderList', () => {
     )
   })
 
+  it('loads the provider editor only when the user opens it', async () => {
+    const user = userEvent.setup()
+
+    render(<ProviderList selectedProviderId="openai" onSelectProvider={vi.fn()} />)
+
+    expect(providerEditorModuleState.loaded).toBe(false)
+
+    await user.click(screen.getByRole('button', { name: '添加服务商' }))
+
+    expect(await screen.findByTestId('provider-editor-drawer')).toHaveAttribute('data-open', 'true')
+    expect(providerEditorModuleState.loaded).toBe(true)
+
+    await user.click(screen.getByRole('button', { name: 'close-provider-editor' }))
+
+    expect(screen.getByTestId('provider-editor-drawer')).toHaveAttribute('data-open', 'false')
+  })
+
   it('filters providers by search text and forwards selection', () => {
     const onSelectProvider = vi.fn()
 
@@ -238,7 +266,8 @@ describe('ProviderList', () => {
     expect(screen.queryByTestId('provider-list-item-cherryai')).not.toBeInTheDocument()
   })
 
-  it('offers only safe canonical preset sources to the custom provider editor', () => {
+  it('offers only safe canonical preset sources to the custom provider editor', async () => {
+    const user = userEvent.setup()
     const canonicalOpenAI = {
       ...providers[0],
       presetProviderId: 'openai',
@@ -271,15 +300,19 @@ describe('ProviderList', () => {
 
     render(<ProviderList selectedProviderId="openai" onSelectProvider={vi.fn()} />)
 
-    expect(providerEditorDrawerSpy).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        presetSources: [canonicalOpenAI, canonicalNewApi],
-        onSelectPreset: expect.any(Function)
-      })
-    )
+    await user.click(screen.getByRole('button', { name: '添加服务商' }))
+
+    await waitFor(() => {
+      expect(providerEditorDrawerSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          presetSources: [canonicalOpenAI, canonicalNewApi],
+          onSelectPreset: expect.any(Function)
+        })
+      )
+    })
   })
 
-  it('triggers add and reorder actions', () => {
+  it('triggers add and reorder actions', async () => {
     const reorderableProviders = [
       { ...providers[0], isEnabled: true },
       { ...providers[1], isEnabled: true }
@@ -293,9 +326,9 @@ describe('ProviderList', () => {
     render(<ProviderList selectedProviderId="openai" onSelectProvider={vi.fn()} />)
 
     expect(useReorderMock).toHaveBeenCalledWith('/providers', { revalidateOnSuccess: false })
-    expect(screen.getByTestId('provider-editor-drawer')).toHaveAttribute('data-open', 'false')
+    expect(screen.queryByTestId('provider-editor-drawer')).not.toBeInTheDocument()
     fireEvent.click(screen.getAllByRole('button', { name: /添加/i })[0])
-    expect(screen.getByTestId('provider-editor-drawer')).toHaveAttribute('data-open', 'true')
+    expect(await screen.findByTestId('provider-editor-drawer')).toHaveAttribute('data-open', 'true')
 
     fireEvent.click(screen.getByRole('button', { name: 'trigger-reorder' }))
     expect(reorderSpy).toHaveBeenCalledWith([reorderableProviders[1], reorderableProviders[0]])

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSetting.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSetting.test.tsx
@@ -6,6 +6,7 @@ import ProviderSetting from '../ProviderSetting'
 
 const useProviderMock = vi.fn()
 const useProviderApiKeyMock = vi.fn()
+const providerApiSetupModuleState = vi.hoisted(() => ({ loaded: false }))
 
 vi.mock('@renderer/hooks/useTheme', () => ({
   useTheme: () => ({
@@ -45,9 +46,13 @@ vi.mock('../ConnectionSettings/AuthenticationSection', async () => {
   }
 })
 
-vi.mock('../ConnectionSettings/ProviderApiSetupDialog', () => ({
-  default: ({ initialStep }: any) => <div role="dialog" aria-label={`api-setup-${initialStep}`} />
-}))
+vi.mock('../ConnectionSettings/ProviderApiSetupDialog', () => {
+  providerApiSetupModuleState.loaded = true
+
+  return {
+    default: ({ initialStep }: any) => <div role="dialog" aria-label={`api-setup-${initialStep}`} />
+  }
+})
 
 vi.mock('../ModelList', async () => {
   const { useAuthenticationApiKey } = await import('../hooks/providerSetting/useAuthenticationApiKey')
@@ -76,6 +81,19 @@ describe('ProviderSetting', () => {
       hasPendingSync: true,
       commitInputApiKeyNow: vi.fn()
     })
+  })
+
+  it('loads API setup only when the user opens it', async () => {
+    const user = userEvent.setup()
+
+    render(<ProviderSetting providerId="openai" />)
+
+    expect(providerApiSetupModuleState.loaded).toBe(false)
+
+    await user.click(screen.getByRole('button', { name: 'continue-model-setup' }))
+
+    expect(await screen.findByRole('dialog', { name: 'api-setup-models' })).toBeInTheDocument()
+    expect(providerApiSetupModuleState.loaded).toBe(true)
   })
 
   it('shares one API-key draft between authentication and model settings', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Provider Settings statically imported the provider editor drawer and API setup dialog, so browsing the page loaded both low-frequency editing module graphs.

After this PR:

The provider editor loads on its first activation and remains mounted afterward to preserve its existing state and close behavior. The API setup dialog loads only while an API setup step exists.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19718

### Why we need it and why it was done in this way

This reduces the initial Provider Settings module graph while keeping activation policy in the two components that already own `editorOpen` and `apiSetupStep`.

The following tradeoffs were made:

The first activation may briefly render a null Suspense fallback while its chunk loads. After loading, the provider editor stays mounted and continues receiving its existing `open` state so close transitions and internal lifecycle are unchanged.

The following alternatives were considered:

A shared loader, registry, or new editor API was rejected because both activation signals already have direct owners. Preloading on hover or focus was also left out because the task only requires on-demand loading.

Links to places where the discussion took place: #19718

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Focused renderer coverage verifies that neither module loads during ordinary browsing, each loads on its existing activation path, and the provider editor remains mounted with `open=false` after closing.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only code splitting in settings UI with no changes to auth, data, or provider configuration logic.
> 
> **Overview**
> **Provider Settings** no longer pulls in the provider editor drawer or API setup dialog on initial page load. Both are loaded on demand via `React.lazy` and `Suspense` (null fallback).
> 
> In the provider list, add/edit/duplicate paths set an `editorActivated` flag before opening the editor so the drawer chunk loads only on first use; the drawer **stays mounted** after that so existing open/close behavior is unchanged. On the provider detail view, `ProviderApiSetupDialog` loads only when an API setup step is active (including `initialApiSetupStep`).
> 
> Tests were updated to assert the modules are not loaded during normal browsing and load on the existing activation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa3cc215a1408b059b9a9c6e94c8c3a65189566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->