### PR TITLE
fix: refine skill details and navigation chrome

### DIFF
--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -199,7 +199,8 @@ export function Sidebar({
             floatingPointerInsideRef.current = true
             clearHoverDismiss()
           }}>
-          <div className={cn('flex shrink-0 px-2', isMac ? 'h-10' : 'h-12 items-center', windowDragClassName)}>
+          <div
+            className={cn('flex shrink-0 px-2', isMac ? 'h-10 items-start' : 'h-12 items-center', windowDragClassName)}>
             {renderHeaderIdentity('default', true)}
           </div>
 
@@ -273,7 +274,7 @@ export function Sidebar({
       <div
         className={cn(
           'flex shrink-0',
-          isMac ? 'h-10' : 'h-12 items-center',
+          isMac ? 'h-10 items-start' : 'h-12 items-center',
           windowDragClassName,
           layout === 'full' ? 'px-2' : 'justify-center'
         )}>

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -72,7 +72,7 @@ export function Sidebar({
     <div
       className={cn(
         'flex shrink-0 items-center justify-center overflow-hidden *:h-full *:w-full',
-        size === 'sm' ? 'size-7.5 rounded-lg' : 'size-6 rounded-lg'
+        size === 'sm' ? 'size-8 rounded-lg' : 'size-6 rounded-lg'
       )}>
       {logoNode}
     </div>
@@ -199,7 +199,7 @@ export function Sidebar({
             floatingPointerInsideRef.current = true
             clearHoverDismiss()
           }}>
-          <div className={cn('flex h-11 shrink-0 items-center px-2', windowDragClassName)}>
+          <div className={cn('flex shrink-0 px-2', isMac ? 'h-10' : 'h-12 items-center', windowDragClassName)}>
             {renderHeaderIdentity('default', true)}
           </div>
 
@@ -272,9 +272,10 @@ export function Sidebar({
       {/* Header */}
       <div
         className={cn(
-          'flex shrink-0 items-center',
+          'flex shrink-0',
+          isMac ? 'h-10' : 'h-12 items-center',
           windowDragClassName,
-          layout === 'full' ? 'h-11 px-2' : 'h-11 justify-center'
+          layout === 'full' ? 'px-2' : 'justify-center'
         )}>
         {renderHeaderIdentity(layout === 'icon' ? 'sm' : 'default', layout === 'full')}
       </div>

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -24,6 +24,7 @@ export interface SidebarProps {
   logo?: React.ReactNode
   user?: SidebarUser
   isFloating?: boolean
+  isFullscreen?: boolean
   searchLabel?: string
   extensionsLabel?: string
   actions?: SidebarFooterActions
@@ -45,6 +46,7 @@ export function Sidebar({
   logo,
   user,
   isFloating = false,
+  isFullscreen = false,
   searchLabel = '',
   extensionsLabel = '',
   actions,
@@ -200,7 +202,11 @@ export function Sidebar({
             clearHoverDismiss()
           }}>
           <div
-            className={cn('flex shrink-0 px-2', isMac ? 'h-10 items-start' : 'h-12 items-center', windowDragClassName)}>
+            className={cn(
+              'flex shrink-0 px-2',
+              isMac && !isFullscreen ? 'h-10 items-start' : 'h-12 items-center',
+              windowDragClassName
+            )}>
             {renderHeaderIdentity('default', true)}
           </div>
 
@@ -274,7 +280,7 @@ export function Sidebar({
       <div
         className={cn(
           'flex shrink-0',
-          isMac ? 'h-10 items-start' : 'h-12 items-center',
+          isMac && !isFullscreen ? 'h-10 items-start' : 'h-12 items-center',
           windowDragClassName,
           layout === 'full' ? 'px-2' : 'justify-center'
         )}>

--- a/src/renderer/components/Sidebar/__tests__/primitives.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/primitives.test.tsx
@@ -19,7 +19,7 @@ describe('UserAvatar', () => {
     const emojiIcon = screen.getByTestId('emoji-icon')
     expect(emojiIcon).toHaveTextContent('🌈')
     expect(emojiIcon).toHaveAttribute('data-fluid', 'true')
-    expect(emojiIcon).toHaveAttribute('data-font-size', '10')
+    expect(emojiIcon).toHaveAttribute('data-font-size', '17')
     expect(screen.getByTestId('emoji-icon-background')).toHaveTextContent('🌈')
     // Emoji avatars must not fall through to the gradient-initial branch.
     // The gradient classes live on the inner fallback div, so query that element directly.

--- a/src/renderer/components/Sidebar/primitives.tsx
+++ b/src/renderer/components/Sidebar/primitives.tsx
@@ -85,7 +85,7 @@ export function UserAvatar({
       {user.avatar && !isTextAvatar(user.avatar) ? (
         <img src={user.avatar} alt={user.name} className="h-full w-full object-cover" />
       ) : isEmojiAvatar ? (
-        <EmojiIcon emoji={user.avatar!} fluid fontSize={10} />
+        <EmojiIcon emoji={user.avatar!} fluid fontSize={17} />
       ) : (
         <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-blue-400 to-indigo-500 text-[10px] text-white">
           {getUserAvatarFallback(user)}

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -38,7 +38,13 @@ import { resolveSidebarEntry, type SidebarVariantContext } from './sidebarVarian
 
 const FeedbackDialog = lazy(() => import('../feedback/FeedbackDialog'))
 
-export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
+export default function Sidebar({
+  ref,
+  isFullscreen = false
+}: {
+  ref?: Ref<HTMLDivElement | null>
+  isFullscreen?: boolean
+}) {
   const { t } = useTranslation()
   const [userName] = usePreference('app.user.name')
   const {
@@ -356,6 +362,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
 
   // Common props shared between normal and floating sidebar
   const sidebarProps = {
+    isFullscreen,
     entries,
     active: { activeItem, activeTabId: activeMiniAppId },
     title: sidebarUser.name,

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -236,7 +236,7 @@ export const AppShell = () => {
           'flex h-screen w-screen flex-row overflow-hidden text-foreground',
           isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
         )}>
-        {!isSettingsTabActive && <Sidebar />}
+        {!isSettingsTabActive && <Sidebar isFullscreen={isFullscreen} />}
         {contentColumn}
       </div>
     )
@@ -264,7 +264,7 @@ export const AppShell = () => {
               className="h-11 shrink-0 [-webkit-app-region:drag]"
             />
           )}
-          <Sidebar />
+          <Sidebar isFullscreen={isFullscreen} />
         </div>
       )}
       {contentColumn}

--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -147,7 +147,8 @@ const PinnedTabButton = ({
   )
 }
 
-const MACOS_TAB_STRIP_TRAFFIC_LIGHT_RESERVE = 'max(0px, calc(env(titlebar-area-x, 0px) - var(--sidebar-width, 0px)))'
+const MACOS_TAB_STRIP_TRAFFIC_LIGHT_RESERVE =
+  'max(0px, calc(env(titlebar-area-x, 0px) - var(--sidebar-width, 0px) + 2px))'
 
 type FocusedTabButtonProps = {
   tab: Tab
@@ -923,7 +924,11 @@ export const AppShellTabBar = ({
           data-testid="app-shell-tab-strip"
           style={
             isMac && !isFullscreen
-              ? { paddingLeft: isFocusedTab ? 'env(titlebar-area-x)' : MACOS_TAB_STRIP_TRAFFIC_LIGHT_RESERVE }
+              ? {
+                  paddingLeft: isFocusedTab
+                    ? 'calc(env(titlebar-area-x, 0px) + 2px)'
+                    : MACOS_TAB_STRIP_TRAFFIC_LIGHT_RESERVE
+                }
               : undefined
           }
           onMouseEnter={() => {

--- a/src/renderer/components/resourceCatalog/dialogs/detail/SkillDetailDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/detail/SkillDetailDialog.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Dialog, DialogContent, DialogHeader, DialogTitle, Separator } from '@cherrystudio/ui'
+import { Badge, Button, Dialog, DialogContent, DialogHeader, DialogTitle, Scrollbar, Separator } from '@cherrystudio/ui'
 import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
 import { ipcApi } from '@renderer/ipc'
 import { loggerService } from '@renderer/services/LoggerService'
@@ -114,7 +114,7 @@ const SkillDetailDialog: FC<Props> = ({ skill, open, onOpenChange }) => {
           </div>
         </DialogHeader>
 
-        <div className="max-h-[60vh] space-y-6 overflow-y-auto pr-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[var(--scrollbar-thumb)] [&::-webkit-scrollbar]:w-1">
+        <Scrollbar className="max-h-[60vh] space-y-6 pr-1">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <Badge
               variant="secondary"
@@ -158,7 +158,7 @@ const SkillDetailDialog: FC<Props> = ({ skill, open, onOpenChange }) => {
               </div>
             </div>
           </section>
-        </div>
+        </Scrollbar>
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/components/resourceCatalog/dialogs/detail/SkillFileBrowser.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/detail/SkillFileBrowser.tsx
@@ -1,4 +1,4 @@
-import { Button, Markdown } from '@cherrystudio/ui'
+import { Button, Markdown, Scrollbar } from '@cherrystudio/ui'
 import { FileTree, type FileTreeNode } from '@renderer/components/FileTree'
 import { useTranslate } from '@renderer/hooks/translate'
 import { loggerService } from '@renderer/services/LoggerService'
@@ -238,7 +238,7 @@ export function SkillFileBrowser({ skillId }: Props) {
             ) : null}
           </div>
 
-          <div className="min-h-0 flex-1 overflow-auto">
+          <Scrollbar className="min-h-0 flex-1 overflow-x-auto">
             {loadingContent ? (
               <PreviewLoading />
             ) : selectedFile && previewContent !== null ? (
@@ -268,7 +268,7 @@ export function SkillFileBrowser({ skillId }: Props) {
                 <span className="text-xs">{t('library.skill_detail.select_file')}</span>
               </div>
             )}
-          </div>
+          </Scrollbar>
         </div>
       </div>
     </section>

--- a/src/renderer/components/resourceCatalog/dialogs/detail/__tests__/SkillDetailDialog.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/detail/__tests__/SkillDetailDialog.test.tsx
@@ -77,6 +77,7 @@ vi.mock('@cherrystudio/ui', () => {
     ),
     DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+    Scrollbar: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     Separator: () => <hr />
   }
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Skills detail views used native scrollbars, and Sidebar avatar sizing and macOS title-bar spacing were visually inconsistent.

After this PR: Skills detail views use the shared Scrollbar, Sidebar avatars have improved sizing and emoji parity, and macOS navigation chrome has refined spacing while other platforms retain their existing layout.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Platform-specific Sidebar and TabBar spacing remains local to the existing components, while scroll behavior reuses `@cherrystudio/ui`.

The following alternatives were considered: Keeping custom scrollbar CSS was rejected because it would continue duplicating the shared component behavior.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validated with focused renderer tests, `pnpm lint`, and an isolated macOS Electron instance.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Improved Skills detail scrolling and Sidebar avatar and title-bar alignment.
```
