### PR TITLE
fix(prepare-release): derive release history from prepared release notes

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -150,7 +150,7 @@ Release notes are for **end users**, not developers. Exclude anything users don'
 
 1. **`package.json`**: Update the `"version"` field to the new version.
 2. **`electron-builder.yml`**: Replace the content under `releaseInfo.releaseNotes: |` with the generated notes. Preserve the 4-space YAML indentation for the block scalar content.
-3. **`resources/cherry-studio/release-history.json`**: For a stable `x.y.z` release, add the version and its exact generated bilingual notes at the start of the array. Replace an existing entry for the same version instead of creating a duplicate. Leave this file unchanged for prereleases.
+3. **`resources/cherry-studio/release-history.json`**: Never edit by hand; the notes must match `electron-builder.yml` byte for byte. Run `node scripts/release/sync-release-history.js --target-version {version}`, which prepends (or replaces) the entry for a stable release and leaves the file untouched for a prerelease. In GitHub Actions, the workflow runs this itself after the Claude step.
 4. **Validate source metadata**: For an interactive local run, run `node scripts/release/validate-prepared-release.js --target-version {version}` before generating the product manifest, and stop if it rejects the changed paths, version ordering, bilingual sections, or stable history. In GitHub Actions, leave validation to the workflow step that runs after Claude.
 5. **Built-in knowledge**: For an interactive local run, run `pnpm build:builtin-knowledge` after validation. This refreshes `resources/builtin-agents/cherry-assistant/product-manifest.json` with the new package version. Never edit the generated manifest by hand. In GitHub Actions, do not run the generator: the workflow runs the same validator first, then runs the trusted generator itself.
 
