### PR TITLE
fix(pdf-preview): preserve PDF document colors

### DIFF
--- a/src/renderer/components/FilePreview/plugins/pdf/PdfFilePreview.tsx
+++ b/src/renderer/components/FilePreview/plugins/pdf/PdfFilePreview.tsx
@@ -39,7 +39,6 @@ const PINCH_WHEEL_MAX_EVENT_DELTA = 0.8
 const PINCH_WHEEL_PIXEL_DIVISOR = 10
 const PINCH_WHEEL_IDLE_RESET_MS = 180
 const PINCH_SCALE_SENSITIVITY = 0.075
-const PDF_PAGE_FOREGROUND = 'CanvasText'
 
 type PdfJsViewer = InstanceType<typeof PDFViewer>
 type PdfJsLinkService = InstanceType<typeof PDFLinkService>
@@ -233,10 +232,7 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
   useEffect(() => {
     const pdfViewer = pdfViewerRef.current
     if (pdfViewer) {
-      pdfViewer.pageColors = {
-        ...(background ? { background } : {}),
-        foreground: PDF_PAGE_FOREGROUND
-      }
+      pdfViewer.pageColors = background ? { background } : null
     }
     applyViewerBackground(background)
   }, [applyViewerBackground, background])
@@ -368,10 +364,7 @@ export default function PdfFilePreview({ filePath, fileName, metadata, refreshKe
         linkService,
         abortSignal: viewerAbortController.signal,
         annotationMode: AnnotationMode.ENABLE,
-        pageColors: {
-          ...(backgroundRef.current ? { background: backgroundRef.current } : {}),
-          foreground: PDF_PAGE_FOREGROUND
-        },
+        ...(backgroundRef.current ? { pageColors: { background: backgroundRef.current } } : {}),
         supportsPinchToZoom: true
       }
       pdfViewer = new PDFViewer(viewerOptions)

--- a/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFilePreview.test.tsx
@@ -39,7 +39,7 @@ const mocks = vi.hoisted(() => ({
   }>,
   safeOpen: vi.fn(),
   toastError: vi.fn(),
-  viewerInstances: [] as Array<{ pageColors: { background?: string; foreground: string } }>
+  viewerInstances: [] as Array<{ pageColors: { background?: string } | null }>
 }))
 
 vi.mock('pdfjs-dist', () => ({
@@ -118,7 +118,7 @@ vi.mock('pdfjs-dist/web/pdf_viewer.mjs', () => {
   class MockPDFViewer {
     cleanup = mocks.pdfViewerCleanup
     firstPagePromise = Promise.resolve()
-    pageColors: { background?: string; foreground: string }
+    pageColors: { background?: string } | null
     setDocument = mocks.pdfViewerSetDocument
     private currentPage = 1
     private scale = 1
@@ -126,7 +126,7 @@ vi.mock('pdfjs-dist/web/pdf_viewer.mjs', () => {
     constructor(
       private options: {
         eventBus: MockEventBus
-        pageColors: { background?: string; foreground: string }
+        pageColors: { background?: string } | null
       }
     ) {
       this.pageColors = options.pageColors
@@ -302,7 +302,7 @@ describe('PdfFilePreview', () => {
       expect.objectContaining({
         annotationMode: 1,
         abortSignal: expect.any(AbortSignal),
-        pageColors: { background: 'rgb(10, 11, 12)', foreground: 'CanvasText' },
+        pageColors: { background: 'rgb(10, 11, 12)' },
         supportsPinchToZoom: true
       })
     )
@@ -391,7 +391,7 @@ describe('PdfFilePreview', () => {
     expect(await screen.findByText('file_preview.pdf.outline.empty')).toBeInTheDocument()
   })
 
-  it('updates PDF page colors when the app theme changes without rebuilding the viewer', async () => {
+  it('preserves PDF colors while updating the page background when the app theme changes', async () => {
     renderPreview()
     await waitFor(() => expect(mocks.viewerInstances).toHaveLength(1))
 
@@ -403,8 +403,7 @@ describe('PdfFilePreview', () => {
 
     await waitFor(() =>
       expect(mocks.viewerInstances[0].pageColors).toEqual({
-        background: 'rgb(30, 31, 32)',
-        foreground: 'CanvasText'
+        background: 'rgb(30, 31, 32)'
       })
     )
     expect(mocks.pdfViewerConstructor).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

PDF previews passed `pageColors.foreground = "CanvasText"` to pdf.js, causing colored PDF documents to render in black and white.

After this PR:

PDF previews preserve document colors while retaining the application theme background.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19914

### Why we need it and why it was done in this way

The following tradeoffs were made:

The foreground color override was removed while the background-only `pageColors` handling was retained, so the existing theme background remains available without enabling pdf.js color replacement.

The following alternatives were considered:

Removing all `pageColors` handling would preserve document colors but would regress the existing theme background behavior. Replacing the foreground with another value would continue to enable pdf.js color replacement.

Links to places where the discussion took place: [Issue #19914](https://github.com/CherryHQ/cherry-studio/issues/19914)

### Breaking changes

None.

### Special notes for your reviewer

- Added regression coverage for preserving PDF colors during initial rendering and theme updates.
- Focused PDF component tests pass: 12/12.
- Documentation: no user-guide update is required because this restores the expected PDF preview behavior without changing the user workflow.


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[PDF preview] Preserve colors in colored PDF documents.
```
