### PR TITLE
fix(web-search): keep private targets out of the Jina fetch fallback

### DIFF
--- a/docs/references/security/remote-fetch.md
+++ b/docs/references/security/remote-fetch.md
@@ -40,10 +40,20 @@ and credential validation, connection pinning, redirect limits, and the response
 Turning it off restores the full guard.
 
 `sanitizeRemoteUrl` takes the same flag as its third argument. Pass it wherever the literal guard
-runs as a precheck in front of `fetchRemoteText` — citation preview and the web-search fetch
-fallback do — otherwise the precheck rejects a target the pinned fetch would have accepted, and the
-preference silently does nothing on that path. Callers that guard a `net.fetch` of a
-provider-configured endpoint keep the default and rely on `configuredApiHost` instead.
+runs as a precheck in front of `fetchRemoteText` — citation preview does — otherwise the precheck
+rejects a target the pinned fetch would have accepted, and the preference silently does nothing on
+that path. Callers that guard a `net.fetch` of a provider-configured endpoint keep the default and
+rely on `configuredApiHost` instead.
+
+The preference governs what this app may connect to, never what may leave it. A guard in front of a
+third-party service — the web-search Jina fetch fallback is the only one — always passes
+`allowPrivateNetwork: false`, whatever the preference says. Such a guard is also weaker than a
+pinned fetch: `resolveRemoteFetchUrl` returns the first non-blocked DNS answer because its caller
+pins the connection to it, but a disclosure guard drops that address and sends the hostname. So a
+hostname with both a public and a private answer passes, and under Clash/Surge fake-IP mode every
+hostname resolves into `198.18.0.0/15` and passes. Both are accepted rather than closed: rejecting
+the second would break the fallback for every fake-IP user. Literal private IPs and `localhost` are
+rejected on every setup.
 
 ## Why Not `net.fetch`
 

--- a/src/main/services/webSearch/WebSearchService.ts
+++ b/src/main/services/webSearch/WebSearchService.ts
@@ -3,7 +3,7 @@ import { loggerService } from '@logger'
 import { TraceMethod } from '@main/ai/observability'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { isAbortError } from '@main/utils/error'