@@ -191,7 +191,7 @@ Otherwise, ask the user to confirm before proceeding to Step 6.
    git log -1 --format=%B | grep -q '^Signed-off-by: '
    git push -u origin release/v{version}
    ```
-2. In GitHub Actions, stop after updating `package.json` and `electron-builder.yml`, plus `resources/cherry-studio/release-history.json` only for a stable release. Temporary helper files and local Git operations are allowed; the workflow extracts those three file changes, restores the frozen source SHA, and discards everything else before validation. It then generates the product manifest, creates the branch, and uses GitHub's API to create and verify the signed, DCO-compliant commit. Never push from the Claude step.
+2. In GitHub Actions, stop after updating `package.json` and `electron-builder.yml`. Temporary helper files and local Git operations are allowed; the workflow extracts those two file changes, restores the frozen source SHA, and discards everything else. It then derives the release history, validates, generates the product manifest, creates the branch, and uses GitHub's API to create and verify the signed, DCO-compliant commit. Never push from the Claude step.
 3. Report the release branch and next steps. Do not create a PR yet: the release must be built and published from this branch first.
 
 ## CI Trigger Chain

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -161,8 +161,8 @@ jobs:
 
             The workflow froze the selected dispatch SHA and owns Step 1 item 1. Do not fetch or compare origin/main. It also completed the tag and published-release checks. Do not repeat those checks, push, or mutate any remote Git state. Local Git operations are temporary because the next step restores the frozen SHA.
 
-            Stop after updating package.json and electron-builder.yml, plus release-history.json only for a stable release. Do not edit the generated product manifest. The next workflow steps validate the contents, generate the manifest, and own release branch creation and the signed commit.
-            You may create temporary helper files if needed; the workflow discards every change except those three release metadata files.
+            Stop after updating package.json and electron-builder.yml. Do not edit release-history.json or the generated product manifest. The next workflow steps derive the release history from your electron-builder.yml notes, validate the contents, generate the manifest, and own release branch creation and the signed commit.
+            You may create temporary helper files if needed; the workflow discards every change except those two release metadata files.
         env:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
 
@@ -174,14 +174,20 @@ jobs:
           RELEASE_PATCH="$RUNNER_TEMP/prepared-release.patch"
           git diff --binary --full-index "$RELEASE_HEAD" -- \
             package.json \
-            electron-builder.yml \
-            resources/cherry-studio/release-history.json > "$RELEASE_PATCH"
+            electron-builder.yml > "$RELEASE_PATCH"
 
           git reset --hard "$RELEASE_HEAD"
           git clean -fd
           if [ -s "$RELEASE_PATCH" ]; then
             git apply "$RELEASE_PATCH"
           fi
+
+      - name: Sync release history from prepared release notes
+        shell: bash
+        env:
+          REQUESTED_VERSION: ${{ steps.release-version.outputs.version }}
+        run: |
+          node scripts/release/sync-release-history.js --target-version "$REQUESTED_VERSION"
 
       - name: Validate prepared release metadata
         shell: bash

--- a/scripts/__tests__/release-workflow.test.ts
+++ b/scripts/__tests__/release-workflow.test.ts
@@ -13,6 +13,7 @@ import {
   readBuilderReleaseNotes,
   updateHotfixReleaseMetadata
 } from '../release/hotfix-release-notes'
+import { syncReleaseHistory } from '../release/sync-release-history'
 import { validatePreparedRelease } from '../release/validate-prepared-release'
 import {
   validateBuildCompletion,
@@ -440,6 +441,42 @@ function createPreparedReleaseFixture(targetVersion = '1.1.0', baseVersion = '1.
   }
   return fixture
 }
+
+describe('release history synchronization', () => {
+  function syncFixture(targetVersion: string): GitFixture {
+    const fixture = createPreparedReleaseFixture(targetVersion)
+    const historyPath = path.join(fixture.repo, 'resources/cherry-studio/release-history.json')
+    git(fixture.repo, 'checkout', '--', 'resources/cherry-studio/release-history.json')
+    syncReleaseHistory({
+      builderPath: path.join(fixture.repo, 'electron-builder.yml'),
+      historyPath,
+      version: targetVersion
+    })
+    return fixture
+  }
+
+  it('derives a stable history entry that satisfies the byte-exact validator', () => {
+    const fixture = syncFixture('1.1.0')
+    expect(() => validatePreparedRelease({ cwd: fixture.repo, targetVersion: '1.1.0' })).not.toThrow()
+    const history = JSON.parse(
+      fs.readFileSync(path.join(fixture.repo, 'resources/cherry-studio/release-history.json'), 'utf8')
+    )
+    expect(history.map((entry: { version: string }) => entry.version)).toEqual(['1.1.0', '1.0.0'])
+  })
+
+  it('replaces an existing entry for the same version instead of duplicating it', () => {
+    const fixture = syncFixture('1.1.0')
+    const historyPath = path.join(fixture.repo, 'resources/cherry-studio/release-history.json')
+    const before = fs.readFileSync(historyPath, 'utf8')
+    syncReleaseHistory({ builderPath: path.join(fixture.repo, 'electron-builder.yml'), historyPath, version: '1.1.0' })
+    expect(fs.readFileSync(historyPath, 'utf8')).toBe(before)
+  })
+
+  it('leaves release history untouched for a prerelease', () => {
+    const fixture = syncFixture('1.1.0-rc.1')
+    expect(() => validatePreparedRelease({ cwd: fixture.repo, targetVersion: '1.1.0-rc.1' })).not.toThrow()
+  })
+})
 
 describe('prepared release validation', () => {
   it('accepts only a version bump, bilingual notes, and the matching stable history entry', () => {
@@ -1088,6 +1125,9 @@ describe('release workflow gates', () => {
     const prepareSteps = workflow.jobs.prepare.steps
     const claudeStep = prepareSteps.find((step: { name?: string }) => step.name === 'Prepare Release via Claude')
     const retainStep = prepareSteps.find((step: { name?: string }) => step.name === 'Retain prepared release metadata')
+    const syncIndex = prepareSteps.findIndex(
+      (step: { name?: string }) => step.name === 'Sync release history from prepared release notes'
+    )
     const validationIndex = prepareSteps.findIndex(
       (step: { name?: string }) => step.name === 'Validate prepared release metadata'
     )
@@ -1098,7 +1138,8 @@ describe('release workflow gates', () => {
     expect(retainStep.run).toContain('git reset --hard "$RELEASE_HEAD"')
     expect(retainStep.run).toContain('git clean -fd')
     expect(retainStep.run).toContain('git apply "$RELEASE_PATCH"')
-    expect(prepareSteps.indexOf(retainStep)).toBeLessThan(validationIndex)
+    expect(prepareSteps.indexOf(retainStep)).toBeLessThan(syncIndex)
+    expect(syncIndex).toBeLessThan(validationIndex)
 
     const fixture = createGitFixture()
     write(fixture.repo, 'package.json', '{"version":"1.0.0"}\n')
@@ -1125,10 +1166,12 @@ describe('release workflow gates', () => {
     expect(fs.readFileSync(path.join(fixture.repo, 'electron-builder.yml'), 'utf8')).toContain('releaseNotes: new')
     expect(fs.readFileSync(path.join(fixture.repo, 'app.txt'), 'utf8')).toBe('base\n')
     expect(fs.existsSync(path.join(fixture.repo, '.release-prep'))).toBe(false)
+    expect(fs.readFileSync(path.join(fixture.repo, 'resources/cherry-studio/release-history.json'), 'utf8')).toBe(
+      '[]\n'
+    )
     expect(git(fixture.repo, 'diff', '--name-only').split('\n').sort()).toEqual([
       'electron-builder.yml',
-      'package.json',
-      'resources/cherry-studio/release-history.json'
+      'package.json'
     ])
   })
 

--- a/scripts/release/sync-release-history.js
+++ b/scripts/release/sync-release-history.js
@@ -1,0 +1,38 @@
+const fs = require('node:fs')
+
+const { readBuilderReleaseNotes } = require('./hotfix-release-notes')
+
+function syncReleaseHistory({ builderPath, historyPath, version }) {
+  if (version.includes('-')) return null
+
+  const { releaseNotes } = readBuilderReleaseNotes(fs.readFileSync(builderPath, 'utf8'))
+  const history = JSON.parse(fs.readFileSync(historyPath, 'utf8')).filter((entry) => entry.version !== version)
+  history.unshift({ version, releaseNotes })
+  fs.writeFileSync(historyPath, `${JSON.stringify(history, null, 2)}\n`)
+
+  return releaseNotes
+}
+
+function main() {
+  const versionFlag = process.argv.indexOf('--target-version')
+  const version = versionFlag >= 0 ? process.argv[versionFlag + 1] : undefined
+  if (!version) throw new Error('--target-version is required')
+
+  const synced = syncReleaseHistory({
+    builderPath: 'electron-builder.yml',
+    historyPath: 'resources/cherry-studio/release-history.json',
+    version
+  })
+  console.log(synced ? `Synced release history for ${version}` : `Skipped release history for prerelease ${version}`)
+}
+
+if (require.main === module) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}
+
+module.exports = { syncReleaseHistory }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: the Pre Release workflow asked Claude to write the same bilingual release notes twice — once into the `electron-builder.yml` block scalar and once into `resources/cherry-studio/release-history.json` — and then validated that the two matched byte for byte, so any transcription drift failed the run ([2.0.11 run](https://github.com/CherryHQ/cherry-studio/actions/runs/33617046566/job/100205195940) failed with `Stable release history notes must exactly match electron-builder.yml`).

After this PR: Claude writes `package.json` and `electron-builder.yml` only, and a new `scripts/release/sync-release-history.js` step copies the prepared notes into the release history between the existing "Retain" and "Validate" steps, so the two files cannot diverge.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: the byte-exact validator is kept even though the check is now trivially satisfied, because it still guards the copy step itself and the artifact revalidation in the `publish` job; the "Retain" step no longer carries `release-history.json` in its patch, so any model edit to that file is silently discarded rather than reported.

The following alternatives were considered: relaxing the validator to a fuzzy or prefix comparison, which was rejected because the release history feeds the in-app changelog and a mismatch would show users different text than the GitHub Release; and dropping `release-history.json` entirely in favour of reading `electron-builder.yml` at runtime, which is a larger product change than this CI fix warrants.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None. Release metadata file formats and the resulting release commit are unchanged.

### Special notes for your reviewer

`syncReleaseHistory()` reuses the existing `readBuilderReleaseNotes()` parser from `hotfix-release-notes.js` rather than adding a second YAML block-scalar reader. It is a no-op for prereleases, matching the previous rule that only stable `x.y.z` releases append history. Three new tests cover the derived entry passing the byte-exact validator, idempotent re-sync, and the prerelease no-op; the existing retain-step contract test now asserts that a model edit to `release-history.json` is discarded. This must merge before the 2.0.11 Pre Release run is retried.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
