### PR TITLE
fix(extension-table-plus): clear stale col width when reusing colgroup entries

### DIFF
--- a/.changeset/table-plus-stale-col-width.md
+++ b/.changeset/table-plus-stale-col-width.md
@@ -1,0 +1,5 @@
+---
+"@cherrystudio/extension-table-plus": patch
+---
+
+Clear a reused `<col>` element's stale `width` and `min-width` before applying the current column declaration in `TableView.updateColumns`. A column that lost its stored width previously kept the old `width` alongside the new `min-width`, so it stayed locked at its previous size after inserting a column or resizing. Columns narrower than `cellMinWidth` are also no longer rewritten on every update.

--- a/packages/extension-table-plus/src/table/TableView.ts
+++ b/packages/extension-table-plus/src/table/TableView.ts
@@ -27,7 +27,8 @@ export function updateColumns(
 
       for (let j = 0; j < colspan; j += 1, col += 1) {
         const hasWidth = overrideCol === col ? overrideValue : ((colwidth && colwidth[j]) as number | undefined)
-        const cssWidth = hasWidth ? `${hasWidth}px` : ''
+        const [propertyKey, propertyValue] = getColStyleDeclaration(cellMinWidth, hasWidth)
+        const cssWidth = propertyKey === 'width' ? propertyValue : ''
 
         totalWidth += hasWidth || cellMinWidth
 
@@ -38,16 +39,16 @@ export function updateColumns(
         if (!nextDOM) {
           const colElement = document.createElement('col')
 
-          const [propertyKey, propertyValue] = getColStyleDeclaration(cellMinWidth, hasWidth)
-
           colElement.style.setProperty(propertyKey, propertyValue)
 
           colgroup.appendChild(colElement)
         } else {
-          if ((nextDOM as HTMLTableColElement).style.width !== cssWidth) {
-            const [propertyKey, propertyValue] = getColStyleDeclaration(cellMinWidth, hasWidth)
+          const colElement = nextDOM as HTMLTableColElement
 
-            ;(nextDOM as HTMLTableColElement).style.setProperty(propertyKey, propertyValue)
+          if (colElement.style.width !== cssWidth) {
+            colElement.style.removeProperty('width')
+            colElement.style.removeProperty('min-width')
+            colElement.style.setProperty(propertyKey, propertyValue)
           }
 
           nextDOM = nextDOM.nextSibling


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`updateColumns` in `packages/extension-table-plus/src/table/TableView.ts` reuses the existing `<col>` elements on every table update. When a reused `<col>` previously had a stored width and its column no longer has one, the code only set `min-width` and never removed the old `width`, so the element ended up with both. The browser keeps honoring `width`, and the column stays locked at its previous size after inserting a column or resizing. A stored width below `cellMinWidth` also rewrote the style on every update, because the guard compared the raw stored value against the clamped value actually applied.

After this PR:

Reusing a `<col>` clears both `width` and `min-width` before applying the current declaration, so reused elements end up with the same style a freshly created one would get. The comparison value is derived from `getColStyleDeclaration`, so the guard compares against the clamped value and skips the rewrite when nothing changed.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

Both properties are reset unconditionally inside the existing change guard instead of branching on which property was previously set. Two `removeProperty` calls are cheaper to reason about than tracking the previous state, and the guard already limits this to columns whose width actually changed.

The following alternatives were considered:

Changing `getColStyleDeclaration` to return a full `cssText` string for both properties. Rejected because the helper is shared with `createColGroup` for `renderHTML`, where the single-property form is the desired output.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This code is inherited from upstream `@tiptap/extension-table`, which has the same behavior. The fork already owns this file, so the fix is applied here. `packages/extension-table-plus` is not wired into any vitest project, so no regression test is included; the fix was verified with a throwaway JSDOM probe that fails on `main` and passes on this branch (stale width dropped, stale min-width dropped, below-minimum column not rewritten on the second pass).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed table columns keeping a stale fixed width after inserting or resizing columns in the notes editor.
```
