### PR TITLE
chore(selection): upgrade selection-hook to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "pdfjs-dist": "5.4.296",
     "ppu-paddle-ocr": "6.0.0",
     "registry-js": "1.16.1",
-    "selection-hook": "2.0.3",
+    "selection-hook": "2.1.1",
     "sharp": "0.35.3",
     "smol-toml": "^1.7.0",
     "sqlite-vec": "npm:@aiany/sqlite-vec@0.1.10-alpha.4.aiany.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: 1.16.1
         version: 1.16.1
       selection-hook:
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: 2.1.1
+        version: 2.1.1
       sharp:
         specifier: 0.35.3
         version: 0.35.3(@types/node@24.10.4)
@@ -14467,8 +14467,8 @@ packages:
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
-  selection-hook@2.0.3:
-    resolution: {integrity: sha512-wo9xqfRG9lnJWtzFCvl3XBDjV/Qfm9QG/hS8IFsWgSgjJdaJCv7oDtFGefAozpNAx5WvalSjdyLKmIOXHT0Xtw==}
+  selection-hook@2.1.1:
+    resolution: {integrity: sha512-8ZqU2ModYR7Ji2s/T4GUgxBeZw2oeOJZeYMyMT6kxZUPkJUD193kGLIF1mxqlV6pYSmo0CBGi9mW8468PsMuYA==}
     engines: {node: '>=18.0.0'}
 
   semver-compare@1.0.0:
@@ -30267,7 +30267,7 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
-  selection-hook@2.0.3:
+  selection-hook@2.1.1:
     dependencies:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`selection-hook` was pinned to `2.0.3`. On Windows the hook ran automatic text retrieval on the caller thread, so a UI Automation provider call issued from the Electron main thread could block or crash the window while an owned file dialog was active (for example, shift-selecting multiple files). On macOS the cursor shape was sampled only at mouse-down and mouse-up, so fast or margin-to-margin drags produced no text-selection event. Tearing down the Node-API environment with an active hook could cause access violations on Windows and hangs on macOS.

After this PR:

`selection-hook` is pinned to `2.1.1`, which fixes all three upstream defects. No source file in this repository changes; the upgrade is confined to `package.json` and `pnpm-lock.yaml`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The upgrade spans two upstream releases (`2.1.0` and `2.1.1`) rather than a single patch bump, because `2.1.1` builds on the thread-model rework in `2.1.0` and upstream does not backport. Both releases are additive: upstream states that `index.js` and `index.d.ts` are unchanged from `2.0.3`, and `pnpm run typecheck:node` passing without any source edit confirms the API surface this app consumes is intact. Nothing in `selectionConfig.ts` is touched, so the predefined blacklist and fine-tuned lists keep their current behavior.

`2.1.0` matters here specifically because `SelectionService` runs the hook directly on the main process — there is no `utilityProcess` isolation anywhere in `src/` — which is exactly the usage pattern that upstream issue 17 describes. `2.1.1` matters because this app force-exits through `app.exit(0)` on relaunch, bypassing service shutdown, so the hook can still be active when the Node-API environment is destroyed; `2.1.1` stops native producers before releasing their thread-safe functions and no longer requires an explicit `stop()` or `cleanup()` first.

The following alternatives were considered:

Upgrading only to `2.1.0` would pick up the Windows and macOS retrieval fixes but leave the teardown races unfixed on the force-exit path this app relies on. Staying on `2.0.3` and adding an application-side workaround (routing the hook through a `utilityProcess`, or excluding the app's own executable from selection monitoring) was rejected: upstream explicitly documents that the `utilityProcess` workaround is no longer needed as of `2.1.0`, and a downstream exclusion would suppress a legitimate feature rather than fix the defect.

Links to places where the discussion took place: [selection-hook v2.1.0](https://github.com/0xfullex/selection-hook/releases/tag/v2.1.0), [selection-hook v2.1.1](https://github.com/0xfullex/selection-hook/releases/tag/v2.1.1)

### Breaking changes

None. Upstream reports no public API, TypeScript definition or configuration changes across both releases. Node.js 18+ / Electron 23+ requirements are unchanged, and no preference, schema or migration is involved.

### Special notes for your reviewer

Native-module upgrades have a build-time failure mode that a passing test suite does not cover, so the packaging path was verified explicitly:

- `electron-builder.yml` excludes `node_modules/selection-hook/prebuilds/**/*` and rebuilds the addon from source, and `2.1.0` restructured the native sources (Windows gained `core/engine.cc` and `core/worker.cc`, macOS gained `core/engine.mm`). The `binding.gyp` `sources` lists were checked against the shipped tree and match one-to-one on all three platforms.
- `electron-rebuild --force --only selection-hook` compiles `2.1.1` cleanly against the Electron headers. Build artifacts produced by that check were removed afterwards, so the installed package matches the published tarball exactly.
- The addon is Node-API (`NAPI_VERSION=8`), so no ABI-specific rebuild step is needed for the Node-based test runner.
- `pnpm run typecheck:node` passes, and `src/main/services/selection/__tests__/SelectionService.test.ts` passes 10/10.
- Windows and Linux behavior could not be exercised on this machine; both rely on upstream CI, which as of `2.1.0` runs unit and integration tiers on Windows, macOS, Linux x64 and Linux arm64 and gates the npm publish workflow.
- Documentation: no user-guide update is required because this restores expected Selection Assistant behavior without changing the user workflow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Selection Assistant] Fix the window hanging or crashing when shift-selecting multiple files in a file dialog on Windows.
[Selection Assistant] Fix text selection being missed on fast or margin-to-margin drags on macOS.
```
