### PR TITLE
fix(agent-sessions): keep pinned sessions in agent groups

### DIFF
--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -691,7 +691,7 @@ const Sessions = ({
         },
         mode: displayMode,
         now: groupNow,
-        pinnedAsSection: displayMode !== 'time',
+        pinnedAsSection: displayMode === 'workdir',
         workdirDisplay
       }),
     [agentById, displayMode, groupNow, t, workdirDisplay]
@@ -724,7 +724,7 @@ const Sessions = ({
     if (displayMode === 'time') return undefined
 
     return (session: SessionListItem): ResourceListSection => {
-      if (session.pinned) {
+      if (displayMode === 'workdir' && session.pinned) {
         return { id: SESSION_PINNED_SECTION_ID, label: t('selector.common.pinned_title') }
       }
 
@@ -1453,8 +1453,18 @@ const Sessions = ({
   )
 
   const canDropSessionItem = useCallback(
-    ({ sourceGroupId, targetGroupId }: { sourceGroupId: string; targetGroupId: string }) =>
-      itemDragReady && canDropSessionItemInDisplayGroup({ mode: displayMode, sourceGroupId, targetGroupId }),
+    ({
+      overItem,
+      sourceGroupId,
+      targetGroupId
+    }: {
+      overItem?: SessionListItem
+      sourceGroupId: string
+      targetGroupId: string
+    }) =>
+      itemDragReady &&
+      !overItem?.pinned &&
+      canDropSessionItemInDisplayGroup({ mode: displayMode, sourceGroupId, targetGroupId }),
     [displayMode, itemDragReady]
   )
 

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -1433,6 +1433,26 @@ describe('Sessions', () => {
     expect(getSessionGroupExpansionCache().agent).not.toContain('session:agent:agent-b')
   })
 
+  it('keeps a pinned session in its expanded agent group', () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [{ id: 'agent-a', model: 'model-a', name: 'Alpha agent', configuration: { avatar: 'A' } }],
+      isLoading: false,
+      error: undefined
+    })
+    setupSessions({
+      sessions: [createSession({ id: 'session-pinned', name: 'Pinned session', agentId: 'agent-a' })],
+      pinIdBySessionId: new Map([['session-pinned', 'pin-session-pinned']])
+    })
+
+    render(<SessionsForTest />)
+
+    expect(screen.queryByRole('button', { name: 'Pinned' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Alpha agent' })).toBeInTheDocument()
+    expect(screen.getByText('Pinned session')).toBeInTheDocument()
+    expect(screen.queryByText('No tasks')).not.toBeInTheDocument()
+  })
+
   it('renders orphan sessions under the unlinked agent group without a virtual agent icon', () => {
     preferenceMocks.values.set('agent.session.display_mode', 'agent')
     setupSessions({
@@ -3125,6 +3145,42 @@ describe('Sessions', () => {
     await vi.waitFor(() =>
       expect(sessionDataMocks.reorderSession).toHaveBeenCalledWith('session-a', { after: 'session-b' })
     )
+  })
+
+  it('rejects drops onto pinned sessions within an agent group', () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [{ id: 'agent-a', model: 'model-a', name: 'Alpha agent' }],
+      isLoading: false,
+      error: undefined
+    })
+    setupSessions({
+      sessions: [
+        createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' }),
+        createSession({ id: 'session-pinned', name: 'Pinned session', agentId: 'agent-a', orderKey: 'b' })
+      ],
+      pinIdBySessionId: new Map([['session-pinned', 'pin-session-pinned']])
+    })
+
+    render(<SessionsForTest />)
+    startDraggingSession('session-a')
+
+    act(() => {
+      dndMocks.onDragEnd?.({
+        active: {
+          data: sortableData('item:session-a'),
+          id: 'item:session-a',
+          rect: { current: { initial: null, translated: { top: 100, height: 20 } } }
+        },
+        over: {
+          data: sortableData('item:session-pinned'),
+          id: 'item:session-pinned',
+          rect: { top: 10, height: 20 }
+        }
+      })
+    })
+
+    expect(sessionDataMocks.reorderSession).not.toHaveBeenCalled()
   })
 
   it('reorders workspace groups through the workspace order endpoint', async () => {

--- a/src/renderer/utils/chat/__tests__/sessionListHelpers.test.ts
+++ b/src/renderer/utils/chat/__tests__/sessionListHelpers.test.ts
@@ -196,6 +196,19 @@ describe('SessionList helpers', () => {
     expect(allPinned(pinned)).toEqual({ id: SESSION_PINNED_GROUP_ID, label: 'Pinned' })
   })
 
+  it('keeps pinned sessions inside their agent group', () => {
+    const groupSession = createSessionDisplayGroupResolver({
+      agentById: new Map([['agent-1', { id: 'agent-1', name: 'Alpha agent' }]]),
+      labels: SESSION_GROUP_LABELS,
+      mode: 'agent'
+    })
+
+    expect(groupSession(createSession({ agentId: 'agent-1', pinned: true }))).toEqual({
+      id: 'session:agent:agent-1',
+      label: 'Alpha agent'
+    })
+  })
+
   it('groups sessions by agent and workdir', () => {
     const agentGroup = createSessionDisplayGroupResolver({
       agentById: new Map([['agent-1', { id: 'agent-1', name: 'Alpha agent' }]]),
@@ -409,6 +422,25 @@ describe('SessionList helpers', () => {
         workdirDisplay: createSessionWorkdirDisplayMaps(sessions, [makeWorkspace('/Users/jd/project-a')])
       }).map((session) => session.id)
     ).toEqual(['pinned', 'newer', 'older'])
+  })
+
+  it('sorts pinned sessions first within each agent group', () => {
+    const sessions = [
+      createSession({ id: 'regular-b', agentId: 'agent-b', orderKey: 'b' }),
+      createSession({ id: 'regular-a', agentId: 'agent-a', orderKey: 'a' }),
+      createSession({ id: 'pinned-b', agentId: 'agent-b', orderKey: 'd', pinned: true }),
+      createSession({ id: 'pinned-a', agentId: 'agent-a', orderKey: 'c', pinned: true })
+    ]
+
+    expect(
+      sortSessionsForDisplayGroups(sessions, {
+        agentRankById: new Map([
+          ['agent-a', 0],
+          ['agent-b', 1]
+        ]),
+        mode: 'agent'
+      }).map((session) => session.id)
+    ).toEqual(['pinned-a', 'regular-a', 'pinned-b', 'regular-b'])
   })
 
   it('keeps system workspace sessions at the bottom only in workdir mode', () => {

--- a/src/renderer/utils/chat/sessionListHelpers.ts
+++ b/src/renderer/utils/chat/sessionListHelpers.ts
@@ -295,12 +295,7 @@ export function createSessionDisplayGroupResolver<T extends SessionListItem>({
   }
 
   if (mode === 'agent') {
-    const pinnedResolver = createPinnedGroupResolver<T>({
-      isPinned: (session) => session.pinned === true,
-      group: { id: SESSION_PINNED_GROUP_ID, label: pinnedGroupLabel } satisfies ResourceListGroup
-    })
-
-    return composeResourceListGroupResolvers(pinnedResolver, (session) => {
+    return (session) => {
       const agentId = session.agentId
       if (!agentId) {
         return { id: SESSION_UNKNOWN_AGENT_GROUP_ID, label: labels.agent.unknown }
@@ -310,7 +305,7 @@ export function createSessionDisplayGroupResolver<T extends SessionListItem>({
       return agent
         ? { id: getSessionAgentGroupId(agent.id), label: agent.name }
         : { id: SESSION_UNKNOWN_AGENT_GROUP_ID, label: labels.agent.unknown }
-    })
+    }
   }
 
   const pinnedResolver = createPinnedGroupResolver<T>({
@@ -369,18 +364,27 @@ export function sortSessionsForDisplayGroups<T extends SessionListItem>(
     })
   }
 
+  if (options.mode === 'agent') {
+    return sessions
+      .map((session, index) => ({ session, index, rank: getAgentGroupRank(session, options.agentRankById) }))
+      .sort((a, b) => {
+        if (a.rank !== b.rank) return a.rank - b.rank
+        const aPinned = isPinned(a.session)
+        const bPinned = isPinned(b.session)
+        if (aPinned !== bPinned) return aPinned ? -1 : 1
+        if (aPinned && bPinned) return a.index - b.index
+        return compareResourceOrderKey(a.session.orderKey, b.session.orderKey) || a.index - b.index
+      })
+      .map(({ session }) => session)
+  }
+
   return sortRankedResourceItems(sessions, {
     getRank: (session) => {
       if (session.pinned === true) return 0
 
-      let displayRank: number
-      if (options.mode === 'workdir' && isSystemWorkspaceSession(session)) {
-        displayRank = NO_PROJECT_GROUP_RANK
-      } else if (options.mode === 'agent') {
-        displayRank = getAgentGroupRank(session, options.agentRankById)
-      } else {
-        displayRank = getWorkdirGroupRank(session, options.workdirDisplay)
-      }
+      const displayRank = isSystemWorkspaceSession(session)
+        ? NO_PROJECT_GROUP_RANK
+        : getWorkdirGroupRank(session, options.workdirDisplay)
 
       return displayRank >= UNKNOWN_GROUP_RANK ? displayRank : displayRank + 1
     },


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

When sessions were grouped by agent, pinning a session moved it into the global Pinned group. The original agent group could then appear empty even though the session still belonged to that agent.

After this PR:

Pinned sessions remain inside their owning agent group and sort before unpinned sessions in that group. Time and work-directory grouping retain their existing behavior, and unpinned sessions cannot be reordered relative to a pinned session.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19881

### Why we need it and why it was done in this way

Agent grouping communicates session ownership. The renderer previously resolved the Pinned group before the agent group, so pinning replaced the visible ownership boundary. This change makes agent ownership authoritative during grouping and applies pinned-first ordering within each agent group, matching the established topic behavior from #19305.

The following tradeoffs were made:

Pinned sessions are shown only in their agent group in agent mode instead of being duplicated in both the agent and global Pinned groups. This keeps ordering and drag-and-drop semantics unambiguous.

The following alternatives were considered:

Showing an alias for the same session in the global Pinned group was considered, but rejected because duplicate list entries would complicate selection, reordering, and drag-and-drop behavior.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19881

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation:
- Focused renderer tests: 116 passed.
- `pnpm typecheck`: passed.
- `pnpm i18n:check`: passed.
- ESLint: 0 errors when local generated directories (`.claude/worktrees` and `.local`) are excluded.
- Changed-file oxlint and Biome checks: passed.

No user-guide update is required because this restores the intended grouping behavior and adds no new setting or workflow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Pinned agent sessions now remain in their agent group and appear before unpinned sessions.
```
