### PR TITLE
fix(chat-citations): resolve [cite:id] markers across turns

### DIFF
--- a/src/main/ai/runtime/aiSdk/prompts/citations.ts
+++ b/src/main/ai/runtime/aiSdk/prompts/citations.ts
@@ -2,8 +2,8 @@
  * Inline-citation guidance, appended to the system prompt only when a
  * citable lookup tool (web_search / web_fetch / kb_search / kb_read) is exposed
  * to the model — inline or deferred behind `tool_search`. The `[cite:id]`
- * markers it mandates are resolved by the renderer against the message's own
- * tool results (see `src/renderer/utils/message/citations.ts`).
+ * markers it mandates are resolved by the renderer against the tool results of
+ * the message and earlier turns (see `src/renderer/utils/message/citations.ts`).
  *
  * Wrapped in XML tags for parser-friendly structure (recommended by
  * Anthropic; tolerated well by other providers).

--- a/src/main/ai/runtime/citationsGuidance.ts
+++ b/src/main/ai/runtime/citationsGuidance.ts
@@ -5,7 +5,7 @@
  * scope is non-empty — a static binding or a per-turn composer selection).
  * Mirrors the assistant-path `CITATIONS_SYSTEM_PROMPT`
  * (`../aiSdk/prompts/citations.ts`); the `[cite:id]` markers are resolved by
- * the renderer against the message's own tool results.
+ * the renderer against the tool results of the message and earlier turns.
  */
 
 import { toCherryBuiltinRuntimeName } from '@main/ai/toolApproval/builtinToolPolicy'

--- a/src/main/ai/utils/citationIds.ts
+++ b/src/main/ai/utils/citationIds.ts
@@ -1,14 +1,14 @@
 /**
  * Citation id batch for one lookup call: "3f2a1b9c-1", "3f2a1b9c-2", …
  *
- * The random per-call prefix keeps ids unique across multiple web/kb lookup
- * calls in one assistant message without any request- or session-scoped state,
- * so the AI-SDK tool wrappers and the in-process MCP bridge mint ids the same
- * way. The model cites a result by echoing its id as `[cite:id]`; the renderer
- * resolves markers by exact id match against the message's own tool results, so
- * only intra-message uniqueness matters — but a collision is silent and
- * mis-attributes the marker to the earlier result, so the prefix carries a full
- * 32 bits rather than the handful of characters that uniqueness alone needs.
+ * The random per-call prefix keeps ids unique across every web/kb lookup call
+ * in a conversation without any request- or session-scoped state, so the
+ * AI-SDK tool wrappers and the in-process MCP bridge mint ids the same way. The
+ * model cites a result by echoing its id as `[cite:id]`; the renderer resolves
+ * markers by exact id match against the tool results of the message and of the
+ * earlier turns it can see, so a collision is silent and mis-attributes the
+ * marker to the earlier result — hence the prefix carries a full 32 bits rather
+ * than the handful of characters that uniqueness alone needs.
  */
 
 import { randomUUID } from 'node:crypto'

--- a/src/renderer/components/chat/messages/MessageListProvider.tsx
+++ b/src/renderer/components/chat/messages/MessageListProvider.tsx
@@ -1,5 +1,13 @@
+import { useStableStringArray } from '@renderer/hooks/useStableStringArray'
+import {
+  buildCitationPartsRegistry,
+  type CitationPartsRegistry,
+  EMPTY_CITATION_PARTS_REGISTRY,
+  getPriorCitationParts
+} from '@renderer/utils/message/citations'
+import type { CherryMessagePart } from '@shared/data/types/message'
 import type { Context, ReactNode } from 'react'
