### PR TITLE
fix(i18n): add missing Turkish finish-reason error string

### DIFF
--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -1256,6 +1256,7 @@
   "error.lastError": "Son Hata",
   "error.maxEmbeddingsPerCall": "Çağrı Başına Maksimum Gömme Sayısı",
   "error.message": "Hata Mesajı",
+  "error.missing_finish_reason": "<provider>{{provider}}</provider> yanıtı bir bitiş nedeni döndürmeden sonlandırdı. Alınan kısmi yanıt korundu; isteği yeniden deneyin.",
   "error.missing_user_message": "Model yanıtı değiştirilemiyor: Kullanıcının özgün mesajı silinmiş. Bu modelden yanıt almak için yeni bir mesaj gönderin.",
   "error.model.exists": "Model zaten mevcut",
   "error.model.not_exists": "Model mevcut değil",


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: `main` CI was red — the `basic-checks / I18N Translation Check` job failed because #19870 added `error.missing_finish_reason` to `en-us.json` and every locale except `tr-tr.json`, so `pnpm i18n:sync` regenerated a `[to be translated]:` placeholder in CI.

After this PR: `tr-tr.json` carries the Turkish translation of that key, `pnpm i18n:sync` produces no diff, and `pnpm i18n:check` passes.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: None — the gate requires a real translation, so the only fix is to supply one.

The following alternatives were considered: None; reverting #19870 or relaxing the i18n gate would be worse than adding the missing string.

Links to places where the discussion took place: [Failing run 33759177064](https://github.com/CherryHQ/cherry-studio/actions/runs/33759177064)

### Breaking changes

None.

### Special notes for your reviewer

Single-line locale addition; the interpolation and `<provider>` tag match the `en-us` source string. A Turkish speaker's sanity check on the wording is welcome.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
