### PR TITLE
fix(release-workflow): keep tag_name and pin previous tag on draft release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -124,10 +124,12 @@ jobs:
           else
             MAKE_LATEST="true"
           fi
+          # PATCH without tag_name resets a draft to untagged-<sha>
           jq -n \
             --arg makeLatest "$MAKE_LATEST" \
+            --arg tag "$TAG" \
             --argjson prerelease "$PRERELEASE" \
-            '{draft: false, prerelease: $prerelease, make_latest: $makeLatest}' \
+            '{tag_name: $tag, draft: false, prerelease: $prerelease, make_latest: $makeLatest}' \
             > "$RUNNER_TEMP/publish-release.json"
 
           echo "Publishing $TAG with hotfix cutoff $HOTFIX_CUTOFF_SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,7 +473,8 @@ jobs:
             electron-builder.yml \
             "$RUNNER_TEMP/generated-release-notes.md" \
             "$RUNNER_TEMP/release-body.md"
-          jq -Rs '{body: .}' < "$RUNNER_TEMP/release-body.md" > "$RUNNER_TEMP/release-body.json"
+          # PATCH without tag_name resets a draft to untagged-<sha>
+          jq -Rs --arg tag "$TAG" '{tag_name: $tag, body: .}' < "$RUNNER_TEMP/release-body.md" > "$RUNNER_TEMP/release-body.json"
           RELEASE="$(gh api --method PATCH "repos/$REPO/releases/$RELEASE_ID" \
             --input "$RUNNER_TEMP/release-body.json")"
           BRANCH_SHA="$(gh api "repos/$REPO/git/ref/heads/$BRANCH" --jq '.object.sha')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,12 +462,21 @@ jobs:
         env:
           BRANCH: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ contains(needs.prepare.outputs.tag, '-') }}
           RELEASE_ID: ${{ steps.draft-release.outputs.id }}
           REPO: ${{ github.repository }}
           TAG: ${{ needs.prepare.outputs.tag }}
         run: |
+          # every release branch forks from main, so GitHub cannot infer the previous tag by ancestry
+          PREVIOUS_TAG="$(gh api "repos/$REPO/releases?per_page=100" | jq -r \
+            --arg tag "$TAG" \
+            --argjson includePrereleases "$PRERELEASE" \
+            '[.[] | select(.draft | not) | select(.tag_name != $tag) | select($includePrereleases or (.prerelease | not))]
+             | sort_by(.published_at) | last | .tag_name')
+          echo "Generating changes since $PREVIOUS_TAG"
           gh api --method POST "repos/$REPO/releases/generate-notes" \
             -f tag_name="$TAG" \
+            -f previous_tag_name="$PREVIOUS_TAG" \
             --jq '.body' > "$RUNNER_TEMP/generated-release-notes.md"
           node scripts/release/compose-release-body.js \
             electron-builder.yml \


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

1. `Update draft release` PATCHes the draft with a body-only payload (`{body: ...}`) and `Publish release` PATCHes it with `{draft, prerelease, make_latest}`. GitHub drops a draft release's `tag_name` when a PATCH omits it, so the release silently becomes `untagged-<sha>`. This failed the `v2.0.11` run at the `build-completion` validation inside the same step (`Draft release untagged-f198a8273a9031dfef69 does not match v2.0.11`), after artifacts, notes and the tag move had all succeeded; the publish PATCH would untag the release the same way.
2. `generate-notes` is called without `previous_tag_name`, so GitHub picks the previous tag by ancestry. Since `prepare-release.yml` creates every `release/v<version>` branch fresh off main's head with its own `chore(release): prepare` commit, no release tag is ever an ancestor of a later one — `v2.0.11` therefore fell back to `v2.0.9` (`git merge-base --is-ancestor v2.0.10 v2.0.11` fails) and re-listed everything already shipped in `v2.0.10`. The range widens with every release.

After this PR:

Both PATCH payloads carry `tag_name: $TAG`, and the notes step resolves `previous_tag_name` itself as the most recently published release — including prereleases only when the release being built is one, so an rc gets the delta since the previous rc while a stable release skips the rcs.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: a stable release that follows a series of rcs now diffs against the last stable rather than the last rc, which re-lists the rc content — that is the useful range for users upgrading between stable builds.

The following alternatives were considered: relaxing `validate-release-state.js` to tolerate `untagged-*`, rejected because the validator correctly caught real damage; merging release branches back into main so ancestry works again, rejected because the `release-sync` PRs are squash-merged by design and the tag commit would still never be an ancestor.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/actions/runs/33624073248/job/100233256134

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

The `v2.0.11` draft release (id `381205715`) is still sitting at `tag_name: untagged-f198a8273a9031dfef69` and needs a manual repair (`gh api --method PATCH repos/CherryHQ/cherry-studio/releases/381205715 -f tag_name=v2.0.11`); the git tag is intact at `86501b0e` and the release body is complete. Re-running the failed job before this fix reaches `release/v2.0.11` would untag the draft again. The `previous_tag_name` jq was checked against the live release list: `v2.0.11 -> v2.0.10`. `npx vitest run scripts/__tests__/release-workflow.test.ts` passes (71 tests).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