-import { sanitizeRemoteUrl } from '@main/utils/remoteUrlSafety'
+import { resolveRemoteFetchUrl } from '@main/utils/remoteUrlSafety'
 import type { WebSearchCapability, WebSearchProvider } from '@shared/data/preference/preferenceTypes'
 import type {
   WebSearchExecutionConfig,
@@ -143,20 +143,27 @@ export class WebSearchService extends BaseService {
       const failedIndexes = mergedResults.flatMap((result, index) => (result.status === 'rejected' ? [index] : []))
       if (failedIndexes.length === 0) break
 
-      const allowPrivateNetwork = application.get('PreferenceService').get('app.fetch.allow_private_network')
-      const fallbackCandidates = failedIndexes.flatMap((index) => {
-        const input = context.inputs[index]
+      const fallbackCandidates = (
+        await Promise.all(
+          failedIndexes.map(async (index) => {
+            const input = context.inputs[index]
 
-        if (context.capability !== 'fetchUrls' || fallbackProviderId !== 'jina') {
-          return [{ index, input }]
-        }
+            if (context.capability !== 'fetchUrls' || fallbackProviderId !== 'jina') {
+              return { index, input }
+            }
 
-        try {
-          return [{ index, input: sanitizeRemoteUrl(input, undefined, allowPrivateNetwork) }]
-        } catch {
-          return []
-        }
-      })
+            // Jina is a third party: private targets stay blocked here regardless of
+            // app.fetch.allow_private_network, which only governs the local fetch.
+            try {
+              const resolved = await resolveRemoteFetchUrl(input, { allowPrivateNetwork: false, signal })
+              return { index, input: resolved.url }
+            } catch {
+              return undefined
+            }
+          })
+        )
+      ).filter((candidate) => candidate !== undefined)
+      signal?.throwIfAborted()
 
       if (fallbackCandidates.length === 0) continue
 

--- a/src/main/services/webSearch/WebSearchService.ts
+++ b/src/main/services/webSearch/WebSearchService.ts
@@ -153,7 +153,7 @@ export class WebSearchService extends BaseService {
             }
 
             // Jina is a third party: private targets stay blocked here regardless of
-            // app.fetch.allow_private_network, which only governs the local fetch.
+            // app.fetch.allow_private_network. Ceiling: docs/references/security/remote-fetch.md
             try {
               const resolved = await resolveRemoteFetchUrl(input, { allowPrivateNetwork: false, signal })
               return { index, input: resolved.url }

--- a/src/main/services/webSearch/__tests__/WebSearchService.test.ts
+++ b/src/main/services/webSearch/__tests__/WebSearchService.test.ts
@@ -7,21 +7,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as WebSearchProviderFactoryModule from '../providers/factory'
 
-const {
-  createWebSearchProviderMock,
-  loggerInfoMock,
-  loggerWarnMock,
-  loggerErrorMock,
-  sanitizeRemoteUrlMock,
-  resolveRemoteFetchUrlMock
-} = vi.hoisted(() => ({
-  createWebSearchProviderMock: vi.fn(),
-  loggerInfoMock: vi.fn(),
-  loggerWarnMock: vi.fn(),
-  loggerErrorMock: vi.fn(),
-  sanitizeRemoteUrlMock: vi.fn(),
-  resolveRemoteFetchUrlMock: vi.fn()
-}))
+const { createWebSearchProviderMock, loggerInfoMock, loggerWarnMock, loggerErrorMock, resolveRemoteFetchUrlMock } =
+  vi.hoisted(() => ({
+    createWebSearchProviderMock: vi.fn(),
+    loggerInfoMock: vi.fn(),
+    loggerWarnMock: vi.fn(),
+    loggerErrorMock: vi.fn(),
+    resolveRemoteFetchUrlMock: vi.fn()
+  }))
 
 vi.mock('../providers/factory', async (importOriginal) => {
   const actual = await importOriginal<typeof WebSearchProviderFactoryModule>()
@@ -48,7 +41,6 @@ vi.mock('@main/utils/remoteUrlSafety', async (importOriginal) => {
 
   return {
     ...actual,
-    sanitizeRemoteUrl: sanitizeRemoteUrlMock,
     resolveRemoteFetchUrl: resolveRemoteFetchUrlMock
   }
 })
@@ -176,7 +168,9 @@ describe('WebSearchService', () => {
   beforeEach(() => {
     BaseService.resetInstances()
     vi.clearAllMocks()
-    sanitizeRemoteUrlMock.mockImplementation((input: string) => input)
+    resolveRemoteFetchUrlMock.mockImplementation((input: string) =>
+      Promise.resolve({ url: input, address: { address: '93.184.216.34', family: 4 } })
+    )
     MockMainPreferenceServiceUtils.resetMocks()
     setWebSearchPreferences()
     webSearchService = new WebSearchService()
@@ -584,7 +578,7 @@ describe('WebSearchService', () => {
     )
     expect(fetchUrls).toHaveBeenCalledWith('https://example.com/first', expect.any(Object), undefined)
     expect(createWebSearchProviderMock).toHaveBeenCalledTimes(1)
-    expect(sanitizeRemoteUrlMock).not.toHaveBeenCalled()
+    expect(resolveRemoteFetchUrlMock).not.toHaveBeenCalled()
     expect(result).toEqual({
       query: 'https://example.com/first',
       providerId: 'fetch',
@@ -674,8 +668,7 @@ describe('WebSearchService', () => {
     expect(result.results[0]?.title).toBe('Recovered')
   })
 
-  it('falls back from native fetch to Jina after passing the failed hostname through the literal URL guard', async () => {
-    MockMainPreferenceServiceUtils.setPreferenceValue('app.fetch.allow_private_network', false)
+  it('falls back from native fetch to Jina after passing the failed hostname through the DNS guard', async () => {
     const primaryError = new Error('native failed')
     const nativeFetch = vi.fn().mockRejectedValue(primaryError)
     const jinaFetch = vi
@@ -691,8 +684,10 @@ describe('WebSearchService', () => {
 
     const result = await webSearchService.fetchUrlsUnprocessed({ urls: ['https://fake-ip.example/article'] })
 
-    expect(sanitizeRemoteUrlMock).toHaveBeenCalledWith('https://fake-ip.example/article', undefined, false)
-    expect(resolveRemoteFetchUrlMock).not.toHaveBeenCalled()
+    expect(resolveRemoteFetchUrlMock).toHaveBeenCalledWith('https://fake-ip.example/article', {
+      allowPrivateNetwork: false,
+      signal: undefined
+    })
     expect(jinaFetch).toHaveBeenCalledWith('https://fake-ip.example/article', expect.any(Object), undefined)
     expect(result.results).toEqual([
       {
@@ -725,7 +720,7 @@ describe('WebSearchService', () => {
     const result = await webSearchService.fetchUrls({ providerId: 'jina', urls: ['https://example.com/article'] })
 
     expect(nativeFetch).toHaveBeenCalledWith('https://example.com/article', expect.any(Object), undefined)
-    expect(sanitizeRemoteUrlMock).not.toHaveBeenCalled()
+    expect(resolveRemoteFetchUrlMock).not.toHaveBeenCalled()
     expect(result.providerId).toBe('fetch')
     expect(result.results).toHaveLength(1)
   })
@@ -783,44 +778,41 @@ describe('WebSearchService', () => {
 
     await expect(request).rejects.toBe(abortError)
     expect(createWebSearchProviderMock).toHaveBeenCalledTimes(1)
-    expect(sanitizeRemoteUrlMock).not.toHaveBeenCalled()
+    expect(resolveRemoteFetchUrlMock).not.toHaveBeenCalled()
   })
 
-  it('keeps the native failure when the literal URL guard rejects a private address before Jina', async () => {
+  it('keeps the native failure when the guard rejects a private address before Jina', async () => {
     MockMainPreferenceServiceUtils.setPreferenceValue('app.fetch.allow_private_network', false)
+    const { resolveRemoteFetchUrl } = await vi.importActual<typeof RemoteUrlSafetyModule>('@main/utils/remoteUrlSafety')
+    resolveRemoteFetchUrlMock.mockImplementation(resolveRemoteFetchUrl)
     const primaryError = new Error('native failed')
     const nativeFetch = vi.fn().mockRejectedValue(primaryError)
-    sanitizeRemoteUrlMock.mockImplementation(() => {
-      throw new Error('Unsafe remote url')
-    })
     createWebSearchProviderMock.mockReturnValue({ fetchUrls: nativeFetch })
 
     await expect(webSearchService.fetchUrls({ urls: ['http://127.0.0.1/article'] })).rejects.toBe(primaryError)
 
     expect(createWebSearchProviderMock).toHaveBeenCalledTimes(1)
-    expect(sanitizeRemoteUrlMock).toHaveBeenCalledWith('http://127.0.0.1/article', undefined, false)
-    expect(resolveRemoteFetchUrlMock).not.toHaveBeenCalled()
   })
 
-  it('reaches the Jina fallback for a private address when app.fetch.allow_private_network is on', async () => {
+  it('never sends a private address to Jina even when app.fetch.allow_private_network is on', async () => {
     MockMainPreferenceServiceUtils.setPreferenceValue('app.fetch.allow_private_network', true)
-    const nativeFetch = vi.fn().mockRejectedValue(new Error('native failed'))
-    const jinaFetch = vi
-      .fn()
-      .mockResolvedValue(
-        response('jina', 'fetchUrls', 'http://192.168.1.10/wiki', [
-          { title: 'NAS', content: 'Wiki content', url: 'http://192.168.1.10/wiki' }
-        ])
-      )
+    const { resolveRemoteFetchUrl } = await vi.importActual<typeof RemoteUrlSafetyModule>('@main/utils/remoteUrlSafety')
+    resolveRemoteFetchUrlMock.mockImplementation(resolveRemoteFetchUrl)
+    const primaryError = new Error('native failed')
+    const nativeFetch = vi.fn().mockRejectedValue(primaryError)
+    const jinaFetch = vi.fn()
     createWebSearchProviderMock.mockImplementation((provider: WebSearchProvider) =>
       provider.id === 'fetch' ? { fetchUrls: nativeFetch } : { fetchUrls: jinaFetch }
     )
 
-    const result = await webSearchService.fetchUrlsUnprocessed({ urls: ['http://192.168.1.10/wiki'] })
+    await expect(
+      webSearchService.fetchUrlsUnprocessed({
+        urls: ['http://192.168.1.10/wiki?token=secret', 'http://localhost:3000/admin']
+      })
+    ).rejects.toBe(primaryError)
 
-    expect(sanitizeRemoteUrlMock).toHaveBeenCalledWith('http://192.168.1.10/wiki', undefined, true)
-    expect(jinaFetch).toHaveBeenCalledWith('http://192.168.1.10/wiki', expect.any(Object), undefined)
-    expect(result.results[0]?.title).toBe('NAS')
+    expect(jinaFetch).not.toHaveBeenCalled()
+    expect(createWebSearchProviderMock).toHaveBeenCalledTimes(1)
   })
 
   it('retains primary and fallback diagnostics when both fetch providers fail', async () => {

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-03-jina-fallback-public-targets-only.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-03-jina-fallback-public-targets-only.md
@@ -2,7 +2,7 @@
 title: Web fetch no longer hands private or unresolvable URLs to Jina Reader
 category: changed
 severity: notice
-introduced_in_pr: TBD
+introduced_in_pr: "#19920"
 date: 2026-09-03
 ---
 

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-03-jina-fallback-public-targets-only.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-03-jina-fallback-public-targets-only.md
@@ -1,0 +1,23 @@
+---
+title: Web fetch no longer hands private or unresolvable URLs to Jina Reader
+category: changed
+severity: notice
+introduced_in_pr: TBD
+date: 2026-09-03
+---
+
+## What changed
+
+When the built-in web fetch fails and falls back to Jina Reader, the URL is now checked against the public-network guard first, and that check ignores "Allow fetching local network addresses". A `localhost` or LAN target, a hostname that resolves to a private address, or a hostname the local DNS cannot resolve at all is never sent to Jina; the original fetch error is reported instead.
+
+## Why this matters to the user
+
+Previously, with "Allow fetching local network addresses" on (the default), a failed fetch of an intranet page such as a NAS, wiki, or dev server sent the full URL, including path and query string, to the third-party Jina Reader service. Jina could never reach those hosts, so no content was lost, but the URL itself was disclosed. That disclosure is now gone. The one visible narrowing: a public domain that the local resolver blocks (for example a Pi-hole or corporate filtering DNS) used to reach Jina through the fallback and now stays failed.
+
+## What the user should do
+
+Nothing — automatic. Users who rely on the Jina fallback for domains their local DNS blocks can select Jina as the fetch provider directly instead of relying on the fallback.
+
+## Notes for release manager
+
+Related to [[2026-08-18-fetch-allows-private-network-by-default]]: that switch still governs what the app itself may connect to; it never governed what may leave the machine, which this entry makes explicit. Clash/Surge fake-IP targets still pass the guard via the `198.18.0.0/15` carve-out from [[2026-08-18-fetch-allows-fake-ip-and-nat64]].


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

When the native fetch provider failed and fell back to Jina Reader, the fallback's URL guard honored `app.fetch.allow_private_network`. That preference is on by default (#18791), so a failed fetch of a `localhost` or LAN page, such as a NAS, wiki, or dev server, sent the full URL, including hostname, path, and query string, to the third-party Jina Reader service. Jina could never reach those hosts, so the only effect was the disclosure. The existing test suite pinned this as expected behavior.

After this PR:

Every fallback candidate goes through `resolveRemoteFetchUrl` with private addresses always blocked, independent of the preference. Literal private IPs, `localhost`, and hostnames that resolve to private addresses are never handed to Jina; the native fetch error is reported instead. Hostnames the local resolver cannot answer fail closed. Candidates resolve in parallel, and the caller's abort still propagates through the guard.

Fixes #

### Why we need it and why it was done in this way

`app.fetch.allow_private_network` governs what the app itself may connect to. It never governed what may leave the machine, and #17806, which introduced the fallback, stated that private targets remain blocked from it. #18791 threaded the preference into the fallback guard without that distinction, which reopened the disclosure.

The following tradeoffs were made:

- The guard resolves DNS rather than only checking literal addresses. The use cases that motivated #18791 are hostnames (`http://wiki.corp/`, `http://nas.local/`), not IPs, so a literal-only guard would leave the headline case leaking. #17806 chose literal-only to keep Surge/Clash fake-IP users working; the `198.18.0.0/15` carve-out added in #18791 now lets those targets pass the DNS guard.
- Local DNS failure fails closed. A public domain the local resolver blocks (Pi-hole, filtering corporate DNS) no longer reaches Jina through the fallback. If the app cannot prove a target is public, it does not disclose it. Users who want Jina for such domains can select Jina as the fetch provider directly, which does not go through this guard.
- DNS lookups for a batch run in parallel so the fallback start is not delayed by the sum of lookups.

The following alternatives were considered:

- Passing `allowPrivateNetwork: false` to the existing literal guard only. One line, but leaves hostname-based intranet URLs leaking.
- A separate preference for the fallback. Rejected: there is no user split that needs it; the right default is to never disclose private targets.

Links to places where the discussion took place: #17806, #18791

### Breaking changes

Web fetch fallback no longer sends private or locally-unresolvable URLs to Jina Reader. Recorded in `v2-refactor-temp/docs/breaking-changes/2026-09-03-jina-fallback-public-targets-only.md`.

### Special notes for your reviewer

- The replaced test asserted the leak. Its replacement uses the real `resolveRemoteFetchUrl` for literal IPs (no DNS involved) and asserts that a LAN IP with a query string and a `localhost` URL never reach the Jina driver with the preference on. It fails on the previous service code.
- `CitationPreviewService` and `remoteFetch` also pass the preference to the guard; both feed the local `fetchRemoteText`, so they are correctly scoped and untouched.
- The second commit only fills `introduced_in_pr` in the breaking-changes entry with this PR's number.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Web fetch no longer sends localhost, LAN, or locally-unresolvable URLs to Jina Reader when the built-in fetch fails, regardless of the "Allow fetching local network addresses" setting.
```