-import { createContext, use, useCallback, useMemo, useSyncExternalStore } from 'react'
+import { createContext, use, useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
 
 import { PartsProvider } from './blocks/MessagePartsContext'
 import type {
@@ -89,9 +97,27 @@ const MessageListUiStaticContext = createContext<MessageListUiStaticValue | null
 const MessageListUiSelectorsContext = createContext<MessageListUiSelectorsValue | null>(null)
 const MessageListActivityContext = createContext<MessageListActivityValue | null>(null)
 const MessageListEditingContext = createContext<string | null>(null)
+const MessageListCitationRegistryContext = createContext<CitationPartsRegistry | null>(null)
+
+/**
+ * Cross-turn citation registry. Keyed on the stable id order and the history
+ * parts layer (never the streaming overlay), so a streaming chunk does not
+ * rebuild it; `previous` keeps the identity when nothing citable changed.
+ */
+function useCitationPartsRegistry(state: MessageListState): CitationPartsRegistry {
+  const messageIds = useStableStringArray(useMemo(() => state.messages.map((message) => message.id), [state.messages]))
+  const partsSource = state.streamingLayers?.historyPartsByMessageId ?? state.partsByMessageId
+  const previousRef = useRef(EMPTY_CITATION_PARTS_REGISTRY)
+  return useMemo(() => {
+    const next = buildCitationPartsRegistry(messageIds, partsSource, previousRef.current)
+    previousRef.current = next
+    return next
+  }, [messageIds, partsSource])
+}
 
 export const MessageListProvider = ({ value, children }: { value: MessageListProviderValue; children: ReactNode }) => {
   const { state, actions, meta } = value
+  const citationRegistry = useCitationPartsRegistry(state)
 
   const data = useMemo<MessageListDataValue>(
     () => ({
@@ -168,23 +194,25 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
     <MessageListDataContext value={data}>
       <MessageListMessagesContext value={state.messages}>
         <PartsProvider value={state.partsByMessageId}>
-          <MessageListActionsContext value={actions}>
-            <MessageListMetaContext value={meta}>
-              <MessageListRenderConfigContext value={state.renderConfig}>
-                <MessageListSelectionContext value={state.selection}>
-                  <MessageListUiStaticContext value={uiStatic}>
-                    <MessageListUiSelectorsContext value={uiSelectors}>
-                      <MessageListActivityContext value={activity}>
-                        <MessageListEditingContext value={state.editingMessageId ?? null}>
-                          {children}
-                        </MessageListEditingContext>
-                      </MessageListActivityContext>
-                    </MessageListUiSelectorsContext>
-                  </MessageListUiStaticContext>
-                </MessageListSelectionContext>
-              </MessageListRenderConfigContext>
-            </MessageListMetaContext>
-          </MessageListActionsContext>
+          <MessageListCitationRegistryContext value={citationRegistry}>
+            <MessageListActionsContext value={actions}>
+              <MessageListMetaContext value={meta}>
+                <MessageListRenderConfigContext value={state.renderConfig}>
+                  <MessageListSelectionContext value={state.selection}>
+                    <MessageListUiStaticContext value={uiStatic}>
+                      <MessageListUiSelectorsContext value={uiSelectors}>
+                        <MessageListActivityContext value={activity}>
+                          <MessageListEditingContext value={state.editingMessageId ?? null}>
+                            {children}
+                          </MessageListEditingContext>
+                        </MessageListActivityContext>
+                      </MessageListUiSelectorsContext>
+                    </MessageListUiStaticContext>
+                  </MessageListSelectionContext>
+                </MessageListRenderConfigContext>
+              </MessageListMetaContext>
+            </MessageListActionsContext>
+          </MessageListCitationRegistryContext>
         </PartsProvider>
       </MessageListMessagesContext>
     </MessageListDataContext>
@@ -326,6 +354,12 @@ export const useMessageListSelection = (): MessageListSelectionState | undefined
 /** Id of the message currently being edited (null when none). Non-throwing: "not editing"
  * is a valid state, so embeds that never set it simply get null. */
 export const useMessageListEditingId = (): string | null => use(MessageListEditingContext)
+
+/** Citable tool parts of every message before `messageId` in list order; empty outside a provider. */
+export const useMessagePriorCitationParts = (messageId: string): readonly CherryMessagePart[] => {
+  const registry = use(MessageListCitationRegistryContext) ?? EMPTY_CITATION_PARTS_REGISTRY
+  return useMemo(() => getPriorCitationParts(registry, messageId), [registry, messageId])
+}
 
 /**
  * Back-compat hook: merged static + selectors UI value. Required variant

--- a/src/renderer/components/chat/messages/__tests__/MessageListProvider.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageListProvider.test.tsx
@@ -1,0 +1,104 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { MessageListProvider, useMessagePriorCitationParts } from '../MessageListProvider'
+import { defaultMessageRenderConfig, type MessageListItem, type MessageListProviderValue } from '../types'
+
+const item = (id: string): MessageListItem => ({
+  id,
+  role: 'assistant',
+  topicId: 'topic-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  status: 'success'
+})
+
+const searchPart = (toolCallId: string): CherryMessagePart =>
+  ({
+    type: 'tool-web_search',
+    toolCallId,
+    state: 'output-available',
+    input: { query: 'q' },
+    output: [{ id: `${toolCallId}-1`, title: 'First', url: 'https://a.com/x', content: 'alpha' }]
+  }) as never
+
+const textPart = (text: string): CherryMessagePart => ({ type: 'text', text }) as never
+
+type ProviderState = Pick<MessageListProviderValue['state'], 'messages' | 'partsByMessageId' | 'streamingLayers'>
+
+const createValue = (state: ProviderState): MessageListProviderValue => ({
+  state: {
+    topic: { id: 'topic-1', name: 'Topic' } as MessageListProviderValue['state']['topic'],
+    messageNavigation: 'none',
+    estimateSize: 400,
+    overscan: 0,
+    loadOlderDelayMs: 0,
+    loadingResetDelayMs: 0,
+    renderConfig: defaultMessageRenderConfig,
+    ...state
+  },
+  actions: {},
+  meta: { selectionLayer: false }
+})
+
+const renderPriorParts = (messageId: string, initialState: ProviderState) => {
+  let state = initialState
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MessageListProvider value={createValue(state)}>{children}</MessageListProvider>
+  )
+  const hook = renderHook(() => useMessagePriorCitationParts(messageId), { wrapper })
+  return {
+    ...hook,
+    update: (nextState: ProviderState) => {
+      state = nextState
+      hook.rerender()
+    }
+  }
+}
+
+describe('useMessagePriorCitationParts', () => {
+  const searched = searchPart('search-1')
+
+  it("exposes earlier messages' citable tool parts in list order and nothing from later ones", () => {
+    const messages = [item('m1'), item('m2'), item('m3')]
+    const partsByMessageId = {
+      m1: [searched, textPart('answer')],
+      m2: [textPart('follow-up')],
+      m3: [searchPart('search-3')]
+    }
+
+    expect(renderPriorParts('m1', { messages, partsByMessageId }).result.current).toEqual([])
+    expect(renderPriorParts('m2', { messages, partsByMessageId }).result.current).toEqual([searched])
+  })
+
+  it('keeps the same array across streaming chunks that only change text', () => {
+    const messages = [item('m1'), item('m2')]
+    const hook = renderPriorParts('m2', {
+      messages,
+      partsByMessageId: { m1: [searched], m2: [textPart('fol')] }
+    })
+    const first = hook.result.current
+
+    // A chunk hands the provider fresh containers but the same settled tool part.
+    hook.update({ messages: [...messages], partsByMessageId: { m1: [searched], m2: [textPart('follow-up')] } })
+
+    expect(hook.result.current).toBe(first)
+  })
+
+  it('reads the history layer rather than the live overlay when streaming layers are present', () => {
+    const messages = [item('m1'), item('m2')]
+    const liveOnly = searchPart('live')
+    const hook = renderPriorParts('m2', {
+      messages,
+      partsByMessageId: { m1: [searched, liveOnly], m2: [] },
+      streamingLayers: { historyPartsByMessageId: { m1: [searched], m2: [] }, liveMessageIds: ['m1'] }
+    })
+
+    expect(hook.result.current).toEqual([searched])
+  })
+
+  it('returns an empty array outside a provider', () => {
+    expect(renderHook(() => useMessagePriorCitationParts('m1')).result.current).toEqual([])
+  })
+})

--- a/src/renderer/components/chat/messages/blocks/MainTextBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/MainTextBlock.tsx
@@ -35,7 +35,7 @@ interface Props {
   isStreaming: boolean
   citations?: Citation[]
   citationReferences?: CitationReferenceView[]
-  /** Tool/source-derived citations resolved from the message's own parts (assistant messages without legacy reference metadata). */
+  /** Tool/source-derived citations resolved from the message's own parts and earlier turns (assistant messages without legacy reference metadata). */
   messageCitations?: MessageCitations
   toolCitationProjection?: ResolvedCitationMarkers
   mentions?: Model[]
@@ -382,7 +382,7 @@ const MainTextBlock: React.FC<Props> = ({
     inlineHtmlPreviewMode === 'ready' && smoothedContent !== content ? 'generating' : inlineHtmlPreviewMode
 
   // Legacy reference metadata (migrated v1 messages) wins; otherwise resolve
-  // [cite:id] markers against the message's own tool/source parts.
+  // [cite:id] markers against the message's own tool/source parts and earlier turns'.
   const toolCitations = useMemo(
     () =>
       citations.length === 0 && messageCitations?.all.length && toolCitationProjection
@@ -399,9 +399,9 @@ const MainTextBlock: React.FC<Props> = ({
       if (toolCitations) {
         return withToolCitationTags(rawText, toolCitations.citations, toolCitations.projection.byMarker).content
       }
-      // No citation at all in this message, so no marker in it can resolve — a model reusing an id
-      // minted by an earlier turn is the usual way here (#19771). Drop them rather than printing
-      // internal ids. User text is left alone: a literal `[cite:…]` there is the author's own.
+      // No citation in this message or any loaded earlier turn, so no marker can resolve — an
+      // unloaded page or an invented id (#19771). Drop them rather than printing internal ids.
+      // User text is left alone: a literal `[cite:…]` there is the author's own.
       return role === 'assistant' ? stripCitationMarkers(rawText) : rawText
     },
     [citationReferences, citations, role, toolCitations]

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -22,6 +22,7 @@ import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
 import { FILE_TYPE } from '@renderer/types/file'
 import type { Citation } from '@renderer/types/message'
 import {
+  isCitationSourcePart,
   type MessageCitations,
   resolveCitationMarkerParts,
   type ResolvedCitationMarkers,
@@ -46,7 +47,12 @@ import { useTranslation } from 'react-i18next'
 
 import MessageAttachments from '../frame/MessageAttachments'
 import ChatMarkdown, { type InlineHtmlPreviewMode } from '../markdown/ChatMarkdown'
-import { useMessageListActions, useMessageListActiveTurnStatus, useMessageRenderConfig } from '../MessageListProvider'
+import {
+  useMessageListActions,
+  useMessageListActiveTurnStatus,
+  useMessagePriorCitationParts,
+  useMessageRenderConfig
+} from '../MessageListProvider'
 import {
   getSessionToolTarget,
   isReportArtifactsToolResponse,
@@ -1342,6 +1348,7 @@ interface MessagePartsRendererContentProps extends Props {
   isActiveTurnProcessing: boolean
   isStreamLive: boolean
   messageParts: CherryMessagePart[]
+  priorCitationParts: readonly CherryMessagePart[]
 }
 
 const MessagePartsRendererContent = React.memo(function MessagePartsRendererContent({
@@ -1349,7 +1356,8 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
   isActiveTurnProcessing,
   isStreamLive,
   message,
-  messageParts
+  messageParts,
+  priorCitationParts
 }: MessagePartsRendererContentProps) {
   // Inline ephemeral status for the live turn (e.g. agent api-retry). Only the active-turn message
   // renders it; the node itself renders nothing when there is no such state.
@@ -1434,7 +1442,14 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
       ),
     [displayEntries, message.id]
   )
-  const messageCitations = useMemo(() => resolveMessageCitations(messageParts), [messageParts])
+  // Settled tool parts keep their identity across streaming chunks, so citations only re-resolve
+  // when a source part changes, not on every text delta.
+  const nextCitationSourceParts = useMemo(() => messageParts.filter(isCitationSourcePart), [messageParts])
+  const citationSourceParts = useStableItemArray(nextCitationSourceParts)
+  const messageCitations = useMemo(
+    () => resolveMessageCitations(citationSourceParts, message.role === 'assistant' ? priorCitationParts : undefined),
+    [citationSourceParts, message.role, priorCitationParts]
+  )
   const citationProjectionByPart = useMemo(() => {
     if (message.role !== 'assistant' || messageCitations.all.length === 0) return EMPTY_CITATION_PROJECTIONS
     const textParts = messageParts.filter((part) => {
@@ -1524,6 +1539,7 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
 
 const MessagePartsRenderer: React.FC<Props> = ({ message }) => {
   const messageParts = useMessageParts(message.id)
+  const priorCitationParts = useMessagePriorCitationParts(message.id)
   const { status: topicStreamStatus } = useTopicStreamStatus(message.topicId)
   const topicTurnState = classifyTurn(topicStreamStatus)
   const isProcessing = useIsActiveTurnTarget(message)
@@ -1540,6 +1556,7 @@ const MessagePartsRenderer: React.FC<Props> = ({ message }) => {
       isStreamLive={isStreamLive}
       message={message}
       messageParts={messageParts}
+      priorCitationParts={priorCitationParts}
     />
   )
 }

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -386,13 +386,17 @@ const renderPartsTree = (
   parts: CherryMessagePart[],
   message: MessageListItem = msg(),
   actions: MessageListProviderValue['actions'] = {},
-  renderConfig: MessageListProviderValue['state']['renderConfig'] = defaultMessageRenderConfig
+  renderConfig: MessageListProviderValue['state']['renderConfig'] = defaultMessageRenderConfig,
+  history: Array<{ message: MessageListItem; parts: CherryMessagePart[] }> = []
 ) => {
   const value: MessageListProviderValue = {
     state: {
       topic: { id: message.topicId, name: 'Topic' } as MessageListProviderValue['state']['topic'],
-      messages: [message],
-      partsByMessageId: { [message.id]: parts },
+      messages: [...history.map((entry) => entry.message), message],
+      partsByMessageId: Object.fromEntries([
+        ...history.map((entry) => [entry.message.id, entry.parts]),
+        [message.id, parts]
+      ]),
       messageNavigation: 'none',
       estimateSize: 400,
       overscan: 0,
@@ -422,8 +426,9 @@ const renderParts = (
   parts: CherryMessagePart[],
   message: MessageListItem = msg(),
   actions: MessageListProviderValue['actions'] = {},
-  renderConfig: MessageListProviderValue['state']['renderConfig'] = defaultMessageRenderConfig
-) => render(renderPartsTree(parts, message, actions, renderConfig))
+  renderConfig: MessageListProviderValue['state']['renderConfig'] = defaultMessageRenderConfig,
+  history: Array<{ message: MessageListItem; parts: CherryMessagePart[] }> = []
+) => render(renderPartsTree(parts, message, actions, renderConfig, history))
 
 function activateTurn(status?: string): void {
   mockIsActiveTurnTarget.mockReturnValue(true)
@@ -966,6 +971,44 @@ describe('MessagePartsRenderer', () => {
       expect(content).toContain("data-citation='1'")
       expect(content).toContain('https://example.com/news')
       expect(content).not.toContain('[cite:70536f0b-1]')
+    })
+
+    // #19771: the follow-up turn re-cites a kb_search result from the previous turn.
+    it('renders a [cite:id] re-cited from an earlier turn as a badge', () => {
+      const earlierTurn = {
+        message: msg({ id: 'msg-0' }),
+        parts: [
+          {
+            type: 'tool-kb_search',
+            toolCallId: 'search-0',
+            state: 'output-available',
+            input: { query: '审计内容', baseIds: ['b'] },
+            output: [
+              {
+                id: '2598d0ab-1',
+                baseId: 'b',
+                conceptId: 'audit/plan.md',
+                title: '审计方案.md',
+                type: 'file',
+                content: '工程立项与审批合规性审计',
+                score: 0.9
+              }
+            ]
+          }
+        ] as unknown as CherryMessagePart[]
+      }
+
+      renderParts(
+        [{ type: 'text', text: '1. 工程立项审计；[cite:2598d0ab-1]' }] as unknown as CherryMessagePart[],
+        msg({ id: 'msg-1' }),
+        {},
+        defaultMessageRenderConfig,
+        [earlierTurn]
+      )
+
+      const content = screen.getByTestId('mock-markdown').textContent ?? ''
+      expect(content).toContain("data-citation='1'")
+      expect(content).not.toContain('[cite:')
     })
 
     it('renders video and error value parts', async () => {

--- a/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
@@ -11,6 +11,7 @@ import {
   useMessageListActions,
   useMessageListSelection,
   useMessageListUi,
+  useMessagePriorCitationParts,
   useMessageRenderConfig
 } from '../MessageListProvider'
 import { defaultMessageMenuConfig, type MessageListItem } from '../types'
@@ -67,7 +68,11 @@ const MessageMenuBar: FC<Props> = (props) => {
   const isUserMessage = message.role === 'user'
 
   const messageParts = useMessageParts(message.id)
-  const messageForExport = useMemo(() => createMessageExportView(message, messageParts), [message, messageParts])
+  const priorCitationParts = useMessagePriorCitationParts(message.id)
+  const messageForExport = useMemo(
+    () => createMessageExportView(message, messageParts, priorCitationParts),
+    [message, messageParts, priorCitationParts]
+  )
 
   const mainTextContent = useMemo(() => getComposerTextFromParts(messageParts), [messageParts])
 

--- a/src/renderer/components/chat/messages/utils/__tests__/messageSelection.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/messageSelection.test.ts
@@ -43,6 +43,26 @@ describe('messageSelection', () => {
     expect(views[1].parts).toEqual(partsByMessageId.b)
   })
 
+  it('lets a selected message cite the tool results of an earlier, unselected message', () => {
+    const messages = [createMessage('a'), createMessage('b')]
+    const searchPart = {
+      type: 'tool-web_search',
+      toolCallId: 'search-1',
+      state: 'output-available',
+      input: { query: 'q' },
+      output: [{ id: '3f2a1b9c-1', title: 'First', url: 'https://a.com/x', content: 'alpha' }]
+    } as unknown as CherryMessagePart
+    const partsByMessageId: Record<string, CherryMessagePart[]> = {
+      a: [searchPart, { type: 'text', text: 'first [cite:3f2a1b9c-1]' }],
+      b: [{ type: 'text', text: 'still [cite:3f2a1b9c-1]' }]
+    }
+
+    const views = createSelectedMessageExportViews(['b'], messages, partsByMessageId)
+
+    expect(views).toHaveLength(1)
+    expect(views[0].priorCitationParts).toEqual([searchPart])
+  })
+
   it('copies selected message text in visible message order', () => {
     const messages = [createMessage('a'), createMessage('b')]
     const partsByMessageId: Record<string, CherryMessagePart[]> = {

--- a/src/renderer/components/chat/messages/utils/messageListItem.ts
+++ b/src/renderer/components/chat/messages/utils/messageListItem.ts
@@ -166,7 +166,11 @@ export function isMessageListItemAwaitingApproval(message: MessageListItem, part
   return parts.some((part) => isToolUIPart(part) && part.state === 'approval-requested')
 }
 
-export function createMessageExportView(message: MessageListItem, parts: CherryMessagePart[]): MessageExportView {
+export function createMessageExportView(
+  message: MessageListItem,
+  parts: CherryMessagePart[],
+  priorCitationParts?: readonly CherryMessagePart[]
+): MessageExportView {
   const model = getMessageListItemModel(message)
   return {
     id: message.id,
@@ -182,6 +186,7 @@ export function createMessageExportView(message: MessageListItem, parts: CherryM
     parentId: message.parentId,
     siblingsGroupId: message.siblingsGroupId,
     stats: message.stats,
-    parts
+    parts,
+    ...(priorCitationParts?.length ? { priorCitationParts } : {})
   }
 }

--- a/src/renderer/components/chat/messages/utils/messageSelection.ts
+++ b/src/renderer/components/chat/messages/utils/messageSelection.ts
@@ -1,4 +1,5 @@
 import type { MessageExportView } from '@renderer/types/messageExport'
+import { buildCitationPartsRegistry, getPriorCitationParts } from '@renderer/utils/message/citations'
 import type { ComposerRichClipboardContent } from '@renderer/utils/message/composerClipboard'
 import { createComposerRichClipboardContentFromPartGroups } from '@renderer/utils/message/composerClipboard'
 import { getComposerTextFromParts } from '@renderer/utils/message/composerTokens'
@@ -26,12 +27,21 @@ export function createSelectedMessageExportViews(
   partsByMessageId: Record<string, CherryMessagePart[]>
 ): MessageExportView[] {
   const messageById = new Map(orderedMessages.map((message) => [message.id, message]))
+  // Earlier messages count as citation sources whether or not they are selected.
+  const citationRegistry = buildCitationPartsRegistry(
+    orderedMessages.map((message) => message.id),
+    partsByMessageId
+  )
 
   return getOrderedSelectedMessageIds(messageIds, orderedMessages)
     .map((messageId) => {
       const message = messageById.get(messageId)
       if (!message) return null
-      return createMessageExportView(message, partsByMessageId[messageId] ?? [])
+      return createMessageExportView(
+        message,
+        partsByMessageId[messageId] ?? [],
+        getPriorCitationParts(citationRegistry, messageId)
+      )
     })
     .filter((message): message is MessageExportView => message !== null)
 }

--- a/src/renderer/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/hooks/__tests__/useTopic.test.ts
@@ -120,6 +120,44 @@ describe('getTopicMessages', () => {
     expect(messages.map((message) => message.id)).toEqual(['older', 'newer'])
   })
 
+  it('lets a later message cite tool results from an earlier page', async () => {
+    const searchPart = {
+      type: 'tool-web_search' as const,
+      toolCallId: 'search-1',
+      state: 'output-available' as const,
+      input: { query: 'q' },
+      output: [{ id: '3f2a1b9c-1', title: 'First', url: 'https://a.com/x', content: 'alpha' }]
+    }
+    const searched = { ...apiMessage('searched'), role: 'assistant' as const, data: { parts: [searchPart] } }
+    const followUp = {
+      ...apiMessage('follow-up'),
+      role: 'assistant' as const,
+      data: { parts: [{ type: 'text' as const, text: 'still [cite:3f2a1b9c-1]' }] }
+    }
+
+    vi.mocked(dataApiService.get)
+      .mockResolvedValueOnce({
+        items: [{ message: followUp }],
+        nextCursor: 'older-page',
+        activeNodeId: 'follow-up',
+        assistantId: 'assistant-1',
+        rootId: 'root'
+      } as never)
+      .mockResolvedValueOnce({
+        items: [{ message: searched }],
+        nextCursor: undefined,
+        activeNodeId: 'follow-up',
+        assistantId: 'assistant-1',
+        rootId: 'root'
+      } as never)
+
+    const messages = await getTopicMessages('topic-a')
+
+    expect(messages.map((message) => message.id)).toEqual(['searched', 'follow-up'])
+    expect(messages[0].priorCitationParts).toBeUndefined()
+    expect(messages[1].priorCitationParts).toEqual([searchPart])
+  })
+
   it('filters awaiting-input messages from sibling groups', async () => {
     const awaitingInputSibling = {
       ...apiMessage('awaiting-input-sibling'),

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -30,6 +30,7 @@ import { useIpcOn } from '@renderer/ipc'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { MessageExportView } from '@renderer/types/messageExport'
 import type { Topic as RendererTopic } from '@renderer/types/topic'
+import { withPriorCitationParts } from '@renderer/utils/message/exportView'
 import { ErrorCode, isDataApiNotFoundError } from '@shared/data/api/errors'
 import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { CreateTopicDto, DeleteTopicsResult, UpdateTopicDto } from '@shared/data/api/schemas/topics'
@@ -224,7 +225,7 @@ export async function getTopicMessages(
       cursor = response.nextCursor
     } while (cursor && (!options.maxMessages || collected < options.maxMessages))
 
-    return pages.reverse().flat()
+    return withPriorCitationParts(pages.reverse().flat())
   } catch (error: unknown) {
     if (error instanceof Object && 'code' in error && error.code === ErrorCode.NOT_FOUND) {
       logger.debug(`Topic ${id} not found in Data API, returning empty`)

--- a/src/renderer/services/__tests__/ExportService.test.ts
+++ b/src/renderer/services/__tests__/ExportService.test.ts
@@ -144,6 +144,7 @@ vi.mock('@renderer/utils/markdown', async (importOriginal) => {
 // Import the functions to test AFTER setting up mocks
 import { type Topic, TopicType } from '@renderer/types/topic'
 import { markdownToPlainText } from '@renderer/utils/markdown'
+import { withPriorCitationParts } from '@renderer/utils/message/exportView'
 
 import {
   exportMarkdownToObsidian,
@@ -509,6 +510,20 @@ describe('ExportService', () => {
 
       expect(markdown).toContain('Answer with citation')
       expect(markdown).toContain('[^1]: [Example](https://example.com)')
+    })
+
+    it('resolves a [cite:id] re-cited from an earlier message in a topic export', async () => {
+      const earlier = createExportView([
+        toolSearchPart([{ id: '3f2a1b9c-1', title: 'Example', url: 'https://example.com', content: 'snippet' }]),
+        { type: 'text', text: 'Prices rose 3%. [cite:3f2a1b9c-1]' }
+      ])
+      const followUp = createExportView([{ type: 'text', text: 'Still 3%. [cite:3f2a1b9c-1]' }])
+
+      const markdown = await messagesToMarkdown(withPriorCitationParts([earlier, followUp]))
+
+      expect(markdown).not.toContain('[cite:')
+      expect(markdown).toContain('Still 3%. [^1]')
+      expect(markdown.match(/\[\^1\]: \[Example\]\(https:\/\/example\.com\)/g)).toHaveLength(2)
     })
 
     it('should resolve tool-part [cite:id] markers and list their sources', async () => {

--- a/src/renderer/services/__tests__/agentSessionExport.test.ts
+++ b/src/renderer/services/__tests__/agentSessionExport.test.ts
@@ -1,5 +1,6 @@
 import { dataApiService } from '@data/DataApiService'
 import type { AgentSessionMessageEntity } from '@shared/data/api/schemas/agentSessionMessages'
+import type { CherryMessagePart } from '@shared/data/types/message'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@data/DataApiService', () => ({
@@ -110,6 +111,34 @@ describe('agentSessionExport', () => {
       provider: 'stored-provider',
       group: ''
     })
+  })
+
+  it('lets a later message cite the tool results of an earlier one in the export', async () => {
+    const searchPart = {
+      type: 'tool-web_search',
+      toolCallId: 'search-1',
+      state: 'output-available',
+      input: { query: 'q' },
+      output: [{ id: '3f2a1b9c-1', title: 'First', url: 'https://a.com/x', content: 'alpha' }]
+    } as unknown as CherryMessagePart
+    // The API pages newest-first; the export reverses into chronological order.
+    vi.mocked(dataApiService.get).mockResolvedValueOnce({
+      items: [
+        createSessionMessage({
+          id: 'follow-up',
+          role: 'assistant',
+          data: { parts: [{ type: 'text', text: 'still [cite:3f2a1b9c-1]' }] }
+        }),
+        createSessionMessage({ id: 'searched', role: 'assistant', data: { parts: [searchPart] } })
+      ],
+      nextCursor: undefined
+    })
+
+    const messages = await getAgentSessionMessagesForExport({ id: 'session-a', agentId: 'agent-a', name: 'Session A' })
+
+    expect(messages.map((message) => message.id)).toEqual(['searched', 'follow-up'])
+    expect(messages[0].priorCitationParts).toBeUndefined()
+    expect(messages[1].priorCitationParts).toEqual([searchPart])
   })
 
   it('stops paging at maxMessages instead of walking the whole session', async () => {

--- a/src/renderer/services/agentSessionExport.ts
+++ b/src/renderer/services/agentSessionExport.ts
@@ -7,6 +7,7 @@ import type { Model } from '@renderer/types/model'
 import { buildAgentSessionTopicId } from '@renderer/utils/agentSession'
 import { messagesToPlainText } from '@renderer/utils/export'
 import { markdownToPlainText } from '@renderer/utils/markdown'
+import { withPriorCitationParts } from '@renderer/utils/message/exportView'
 import {
   AGENT_SESSION_MESSAGES_MAX_LIMIT,
   type AgentSessionMessageEntity
@@ -95,7 +96,7 @@ export async function getAgentSessionMessagesForExport(
     cursor = response.nextCursor
   } while (cursor && (!options.maxMessages || collected < options.maxMessages))
 
-  return pages.reverse().flatMap((page) => page.reverse())
+  return withPriorCitationParts(pages.reverse().flatMap((page) => page.reverse()))
 }
 
 export async function agentSessionToMarkdown(

--- a/src/renderer/types/messageExport.ts
+++ b/src/renderer/types/messageExport.ts
@@ -25,6 +25,8 @@ export interface MessageExportView {
   siblingsGroupId?: number
   stats?: MessageStats
   parts: CherryMessagePart[]
+  /** Citable tool parts of earlier messages, so an id re-cited from a previous turn exports like it renders. */
+  priorCitationParts?: readonly CherryMessagePart[]
 }
 
 // `Message` (v1) is still produced only by the v1-block-based export/copy test

--- a/src/renderer/utils/__tests__/export.test.ts
+++ b/src/renderer/utils/__tests__/export.test.ts
@@ -239,6 +239,24 @@ describe('export', () => {
       expect(markdownToPlainText).toHaveBeenCalledWith('/pdf/ hello')
     })
 
+    it('copies an id re-cited from an earlier turn as a plain number', () => {
+      const testMessage: MessageExportView = {
+        ...createExportView([{ type: 'text', text: 'Still true. [cite:3f2a1b9c-1]' }]),
+        priorCitationParts: [
+          {
+            type: 'tool-web_search',
+            toolCallId: 'earlier-turn',
+            state: 'output-available',
+            input: { query: 'q' },
+            output: [{ id: '3f2a1b9c-1', title: 'First', url: 'https://a.com/x', content: 'alpha' }]
+          }
+        ] as MessageExportView['parts']
+      }
+      ;(markdownToPlainText as any).mockImplementation((str: string) => str)
+
+      expect(messageToPlainText(testMessage)).toBe('Still true. [1]')
+    })
+
     it('should resolve tool citation markers to plain numbers before copying', () => {
       // Left in place, `remove-markdown` mangles a chain of markers down to a bare
       // `cite:<id>` and the internal id lands on the clipboard.

--- a/src/renderer/utils/citation.ts
+++ b/src/renderer/utils/citation.ts
@@ -6,7 +6,7 @@
  * This module lives in the renderer because it encodes business knowledge:
  * the LLM provider enumeration, each provider's wire format for citation
  * markers, and how to project our chat `Citation` shape into rendered markers.
- * Tooltip data stays out-of-band in the current message's trusted registry. The markdown package
+ * Tooltip data stays out-of-band in the message's trusted registry. The markdown package
  * upstream is intentionally provider-agnostic.
  */
 
@@ -210,9 +210,9 @@ export const CITATION_MARKER_PATTERN = /([ \t]?)\[cite:([\w-]+)\]/g
  * tool-result ids keep their `<prefix>-<n>` form.
  *
  * An id that resolves to nothing is dropped rather than echoed: the id is an
- * internal, message-scoped handle, so printing it puts implementation detail on
- * screen (#19771). A model that reuses an id minted in an earlier turn is the
- * common way to get here, and its markers cannot be resolved from this message.
+ * internal, conversation-scoped handle, so printing it puts implementation
+ * detail on screen (#19771). An id from a turn that is not loaded, or one the
+ * model invented, is how a marker gets here.
  */
 export function mapCitationMarksToTags(content: string, citationMap: Map<string, Citation>): string {
   return mapMarkdownOutsideCode(content, (text) =>

--- a/src/renderer/utils/message/__tests__/citations.test.ts
+++ b/src/renderer/utils/message/__tests__/citations.test.ts
@@ -2,6 +2,8 @@ import type { CherryMessagePart } from '@shared/data/types/message'
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildCitationPartsRegistry,
+  getPriorCitationParts,
   resolveCitationMarkerParts,
   resolveMessageCitations,
   stripCitationMarkers,
@@ -400,10 +402,10 @@ describe('withToolCitationTags', () => {
     expect(cited).toHaveLength(0)
   })
 
-  // #19771: a model that reuses an id minted by an earlier turn leaves this message with markers
-  // nothing can resolve. Printing them puts an internal id on screen; the export path already
+  // An id from a turn that is not loaded (older page) or that the model invented leaves markers
+  // nothing can resolve. Printing them puts an internal id on screen (#19771); the export path
   // drops such markers, so rendering has to agree.
-  it('drops every marker when the message carries no citation at all', () => {
+  it('drops every marker when the message carries no citation and no earlier turn is loaded', () => {
     const mc = resolveMessageCitations([textPart('no tool ran in this message')])
     const { content, cited } = withToolCitationTags(
       '1. 工程立项审计；[cite:2598d0ab-1]\n2. 工程采购审计；[cite:2598d0ab-1]',
@@ -495,7 +497,7 @@ describe('toExportableCitations', () => {
     expect(cited).toEqual([])
   })
 
-  it('strips markers even when the message carries no tool results', () => {
+  it('strips markers when neither the message nor an earlier turn carries tool results', () => {
     const { content } = toExportableCitations('Claim [cite:abc-1].', [textPart('hi')])
     expect(content).toBe('Claim.')
   })
@@ -551,5 +553,115 @@ describe('stripCitationMarkers', () => {
   it('preserves canonical markers in inline and fenced code', () => {
     const input = '`[cite:abc-1]`\n```txt\n[cite:def-2, def-3]\n```\nOutside [cite:abc-1, abc-2]'
     expect(stripCitationMarkers(input)).toBe('`[cite:abc-1]`\n```txt\n[cite:def-2, def-3]\n```\nOutside')
+  })
+})
+
+describe('cross-turn citations', () => {
+  // A follow-up turn cites a result the model already saw in an earlier turn (#19771, #19324).
+  it("resolves a marker against an earlier turn's kb_search result", () => {
+    const mc = resolveMessageCitations([textPart('follow-up')], [kbToolPart(kbResults('2598d0ab'))])
+    const { content, cited } = withToolCitationTags(
+      '1. 工程立项审计；[cite:2598d0ab-1]\n2. 工程采购审计；[cite:2598d0ab-1]',
+      mc
+    )
+    expect(content).toBe(
+      "1. 工程立项审计；<sup data-citation='1'>1</sup>\n2. 工程采购审计；<sup data-citation='1'>1</sup>"
+    )
+    expect(cited.map((citation) => citation.title)).toEqual(['One.md'])
+  })
+
+  it("resolves a marker against an earlier turn's web_search result", () => {
+    const mc = resolveMessageCitations([textPart('follow-up')], [webToolPart(webResults('abc'))])
+    const { content, cited } = withToolCitationTags('Prices rose. [cite:abc-2]', mc)
+    expect(content).toBe("Prices rose. [<sup data-citation='1'>1</sup>](https://b.com/y)")
+    expect(cited.map((citation) => citation.url)).toEqual(['https://b.com/y'])
+  })
+
+  it("aliases an earlier turn's result to this message's own citation of the same document", () => {
+    const own = [kbToolPart([{ ...kbResults('new')[0], content: 'fresh chunk' }])]
+    const mc = resolveMessageCitations(own, [kbToolPart(kbResults('old'))])
+    const { content, cited } = withToolCitationTags('A [cite:old-1] B [cite:new-1]', mc)
+    expect(cited).toHaveLength(1)
+    expect(cited[0].content).toBe('fresh chunk')
+    expect(content.match(/data-citation='1'/g)).toHaveLength(2)
+  })
+
+  it("aliases an earlier turn's web result to the own result with the same URL", () => {
+    const mc = resolveMessageCitations([webToolPart(webResults('new'))], [webToolPart(webResults('old'))])
+    expect(mc.byId.get('old-1')).toBe(mc.byId.get('new-1'))
+    expect(mc.all).toHaveLength(2)
+  })
+
+  it("never lets an earlier turn's call decide bare [N] resolution", () => {
+    const priorCall = webToolPart([{ id: 1, title: 'Old', url: 'https://old.com', content: 'legacy' }])
+    // No own call: a bare number has nothing local to point at.
+    expect(resolveMessageCitations([textPart('x')], [priorCall]).byMarkerNumber.size).toBe(0)
+    // Exactly one own call: promoted regardless of how many calls earlier turns made.
+    const own = webToolPart([{ id: 1, title: 'Now', url: 'https://now.com', content: 'now' }])
+    const mc = resolveMessageCitations([own], [priorCall, kbToolPart(kbResults('bbb'))])
+    expect(mc.byMarkerNumber.get(1)).toMatchObject({ url: 'https://now.com' })
+  })
+
+  it('ignores source-url parts handed in as earlier-turn parts', () => {
+    const mc = resolveMessageCitations([textPart('x')], [sourceUrlPart(0, 'https://native.com')])
+    expect(mc.all).toHaveLength(0)
+  })
+
+  it('still drops an id no loaded turn produced', () => {
+    const mc = resolveMessageCitations([textPart('x')], [webToolPart(webResults('abc'))])
+    const { content, cited } = withToolCitationTags('Claim [cite:zzz-9].', mc)
+    expect(content).toBe('Claim.')
+    expect(cited).toHaveLength(0)
+  })
+
+  it('exports a marker re-cited from an earlier turn as [N] with its source listed', () => {
+    const { content, cited } = toExportableCitations(
+      'Claim [cite:abc-1].',
+      [textPart('x')],
+      [webToolPart(webResults('abc'))]
+    )
+    expect(content).toBe('Claim [1].')
+    expect(cited.map((citation) => citation.url)).toEqual(['https://a.com/x'])
+  })
+})
+
+describe('buildCitationPartsRegistry', () => {
+  const kb = kbToolPart(kbResults('k1'))
+  const web = webToolPart(webResults('w1'))
+  const partsByMessageId = {
+    m1: [textPart('question')],
+    m2: [kb, textPart('answer [cite:k1-1]'), sourceUrlPart(0, 'https://native.com')],
+    m3: [
+      textPart('follow-up'),
+      webToolPart(webResults('pending'), 'input-available'),
+      dynamicMcpPart('web_search', [], 'other-server')
+    ],
+    m4: [web, textPart('x')]
+  }
+  const ids = ['m1', 'm2', 'm3', 'm4']
+
+  it('collects completed citable tool parts in list order and nothing else', () => {
+    expect(buildCitationPartsRegistry(ids, partsByMessageId).parts).toEqual([kb, web])
+  })
+
+  it('gives a message only the parts of messages before it, and everything to an id it does not know', () => {
+    const registry = buildCitationPartsRegistry(ids, partsByMessageId)
+    expect(getPriorCitationParts(registry, 'm2')).toHaveLength(0)
+    expect(getPriorCitationParts(registry, 'm3')).toEqual([kb])
+    expect(getPriorCitationParts(registry, 'm4')).toEqual([kb])
+    expect(getPriorCitationParts(registry, 'live-not-listed-yet')).toEqual([kb, web])
+  })
+
+  it('shares one empty array for every message nothing precedes', () => {
+    const registry = buildCitationPartsRegistry(ids, partsByMessageId)
+    expect(getPriorCitationParts(registry, 'm1')).toBe(getPriorCitationParts(registry, 'm2'))
+  })
+
+  it('keeps the previous registry while only text parts change', () => {
+    const previous = buildCitationPartsRegistry(ids, partsByMessageId)
+    const streamed = { ...partsByMessageId, m4: [web, textPart('x plus a chunk')] }
+    expect(buildCitationPartsRegistry(ids, streamed, previous)).toBe(previous)
+    const searchedAgain = { ...partsByMessageId, m4: [web, kbToolPart(kbResults('k2'))] }
+    expect(buildCitationPartsRegistry(ids, searchedAgain, previous)).not.toBe(previous)
   })
 })

--- a/src/renderer/utils/message/__tests__/find.test.ts
+++ b/src/renderer/utils/message/__tests__/find.test.ts
@@ -166,3 +166,28 @@ describe('getToolCitationExport', () => {
     })
   })
 })
+
+describe('getToolCitationExport across turns', () => {
+  it('resolves a marker against priorCitationParts and lists that source', () => {
+    const message: MessageExportView = {
+      ...createExportView([{ type: 'text', text: 'Prices rose. [cite:3f2a1b9c-2]' }] as MessageExportView['parts']),
+      priorCitationParts: [
+        {
+          type: 'tool-web_search',
+          toolCallId: 'earlier-turn',
+          state: 'output-available',
+          input: { query: 'q' },
+          output: [
+            { id: '3f2a1b9c-1', title: 'First', url: 'https://a.com/x', content: 'alpha' },
+            { id: '3f2a1b9c-2', title: 'Second', url: 'https://b.com/y', content: 'beta' }
+          ]
+        }
+      ] as MessageExportView['parts']
+    }
+
+    const { content, citation } = getToolCitationExport(message, 'Prices rose. [cite:3f2a1b9c-2]')
+
+    expect(content).toBe('Prices rose. [1]')
+    expect(citation).toBe('[1] [Second](https://b.com/y)')
+  })
+})

--- a/src/renderer/utils/message/citations.ts
+++ b/src/renderer/utils/message/citations.ts
@@ -1,6 +1,8 @@
 /**
  * Citation registry — resolves a message's inline citations directly from its
- * own parts, with no persisted reference metadata:
+ * own parts plus, via `priorParts`, the citable tool parts of earlier messages
+ * in the same conversation (the model re-cites a result it already saw in a
+ * previous turn, #19771), with no persisted reference metadata:
  *
  * - `tool-web_search` / `tool-web_fetch` / `tool-kb_search` / `tool-kb_read`
  *   results (assistant runtime), including the same tools called through
@@ -58,8 +60,9 @@ export interface MessageCitations {
   /**
    * Bare `[N]` marker resolution: provider-native `source-url` numbers always;
    * lookup-tool ids by their numeric value/suffix only when the message holds a
-   * single lookup call (old numeric-id messages and weak-model fallback) —
-   * with more calls a bare number is ambiguous and stays literal.
+   * single lookup call of its own (old numeric-id messages and weak-model
+   * fallback; earlier turns' calls do not count) — with more calls a bare
+   * number is ambiguous and stays literal.
    */
   byMarkerNumber: Map<number, Citation>
   /** All citations in part order, display numbers 1..K. */
@@ -67,6 +70,7 @@ export interface MessageCitations {
 }
 
 const EMPTY_MESSAGE_CITATIONS: MessageCitations = { byId: new Map(), byMarkerNumber: new Map(), all: [] }
+const EMPTY_PARTS: readonly CherryMessagePart[] = []
 
 const CITABLE_TOOL_NAMES: ReadonlySet<string> = new Set([
   WEB_SEARCH_TOOL_NAME,
@@ -207,7 +211,15 @@ function markerNumberOfId(id: string | number): number | undefined {
   return suffix ? Number(suffix) : undefined
 }
 
-export function resolveMessageCitations(parts: readonly CherryMessagePart[]): MessageCitations {
+/**
+ * Own parts define the citations; `priorParts` (earlier turns) only answer ids
+ * the message does not mint itself, aliasing by document/URL, and never count
+ * as lookup calls.
+ */
+export function resolveMessageCitations(
+  parts: readonly CherryMessagePart[],
+  priorParts: readonly CherryMessagePart[] = EMPTY_PARTS
+): MessageCitations {
   const byId = new Map<string, Citation>()
   const byMarkerNumber = new Map<number, Citation>()
   const all: Citation[] = []
@@ -234,8 +246,17 @@ export function resolveMessageCitations(parts: readonly CherryMessagePart[]): Me
 
   let nextNumber = all.reduce((max, citation) => Math.max(max, citation.number), 0) + 1
   let lookupCallCount = 0
+  let ownScope = true
   const toolMarkerCandidates = new Map<number, Citation>()
   const byDocument = new Map<string, Citation>()
+
+  const trackMarkerNumber = (id: string | number, citation: Citation) => {
+    if (!ownScope) return
+    const markerNumber = markerNumberOfId(id)
+    if (markerNumber !== undefined && !toolMarkerCandidates.has(markerNumber)) {
+      toolMarkerCandidates.set(markerNumber, citation)
+    }
+  }
 
   const addKnowledgeCitation = (item: {
     id: string | number
@@ -266,24 +287,21 @@ export function resolveMessageCitations(parts: readonly CherryMessagePart[]): Me
     byId.set(key, citation)
     if (document) byDocument.set(document, citation)
     all.push(citation)
-    const markerNumber = markerNumberOfId(item.id)
-    if (markerNumber !== undefined && !toolMarkerCandidates.has(markerNumber)) {
-      toolMarkerCandidates.set(markerNumber, citation)
-    }
+    trackMarkerNumber(item.id, citation)
   }
 
-  for (const part of parts) {
+  const addToolPart = (part: CherryMessagePart) => {
     const toolName = resolveCitableToolName(part)
-    if (!toolName) continue
+    if (!toolName) return
     const rawOutput = unwrapCitableOutput((part as { output?: unknown }).output)
     const output = normalizeToolOutputResponse(rawOutput)
 
     if (toolName === KB_SEARCH_TOOL_NAME) {
       const parsed = kbSearchOutputSchema.safeParse(output)
-      if (!parsed.success || parsed.data.length === 0) continue
-      lookupCallCount += 1
+      if (!parsed.success || parsed.data.length === 0) return
+      if (ownScope) lookupCallCount += 1
       for (const item of parsed.data) addKnowledgeCitation(item)
-      continue
+      return
     }
 
     if (toolName === KB_READ_TOOL_NAME) {
@@ -292,15 +310,15 @@ export function resolveMessageCitations(parts: readonly CherryMessagePart[]): Me
       // text. Try the raw output first (assistant path); the unwrapped form only wins on the agent
       // path, where a real envelope does wrap the payload.
       const item = parseKbReadCitation(rawOutput) ?? parseKbReadCitation(output)
-      if (!item) continue
-      lookupCallCount += 1
+      if (!item) return
+      if (ownScope) lookupCallCount += 1
       addKnowledgeCitation(item)
-      continue
+      return
     }
 
     const parsed = webSearchOutputSchema.safeParse(output)
-    if (!parsed.success || parsed.data.length === 0) continue
-    lookupCallCount += 1
+    if (!parsed.success || parsed.data.length === 0) return
+    if (ownScope) lookupCallCount += 1
     for (const item of parsed.data) {
       const key = String(item.id)
       if (byId.has(key)) continue
@@ -321,12 +339,13 @@ export function resolveMessageCitations(parts: readonly CherryMessagePart[]): Me
       byId.set(key, citation)
       if (item.url) byUrl.set(item.url, citation)
       all.push(citation)
-      const markerNumber = markerNumberOfId(item.id)
-      if (markerNumber !== undefined && !toolMarkerCandidates.has(markerNumber)) {
-        toolMarkerCandidates.set(markerNumber, citation)
-      }
+      trackMarkerNumber(item.id, citation)
     }
   }
+
+  for (const part of parts) addToolPart(part)
+  ownScope = false
+  for (const part of priorParts) addToolPart(part)
 
   if (lookupCallCount === 1) {
     for (const [markerNumber, citation] of toolMarkerCandidates) {
@@ -336,6 +355,73 @@ export function resolveMessageCitations(parts: readonly CherryMessagePart[]): Me
 
   if (all.length === 0) return EMPTY_MESSAGE_CITATIONS
   return { byId, byMarkerNumber, all }
+}
+
+/** `source-url` or a completed citable tool part — exactly the parts `resolveMessageCitations` reads. */
+export function isCitationSourcePart(part: CherryMessagePart): boolean {
+  return part.type === 'source-url' || resolveCitableToolName(part) !== null
+}
+
+/**
+ * Citable tool parts of an ordered message list, so a later message can resolve
+ * an id the model re-cites from an earlier turn. `source-url` parts stay out:
+ * provider-native `[N]` numbering is message-local.
+ */
+export interface CitationPartsRegistry {
+  /** Completed citable tool parts in list order. */
+  parts: readonly CherryMessagePart[]
+  /** Message id → how many of `parts` belong to messages before it. */
+  prefixCountByMessageId: ReadonlyMap<string, number>
+}
+
+export const EMPTY_CITATION_PARTS_REGISTRY: CitationPartsRegistry = {
+  parts: EMPTY_PARTS,
+  prefixCountByMessageId: new Map()
+}
+
+function isSameRegistry(
+  previous: CitationPartsRegistry,
+  parts: readonly CherryMessagePart[],
+  prefixCountByMessageId: ReadonlyMap<string, number>
+): boolean {
+  if (previous.parts.length !== parts.length) return false
+  if (previous.prefixCountByMessageId.size !== prefixCountByMessageId.size) return false
+  if (parts.some((part, index) => previous.parts[index] !== part)) return false
+  for (const [messageId, count] of prefixCountByMessageId) {
+    if (previous.prefixCountByMessageId.get(messageId) !== count) return false
+  }
+  return true
+}
+
+/**
+ * Returns `previous` when nothing citable changed (same part references, same
+ * prefix counts), so a streaming text chunk never invalidates every message's
+ * prior-parts slice.
+ */
+export function buildCitationPartsRegistry(
+  messageIds: readonly string[],
+  partsByMessageId: Readonly<Record<string, readonly CherryMessagePart[] | undefined>>,
+  previous?: CitationPartsRegistry
+): CitationPartsRegistry {
+  const parts: CherryMessagePart[] = []
+  const prefixCountByMessageId = new Map<string, number>()
+  for (const messageId of messageIds) {
+    prefixCountByMessageId.set(messageId, parts.length)
+    for (const part of partsByMessageId[messageId] ?? EMPTY_PARTS) {
+      if (resolveCitableToolName(part) !== null) parts.push(part)
+    }
+  }
+  if (previous && isSameRegistry(previous, parts, prefixCountByMessageId)) return previous
+  return { parts, prefixCountByMessageId }
+}
+
+/** Parts of every message before `messageId`; an id the list does not know sees all of them. */
+export function getPriorCitationParts(
+  registry: CitationPartsRegistry,
+  messageId: string
+): readonly CherryMessagePart[] {
+  const count = registry.prefixCountByMessageId.get(messageId) ?? registry.parts.length
+  return count === 0 ? EMPTY_PARTS : registry.parts.slice(0, count)
 }
 
 /** Resolved markers, ready for a caller to render, rewrite or strip. */
@@ -481,9 +567,14 @@ export function resolveCitationMarkers(content: string, citations: MessageCitati
  */
 export function toExportableCitations(
   content: string,
-  parts: readonly CherryMessagePart[]
+  parts: readonly CherryMessagePart[],
+  priorParts: readonly CherryMessagePart[] = EMPTY_PARTS
 ): { content: string; cited: Citation[] } {
-  const { content: resolved, byMarker, cited } = resolveCitationMarkers(content, resolveMessageCitations(parts))
+  const {
+    content: resolved,
+    byMarker,
+    cited
+  } = resolveCitationMarkers(content, resolveMessageCitations(parts, priorParts))
   return {
     content: mapMarkdownOutsideCode(resolved, (text) =>
       text.replace(CITATION_MARKER_PATTERN, (_match, space: string, id: string) => {

--- a/src/renderer/utils/message/exportView.ts
+++ b/src/renderer/utils/message/exportView.ts
@@ -1,6 +1,8 @@
 import type { MessageExportView } from '@renderer/types/messageExport'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
 
+import { buildCitationPartsRegistry, getPriorCitationParts } from './citations'
+
 export function exportViewToUIMessage(message: MessageExportView): CherryUIMessage {
   const metadata: CherryUIMessage['metadata'] = {
     status: message.status,
@@ -23,6 +25,20 @@ export function exportViewToUIMessage(message: MessageExportView): CherryUIMessa
     parts: message.parts as CherryUIMessage['parts'],
     metadata
   } as CherryUIMessage
+}
+
+/** Attach each message's earlier citable tool parts so a list export resolves re-cited ids like the screen. */
+export function withPriorCitationParts(messages: MessageExportView[]): MessageExportView[] {
+  const partsByMessageId: Record<string, CherryMessagePart[]> = {}
+  for (const message of messages) partsByMessageId[message.id] = message.parts
+  const registry = buildCitationPartsRegistry(
+    messages.map((message) => message.id),
+    partsByMessageId
+  )
+  return messages.map((message) => {
+    const priorCitationParts = getPriorCitationParts(registry, message.id)
+    return priorCitationParts.length === 0 ? message : { ...message, priorCitationParts }
+  })
 }
 
 export function createPartsByMessageId(messages: CherryUIMessage[]): Record<string, CherryMessagePart[]> {

--- a/src/renderer/utils/message/find.ts
+++ b/src/renderer/utils/message/find.ts
@@ -131,7 +131,8 @@ const formatCitationLines = (citations: Citation[]): string =>
     .join('\n\n')
 
 /**
- * Export / copy view of a message whose citations come from its own tool results.
+ * Export / copy view of a message whose citations come from its own tool results
+ * and, via `priorCitationParts`, those of earlier messages in the conversation.
  *
  * These carry no `providerMetadata.cherry.references`: the model writes `[cite:id]`
  * markers straight into the text (see `./citations`). Both halves therefore have to
@@ -156,6 +157,7 @@ export const getToolCitationExport = (
     return !!references?.length && convertReferencesToCitations(references).length > 0
   })
   if (rendersLegacyCitations) return { content, citation: '' }
-  const { content: exported, cited } = toExportableCitations(content, getParts(message))
+  const priorParts = 'priorCitationParts' in message ? (message.priorCitationParts ?? []) : []
+  const { content: exported, cited } = toExportableCitations(content, getParts(message), priorParts)
   return { content: exported, citation: formatCitationLines(cited) }
 }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A `[cite:id]` marker is only resolved against the tool results of the message that contains it. When the model re-cites a result from an earlier turn — which is legitimate, because the earlier turn's `kb_search` / `web_search` results and markers are part of the model history — the id matches nothing. Before #19780 the raw `[cite:2598d0ab-1]` leaked into the answer (#19771); since #19780 the marker is dropped silently, so the citation is lost. The same happened in "copy as plain text", Markdown export, Notes/Notion/Yuque/… export, multi-select export, and topic / agent-session export.

After this PR:

A marker is resolved against the message's own tool results first and then against the tool results of every earlier message loaded in the same topic / agent session. A re-cited id becomes a normal numbered badge with tooltip and the "N sources" footer, and copy/export paths emit `[N]` plus the source line. Resolution happens at render/export time, so existing conversations are healed without any migration or persisted metadata. Ids from turns that are not loaded (older than the current page) or invented ids are still dropped as before.

Bounded scope that is intentionally unchanged:

- Bare `[N]` fallback stays message-local: earlier turns never count toward the "exactly one lookup call" heuristic.
- Provider-native `source-url` parts stay message-local.
- Prompt wording is unchanged; only stale comments were updated.

Fixes #19771, fixes #19324

### Why we need it and why it was done in this way

The root cause is not model hallucination: `toModelMessages` keeps prior turns' tool parts and answer markers in the history, so re-citing an earlier id is exactly what the citation prompt asks for. The mismatch is only in the renderer, which looked at one message in isolation.

Implementation:

- `resolveMessageCitations(parts, priorParts)` / `toExportableCitations(content, parts, priorParts)` take the earlier messages' citable tool parts. Own parts are processed first, so a re-search of the same document/URL in the current turn still wins and the earlier hit is aliased to it by the existing document/URL dedup.
- `MessageListProvider` builds a `CitationPartsRegistry` (ordered citable tool parts + per-message prefix count) from `streamingLayers.historyPartsByMessageId` (the settled layer, never the streaming overlay) and stable message ids, returning the previous registry when nothing citable changed. `useMessagePriorCitationParts(messageId)` gives each message the slice before it.
- `MessagePartsRenderer` resolves against a stable subset of citable parts (`useStableItemArray`), so text chunks of the streaming message no longer re-run resolution for that message either.
- Export: `MessageExportView.priorCitationParts` threads the same slice through `getToolCitationExport`; single-message menu actions get it from the hook, topic / agent-session / multi-select exports build the registry over the full ordered list (`withPriorCitationParts`).

The following tradeoffs were made:

- Render-time resolution instead of persisting resolved citations: heals old conversations for free and keeps the DB schema untouched, at the cost of one registry rebuild per message append (never per stream chunk — verified below).
- Ids from unloaded pages are still dropped rather than fetched on demand.

The following alternatives were considered:

- Rewriting markers in main when the answer is persisted: would not fix already-stored conversations and duplicates renderer logic.
- Changing the prompt to forbid re-citing earlier results: forces a redundant search every turn and needs benchmark validation; left as a possible follow-up.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19771#issuecomment-5504446847

### Breaking changes

None.

### Special notes for your reviewer

Verified on a dev build (macOS, agent session bound to a BM25 knowledge base, GPT-5.6 via a custom provider):

- Turn 1 runs `kb_search`; turn 2 asked not to search and re-cited turn-1 ids — the persisted text carries the old-prefix `[cite:…]` markers, the DOM renders `sup[data-citation]` 1–3 with tooltips and the "3 sources" footer, and this survives a window reload.
- "Copy as plain text" and "Save to Notes" on the re-citing message emit `[1]…[3]` plus the three source lines; no `[cite:` reaches the clipboard/note.
- React fiber sampling at 100 ms during a 22 s stream: earlier messages' `MessagePartsRendererContent` saw no `priorCitationParts` prop change per chunk; the only change is one per appended message.

Out of scope, pre-existing (will file separately): the main "Copy" button (`message.copy`, rich clipboard path) never resolves `[cite:id]`; and `remove-markdown` mangles adjacent `[1][2]` chains in "copy as plain text" for same-turn citations as well.

`pnpm lint` green. `pnpm test:renderer` green except two pre-existing failures unrelated to this change (`BasicDataSettings.test.tsx`, `legacyV1BrowserData.test.ts`, BigInt serialization under Node 25), identical on `main`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Knowledge base and web search citations referenced again in a later turn now render as numbered citations (with tooltip and sources) and export as [N] with their source, instead of being dropped or shown as raw [cite:id] markers.
```
