### PR TITLE
fix(composer): persist atomic chat draft snapshots

### DIFF
--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -1078,7 +1078,7 @@ const ChatComposerInner = ({
     }
     const draft = actionsRef.current.getDraft()
     writeChatDraftCache(draftCacheScopeKey, {
-      text,
+      text: draft.text,
       tokens: draft.tokens,
       files,
       knowledgeBaseIds: knowledgeBaseIdsRef.current,
@@ -1106,7 +1106,7 @@ const ChatComposerInner = ({
     if (editingMessage && !savedDraft) return
     const draft = savedDraft ? { text: savedDraft.text, tokens: savedDraft.draftTokens } : surfaceGetDraftRef.current()
     writeChatDraftCache(draftCacheScopeKey, {
-      text: savedDraft ? draft.text : text,
+      text: draft.text,
       tokens: draft.tokens,
       files: savedDraft?.files ?? filesRef.current,
       knowledgeBaseIds: savedDraft?.knowledgeBaseIds ?? knowledgeBaseIdsRef.current,

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -160,7 +160,10 @@ vi.mock('@renderer/components/composer/ComposerSurface', () => {
         removeToken: vi.fn(),
         insertToken: mocks.insertToken,
         replaceDraft: mocks.replaceDraft,
-        getDraft: mocks.getDraft
+        // Bind the draft getter to this surface instance. During a topic switch, the old
+        // surface may be unmounted after the new surface has rendered; using the shared
+        // `surfaceProps` there would make the old instance read the new topic's draft.
+        getDraft: () => mocks.getDraft(props)
       })
     }, [props])
 
@@ -2741,7 +2744,10 @@ describe('ChatComposer', () => {
   it('keeps a mentioned-model selection made while previewing history', async () => {
     seedInputHistory(['history entry'])
     mocks.mentionedModels = [model]
-    mocks.getDraft.mockImplementation(() => ({ text: mocks.surfaceProps?.text ?? '', tokens: [] }))
+    mocks.getDraft.mockImplementation((surfaceProps?: ComposerSurfaceProps) => ({
+      text: surfaceProps?.text ?? '',
+      tokens: []
+    }))
 
     render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
 
@@ -2879,7 +2885,10 @@ describe('ChatComposer', () => {
     vi.mocked(cacheService.set).mockImplementation((key: string, value: unknown) => {
       drafts.set(key, value)
     })
-    mocks.getDraft.mockImplementation(() => ({ text: mocks.surfaceProps?.text ?? '', tokens: [] }))
+    mocks.getDraft.mockImplementation((surfaceProps?: ComposerSurfaceProps) => ({
+      text: surfaceProps?.text ?? '',
+      tokens: []
+    }))
     const topicTwo = { ...topic, id: 'topic-2' }
     const view = render(<ChatComposer topic={topic} onSend={vi.fn()} />)
 
@@ -2970,6 +2979,10 @@ describe('ChatComposer', () => {
     })
     mocks.knowledgeBasesLoading = true
     mocks.modelPending = true
+    mocks.getDraft.mockImplementation((surfaceProps?: ComposerSurfaceProps) => ({
+      text: surfaceProps?.text ?? '',
+      tokens: surfaceProps?.draftTokens?.map(serializeComposerToken) ?? []
+    }))
     const topicTwo = { ...topic, id: 'topic-2' }
     const view = render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
 
@@ -3085,6 +3098,74 @@ describe('ChatComposer', () => {
         expect.any(Number)
       )
     })
+  })
+
+  it('persists text and tokens from the same live composer snapshot', async () => {
+    const knowledgePrompt = 'The user attached knowledge base "Base 1" (id: base-1).'
+    const liveDraft = {
+      text: `summarize ${knowledgePrompt}`,
+      tokens: [
+        {
+          id: 'knowledge:base-1',
+          kind: 'knowledge',
+          label: 'Base 1',
+          promptText: knowledgePrompt,
+          index: 0,
+          textOffset: 'summarize '.length
+        } as ComposerSerializedToken
+      ]
+    }
+    mocks.getDraft.mockReturnValue(liveDraft)
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    act(() => {
+      // The editor snapshot can be newer than the React text prop during token synchronization.
+      mocks.surfaceProps?.onTextChange('summarize')
+    })
+
+    await waitFor(() => {
+      expect(cacheService.set).toHaveBeenCalledWith(
+        'chat.composer_draft.topic-1',
+        expect.objectContaining({
+          text: liveDraft.text,
+          tokens: liveDraft.tokens
+        }),
+        expect.any(Number)
+      )
+    })
+  })
+
+  it('persists the live draft snapshot when the chat composer unmounts', () => {
+    const knowledgePrompt = 'The user attached knowledge base "Base 1" (id: base-1).'
+    const liveDraft = {
+      text: `summarize ${knowledgePrompt}`,
+      tokens: [
+        {
+          id: 'knowledge:base-1',
+          kind: 'knowledge',
+          label: 'Base 1',
+          promptText: knowledgePrompt,
+          index: 0,
+          textOffset: 'summarize '.length
+        } as ComposerSerializedToken
+      ]
+    }
+    mocks.getDraft.mockReturnValue(liveDraft)
+
+    const view = render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+    vi.mocked(cacheService.set).mockClear()
+
+    view.unmount()
+
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'chat.composer_draft.topic-1',
+      expect.objectContaining({
+        text: liveDraft.text,
+        tokens: liveDraft.tokens
+      }),
+      expect.any(Number)
+    )
   })
 
   it('persists token-only draft changes when the serialized text stays unchanged', async () => {

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -160,9 +160,8 @@ vi.mock('@renderer/components/composer/ComposerSurface', () => {
         removeToken: vi.fn(),
         insertToken: mocks.insertToken,
         replaceDraft: mocks.replaceDraft,
-        // Bind the draft getter to this surface instance. During a topic switch, the old
-        // surface may be unmounted after the new surface has rendered; using the shared
-        // `surfaceProps` there would make the old instance read the new topic's draft.
+        // Bind the draft getter to this surface instance; during topic switches the old surface can unmount after the new renders.
+        // Avoid reading shared `surfaceProps`, which would point at the new topic.
         getDraft: () => mocks.getDraft(props)
       })
     }, [props])


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

ChatComposer could persist the React text together with tokens serialized from a different editor state. When knowledge-base managed-token synchronization occurred around topic navigation or unmount, the hidden knowledge-base injection instruction could be restored as visible plain text in the editable chat input.

After this PR:

ChatComposer persists `text` and `tokens` from the same live composer snapshot for both periodic and final draft writes. Knowledge-base instructions therefore remain represented by their removable chip instead of becoming editable message text. Regression tests cover periodic persistence, unmount persistence, and topic switching.

Fixes #19866

### Why we need it and why it was done in this way

The editor is the source of truth for the serialized draft. Managed token synchronization intentionally does not echo tokens through the shadow React state, so pairing React `text` with editor tokens can produce a mismatched `{ text, tokens }` cache entry. On the next restore, the token no longer matches the prompt text at its stored offset and the internal instruction is left as ordinary input text.

The following tradeoffs were made:

- Both cache writers now use one live editor serialization for the text/token pair, while the existing tool state continues to provide attachments, knowledge-base IDs, and model selections.
- The existing draft-cache format and 24-hour lifecycle are unchanged.
- Existing malformed draft entries are not automatically rewritten, because an internal-looking sentence can also be legitimate user-authored text; this fix prevents new mismatched entries.

The following alternatives were considered:

- Updating the shadow token state during managed synchronization was rejected because the suppression is deliberate and echoing derived tokens would reintroduce editor/state feedback loops.
- Removing knowledge-base instruction text during restore was rejected because it could delete intentional user text and would mask the inconsistent cache writer rather than preserving the atomic snapshot invariant.

Links to places where the discussion took place: [Issue #19866](https://github.com/CherryHQ/cherry-studio/issues/19866)

### Breaking changes

None. The composer draft cache fields and serialization format remain unchanged.

### Special notes for your reviewer

- The periodic and unmount paths now both persist the `{ text, tokens }` pair returned by the live ComposerSurface snapshot.
- No documentation update is required: this is a bug fix to existing behavior and does not add or change a user workflow.
- Validation completed: `ChatComposer.test.tsx` 149/149 tests passed; `pnpm test:lint` passed with 0 errors (the repository still reports 47 existing ESLint warnings); `pnpm typecheck:web` passed; targeted Biome format/lint and `git diff --check` passed.
- The commit is signed with an SSH signature and includes the DCO sign-off.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: The affected persistence path is cleaner and keeps the existing ownership structure
- [x] Upgrade: Impact of this change on upgrade flows was considered; the cache format is unchanged
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this bug fix
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Chat input] Fixed knowledge-base injection instructions appearing as editable text after navigating away from and back to a conversation.
[聊天输入框] 修复切换会话后返回时，知识库注入指令可能以可编辑文本出现在输入框中的问题。
```

