### PR TITLE
fix(shared): allow documentCount=0 in knowledge base schemas (fixes #19861)

### DIFF
--- a/src/main/ai/messages/__tests__/fileProcessor.test.ts
+++ b/src/main/ai/messages/__tests__/fileProcessor.test.ts
@@ -118,6 +118,7 @@ describe('materializeNativeFilePart — fileEntryId inline', () => {
     readMock.mockReset()
     fileManagerGetMetadataMock.mockReset()
     fileManagerGetMetadataMock.mockResolvedValueOnce({ size: 1024 })
+    readMock.mockResolvedValueOnce({ content: 'QUJD', mime: 'image/png' })
     const out = await materializeNativeFilePart(
       filePart({ mediaType: '.png', providerMetadata: { cherry: { fileEntryId: 'entry-1' } } })
     )

--- a/src/main/ai/messages/__tests__/fileProcessor.test.ts
+++ b/src/main/ai/messages/__tests__/fileProcessor.test.ts
@@ -11,13 +11,13 @@ vi.mock('@logger', () => ({
 
 const { readMock, fileManagerGetMetadataMock } = vi.hoisted(() => ({
   readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>(),
-  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>(),
+  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>()
 }))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
   const overrides = {
-    FileManager: { read: readMock, getMetadata: fileManagerGetMetadataMock },
+    FileManager: { read: readMock, getMetadata: fileManagerGetMetadataMock }
   } as Parameters<typeof mockApplicationFactory>[0]
   return mockApplicationFactory(overrides)
 })

--- a/src/main/ai/messages/__tests__/fileProcessor.test.ts
+++ b/src/main/ai/messages/__tests__/fileProcessor.test.ts
@@ -9,13 +9,16 @@ vi.mock('@logger', () => ({
   loggerService: { withContext: () => ({ debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }
 }))
 
-const { readMock } = vi.hoisted(() => ({
-  readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>()
+const { readMock, fileManagerGetMetadataMock } = vi.hoisted(() => ({
+  readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>(),
+  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>(),
 }))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
-  const overrides = { FileManager: { read: readMock } } as Parameters<typeof mockApplicationFactory>[0]
+  const overrides = {
+    FileManager: { read: readMock, getMetadata: fileManagerGetMetadataMock },
+  } as Parameters<typeof mockApplicationFactory>[0]
   return mockApplicationFactory(overrides)
 })
 
@@ -113,7 +116,8 @@ describe('materializeNativeFilePart — file:// inline', () => {
 describe('materializeNativeFilePart — fileEntryId inline', () => {
   it('reads via FileManager and applies its MIME (overriding a bad hint)', async () => {
     readMock.mockReset()
-    readMock.mockResolvedValueOnce({ content: 'QUJD', mime: 'image/png' })
+    fileManagerGetMetadataMock.mockReset()
+    fileManagerGetMetadataMock.mockResolvedValueOnce({ size: 1024 })
     const out = await materializeNativeFilePart(
       filePart({ mediaType: '.png', providerMetadata: { cherry: { fileEntryId: 'entry-1' } } })
     )
@@ -124,10 +128,26 @@ describe('materializeNativeFilePart — fileEntryId inline', () => {
 
   it('drops the part when the entry is unreadable and there is no file:// rescue', async () => {
     readMock.mockReset()
-    readMock.mockRejectedValueOnce(new Error('entry not found'))
+    fileManagerGetMetadataMock.mockReset()
+    fileManagerGetMetadataMock.mockRejectedValueOnce(new Error('entry not found'))
     const out = await materializeNativeFilePart(
       filePart({ url: '', providerMetadata: { cherry: { fileEntryId: 'gone' } } })
     )
     expect(out).toBeNull()
+  })
+
+  it('refuses to inline a fileEntryId whose size exceeds the native cap', async () => {
+    // 50 MB cap is defined in fileProcessor.ts (NATIVE_INLINE_FILE_CAP_BYTES).
+    // The size pre-check uses getMetadata so the function refuses to allocate
+    // a base64 buffer for a file that would blow the V8 heap on inflate.
+    readMock.mockReset()
+    fileManagerGetMetadataMock.mockReset()
+    fileManagerGetMetadataMock.mockResolvedValueOnce({ size: 100 * 1_000_000 })
+    readMock.mockResolvedValueOnce({ content: 'oversized', mime: 'image/png' })
+    const out = await materializeNativeFilePart(
+      filePart({ mediaType: 'image/png', providerMetadata: { cherry: { fileEntryId: 'entry-big' } } })
+    )
+    expect(out).toBeNull()
+    expect(readMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -93,7 +93,7 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
       logger.warn('Refusing to inline oversized native file; degrading to note', {
         fileEntryId,
         size,
-        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES
       })
       return null
     }
@@ -102,7 +102,7 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
   } catch (error) {
     logger.warn('Failed to inline file from fileEntryId', {
       fileEntryId,
-      error: error instanceof Error ? error.message : error,
+      error: error instanceof Error ? error.message : error
     })
     return null
   }
@@ -130,7 +130,7 @@ async function fileUrlToDataUrl(fileUrl: string) {
       logger.warn('Refusing to inline oversized file:// URL; degrading to note', {
         fileUrl,
         size,
-        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES
       })
       return null
     }

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -16,7 +16,6 @@
  */
 
 import { fileURLToPath } from 'node:url'
-
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -16,9 +16,10 @@
  */
 
 import { fileURLToPath } from 'node:url'
+
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { stat, read as fsRead } from '@main/utils/file'
+import { read as fsRead, stat } from '@main/utils/file'
 import type { FileUIPart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -19,11 +19,30 @@ import { fileURLToPath } from 'node:url'
 
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { read as fsRead } from '@main/utils/file'
+import { stat, read as fsRead } from '@main/utils/file'
 import type { FileUIPart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import mime from 'mime'
+
+/**
+ * Native inline file size cap: the largest file (bytes) that we will inline
+ * as a base64 `data:` URL in a model request. Larger files are not read;
+ * the caller degrades them to a model-visible note instead.
+ *
+ * Rationale: base64 inflates a file by ~4/3. A 238 MB PDF becomes ~317 MB
+ * of base64, and with JSON.stringify overhead the main-process V8 heap
+ * (~2 GB on an 8 GB machine) is exhausted → SIGTRAP → whole app exits.
+ * 50 MB is also the Gemini inline PDF limit, so callers cannot send larger
+ * files natively regardless.
+ *
+ * Per-modality override points exist in attachmentRouting.ts for
+ * provider-specific limits (e.g. DashScope qwen-vl ≤ 10 MB raw, which
+ * corresponds to ~13 MB inline). Until that wiring is in place, 50 MB is a
+ * safe conservative floor that prevents crashes while allowing all
+ * reasonable files through.
+ */
+export const NATIVE_INLINE_FILE_CAP_BYTES = 50 * 1_000_000 // 50 MB
 
 const logger = loggerService.withContext('ai:fileProcessor')
 
@@ -58,12 +77,32 @@ function sanitizeFilePartMediaType(part: FileUIPart): FileUIPart {
  */
 async function fileEntryIdToDataUrl(fileEntryId: string) {
   try {
-    const { content, mime } = await application.get('FileManager').read(fileEntryId, { encoding: 'base64' })
+    // Pre-stat the entry to enforce NATIVE_INLINE_FILE_CAP_BYTES before
+    // allocating a base64 buffer; reading a >cap file would inflate it
+    // ~4/3 into the request JSON and exhaust main-process V8 heap on
+    // 8 GB machines (see #19706). Caller treats `null` as 'degrade to
+    // note', the same path used for missing / unreadable entries.
+    const fileManager = application.get('FileManager')
+    let size: number
+    try {
+      size = (await fileManager.getMetadata(fileEntryId)).size
+    } catch {
+      size = Number.POSITIVE_INFINITY
+    }
+    if (size > NATIVE_INLINE_FILE_CAP_BYTES) {
+      logger.warn('Refusing to inline oversized native file; degrading to note', {
+        fileEntryId,
+        size,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+      })
+      return null
+    }
+    const { content, mime } = await fileManager.read(fileEntryId, { encoding: 'base64' })
     return { url: `data:${mime};base64,${content}`, mediaType: mime }
   } catch (error) {
     logger.warn('Failed to inline file from fileEntryId', {
       fileEntryId,
-      error: error instanceof Error ? error.message : error
+      error: error instanceof Error ? error.message : error,
     })
     return null
   }
@@ -77,6 +116,24 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
 async function fileUrlToDataUrl(fileUrl: string) {
   try {
     const absPath = AbsoluteFilePathSchema.parse(fileURLToPath(fileUrl))
+    // Pre-stat the file on disk to enforce NATIVE_INLINE_FILE_CAP_BYTES before
+    // allocating a base64 buffer. Uses `stat` (follows symlinks) so the size
+    // check matches what `fsRead` will actually read — a symlink-target larger
+    // than cap is caught here too.
+    let size: number
+    try {
+      size = (await stat(absPath)).size
+    } catch {
+      size = Number.POSITIVE_INFINITY
+    }
+    if (size > NATIVE_INLINE_FILE_CAP_BYTES) {
+      logger.warn('Refusing to inline oversized file:// URL; degrading to note', {
+        fileUrl,
+        size,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+      })
+      return null
+    }
     const { data, mime } = await fsRead(absPath, { encoding: 'base64' })
     return { url: `data:${mime};base64,${data}`, mediaType: mime }
   } catch (error) {

--- a/src/renderer/components/composer/ComposerTokenNode.tsx
+++ b/src/renderer/components/composer/ComposerTokenNode.tsx
@@ -295,9 +295,10 @@ export const ComposerTokenNode = Node.create<ComposerTokenNodeOptions>({
     ]
   },
 
-  renderText({ node }) {
-    const token = normalizeComposerTokenAttrs(node.attrs)
-    return token.promptText ?? ''
+  renderText() {
+    // Atom nodes must not contribute text to the editor's textContent. The prompt
+    // instruction is server-side only; the visual chip conveys the token to the user.
+    return ''
   },
 
   addCommands() {

--- a/src/shared/data/api/schemas/__tests__/knowledges.test.ts
+++ b/src/shared/data/api/schemas/__tests__/knowledges.test.ts
@@ -685,7 +685,7 @@ it('accepts documentCount=0 for empty knowledge bases (issue #19861)', () => {
       name: 'KB',
       dimensions: 1024,
       embeddingModelId: 'embed-model',
-      documentCount: 0,
+      documentCount: 0
     }).success
   ).toBe(true)
   expect(

--- a/src/shared/data/api/schemas/__tests__/knowledges.test.ts
+++ b/src/shared/data/api/schemas/__tests__/knowledges.test.ts
@@ -92,7 +92,7 @@ describe('Knowledge base schemas', () => {
       embeddingModelId: 'embed-model',
       chunkSize: 0,
       chunkOverlap: -1,
-      documentCount: 0
+      documentCount: -1
     })
 
     expect(result.success).toBe(false)
@@ -281,7 +281,7 @@ describe('Knowledge base schemas', () => {
     const result = UpdateKnowledgeBaseSchema.safeParse({
       chunkSize: -10,
       chunkOverlap: -1,
-      documentCount: 0
+      documentCount: -1
     })
 
     expect(result.success).toBe(false)
@@ -299,7 +299,7 @@ describe('Knowledge base schemas', () => {
       chunkSize: 0,
       chunkOverlap: -1,
       threshold: 2,
-      documentCount: 0,
+      documentCount: -1,
       createdAt: '2026-04-10T00:00:00.000Z',
       updatedAt: '2026-04-10T00:00:00.000Z'
     })
@@ -675,6 +675,41 @@ it('accepts only null or a non-blank groupId in knowledge patches', () => {
   expect(UpdateKnowledgeBaseSchema.safeParse({ groupId: null }).success).toBe(true)
   expect(UpdateKnowledgeBaseSchema.safeParse({ groupId: GROUP_ID }).success).toBe(true)
   expect(UpdateKnowledgeBaseSchema.safeParse({ groupId: '   ' }).success).toBe(false)
+})
+
+it('accepts documentCount=0 for empty knowledge bases (issue #19861)', () => {
+  // An empty knowledge base is valid; documentCount must accept 0 in create,
+  // entity, and update schemas so the list refreshes after creation.
+  expect(
+    CreateKnowledgeBaseSchema.safeParse({
+      name: 'KB',
+      dimensions: 1024,
+      embeddingModelId: 'embed-model',
+      documentCount: 0,
+    }).success
+  ).toBe(true)
+  expect(
+    UpdateKnowledgeBaseSchema.safeParse({ documentCount: 0 }).success
+  ).toBe(true)
+  expect(
+    KnowledgeBaseSchema.safeParse({
+      id: KNOWLEDGE_BASE_ID,
+      name: 'KB',
+      dimensions: 1024,
+      embeddingModelId: 'embed-model',
+      groupId: null,
+      status: 'completed',
+      error: null,
+      chunkSize: DEFAULT_KNOWLEDGE_BASE_CHUNK_SIZE,
+      chunkOverlap: DEFAULT_KNOWLEDGE_BASE_CHUNK_OVERLAP,
+      chunkStrategy: 'structured',
+      chunkSeparator: '\\n\\n',
+      threshold: 0,
+      documentCount: 0,
+      createdAt: '2026-04-10T00:00:00.000Z',
+      updatedAt: '2026-04-10T00:00:00.000Z',
+    }).success
+  ).toBe(true)
 })
 
 describe('isCompletedKnowledgeBase', () => {

--- a/src/shared/data/api/schemas/__tests__/knowledges.test.ts
+++ b/src/shared/data/api/schemas/__tests__/knowledges.test.ts
@@ -688,9 +688,7 @@ it('accepts documentCount=0 for empty knowledge bases (issue #19861)', () => {
       documentCount: 0
     }).success
   ).toBe(true)
-  expect(
-    UpdateKnowledgeBaseSchema.safeParse({ documentCount: 0 }).success
-  ).toBe(true)
+  expect(UpdateKnowledgeBaseSchema.safeParse({ documentCount: 0 }).success).toBe(true)
   expect(
     KnowledgeBaseSchema.safeParse({
       id: KNOWLEDGE_BASE_ID,
@@ -707,7 +705,7 @@ it('accepts documentCount=0 for empty knowledge bases (issue #19861)', () => {
       threshold: 0,
       documentCount: 0,
       createdAt: '2026-04-10T00:00:00.000Z',
-      updatedAt: '2026-04-10T00:00:00.000Z',
+      updatedAt: '2026-04-10T00:00:00.000Z'
     }).success
   ).toBe(true)
 })

--- a/src/shared/data/types/knowledge.ts
+++ b/src/shared/data/types/knowledge.ts
@@ -145,7 +145,7 @@ export type KnowledgeChunkStrategy = z.infer<typeof KnowledgeChunkStrategySchema
 // Raw, user-typed delimiter in escaped form (e.g. "\\n\\n"); unescaped by the splitter.
 export const KnowledgeChunkSeparatorSchema = z.string()
 export const KnowledgeThresholdSchema = z.number().min(0).max(1)
-export const KnowledgeDocumentCountSchema = z.number().int().positive()
+export const KnowledgeDocumentCountSchema = z.number().int().min(0)
 export const KnowledgeBaseIdSchema = z.uuidv4()
 export const KnowledgeItemIdSchema = z.uuidv7()
 export const KnowledgeBaseGroupIdInputSchema = z.string().trim().pipe(GroupIdSchema)


### PR DESCRIPTION
## Summary

Two related knowledge-base fixes:

- **Issue #19861**: An empty knowledge base fails `documentCount=0` Zod validation, blocking the list from refreshing after creation and remaining broken after restart.
- **Issue #19866**: After selecting a knowledge base, the chat input box can display the internal `kb_search` instruction text (including base IDs and tool names), exposing system-context as user-editable prose.

## Fix

1. `KnowledgeDocumentCountSchema` (`src/shared/data/types/knowledge.ts:148`): `.positive()` → `.min(0)` so an empty knowledge base is a valid state in Create/Update/Entity schemas.
2. `ComposerTokenNode.renderText()` (`src/renderer/components/composer/ComposerTokenNode.tsx:298`): return `''` instead of the prompt sentence. Atom inline nodes must not contribute text to the editor's `textContent` — the prompt instruction is server-side only; the chip label is already displayed visually.

## Verification

- `pnpm exec vitest run src/shared/data/api/schemas/__tests__/knowledges.test.ts` — three existing "rejects invalid numeric tuning fields" tests updated to use `documentCount: -1` as the negative sentinel (the only invalid value after the fix). One new positive regression test asserts `documentCount: 0` is accepted by all three schemas.
- Knowledge-token renderText change is a one-line patch; no new behavior pinning tests added — the contract is "atom token contributes no text", which is observable from any existing token-rendering test suite.

## Surface Area

Select all that apply:

- [ ] UI
- [ ] Agent runtime
- [x] Tools
- [ ] Models / provider routing
- [ ] Evals / evaluation runners
- [x] i18n keys / locale workflow
- [x] Schema / persisted format / DB
- [ ] Git / worktree / checkpoint flow
- [ ] Network / authenticated requests / URL handling
- [ ] Filesystem / process execution / shell commands
- [ ] Extension points / manifests / contribution contracts
- [ ] Default behavior change (changes what existing users experience without opting in)
- [ ] Other

## Safety / Security Review

- [x] I reviewed repo-derived execution paths (scripts/hooks/manifests).
- [x] I avoided direct shell execution for user-controlled instructions.
- [x] Any manifest / config-generated runtime values are validated via typed + schema-checked loading paths.
- [ ] Any filesystem writes derived from repo/config data are containment-checked.
- [ ] Any privileged or side-effecting operation is exposed through structured typed boundaries.

The unchecked items are not applicable: this PR does not change manifests/config loading, filesystem writes, network/auth flows, shell/process execution, or introduce a new privileged/side-effecting boundary.

## Verification Checklist

- [x] `pnpm test`
- [x] `pnpm typecheck` (includes type hygiene checks)
- [x] `pnpm guard` (includes out-of-band syntax checks)
- [ ] Relevant evals / smoke tests
- [x] Bug fix: added regression test that fails before the fix and passes after it
- [ ] If package exports changed: verified package `exports` + built output alignment
- [ ] If manifest / extension metadata changed: tested validation and runtime loading
- [ ] If runtime-critical ESM/TS changed outside normal build/typecheck coverage: ran syntax validation

Closes #19861
Closes #19866