### PR TITLE
feat(claude-code-runtime): deny Bash calls that repeat without new output

### DIFF
--- a/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
@@ -156,6 +156,11 @@ export class ClaudeCodeSessionStateService extends BaseService {
     if (history.length > BASH_HISTORY_LIMIT) history.shift()
   }
 
+  /** Drops a subagent's Bash history when the subagent stops; the parent scope is untouched. */
+  disposeBashScope(sessionId: string, agentId: string): void {
+    this.bashOutcomes.delete(this.bashScopeKey(sessionId, agentId))
+  }
+
   disposeToolPolicySnapshot(sessionId: string): void {
     this.toolPolicySnapshots.delete(sessionId)
     // Subagent scopes key as `${sessionId} ${agentId}` — sweep them with the parent.

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
@@ -23,6 +23,7 @@ import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecyc
 
 import {
   BASH_HISTORY_LIMIT,
+  BASH_RUN_BREAK_MARKER,
   bashNoProgressRunLength,
   type BashOutcome,
   fingerprintBashOutput,
@@ -131,6 +132,19 @@ export class ClaudeCodeSessionStateService extends BaseService {
   getBashNoProgressRun(sessionId: string, command: string): number | undefined {
     const history = this.bashOutcomes.get(sessionId)
     return history ? bashNoProgressRunLength(history, command) : undefined
+  }
+
+  /**
+   * Ends any trailing no-progress run without recording output: a mutating tool changed the
+   * workspace, so an unchanged verifier output afterwards is fresh evidence, not a stuck loop.
+   * No-op when the session has no Bash history — there is no run to break, and sessions that
+   * never touch Bash should not grow this map.
+   */
+  recordBashRunBreak(sessionId: string): void {
+    const history = this.bashOutcomes.get(sessionId)
+    if (!history?.length) return
+    history.push({ command: BASH_RUN_BREAK_MARKER, fingerprint: '' })
+    if (history.length > BASH_HISTORY_LIMIT) history.shift()
   }
 
   disposeToolPolicySnapshot(sessionId: string): void {

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
@@ -120,28 +120,37 @@ export class ClaudeCodeSessionStateService extends BaseService {
     return this.toolPolicySnapshots.get(sessionId)
   }
 
-  recordBashOutcome(sessionId: string, command: string, output: unknown, failed: boolean): void {
-    const normalized = normalizeBashCommand(command)
-    if (!normalized) return
-    const history = this.bashOutcomes.get(sessionId) ?? []
-    history.push({ command: normalized, fingerprint: fingerprintBashOutput(output, failed) })
-    if (history.length > BASH_HISTORY_LIMIT) history.shift()
-    this.bashOutcomes.set(sessionId, history)
+  /**
+   * Bash outcome history is scoped per agent within the session: subagent (Task) hook events carry
+   * `agent_id`, and a child's repeated calls must not poison the parent's run detection.
+   */
+  private bashScopeKey(sessionId: string, agentId?: string): string {
+    return agentId ? `${sessionId} ${agentId}` : sessionId
   }
 
-  getBashNoProgressRun(sessionId: string, command: string): number | undefined {
-    const history = this.bashOutcomes.get(sessionId)
+  recordBashOutcome(sessionId: string, command: string, output: unknown, failed: boolean, agentId?: string): void {
+    const normalized = normalizeBashCommand(command)
+    if (!normalized) return
+    const key = this.bashScopeKey(sessionId, agentId)
+    const history = this.bashOutcomes.get(key) ?? []
+    history.push({ command: normalized, fingerprint: fingerprintBashOutput(output, failed) })
+    if (history.length > BASH_HISTORY_LIMIT) history.shift()
+    this.bashOutcomes.set(key, history)
+  }
+
+  getBashNoProgressRun(sessionId: string, command: string, agentId?: string): number | undefined {
+    const history = this.bashOutcomes.get(this.bashScopeKey(sessionId, agentId))
     return history ? bashNoProgressRunLength(history, command) : undefined
   }
 
   /**
    * Ends any trailing no-progress run without recording output: a mutating tool changed the
    * workspace, so an unchanged verifier output afterwards is fresh evidence, not a stuck loop.
-   * No-op when the session has no Bash history — there is no run to break, and sessions that
+   * No-op when the scope has no Bash history — there is no run to break, and scopes that
    * never touch Bash should not grow this map.
    */
-  recordBashRunBreak(sessionId: string): void {
-    const history = this.bashOutcomes.get(sessionId)
+  recordBashRunBreak(sessionId: string, agentId?: string): void {
+    const history = this.bashOutcomes.get(this.bashScopeKey(sessionId, agentId))
     if (!history?.length) return
     history.push({ command: BASH_RUN_BREAK_MARKER, fingerprint: '' })
     if (history.length > BASH_HISTORY_LIMIT) history.shift()
@@ -149,7 +158,10 @@ export class ClaudeCodeSessionStateService extends BaseService {
 
   disposeToolPolicySnapshot(sessionId: string): void {
     this.toolPolicySnapshots.delete(sessionId)
-    this.bashOutcomes.delete(sessionId)
+    // Subagent scopes key as `${sessionId} ${agentId}` — sweep them with the parent.
+    for (const key of [...this.bashOutcomes.keys()]) {
+      if (key === sessionId || key.startsWith(`${sessionId} `)) this.bashOutcomes.delete(key)
+    }
     this.mcpSessionCatalogStates.get(sessionId)?.subscription?.dispose()
     this.mcpSessionCatalogStates.delete(sessionId)
   }

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
@@ -21,6 +21,13 @@ import { toolApprovalRegistry } from '@main/ai/toolApproval/ToolApprovalRegistry
 import { createClaudeAgentToolPolicySnapshot } from '@main/ai/tools/adapters/claudeCode/agentTools'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 
+import {
+  BASH_HISTORY_LIMIT,
+  bashNoProgressRunLength,
+  type BashOutcome,
+  fingerprintBashOutput,
+  normalizeBashCommand
+} from './bashNoProgress'
 import { buildMcpToolMetadata } from './mcpCatalog'
 import type { McpToolDisplayMetadata, SteerHolder, ToolApprovalEmitterHolder } from './types'
 
@@ -43,6 +50,7 @@ export class ClaudeCodeSessionStateService extends BaseService {
   private readonly steerHolders = new Map<string, SteerHolder>()
   private readonly toolPolicySnapshots = new Map<string, ToolPolicySnapshot>()
   private readonly mcpSessionCatalogStates = new Map<string, McpSessionCatalogState>()
+  private readonly bashOutcomes = new Map<string, BashOutcome[]>()
 
   getToolApprovalEmitterHolder(sessionId: string): ToolApprovalEmitterHolder {
     let holder = this.toolApprovalEmitters.get(sessionId)
@@ -111,8 +119,23 @@ export class ClaudeCodeSessionStateService extends BaseService {
     return this.toolPolicySnapshots.get(sessionId)
   }
 
+  recordBashOutcome(sessionId: string, command: string, output: unknown, failed: boolean): void {
+    const normalized = normalizeBashCommand(command)
+    if (!normalized) return
+    const history = this.bashOutcomes.get(sessionId) ?? []
+    history.push({ command: normalized, fingerprint: fingerprintBashOutput(output, failed) })
+    if (history.length > BASH_HISTORY_LIMIT) history.shift()
+    this.bashOutcomes.set(sessionId, history)
+  }
+
+  getBashNoProgressRun(sessionId: string, command: string): number | undefined {
+    const history = this.bashOutcomes.get(sessionId)
+    return history ? bashNoProgressRunLength(history, command) : undefined
+  }
+
   disposeToolPolicySnapshot(sessionId: string): void {
     this.toolPolicySnapshots.delete(sessionId)
+    this.bashOutcomes.delete(sessionId)
     this.mcpSessionCatalogStates.get(sessionId)?.subscription?.dispose()
     this.mcpSessionCatalogStates.delete(sessionId)
   }
@@ -188,6 +211,7 @@ export class ClaudeCodeSessionStateService extends BaseService {
     for (const holder of [...this.steerHolders.values()]) holder.dispose()
     this.steerHolders.clear()
     this.toolPolicySnapshots.clear()
+    this.bashOutcomes.clear()
     for (const state of [...this.mcpSessionCatalogStates.values()]) state.subscription?.dispose()
     this.mcpSessionCatalogStates.clear()
   }

--- a/src/main/ai/runtime/claudeCode/__tests__/bashNoProgress.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashNoProgress.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BASH_NO_PROGRESS_THRESHOLD,
+  bashNoProgressRunLength,
+  type BashOutcome,
+  fingerprintBashOutput,
+  normalizeBashCommand
+} from '../bashNoProgress'
+
+const outcome = (command: string, fingerprint: string): BashOutcome => ({ command, fingerprint })
+
+describe('normalizeBashCommand', () => {
+  it('trims and collapses whitespace so formatting variants count as the same command', () => {
+    expect(normalizeBashCommand('  curl   -s  http://x  \n')).toBe('curl -s http://x')
+  })
+})
+
+describe('fingerprintBashOutput', () => {
+  it('is deterministic for identical output', () => {
+    expect(fingerprintBashOutput('ready', false)).toBe(fingerprintBashOutput('ready', false))
+    expect(fingerprintBashOutput({ stdout: 'a', returnCode: 0 }, false)).toBe(
+      fingerprintBashOutput({ stdout: 'a', returnCode: 0 }, false)
+    )
+  })
+
+  it('never collides between success and failure, so a fixed-after-flaky run reads as progress', () => {
+    expect(fingerprintBashOutput('boom', false)).not.toBe(fingerprintBashOutput('boom', true))
+  })
+})
+
+describe('bashNoProgressRunLength', () => {
+  it('ignores runs shorter than the threshold', () => {
+    const history = [outcome('curl x', 'ok:a'), outcome('curl x', 'ok:a')]
+    expect(bashNoProgressRunLength(history, 'curl x')).toBeUndefined()
+    expect(bashNoProgressRunLength([], 'curl x')).toBeUndefined()
+  })
+
+  it('reports the trailing run once identical output repeats past the threshold', () => {
+    const history = [outcome('curl x', 'ok:a'), outcome('curl x', 'ok:a'), outcome('curl x', 'ok:a')]
+    expect(bashNoProgressRunLength(history, 'curl x')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
+  it('treats any output change as progress and clears the signal', () => {
+    const history = [outcome('curl x', 'ok:a'), outcome('curl x', 'ok:b'), outcome('curl x', 'ok:a')]
+    expect(bashNoProgressRunLength(history, 'curl x')).toBeUndefined()
+  })
+
+  it('is broken by an interleaved different command', () => {
+    const history = [outcome('curl x', 'ok:a'), outcome('ls', 'ok:a'), outcome('curl x', 'ok:a')]
+    expect(bashNoProgressRunLength(history, 'curl x')).toBeUndefined()
+  })
+
+  it('catches failure loops the same way — an unchanged error is also no progress', () => {
+    const history = [outcome('curl x', 'err:e'), outcome('curl x', 'err:e'), outcome('curl x', 'err:e')]
+    expect(bashNoProgressRunLength(history, 'curl x')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
+  it('matches whitespace variants of the incoming command', () => {
+    const history = [outcome('curl -s x', 'ok:a'), outcome('curl -s x', 'ok:a'), outcome('curl -s x', 'ok:a')]
+    expect(bashNoProgressRunLength(history, '  curl   -s x ')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
+  it('ignores empty commands', () => {
+    const history = [outcome('curl x', 'ok:a'), outcome('curl x', 'ok:a'), outcome('curl x', 'ok:a')]
+    expect(bashNoProgressRunLength(history, '   ')).toBeUndefined()
+  })
+})

--- a/src/main/ai/runtime/claudeCode/__tests__/bashNoProgress.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashNoProgress.test.ts
@@ -46,6 +46,17 @@ describe('bashNoProgressRunLength', () => {
     expect(bashNoProgressRunLength(history, 'curl x')).toBeUndefined()
   })
 
+  it('ends the scan at an older differing fingerprint instead of discarding the trailing run', () => {
+    // The ordinary loop: one different output (a first attempt, an earlier success), then the wedge.
+    const history = [
+      outcome('curl x', 'ok:a'),
+      outcome('curl x', 'ok:b'),
+      outcome('curl x', 'ok:b'),
+      outcome('curl x', 'ok:b')
+    ]
+    expect(bashNoProgressRunLength(history, 'curl x')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
   it('is broken by an interleaved different command', () => {
     const history = [outcome('curl x', 'ok:a'), outcome('ls', 'ok:a'), outcome('curl x', 'ok:a')]
     expect(bashNoProgressRunLength(history, 'curl x')).toBeUndefined()

--- a/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
@@ -33,6 +33,8 @@ vi.mock('@main/utils/rtk', () => ({ rtkRewrite: vi.fn(async () => null) }))
 vi.mock('../guardRules', () => ({ CLAUDE_TOOL_GUARD_RULES: [] }))
 vi.mock('../skillDependencies', () => ({ SKILL_TOOL_NAME: 'Skill', checkSkillRuntimeDependencies: vi.fn() }))
 
+import { evaluateToolGuards } from '@main/ai/toolApproval/toolGuards'
+
 import { BASH_HISTORY_LIMIT, BASH_NO_PROGRESS_THRESHOLD } from '../bashNoProgress'
 import { ClaudeCodeSessionStateService } from '../ClaudeCodeSessionStateService'
 import { buildClaudeCodeHooks } from '../hooks'
@@ -94,17 +96,51 @@ describe('ClaudeCodeSessionStateService bash outcome recording', () => {
 
     expect(bashOutcomesOf(svc, SESSION)).toBeUndefined()
   })
+
+  it('scopes outcome history per agent: a subagent loop never reaches the main thread', () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false, 'agent-1')
+    }
+
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x', 'agent-1')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBeUndefined()
+  })
+
+  it('a run break in one scope leaves the other scope intact', () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false, 'agent-1')
+    }
+    svc.recordBashRunBreak(SESSION)
+
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBeUndefined()
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x', 'agent-1')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
+  it('dispose sweeps subagent scopes together with the parent session', () => {
+    svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
+    svc.recordBashOutcome(SESSION, 'curl x', 'same', false, 'agent-1')
+
+    svc.disposeToolPolicySnapshot(SESSION)
+
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBeUndefined()
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x', 'agent-1')).toBeUndefined()
+    expect((svc as unknown as { bashOutcomes: Map<string, unknown[]> }).bashOutcomes.size).toBe(0)
+  })
 })
 
 describe('bashOutcomeHook', () => {
   const svc = new ClaudeCodeSessionStateService()
   let bashOutcomeHook: HookCallback
+  let toolGuardHook: HookCallback
 
   beforeEach(() => {
     applicationMock.get.mockImplementation((name: string) => {
       if (name === 'ClaudeCodeSessionStateService') return svc
+      if (name === 'AgentSessionRuntimeService') return { getInteractionState: () => undefined }
       throw new Error(`unexpected service: ${name}`)
     })
+    vi.mocked(evaluateToolGuards).mockClear()
     svc.disposeToolPolicySnapshot(SESSION)
 
     const hooks = buildClaudeCodeHooks({
@@ -117,18 +153,21 @@ describe('bashOutcomeHook', () => {
       supportsImages: false,
       agentsMdLoader: { createPreToolUseHook: () => async () => ({}) } as never
     })
-    // [postToolTimingHook, bashOutcomeHook] — the outcome hook is the second entry.
+    // PreToolUse: [toolGuardHook, skillDependencyAdvisoryHook, agentsMdHook, rtkRewriteHook, steerHook].
+    toolGuardHook = hooks!.PreToolUse![0].hooks[0]
+    // PostToolUse: [postToolTimingHook, bashOutcomeHook] — the outcome hook is the second entry.
     bashOutcomeHook = hooks!.PostToolUse![0].hooks[1]
   })
 
   const fire = (input: Record<string, unknown>) => bashOutcomeHook(input as never, undefined, {} as never)
 
-  const bashSuccess = (response: unknown) => ({
+  const bashSuccess = (response: unknown, agentId?: string) => ({
     hook_event_name: 'PostToolUse',
     tool_name: 'Bash',
     tool_input: { command: 'npx tsc --noEmit' },
     tool_response: response,
-    tool_use_id: 'tu-1'
+    tool_use_id: 'tu-1',
+    ...(agentId ? { agent_id: agentId } : {})
   })
 
   it('records a real PostToolUse payload into the session history', async () => {
@@ -232,5 +271,43 @@ describe('bashOutcomeHook', () => {
     })
 
     expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
+  it('records subagent outcomes under the subagent scope, never the main thread', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire(bashSuccess({ stdout: 'error TS2322' }, 'agent-1'))
+    }
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit', 'agent-1')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
+  })
+
+  it('the guard query reads the scope of the calling agent', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'npx tsc --noEmit', 'same', false, 'agent-1')
+    }
+
+    const preToolUse = (agentId?: string) =>
+      toolGuardHook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'npx tsc --noEmit' },
+          tool_use_id: 'tu-9',
+          ...(agentId ? { agent_id: agentId } : {})
+        } as never,
+        undefined,
+        {} as never
+      )
+
+    await preToolUse('agent-1')
+    await preToolUse()
+
+    const ctxOf = (call: number) =>
+      vi.mocked(evaluateToolGuards).mock.calls[call][1] as unknown as {
+        bashNoProgressRun?: (command: string) => number | undefined
+      }
+    expect(ctxOf(0).bashNoProgressRun?.('npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+    expect(ctxOf(1).bashNoProgressRun?.('npx tsc --noEmit')).toBeUndefined()
   })
 })

--- a/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
@@ -117,6 +117,20 @@ describe('ClaudeCodeSessionStateService bash outcome recording', () => {
     expect(svc.getBashNoProgressRun(SESSION, 'curl x', 'agent-1')).toBe(BASH_NO_PROGRESS_THRESHOLD)
   })
 
+  it('disposeBashScope drops only the named subagent scope', () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false, 'agent-1')
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false, 'agent-2')
+    }
+
+    svc.disposeBashScope(SESSION, 'agent-1')
+
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x', 'agent-1')).toBeUndefined()
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x', 'agent-2')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
   it('dispose sweeps subagent scopes together with the parent session', () => {
     svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
     svc.recordBashOutcome(SESSION, 'curl x', 'same', false, 'agent-1')
@@ -133,6 +147,7 @@ describe('bashOutcomeHook', () => {
   const svc = new ClaudeCodeSessionStateService()
   let bashOutcomeHook: HookCallback
   let toolGuardHook: HookCallback
+  let subagentStopHook: HookCallback
 
   beforeEach(() => {
     applicationMock.get.mockImplementation((name: string) => {
@@ -157,6 +172,7 @@ describe('bashOutcomeHook', () => {
     toolGuardHook = hooks!.PreToolUse![0].hooks[0]
     // PostToolUse: [postToolTimingHook, bashOutcomeHook] — the outcome hook is the second entry.
     bashOutcomeHook = hooks!.PostToolUse![0].hooks[1]
+    subagentStopHook = hooks!.SubagentStop![0].hooks[0]
   })
 
   const fire = (input: Record<string, unknown>) => bashOutcomeHook(input as never, undefined, {} as never)
@@ -309,5 +325,40 @@ describe('bashOutcomeHook', () => {
       }
     expect(ctxOf(0).bashNoProgressRun?.('npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
     expect(ctxOf(1).bashNoProgressRun?.('npx tsc --noEmit')).toBeUndefined()
+  })
+
+  it('breaks the run when an assistant-files MCP tool mutates the workspace', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire(bashSuccess({ stdout: 'error TS2322' }))
+    }
+    await fire({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'mcp__assistant-files__save_attachment',
+      tool_input: {},
+      tool_response: {},
+      tool_use_id: 'tu-4'
+    })
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
+  })
+
+  it('drops the subagent scope when the subagent stops', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire(bashSuccess({ stdout: 'error TS2322' }, 'agent-1'))
+    }
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit', 'agent-1')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+
+    await subagentStopHook(
+      {
+        hook_event_name: 'SubagentStop',
+        agent_id: 'agent-1',
+        agent_type: 'general-purpose',
+        stop_hook_active: false
+      } as never,
+      undefined,
+      {} as never
+    )
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit', 'agent-1')).toBeUndefined()
   })
 })

--- a/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Wiring coverage for the bash-repeat-no-progress recorder path: the session-state ring on
+ * ClaudeCodeSessionStateService (record / run query / eviction / dispose) and bashOutcomeHook
+ * (the PostToolUse/PostToolUseFailure half that feeds it). bashNoProgress.test.ts covers the
+ * pure detection module; these cases exist because the guard-rule tests stub bashNoProgressRun
+ * directly and never exercise this wiring.
+ */
+
+import type { HookCallback } from '@anthropic-ai/claude-agent-sdk'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { loggerMock, applicationMock } = vi.hoisted(() => {
+  const loggerMock = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }
+  const applicationMock = { get: vi.fn() }
+  return { loggerMock, applicationMock }
+})
+
+vi.mock('@application', () => ({ application: applicationMock }))
+vi.mock('@logger', () => ({ loggerService: { withContext: () => loggerMock } }))
+vi.mock('@data/services/AgentService', () => ({ agentService: {} }))
+vi.mock('@data/services/McpServerService', () => ({ mcpServerService: {} }))
+vi.mock('@main/ai/toolApproval/ToolApprovalRegistry', () => ({ toolApprovalRegistry: { abort: vi.fn() } }))
+vi.mock('@main/ai/tools/adapters/claudeCode/agentTools', () => ({ createClaudeAgentToolPolicySnapshot: vi.fn() }))
+vi.mock('@main/core/lifecycle', async () => {
+  const actual = (await vi.importActual('@main/core/lifecycle')) as Record<string, unknown>
+  class StubBase {}
+  return { ...actual, BaseService: StubBase }
+})
+// hooks.ts module-load deps the outcome hook never touches.
+vi.mock('@main/ai/steerReminder', () => ({ wrapSteerReminder: (text: string) => text }))
+vi.mock('@main/ai/toolApproval/toolGuards', () => ({ evaluateToolGuards: vi.fn(async () => undefined) }))
+vi.mock('@main/utils/rtk', () => ({ rtkRewrite: vi.fn(async () => null) }))
+vi.mock('../guardRules', () => ({ CLAUDE_TOOL_GUARD_RULES: [] }))
+vi.mock('../skillDependencies', () => ({ SKILL_TOOL_NAME: 'Skill', checkSkillRuntimeDependencies: vi.fn() }))
+
+import { BASH_HISTORY_LIMIT, BASH_NO_PROGRESS_THRESHOLD } from '../bashNoProgress'
+import { ClaudeCodeSessionStateService } from '../ClaudeCodeSessionStateService'
+import { buildClaudeCodeHooks } from '../hooks'
+
+const SESSION = 'session-1'
+
+describe('ClaudeCodeSessionStateService bash outcome recording', () => {
+  let svc: ClaudeCodeSessionStateService
+
+  beforeEach(() => {
+    svc = new ClaudeCodeSessionStateService()
+  })
+
+  const bashOutcomesOf = (sessionId: string) =>
+    (svc as unknown as { bashOutcomes: Map<string, unknown[]> }).bashOutcomes.get(sessionId)
+
+  it('records outcomes and reports the trailing no-progress run', () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'curl -s http://x', 'same body', false)
+    }
+    expect(svc.getBashNoProgressRun(SESSION, 'curl -s http://x')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
+  it('evicts the oldest entry at BASH_HISTORY_LIMIT without corrupting the trailing run', () => {
+    for (let i = 0; i < BASH_HISTORY_LIMIT - BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, `filler ${i}`, 'x', false)
+    }
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
+    }
+    svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
+
+    // The 17th entry drops the oldest filler; the trailing run survives and keeps growing.
+    expect(bashOutcomesOf(SESSION)).toHaveLength(BASH_HISTORY_LIMIT)
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBe(BASH_NO_PROGRESS_THRESHOLD + 1)
+  })
+
+  it('clears the session bash history on disposeToolPolicySnapshot', () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
+    }
+    svc.disposeToolPolicySnapshot(SESSION)
+
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBeUndefined()
+    expect(bashOutcomesOf(SESSION)).toBeUndefined()
+  })
+
+  it('ends the trailing run on a recorded run break', () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
+    }
+    svc.recordBashRunBreak(SESSION)
+
+    expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBeUndefined()
+  })
+
+  it('run break is a no-op when the session has no Bash history', () => {
+    svc.recordBashRunBreak(SESSION)
+
+    expect(bashOutcomesOf(SESSION)).toBeUndefined()
+  })
+})
+
+describe('bashOutcomeHook', () => {
+  const svc = new ClaudeCodeSessionStateService()
+  let bashOutcomeHook: HookCallback
+
+  beforeEach(() => {
+    applicationMock.get.mockImplementation((name: string) => {
+      if (name === 'ClaudeCodeSessionStateService') return svc
+      throw new Error(`unexpected service: ${name}`)
+    })
+    svc.disposeToolPolicySnapshot(SESSION)
+
+    const hooks = buildClaudeCodeHooks({
+      sessionId: SESSION,
+      cwd: '/ws',
+      agentDataPath: '/data',
+      builtinRole: undefined,
+      mountedServers: new Set(),
+      pluginDirectories: new Map(),
+      supportsImages: false,
+      agentsMdLoader: { createPreToolUseHook: () => async () => ({}) } as never
+    })
+    // [postToolTimingHook, bashOutcomeHook] — the outcome hook is the second entry.
+    bashOutcomeHook = hooks!.PostToolUse![0].hooks[1]
+  })
+
+  const fire = (input: Record<string, unknown>) => bashOutcomeHook(input as never, undefined, {} as never)
+
+  const bashSuccess = (response: unknown) => ({
+    hook_event_name: 'PostToolUse',
+    tool_name: 'Bash',
+    tool_input: { command: 'npx tsc --noEmit' },
+    tool_response: response,
+    tool_use_id: 'tu-1'
+  })
+
+  it('records a real PostToolUse payload into the session history', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire(bashSuccess({ stdout: 'error TS2322', interrupted: false }))
+    }
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
+  it('records a PostToolUseFailure as a failed outcome, so an unchanged error also counts', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire({
+        hook_event_name: 'PostToolUseFailure',
+        tool_name: 'Bash',
+        tool_input: { command: 'npx tsc --noEmit' },
+        tool_use_id: 'tu-1',
+        error: 'exited 2'
+      })
+    }
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+
+  it('skips a PostToolUseFailure carrying is_interrupt — an Esc is a deliberate stop', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire({
+        hook_event_name: 'PostToolUseFailure',
+        tool_name: 'Bash',
+        tool_input: { command: 'npx tsc --noEmit' },
+        tool_use_id: 'tu-1',
+        error: 'interrupted',
+        is_interrupt: true
+      })
+    }
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
+  })
+
+  it('skips a PostToolUse whose Bash response reports interrupted', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire(bashSuccess({ stdout: 'partial', interrupted: true }))
+    }
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
+  })
+
+  it('breaks the run when a mutating tool completes between verifier runs', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire(bashSuccess({ stdout: 'error TS2322' }))
+    }
+    await fire({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Edit',
+      tool_input: {},
+      tool_response: {},
+      tool_use_id: 'tu-2'
+    })
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
+  })
+
+  it('does not break the run on a failed mutation or a read-only tool', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire(bashSuccess({ stdout: 'error TS2322' }))
+    }
+    await fire({
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'Edit',
+      tool_input: {},
+      tool_use_id: 'tu-2',
+      error: 'old_string not found'
+    })
+    await fire({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Read',
+      tool_input: {},
+      tool_response: {},
+      tool_use_id: 'tu-3'
+    })
+
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+  })
+})

--- a/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
@@ -35,7 +35,7 @@ vi.mock('../skillDependencies', () => ({ SKILL_TOOL_NAME: 'Skill', checkSkillRun
 
 import { evaluateToolGuards } from '@main/ai/toolApproval/toolGuards'
 
-import { BASH_HISTORY_LIMIT, BASH_NO_PROGRESS_THRESHOLD } from '../bashNoProgress'
+import { BASH_HISTORY_LIMIT, BASH_NO_PROGRESS_HARD_THRESHOLD, BASH_NO_PROGRESS_THRESHOLD } from '../bashNoProgress'
 import { ClaudeCodeSessionStateService } from '../ClaudeCodeSessionStateService'
 import { buildClaudeCodeHooks } from '../hooks'
 
@@ -325,6 +325,56 @@ describe('bashOutcomeHook', () => {
       }
     expect(ctxOf(0).bashNoProgressRun?.('npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
     expect(ctxOf(1).bashNoProgressRun?.('npx tsc --noEmit')).toBeUndefined()
+  })
+
+  it('warns once at the soft threshold instead of denying, in the calling agent scope', async () => {
+    const preToolUse = () =>
+      toolGuardHook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'npx tsc --noEmit' },
+          tool_use_id: 'tu-9'
+        } as never,
+        undefined,
+        {} as never
+      )
+
+    // Below the soft threshold: no warning.
+    svc.recordBashOutcome(SESSION, 'npx tsc --noEmit', 'same', false)
+    svc.recordBashOutcome(SESSION, 'npx tsc --noEmit', 'same', false)
+    let result = (await preToolUse()) as { hookSpecificOutput?: { additionalContext?: string } }
+    expect(result.hookSpecificOutput?.additionalContext).toBeUndefined()
+
+    // Exactly at the soft threshold: one warning that names the hard threshold.
+    svc.recordBashOutcome(SESSION, 'npx tsc --noEmit', 'same', false)
+    result = (await preToolUse()) as { hookSpecificOutput?: { additionalContext?: string } }
+    expect(result.hookSpecificOutput?.additionalContext).toContain('3 times')
+    expect(result.hookSpecificOutput?.additionalContext).toContain(String(BASH_NO_PROGRESS_HARD_THRESHOLD))
+
+    // Past the soft threshold the warning does not repeat; the hard deny is the rule's job.
+    svc.recordBashOutcome(SESSION, 'npx tsc --noEmit', 'same', false)
+    result = (await preToolUse()) as { hookSpecificOutput?: { additionalContext?: string } }
+    expect(result.hookSpecificOutput?.additionalContext).toBeUndefined()
+  })
+
+  it('does not warn when the run belongs to a different agent scope', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      svc.recordBashOutcome(SESSION, 'npx tsc --noEmit', 'same', false, 'agent-1')
+    }
+
+    const result = (await toolGuardHook(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'npx tsc --noEmit' },
+        tool_use_id: 'tu-9'
+      } as never,
+      undefined,
+      {} as never
+    )) as { hookSpecificOutput?: { additionalContext?: string } }
+
+    expect(result.hookSpecificOutput?.additionalContext).toBeUndefined()
   })
 
   it('breaks the run when an assistant-files MCP tool mutates the workspace', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
@@ -39,15 +39,15 @@ import { buildClaudeCodeHooks } from '../hooks'
 
 const SESSION = 'session-1'
 
+const bashOutcomesOf = (svc: ClaudeCodeSessionStateService, sessionId: string) =>
+  (svc as unknown as { bashOutcomes: Map<string, unknown[]> }).bashOutcomes.get(sessionId)
+
 describe('ClaudeCodeSessionStateService bash outcome recording', () => {
   let svc: ClaudeCodeSessionStateService
 
   beforeEach(() => {
     svc = new ClaudeCodeSessionStateService()
   })
-
-  const bashOutcomesOf = (sessionId: string) =>
-    (svc as unknown as { bashOutcomes: Map<string, unknown[]> }).bashOutcomes.get(sessionId)
 
   it('records outcomes and reports the trailing no-progress run', () => {
     for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
@@ -66,7 +66,7 @@ describe('ClaudeCodeSessionStateService bash outcome recording', () => {
     svc.recordBashOutcome(SESSION, 'curl x', 'same', false)
 
     // The 17th entry drops the oldest filler; the trailing run survives and keeps growing.
-    expect(bashOutcomesOf(SESSION)).toHaveLength(BASH_HISTORY_LIMIT)
+    expect(bashOutcomesOf(svc, SESSION)).toHaveLength(BASH_HISTORY_LIMIT)
     expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBe(BASH_NO_PROGRESS_THRESHOLD + 1)
   })
 
@@ -77,7 +77,7 @@ describe('ClaudeCodeSessionStateService bash outcome recording', () => {
     svc.disposeToolPolicySnapshot(SESSION)
 
     expect(svc.getBashNoProgressRun(SESSION, 'curl x')).toBeUndefined()
-    expect(bashOutcomesOf(SESSION)).toBeUndefined()
+    expect(bashOutcomesOf(svc, SESSION)).toBeUndefined()
   })
 
   it('ends the trailing run on a recorded run break', () => {
@@ -92,7 +92,7 @@ describe('ClaudeCodeSessionStateService bash outcome recording', () => {
   it('run break is a no-op when the session has no Bash history', () => {
     svc.recordBashRunBreak(SESSION)
 
-    expect(bashOutcomesOf(SESSION)).toBeUndefined()
+    expect(bashOutcomesOf(svc, SESSION)).toBeUndefined()
   })
 })
 
@@ -153,27 +153,48 @@ describe('bashOutcomeHook', () => {
     expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
   })
 
-  it('skips a PostToolUseFailure carrying is_interrupt — an Esc is a deliberate stop', async () => {
+  it('clears an existing run on a PostToolUseFailure carrying is_interrupt — an Esc is a deliberate stop', async () => {
     for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
-      await fire({
-        hook_event_name: 'PostToolUseFailure',
-        tool_name: 'Bash',
-        tool_input: { command: 'npx tsc --noEmit' },
-        tool_use_id: 'tu-1',
-        error: 'interrupted',
-        is_interrupt: true
-      })
+      await fire(bashSuccess({ stdout: 'error TS2322' }))
     }
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+
+    await fire({
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'Bash',
+      tool_input: { command: 'npx tsc --noEmit' },
+      tool_use_id: 'tu-1',
+      error: 'interrupted',
+      is_interrupt: true
+    })
+
+    // Merely skipping the recording would leave the run in place and deny the user's next retry.
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
+  })
+
+  it('clears an existing run on a PostToolUse whose Bash response reports interrupted', async () => {
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      await fire(bashSuccess({ stdout: 'error TS2322' }))
+    }
+    expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBe(BASH_NO_PROGRESS_THRESHOLD)
+
+    await fire(bashSuccess({ stdout: 'partial', interrupted: true }))
 
     expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
   })
 
-  it('skips a PostToolUse whose Bash response reports interrupted', async () => {
-    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
-      await fire(bashSuccess({ stdout: 'partial', interrupted: true }))
-    }
+  it('an interrupt with no prior history records nothing', async () => {
+    await fire({
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'Bash',
+      tool_input: { command: 'npx tsc --noEmit' },
+      tool_use_id: 'tu-1',
+      error: 'interrupted',
+      is_interrupt: true
+    })
 
     expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
+    expect(bashOutcomesOf(svc, SESSION)).toBeUndefined()
   })
 
   it('breaks the run when a mutating tool completes between verifier runs', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
@@ -227,14 +227,19 @@ describe('CLAUDE_TOOL_GUARD_RULES', () => {
       bashNoProgressRun: () => run
     })
 
-    it('denies a stuck loop in every mode, bypass included', async () => {
+    it('denies a stuck loop at the hard threshold in every mode, bypass included', async () => {
       for (const mode of ['default', 'bypassPermissions'] as const) {
-        const decision = await evaluate(makeCtx({ ...loopingCtx(3), permissionMode: mode }))
+        const decision = await evaluate(makeCtx({ ...loopingCtx(5), permissionMode: mode }))
         expect(decision?.ruleId).toBe('bash-repeat-no-progress')
         expect(decision?.effect).toBe('deny')
-        expect(decision?.reason).toContain('3 times')
+        expect(decision?.reason).toContain('5 times')
         expect(decision?.reason).toContain('byte-identical')
       }
+    })
+
+    it('leaves the soft-threshold runs to the hook-plane warning instead of denying', async () => {
+      await expect(evaluate(makeCtx(loopingCtx(3)))).resolves.toBeUndefined()
+      await expect(evaluate(makeCtx(loopingCtx(4)))).resolves.toBeUndefined()
     })
 
     it('stays silent while the run is still forming or the session has no Bash history', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
@@ -221,6 +221,35 @@ describe('CLAUDE_TOOL_GUARD_RULES', () => {
     })
   })
 
+  describe('bash-repeat-no-progress', () => {
+    const loopingCtx = (run: number | undefined) => ({
+      input: { command: 'curl -s http://localhost/health' },
+      bashNoProgressRun: () => run
+    })
+
+    it('denies a stuck loop in every mode, bypass included', async () => {
+      for (const mode of ['default', 'bypassPermissions'] as const) {
+        const decision = await evaluate(makeCtx({ ...loopingCtx(3), permissionMode: mode }))
+        expect(decision?.ruleId).toBe('bash-repeat-no-progress')
+        expect(decision?.effect).toBe('deny')
+        expect(decision?.reason).toContain('3 times')
+        expect(decision?.reason).toContain('byte-identical')
+      }
+    })
+
+    it('stays silent while the run is still forming or the session has no Bash history', async () => {
+      await expect(evaluate(makeCtx(loopingCtx(undefined)))).resolves.toBeUndefined()
+      await expect(
+        evaluate(makeCtx({ input: { command: 'curl -s http://localhost/health' } }))
+      ).resolves.toBeUndefined()
+    })
+
+    it('does not gate non-Bash tools or calls without a command', async () => {
+      await expect(evaluate(makeCtx({ toolName: 'Read', bashNoProgressRun: () => 5 }))).resolves.toBeUndefined()
+      await expect(evaluate(makeCtx({ bashNoProgressRun: () => 5 }))).resolves.toBeUndefined()
+    })
+  })
+
   describe('headless-config-mutation', () => {
     const configTool = toCherryBuiltinRuntimeName('config')
 

--- a/src/main/ai/runtime/claudeCode/bashNoProgress.ts
+++ b/src/main/ai/runtime/claudeCode/bashNoProgress.ts
@@ -5,7 +5,8 @@
  * break-marker when a mutating tool completes; the `bash-repeat-no-progress` guard rule denies the
  * next identical call once the trailing run of the same normalized command reaches the threshold
  * with a single unchanged fingerprint. Output that changes at all — new bytes, different error
- * text — counts as progress and resets the signal, as does any completed workspace mutation.
+ * text — counts as progress and resets the signal, as does any completed workspace mutation or a
+ * user interrupt (Esc).
  */
 
 import { createHash } from 'node:crypto'
@@ -29,6 +30,12 @@ export interface BashOutcome {
   readonly fingerprint: string
 }
 
+/**
+ * Collapses all whitespace — including inside shell syntax and quoted arguments — so formatting
+ * variants count as the same command. Two genuinely distinct commands can therefore alias onto one
+ * run; that is acceptable because the guard only fires when the OUTPUT is also byte-identical,
+ * in which case the retry carries no new information either way.
+ */
 export function normalizeBashCommand(command: string): string {
   return command.trim().replace(/\s+/g, ' ')
 }

--- a/src/main/ai/runtime/claudeCode/bashNoProgress.ts
+++ b/src/main/ai/runtime/claudeCode/bashNoProgress.ts
@@ -1,0 +1,51 @@
+/**
+ * Stuck-loop detection for repeated Bash calls that never produce new output.
+ *
+ * The recorder (a PostToolUse/PostToolUseFailure hook) appends one entry per Bash execution; the
+ * `bash-repeat-no-progress` guard rule denies the next identical call once the trailing run of the
+ * same normalized command reaches the threshold with a single unchanged fingerprint. Output that
+ * changes at all — new bytes, different error text — counts as progress and resets the signal.
+ */
+
+import { createHash } from 'node:crypto'
+
+/** Consecutive identical-output runs of one command that must be recorded before the next is denied. */
+export const BASH_NO_PROGRESS_THRESHOLD = 3
+/** Per-session ring size; only the tail matters, so old entries are dropped. */
+export const BASH_HISTORY_LIMIT = 16
+
+export interface BashOutcome {
+  readonly command: string
+  readonly fingerprint: string
+}
+
+export function normalizeBashCommand(command: string): string {
+  return command.trim().replace(/\s+/g, ' ')
+}
+
+/** Success and failure fingerprints never collide, so a flaky-then-fixed run reads as progress. */
+export function fingerprintBashOutput(output: unknown, failed: boolean): string {
+  const text = typeof output === 'string' ? output : (JSON.stringify(output) ?? '')
+  const hash = createHash('sha256').update(text).digest('hex').slice(0, 16)
+  return `${failed ? 'err' : 'ok'}:${hash}`
+}
+
+/**
+ * Returns the trailing run length when `command` already heads a run of at least
+ * BASH_NO_PROGRESS_THRESHOLD identical-fingerprint outcomes, undefined otherwise.
+ */
+export function bashNoProgressRunLength(history: readonly BashOutcome[], command: string): number | undefined {
+  const normalized = normalizeBashCommand(command)
+  if (!normalized) return undefined
+
+  let run = 0
+  let fingerprint: string | undefined
+  for (let i = history.length - 1; i >= 0; i--) {
+    const entry = history[i]
+    if (entry.command !== normalized) break
+    fingerprint ??= entry.fingerprint
+    if (entry.fingerprint !== fingerprint) return undefined
+    run++
+  }
+  return run >= BASH_NO_PROGRESS_THRESHOLD ? run : undefined
+}

--- a/src/main/ai/runtime/claudeCode/bashNoProgress.ts
+++ b/src/main/ai/runtime/claudeCode/bashNoProgress.ts
@@ -1,10 +1,11 @@
 /**
  * Stuck-loop detection for repeated Bash calls that never produce new output.
  *
- * The recorder (a PostToolUse/PostToolUseFailure hook) appends one entry per Bash execution; the
- * `bash-repeat-no-progress` guard rule denies the next identical call once the trailing run of the
- * same normalized command reaches the threshold with a single unchanged fingerprint. Output that
- * changes at all — new bytes, different error text — counts as progress and resets the signal.
+ * The recorder (a PostToolUse/PostToolUseFailure hook) appends one entry per Bash execution, plus a
+ * break-marker when a mutating tool completes; the `bash-repeat-no-progress` guard rule denies the
+ * next identical call once the trailing run of the same normalized command reaches the threshold
+ * with a single unchanged fingerprint. Output that changes at all — new bytes, different error
+ * text — counts as progress and resets the signal, as does any completed workspace mutation.
  */
 
 import { createHash } from 'node:crypto'
@@ -13,6 +14,15 @@ import { createHash } from 'node:crypto'
 export const BASH_NO_PROGRESS_THRESHOLD = 3
 /** Per-session ring size; only the tail matters, so old entries are dropped. */
 export const BASH_HISTORY_LIMIT = 16
+
+/**
+ * Sentinel command for break-marker entries: a mutating tool changed the workspace, so any run in
+ * progress ends here. The NUL prefix can never equal a normalized real command.
+ */
+export const BASH_RUN_BREAK_MARKER = '\0tool-mutation'
+
+/** Claude Code tools whose successful completion mutates the workspace and therefore breaks a run. */
+export const BASH_RUN_BREAK_TOOLS: ReadonlySet<string> = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit'])
 
 export interface BashOutcome {
   readonly command: string
@@ -44,7 +54,8 @@ export function bashNoProgressRunLength(history: readonly BashOutcome[], command
     const entry = history[i]
     if (entry.command !== normalized) break
     fingerprint ??= entry.fingerprint
-    if (entry.fingerprint !== fingerprint) return undefined
+    // An older differing fingerprint ends the trailing run; it does not abort the scan.
+    if (entry.fingerprint !== fingerprint) break
     run++
   }
   return run >= BASH_NO_PROGRESS_THRESHOLD ? run : undefined

--- a/src/main/ai/runtime/claudeCode/bashNoProgress.ts
+++ b/src/main/ai/runtime/claudeCode/bashNoProgress.ts
@@ -2,17 +2,21 @@
  * Stuck-loop detection for repeated Bash calls that never produce new output.
  *
  * The recorder (a PostToolUse/PostToolUseFailure hook) appends one entry per Bash execution, plus a
- * break-marker when a mutating tool completes; the `bash-repeat-no-progress` guard rule denies the
- * next identical call once the trailing run of the same normalized command reaches the threshold
- * with a single unchanged fingerprint. Output that changes at all — new bytes, different error
- * text — counts as progress and resets the signal, as does any completed workspace mutation or a
- * user interrupt (Esc).
+ * break-marker when a mutating tool completes; the response is two-tiered (the same shape as
+ * Cline's soft/hard loop guard): once the trailing run of one normalized command reaches
+ * BASH_NO_PROGRESS_THRESHOLD with a single unchanged fingerprint, the next identical call is
+ * allowed with a warning so the model can self-correct; only at BASH_NO_PROGRESS_HARD_THRESHOLD
+ * does the `bash-repeat-no-progress` guard rule deny it outright. Output that changes at all — new
+ * bytes, different error text — counts as progress and resets the signal, as does any completed
+ * workspace mutation or a user interrupt (Esc).
  */
 
 import { createHash } from 'node:crypto'
 
-/** Consecutive identical-output runs of one command that must be recorded before the next is denied. */
+/** Identical-output runs at which the next identical call is allowed with a soft warning. */
 export const BASH_NO_PROGRESS_THRESHOLD = 3
+/** Identical-output runs at which the next identical call is denied outright. */
+export const BASH_NO_PROGRESS_HARD_THRESHOLD = 5
 /** Per-session ring size; only the tail matters, so old entries are dropped. */
 export const BASH_HISTORY_LIMIT = 16
 

--- a/src/main/ai/runtime/claudeCode/guardRules.ts
+++ b/src/main/ai/runtime/claudeCode/guardRules.ts
@@ -101,6 +101,13 @@ const skillWithAbsentDependency = async (ctx: ToolGuardContext): Promise<GuardHi
   return deny ? { evidence: deny } : null
 }
 
+const bashRepeatWithoutProgress = (ctx: ToolGuardContext): GuardHit | null => {
+  const command = bashCommand(ctx)
+  if (!command) return null
+  const run = ctx.bashNoProgressRun?.(command)
+  return run !== undefined ? { evidence: String(run) } : null
+}
+
 const matchesRequiredApproval = (ctx: ToolGuardContext, bypassApproval: 'lift' | 'enforce'): GuardHit | null => {
   const policy = findBuiltinToolPolicy(ctx.toolName, ctx.mountedServers)
   return policy?.approval === 'required' && policy.bypassApproval === bypassApproval ? {} : null
@@ -141,6 +148,16 @@ const CROSS_CUTTING_TOOL_GUARD_RULES: readonly ToolGuardRule[] = [
     match: { tool: SKILL_TOOL_NAME, when: skillWithAbsentDependency },
     effect: 'deny',
     reason: (hit) => hit.evidence ?? 'The skill declares a runtime dependency that is not installed.'
+  },
+  {
+    // A stuck loop burns tokens fastest on unattended bypass runs, so this is a conduct rule, not
+    // an approval — bypassPermissions does not lift it.
+    id: 'bash-repeat-no-progress',
+    bypassBehavior: 'enforce',
+    match: { tool: 'Bash', when: bashRepeatWithoutProgress },
+    effect: 'deny',
+    reason: (hit) =>
+      `This exact Bash command already ran ${hit.evidence} times in a row with byte-identical output — repeating it yields no new information. Diagnose why the output is not changing, vary the command, or report the blocker instead of retrying.`
   },
   {
     id: 'headless-config-mutation',

--- a/src/main/ai/runtime/claudeCode/guardRules.ts
+++ b/src/main/ai/runtime/claudeCode/guardRules.ts
@@ -27,6 +27,7 @@ import { CONFIG_TOOL_NAME } from '@shared/ai/builtinTools'
 import { claudeToolRequiresUserInteraction } from '@shared/ai/claudecode/toolRegistry'
 import { imageExts } from '@shared/utils/file'
 
+import { BASH_NO_PROGRESS_HARD_THRESHOLD } from './bashNoProgress'
 import { isPathWithinAllowedRoots } from './pathContainment'
 import { checkSkillRuntimeDependencies, SKILL_TOOL_NAME } from './skillDependencies'
 
@@ -105,7 +106,9 @@ const bashRepeatWithoutProgress = (ctx: ToolGuardContext): GuardHit | null => {
   const command = bashCommand(ctx)
   if (!command) return null
   const run = ctx.bashNoProgressRun?.(command)
-  return run !== undefined ? { evidence: String(run) } : null
+  // Hard tier only: the soft tier (a one-shot warning at BASH_NO_PROGRESS_THRESHOLD) lives in the
+  // hook plane, the same split as skill-dependency's deny/advisory halves.
+  return run !== undefined && run >= BASH_NO_PROGRESS_HARD_THRESHOLD ? { evidence: String(run) } : null
 }
 
 const matchesRequiredApproval = (ctx: ToolGuardContext, bypassApproval: 'lift' | 'enforce'): GuardHit | null => {

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -20,6 +20,7 @@ import { rtkRewrite } from '@main/utils/rtk'
 
 import type { AgentRuntimeUserInput } from '../types'
 import type { AgentsMdLoader } from './AgentsMdLoader'
+import { BASH_RUN_BREAK_TOOLS } from './bashNoProgress'
 import { CLAUDE_TOOL_GUARD_RULES } from './guardRules'
 import { checkSkillRuntimeDependencies, SKILL_TOOL_NAME } from './skillDependencies'
 import type { ClaudeCodeSettings } from './types'
@@ -171,18 +172,41 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
   const agentsMdHook = ctx.agentsMdLoader.createPreToolUseHook()
 
   // Feeds the bash-repeat-no-progress guard rule. User interrupts are excluded: an Esc-aborted call
-  // is a deliberate stop, not loop evidence.
+  // is a deliberate stop, not loop evidence. Esc surfaces either as PostToolUseFailure with
+  // is_interrupt, or as PostToolUse whose Bash tool_response carries interrupted: true.
   const bashOutcomeHook: HookCallback = async (input): Promise<HookJSONOutput> => {
     if (!input || (input.hook_event_name !== 'PostToolUse' && input.hook_event_name !== 'PostToolUseFailure')) {
       return {}
     }
-    const event = input as unknown as Record<string, unknown>
-    if (event.tool_name !== 'Bash' || event.is_interrupt === true) return {}
-    const command = (event.tool_input as Record<string, unknown> | undefined)?.command
+
+    if (input.tool_name !== 'Bash') {
+      // A completed mutating tool changed the workspace: break the run so a verifier still printing
+      // the same remaining errors is not misread as a stuck loop. Read-only tools do not break it —
+      // an agent alternating Bash with Read is still looping.
+      if (input.hook_event_name === 'PostToolUse' && BASH_RUN_BREAK_TOOLS.has(input.tool_name)) {
+        sessionState().recordBashRunBreak(sessionId)
+      }
+      return {}
+    }
+
+    const command = (input.tool_input as { command?: unknown } | undefined)?.command
     if (typeof command !== 'string') return {}
 
-    const failed = input.hook_event_name === 'PostToolUseFailure'
-    sessionState().recordBashOutcome(sessionId, command, failed ? event.error : event.tool_response, failed)
+    if (input.hook_event_name === 'PostToolUseFailure') {
+      if (input.is_interrupt === true) return {}
+      sessionState().recordBashOutcome(sessionId, command, input.error, true)
+      return {}
+    }
+
+    const response = input.tool_response
+    if (
+      typeof response === 'object' &&
+      response !== null &&
+      (response as { interrupted?: unknown }).interrupted === true
+    ) {
+      return {}
+    }
+    sessionState().recordBashOutcome(sessionId, command, response, false)
     return {}
   }
 

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -15,7 +15,10 @@ import type { HookCallback, HookJSONOutput } from '@anthropic-ai/claude-agent-sd
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { wrapSteerReminder } from '@main/ai/steerReminder'
+import { CHERRY_MCP_SERVER, toMcpRuntimeName } from '@main/ai/toolApproval/builtinToolPolicy'
 import { evaluateToolGuards } from '@main/ai/toolApproval/toolGuards'
+import { MOVE_TO_TRASH_TOOL_NAME } from '@main/ai/tools/moveToTrash'
+import { SAVE_ATTACHMENT_TOOL_NAME } from '@main/ai/tools/saveAttachment'
 import { rtkRewrite } from '@main/utils/rtk'
 
 import type { AgentRuntimeUserInput } from '../types'
@@ -27,6 +30,14 @@ import type { ClaudeCodeSettings } from './types'
 
 const logger = loggerService.withContext('ClaudeCodeHooks')
 const EXIT_PLAN_MODE_TOOL_NAME = 'ExitPlanMode'
+
+// Tools whose successful completion mutates the workspace and therefore breaks a no-progress run:
+// the native edit tools, plus the assistant-files MCP tools (referenced by runtime name).
+const RUN_BREAK_TOOLS: ReadonlySet<string> = new Set([
+  ...BASH_RUN_BREAK_TOOLS,
+  toMcpRuntimeName({ serverName: CHERRY_MCP_SERVER.ASSISTANT_FILES, toolName: SAVE_ATTACHMENT_TOOL_NAME }),
+  toMcpRuntimeName({ serverName: CHERRY_MCP_SERVER.ASSISTANT_FILES, toolName: MOVE_TO_TRASH_TOOL_NAME })
+])
 
 const sessionState = () => application.get('ClaudeCodeSessionStateService')
 
@@ -171,6 +182,14 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
 
   const agentsMdHook = ctx.agentsMdLoader.createPreToolUseHook()
 
+  // Subagent Bash history is scoped per agent_id; when the subagent stops, its scope is dropped so
+  // long-lived sessions don't retain every completed child's history until whole-session disposal.
+  const subagentStopHook: HookCallback = async (input): Promise<HookJSONOutput> => {
+    if (!input || input.hook_event_name !== 'SubagentStop') return {}
+    sessionState().disposeBashScope(sessionId, input.agent_id)
+    return {}
+  }
+
   // Feeds the bash-repeat-no-progress guard rule. History is scoped per agent: subagent hook
   // events carry agent_id, and a child's repeated calls must not poison the parent's run
   // detection (and vice versa). A user interrupt (Esc) is a deliberate stop, so it counts as
@@ -188,7 +207,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       // A completed mutating tool changed the workspace: break the run so a verifier still printing
       // the same remaining errors is not misread as a stuck loop. Read-only tools do not break it —
       // an agent alternating Bash with Read is still looping.
-      if (input.hook_event_name === 'PostToolUse' && BASH_RUN_BREAK_TOOLS.has(input.tool_name)) {
+      if (input.hook_event_name === 'PostToolUse' && RUN_BREAK_TOOLS.has(input.tool_name)) {
         sessionState().recordBashRunBreak(sessionId, agentId)
       }
       return {}
@@ -247,6 +266,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
   return {
     PreToolUse: [{ hooks: [toolGuardHook, skillDependencyAdvisoryHook, agentsMdHook, rtkRewriteHook, steerHook] }],
     PostToolUse: [{ hooks: [postToolTimingHook, bashOutcomeHook] }],
-    PostToolUseFailure: [{ hooks: [postToolTimingHook, bashOutcomeHook] }]
+    PostToolUseFailure: [{ hooks: [postToolTimingHook, bashOutcomeHook] }],
+    SubagentStop: [{ hooks: [subagentStopHook] }]
   }
 }

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -171,9 +171,11 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
 
   const agentsMdHook = ctx.agentsMdLoader.createPreToolUseHook()
 
-  // Feeds the bash-repeat-no-progress guard rule. User interrupts are excluded: an Esc-aborted call
-  // is a deliberate stop, not loop evidence. Esc surfaces either as PostToolUseFailure with
-  // is_interrupt, or as PostToolUse whose Bash tool_response carries interrupted: true.
+  // Feeds the bash-repeat-no-progress guard rule. A user interrupt (Esc) is a deliberate stop, so
+  // it counts as progress and CLEARS the signal — merely skipping the recording would leave a
+  // trailing run in place and the user's next retry would still be denied. Esc surfaces either as
+  // PostToolUseFailure with is_interrupt, or as PostToolUse whose Bash tool_response carries
+  // interrupted: true.
   const bashOutcomeHook: HookCallback = async (input): Promise<HookJSONOutput> => {
     if (!input || (input.hook_event_name !== 'PostToolUse' && input.hook_event_name !== 'PostToolUseFailure')) {
       return {}
@@ -193,7 +195,10 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
     if (typeof command !== 'string') return {}
 
     if (input.hook_event_name === 'PostToolUseFailure') {
-      if (input.is_interrupt === true) return {}
+      if (input.is_interrupt === true) {
+        sessionState().recordBashRunBreak(sessionId)
+        return {}
+      }
       sessionState().recordBashOutcome(sessionId, command, input.error, true)
       return {}
     }
@@ -204,6 +209,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       response !== null &&
       (response as { interrupted?: unknown }).interrupted === true
     ) {
+      sessionState().recordBashRunBreak(sessionId)
       return {}
     }
     sessionState().recordBashOutcome(sessionId, command, response, false)

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -92,7 +92,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       supportsImages: ctx.supportsImages,
       interaction: application.get('AgentSessionRuntimeService').getInteractionState(sessionId),
       isDisabled: (name) => snapshot?.isDisabled(name) ?? false,
-      bashNoProgressRun: (command) => sessionState().getBashNoProgressRun(sessionId, command)
+      bashNoProgressRun: (command) => sessionState().getBashNoProgressRun(sessionId, command, input.agent_id)
     })
     if (!decision) return {}
     if (decision.effect === 'deny') {
@@ -171,22 +171,25 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
 
   const agentsMdHook = ctx.agentsMdLoader.createPreToolUseHook()
 
-  // Feeds the bash-repeat-no-progress guard rule. A user interrupt (Esc) is a deliberate stop, so
-  // it counts as progress and CLEARS the signal — merely skipping the recording would leave a
-  // trailing run in place and the user's next retry would still be denied. Esc surfaces either as
+  // Feeds the bash-repeat-no-progress guard rule. History is scoped per agent: subagent hook
+  // events carry agent_id, and a child's repeated calls must not poison the parent's run
+  // detection (and vice versa). A user interrupt (Esc) is a deliberate stop, so it counts as
+  // progress and CLEARS the signal — merely skipping the recording would leave a trailing run in
+  // place and the user's next retry would still be denied. Esc surfaces either as
   // PostToolUseFailure with is_interrupt, or as PostToolUse whose Bash tool_response carries
   // interrupted: true.
   const bashOutcomeHook: HookCallback = async (input): Promise<HookJSONOutput> => {
     if (!input || (input.hook_event_name !== 'PostToolUse' && input.hook_event_name !== 'PostToolUseFailure')) {
       return {}
     }
+    const agentId = input.agent_id
 
     if (input.tool_name !== 'Bash') {
       // A completed mutating tool changed the workspace: break the run so a verifier still printing
       // the same remaining errors is not misread as a stuck loop. Read-only tools do not break it —
       // an agent alternating Bash with Read is still looping.
       if (input.hook_event_name === 'PostToolUse' && BASH_RUN_BREAK_TOOLS.has(input.tool_name)) {
-        sessionState().recordBashRunBreak(sessionId)
+        sessionState().recordBashRunBreak(sessionId, agentId)
       }
       return {}
     }
@@ -196,10 +199,10 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
 
     if (input.hook_event_name === 'PostToolUseFailure') {
       if (input.is_interrupt === true) {
-        sessionState().recordBashRunBreak(sessionId)
+        sessionState().recordBashRunBreak(sessionId, agentId)
         return {}
       }
-      sessionState().recordBashOutcome(sessionId, command, input.error, true)
+      sessionState().recordBashOutcome(sessionId, command, input.error, true, agentId)
       return {}
     }
 
@@ -209,10 +212,10 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       response !== null &&
       (response as { interrupted?: unknown }).interrupted === true
     ) {
-      sessionState().recordBashRunBreak(sessionId)
+      sessionState().recordBashRunBreak(sessionId, agentId)
       return {}
     }
-    sessionState().recordBashOutcome(sessionId, command, response, false)
+    sessionState().recordBashOutcome(sessionId, command, response, false, agentId)
     return {}
   }
 

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -23,7 +23,7 @@ import { rtkRewrite } from '@main/utils/rtk'
 
 import type { AgentRuntimeUserInput } from '../types'
 import type { AgentsMdLoader } from './AgentsMdLoader'
-import { BASH_RUN_BREAK_TOOLS } from './bashNoProgress'
+import { BASH_NO_PROGRESS_HARD_THRESHOLD, BASH_NO_PROGRESS_THRESHOLD, BASH_RUN_BREAK_TOOLS } from './bashNoProgress'
 import { CLAUDE_TOOL_GUARD_RULES } from './guardRules'
 import { checkSkillRuntimeDependencies, SKILL_TOOL_NAME } from './skillDependencies'
 import type { ClaudeCodeSettings } from './types'
@@ -105,7 +105,23 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       isDisabled: (name) => snapshot?.isDisabled(name) ?? false,
       bashNoProgressRun: (command) => sessionState().getBashNoProgressRun(sessionId, command, input.agent_id)
     })
-    if (!decision) return {}
+    if (!decision) {
+      // Soft tier of the bash-repeat-no-progress guard (the hard deny is the guard rule): the
+      // first call past the soft threshold is allowed with a one-shot warning so the model can
+      // self-correct; exactly-at-threshold fires it once, before the run grows past it.
+      if (toolName === 'Bash' && typeof toolInput?.command === 'string') {
+        const run = sessionState().getBashNoProgressRun(sessionId, toolInput.command, input.agent_id)
+        if (run === BASH_NO_PROGRESS_THRESHOLD) {
+          return {
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              additionalContext: `Loop warning: this exact Bash command has already run ${run} times in a row with byte-identical output, and is denied outright once the run reaches ${BASH_NO_PROGRESS_HARD_THRESHOLD}. If you are waiting for a change, make the edit first; if you are stuck, diagnose the cause or report the blocker instead of retrying.`
+            }
+          }
+        }
+      }
+      return {}
+    }
     if (decision.effect === 'deny') {
       logger.info('Tool guard denied a tool call', { sessionId, toolName, ruleId: decision.ruleId })
     }

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -90,7 +90,8 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       agentDataPath,
       supportsImages: ctx.supportsImages,
       interaction: application.get('AgentSessionRuntimeService').getInteractionState(sessionId),
-      isDisabled: (name) => snapshot?.isDisabled(name) ?? false
+      isDisabled: (name) => snapshot?.isDisabled(name) ?? false,
+      bashNoProgressRun: (command) => sessionState().getBashNoProgressRun(sessionId, command)
     })
     if (!decision) return {}
     if (decision.effect === 'deny') {
@@ -169,6 +170,22 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
 
   const agentsMdHook = ctx.agentsMdLoader.createPreToolUseHook()
 
+  // Feeds the bash-repeat-no-progress guard rule. User interrupts are excluded: an Esc-aborted call
+  // is a deliberate stop, not loop evidence.
+  const bashOutcomeHook: HookCallback = async (input): Promise<HookJSONOutput> => {
+    if (!input || (input.hook_event_name !== 'PostToolUse' && input.hook_event_name !== 'PostToolUseFailure')) {
+      return {}
+    }
+    const event = input as unknown as Record<string, unknown>
+    if (event.tool_name !== 'Bash' || event.is_interrupt === true) return {}
+    const command = (event.tool_input as Record<string, unknown> | undefined)?.command
+    if (typeof command !== 'string') return {}
+
+    const failed = input.hook_event_name === 'PostToolUseFailure'
+    sessionState().recordBashOutcome(sessionId, command, failed ? event.error : event.tool_response, failed)
+    return {}
+  }
+
   const postToolTimingHook: HookCallback = async (input): Promise<HookJSONOutput> => {
     if (!input || (input.hook_event_name !== 'PostToolUse' && input.hook_event_name !== 'PostToolUseFailure')) {
       return {}
@@ -196,7 +213,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
 
   return {
     PreToolUse: [{ hooks: [toolGuardHook, skillDependencyAdvisoryHook, agentsMdHook, rtkRewriteHook, steerHook] }],
-    PostToolUse: [{ hooks: [postToolTimingHook] }],
-    PostToolUseFailure: [{ hooks: [postToolTimingHook] }]
+    PostToolUse: [{ hooks: [postToolTimingHook, bashOutcomeHook] }],
+    PostToolUseFailure: [{ hooks: [postToolTimingHook, bashOutcomeHook] }]
   }
 }

--- a/src/main/ai/toolApproval/toolGuards.ts
+++ b/src/main/ai/toolApproval/toolGuards.ts
@@ -41,6 +41,11 @@ export interface ToolGuardContext {
   readonly interaction: ToolGuardInteractionState
   /** Live disabled predicate; returns false when no snapshot is bound (canUseTool fails closed). */
   readonly isDisabled: (toolName: string) => boolean
+  /**
+   * Live stuck-loop predicate for Bash; returns the identical-output run length when the command
+   * is looping without progress, undefined when no history is bound or the run has not formed.
+   */
+  readonly bashNoProgressRun?: (command: string) => number | undefined
 }
 
 /** A condition match; `evidence` carries detector output for dynamic reasons. */

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-04-bash-no-progress-denial.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-04-bash-no-progress-denial.md
@@ -1,0 +1,23 @@
+---
+title: Agent Bash calls that repeat with byte-identical output are now denied
+category: changed
+severity: notice
+introduced_in_pr: "#19906"
+date: 2026-09-04
+---
+
+## What changed
+
+In Claude Code agent sessions, when the exact same Bash command has already run 3 times in a row with byte-identical output, the next identical call is denied with an explanation instead of executing. Any output change, a completed file edit, or the user pressing Esc resets the count. The denial applies in every permission mode, including bypass-permissions runs.
+
+## Why this matters to the user
+
+Unattended agent runs could previously burn tokens retrying a command that provably returns the same result. Those loops now stop at the 4th attempt and the agent is told to diagnose, vary the command, or report the blocker. The one visible narrowing: a deliberate workflow that polls a command expecting identical output (for example waiting on a health endpoint that never changes) is interrupted after 3 identical results and must vary the invocation or ask the user.
+
+## What the user should do
+
+Nothing — automatic. If an agent legitimately needs to poll, re-running the command after any edit, after pressing Esc once, or with a trivially varied invocation (such as adding `&& true`) starts a fresh count.
+
+## Notes for release manager
+
+Only affects the Claude Code runtime's agent sessions; terminal usage by the user directly is untouched.

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-04-bash-no-progress-denial.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-04-bash-no-progress-denial.md
@@ -1,5 +1,5 @@
 ---
-title: Agent Bash calls that repeat with byte-identical output are now denied
+title: Agent Bash calls that repeat with byte-identical output are now warned about, then denied
 category: changed
 severity: notice
 introduced_in_pr: "#19906"
@@ -8,15 +8,15 @@ date: 2026-09-04
 
 ## What changed
 
-In Claude Code agent sessions, when the exact same Bash command has already run 3 times in a row with byte-identical output, the next identical call is denied with an explanation instead of executing. Any output change, a completed file edit, or the user pressing Esc resets the count. The denial applies in every permission mode, including bypass-permissions runs.
+In Claude Code agent sessions, repeated identical Bash calls are now guarded in two tiers. When the exact same command has run 3 times in a row with byte-identical output, the next identical call is allowed but the agent receives a loop warning so it can self-correct. When the run reaches 5, the next identical call is denied with an explanation. Any output change, a completed file edit, or the user pressing Esc resets the count. The denial applies in every permission mode, including bypass-permissions runs.
 
 ## Why this matters to the user
 
-Unattended agent runs could previously burn tokens retrying a command that provably returns the same result. Those loops now stop at the 4th attempt and the agent is told to diagnose, vary the command, or report the blocker. The one visible narrowing: a deliberate workflow that polls a command expecting identical output (for example waiting on a health endpoint that never changes) is interrupted after 3 identical results and must vary the invocation or ask the user.
+Unattended agent runs could previously burn tokens retrying a command that provably returns the same result. Those loops now surface a warning at the 4th identical call and stop at the 6th, with the agent told to diagnose, vary the command, or report the blocker. The one visible narrowing: a deliberate workflow that polls a command expecting identical output (for example waiting on a health endpoint that never changes) is interrupted and must vary the invocation or ask the user.
 
 ## What the user should do
 
-Nothing — automatic. If an agent legitimately needs to poll, re-running the command after any edit, after pressing Esc once, or with a trivially varied invocation (such as adding `&& true`) starts a fresh count.
+Nothing — automatic. If an agent legitimately needs to poll, any edit, pressing Esc once, or a trivially varied invocation (such as adding `&& true`) starts a fresh count.
 
 ## Notes for release manager
 


### PR DESCRIPTION
### What this PR does

Before this PR: an agent stuck in a retry loop can re-run the same Bash command indefinitely while its output never changes, burning tokens until the turn or the user's patience ends. Cherry Studio's guard table had no rule for this — neither did the loop reports in #19188 have any runtime-side mitigation.

After this PR: a PostToolUse/PostToolUseFailure hook records each Bash outcome's fingerprint per session **per agent** (subagent runs are scoped by the SDK's `agent_id`, so a wedged child never denies the parent), and the response is **two-tiered**:

- **Soft (run of 3):** the next identical call is allowed, with a one-shot `additionalContext` warning naming the hard threshold — the model gets a chance to self-correct.
- **Hard (run of 5):** the `bash-repeat-no-progress` guard rule denies the next identical call in every permission mode, telling the model to diagnose why the output is not changing, vary the command, or report the blocker.

Any output change, a completed workspace mutation (native edit tools **and** the assistant-files MCP tools), or a user interrupt (Esc — on both its `PostToolUseFailure.is_interrupt` and `PostToolUse` `tool_response.interrupted` surfaces) counts as progress and clears the signal. Read-only interleaving (`Read`/`Grep`) deliberately does not — an agent alternating Bash with Read is still looping.

Fixes #None

### Why we need it and why it was done in this way

Policy is added as one row in the declarative guard table (`guardRules.ts`), matching how `global-install` and `unsupported-image-read` landed. The hard tier's `bypassBehavior` is `enforce`: unattended bypass runs are exactly where a stuck loop burns tokens fastest, so this is a conduct rule, not an approval. The soft tier lives on the hook plane (`additionalContext`), the same deny/advisory split the skill-dependency check already uses.

Live state follows the established fire-time pattern: the hook records into `ClaudeCodeSessionStateService` (bounded to 16 entries per agent scope, a scope dropped on `SubagentStop`, all scopes disposed with the session), and the guard reads it through a `bashNoProgressRun` predicate on `ToolGuardContext`, mirroring the existing `isDisabled` live predicate. Detection is a pure, separately unit-tested module (`bashNoProgress.ts`).

Design points cross-checked against other agent runtimes (details in the comment below):

- **Two-tier soft/hard response** mirrors Cline's `LoopDetectionTracker` (soft 3 / hard 5), instead of a hard deny at first detection — an immediate deny gives the model no chance to self-correct.
- **Output-fingerprint equality** (not just command equality like Cline/Goose) keeps legitimate polling with *changing* output unaffected; commands embedding timestamps simply never match, which is the correct read: changing output *is* new information.
- **Mutation-based reset** instead of Cline/Goose's any-different-call reset: `Edit → tsc → Edit → tsc` with unchanged errors is progress, while `Bash → Read → Bash → Read` alternation still trips the guard (a broad reset would miss it; Gemini CLI covers that case only via its periodic-pattern detector).
- Escape routes stay documented instead of adding a settings toggle (Goose's configurable `max_repetitions`, Gemini's session disable): any edit, one Esc, or a trivially varied command starts a fresh count.

The following alternatives were considered:

- Command hooks from user `settings.json`: not viable today — the runtime passes `hooks` programmatically, which overrides settings-file hooks (see the still-open #14977).
- Sandboxing or rate-limiting Bash: previously reverted (a360318d05); the guard table is the accepted surface for this class of policy.
- Per-prompt history reset (Gemini CLI resets per prompt): rejected — cross-turn continuation loops are exactly what an unattended session needs caught, and the mutation/interrupt resets already separate deliberate re-runs from loops.

Known limitation: when the optional rtk plugin rewrites a command, PostToolUse records the rewritten form while the guard evaluates the pre-rewrite text, so rtk-enabled sessions get weaker coverage for rewritable commands. Closing that gap would mean running `rtkRewrite` twice per Bash call (an extra process spawn each), which did not seem worth it for an opt-in plugin; happy to revisit if reviewers disagree.

Links to places where the discussion took place: None

### Breaking changes

None. A v2 breaking-change log entry is included (`v2-refactor-temp/docs/breaking-changes/2026-09-04-bash-no-progress-denial.md`) since the denial is user-perceivable.

### Special notes for your reviewer

- Tests: `bashNoProgress.test.ts` (pure detection logic), `guardRules.test.ts` (hard-tier deny in every mode incl. bypass, soft tiers left to the hook, non-Bash tools untouched), and `bashOutcomeRecording.test.ts` (recorder/service/hook wiring: ring eviction, dispose sweep, interrupt clears, mutation breaks, per-agent scoping incl. the guard-query path, SubagentStop cleanup, soft-warning tiers). Each behavior was mutation-checked during development: reverting a fix fails exactly its pinning tests.
- `pnpm lint`, node typecheck, and the targeted `pnpm test:main` runs all pass locally (586 tests across the claudeCode suites).
- User-guide update: considered, not required — the feature has no settings surface; its only user-visible artifacts are the one-shot warning and the deny reason text.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others
