### PR TITLE
perf(citations): fold earlier-turn parts only when a marker stays unresolved

### DIFF
--- a/src/renderer/utils/message/__tests__/citations.test.ts
+++ b/src/renderer/utils/message/__tests__/citations.test.ts
@@ -623,6 +623,62 @@ describe('cross-turn citations', () => {
     expect(content).toBe('Claim [1].')
     expect(cited.map((citation) => citation.url)).toEqual(['https://a.com/x'])
   })
+
+  it('exports an own id and a re-cited earlier id numbered by first appearance', () => {
+    const { content, cited } = toExportableCitations(
+      'Old [cite:old-2] then new [cite:new-1].',
+      [webToolPart(webResults('new'))],
+      [webToolPart(webResults('old'))]
+    )
+    expect(content).toBe('Old [1] then new [2].')
+    expect(cited.map((citation) => citation.url)).toEqual(['https://b.com/y', 'https://a.com/x'])
+  })
+
+  it('exports a re-cited earlier id that shares a URL with an own result as one source', () => {
+    const { content, cited } = toExportableCitations(
+      'A [cite:old-1] B [cite:new-1]',
+      [webToolPart(webResults('new'))],
+      [webToolPart(webResults('old'))]
+    )
+    expect(content).toBe('A [1] B [1]')
+    expect(cited).toHaveLength(1)
+  })
+
+  it('exports a re-cited earlier id that sits in a run behind an own id', () => {
+    const { content, cited } = toExportableCitations(
+      'Own [cite:new-1][cite:old-2].',
+      [webToolPart(webResults('new'))],
+      [webToolPart(webResults('old'))]
+    )
+    expect(content).toBe('Own [1][2].')
+    expect(cited.map((citation) => citation.url)).toEqual(['https://a.com/x', 'https://b.com/y'])
+  })
+
+  it('does not read earlier turns when every marker resolves from own parts', () => {
+    const untouchable = new Proxy([webToolPart(webResults('old'))], {
+      get(target, property) {
+        if (property === 'length') return target.length
+        throw new Error(`earlier turn part read via ${String(property)}`)
+      }
+    })
+    const { content, cited } = toExportableCitations(
+      'Own [cite:new-1] only.',
+      [webToolPart(webResults('new'))],
+      untouchable
+    )
+    expect(content).toBe('Own [1] only.')
+    expect(cited.map((citation) => citation.url)).toEqual(['https://a.com/x'])
+  })
+
+  it('still reads earlier turns for a marker inside prose when own parts have no citations', () => {
+    const { content, cited } = toExportableCitations(
+      'See `[cite:abc-1]` in code, and [cite:abc-2] in prose.',
+      [],
+      [webToolPart(webResults('abc'))]
+    )
+    expect(content).toBe('See `[cite:abc-1]` in code, and [1] in prose.')
+    expect(cited.map((citation) => citation.url)).toEqual(['https://b.com/y'])
+  })
 })
 
 describe('buildCitationPartsRegistry', () => {

--- a/src/renderer/utils/message/citations.ts
+++ b/src/renderer/utils/message/citations.ts
@@ -570,11 +570,13 @@ export function toExportableCitations(
   parts: readonly CherryMessagePart[],
   priorParts: readonly CherryMessagePart[] = EMPTY_PARTS
 ): { content: string; cited: Citation[] } {
-  const {
-    content: resolved,
-    byMarker,
-    cited
-  } = resolveCitationMarkers(content, resolveMessageCitations(parts, priorParts))
+  // Earlier turns only answer ids own parts do not mint, so fold them only on an unresolved
+  // marker: eager folding made a whole-topic export quadratic in the number of search calls.
+  let resolution = resolveCitationMarkers(content, resolveMessageCitations(parts))
+  if (priorParts.length > 0 && hasUnresolvedMarker(resolution)) {
+    resolution = resolveCitationMarkers(content, resolveMessageCitations(parts, priorParts))
+  }
+  const { content: resolved, byMarker, cited } = resolution
   return {
     content: mapMarkdownOutsideCode(resolved, (text) =>
       text.replace(CITATION_MARKER_PATTERN, (_match, space: string, id: string) => {
@@ -584,6 +586,22 @@ export function toExportableCitations(
     ),
     cited
   }
+}
+
+function hasUnresolvedMarker({ content, byMarker }: ResolvedCitationMarkers): boolean {
+  let unresolved = false
+  mapMarkdownOutsideCode(content, (text) => {
+    if (!unresolved) {
+      for (const match of text.matchAll(CITATION_MARKER_PATTERN)) {
+        if (!byMarker.has(match[2])) {
+          unresolved = true
+          break
+        }
+      }
+    }
+    return text
+  })
+  return unresolved
 }
 
 /**


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`toExportableCitations` folded every earlier citable tool part (`priorParts`) into the citation map of every message before resolving its markers. Whole-topic consumers (Markdown/Notion/Obsidian export, knowledge analysis, batch copy) call it once per message, so the export was quadratic in the number of search calls: each message re-parsed and re-cleaned every earlier `web_search` / `kb_search` / `kb_read` result even when it never re-cited one.

After this PR:

Own parts are resolved first. Earlier turns are folded only when that pass leaves a `[cite:id]` marker unresolved, which is exactly the case earlier turns exist for (`resolveMessageCitations`: "priorParts only answer ids the message does not mint itself"). Output is byte-identical: every marker that resolved before resolves to the same source and number now.

Fixes #

### Why we need it and why it was done in this way

Benchmark (Vitest, renderer project, every second message runs one `web_search` with 8 results; `before` = eager fold, `after` = this PR; each row asserts both paths return identical citation lists):

| messages | search calls | re-cite frequency | before | after | speedup |
|---|---|---|---|---|---|
| 500 | 250 | none | 445 ms | 4 ms | 113x |
| 1000 | 500 | none | 1721 ms | 6 ms | 305x |
| 2000 | 1000 | none | 7022 ms | 11 ms | 625x |
| 500 | 250 | every 10th message | 422 ms | 45 ms | 9x |
| 1000 | 500 | every 10th message | 1701 ms | 174 ms | 10x |
| 2000 | 1000 | every 10th message | 7034 ms | 712 ms | 10x |
| 500 | 250 | every 2nd message | 421 ms | 213 ms | 2x |
| 1000 | 500 | every 2nd message | 1694 ms | 854 ms | 2x |
| 2000 | 1000 | every 2nd message | 7027 ms | 3543 ms | 2x |

"re-cite" means a message whose text references a result id from an earlier turn; those messages still pay the full fold, everything else skips it.

The following tradeoffs were made:

- A message that does re-cite an earlier id resolves its own parts twice (own-only pass, then the full pass). That is bounded by the message's own parts and is negligible next to the fold it replaces.
- The renderer path (`MessagePartsRenderer` → `resolveMessageCitations(parts, priorCitationParts)`) is left eager on purpose: it is memoized per mounted message behind a virtualized list, so it never runs over the whole topic.
- The `getPriorCitationParts` slices are untouched. They copy part references only (about 8 MB of pointers at 2000 messages), not part contents; the cost was CPU, not memory.

The following alternatives were considered:

- A registry-level lazy id index consulted on marker miss, passed instead of the sliced arrays. It removes the remaining O(K) fold for re-citing messages too, but changes `MessageExportView.priorCitationParts` and nine call sites. Not worth it without evidence that re-cite-heavy topics are common.
- Caching parsed tool outputs per part in a `WeakMap`. Removes the zod/normalize cost but still inserts every earlier citation into every message's maps and still runs `cleanMarkdownContent` over all of them.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The gate reuses `CITATION_MARKER_PATTERN` on the own-only resolved text, wrapped in `mapMarkdownOutsideCode`, so markers inside code blocks do not trigger a fold, matching what the final replace already ignores.
- `collapseMarkerRuns` keeps unresolved markers, so an earlier-turn id sitting inside a run behind an own id (`[cite:new-1][cite:old-2]`) is still detected; there is a test for it.
- The "does not read earlier turns" test hands in a `Proxy` that throws on iteration. It fails on the previous implementation and guards the performance contract itself.
- Verification run locally on the changed files only: `npx vitest run src/renderer/utils/message/__tests__/citations.test.ts --project renderer` (73 passed), plus Biome, ESLint and oxlint on the two files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Export] Exporting or analysing a long topic with many web/knowledge searches no longer slows down quadratically with the number of searches.
```

https://claude.ai/code/session_018iipvPon2t7w3tMHbiLaft
