### PR TITLE
fix(topic-naming): preserve OpenCode session identity

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -222,6 +222,8 @@ export type AsInProcess<T extends AiBaseRequest> = Omit<T, 'requestOptions'> & {
 
 /** Non-streaming text generation request — pure transport data. */
 export interface AiGenerateRequest extends AiBaseRequest {
+  /** Stable conversation identity used for provider routing and request tracing. */
+  chatId?: string
   system?: string
   prompt?: string
   messages?: ModelMessage[]

--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -208,7 +208,11 @@ export class TopicNamingService {
       ]
 
       const uniqueModelId = this.resolveNamingModelId()
-      const title = await this.generateSummaryTitle(uniqueModelId, buildStructuredConversation(structuredConversation))
+      const title = await this.generateSummaryTitle(
+        uniqueModelId,
+        topicId,
+        buildStructuredConversation(structuredConversation)
+      )
       if (!title) return
 
       this.renameTopicIfStillAuto(topic.id, title, userText)
@@ -307,7 +311,11 @@ export class TopicNamingService {
         { role: finalMessage.role, mainText: cleanMarkdownImages(getMainTextContentFromUiMessage(finalMessage)) }
       ]
 
-      const title = await this.generateSummaryTitle(uniqueModelId, buildStructuredConversation(structuredConversation))
+      const title = await this.generateSummaryTitle(
+        uniqueModelId,
+        sessionId,
+        buildStructuredConversation(structuredConversation)
+      )
       if (!title) return
 
       const nextName = sanitizeConversationTitle(title)
@@ -355,7 +363,11 @@ export class TopicNamingService {
     }
   }
 
-  private async generateSummaryTitle(uniqueModelId: UniqueModelId, prompt: string): Promise<string | null> {
+  private async generateSummaryTitle(
+    uniqueModelId: UniqueModelId,
+    chatId: string,
+    prompt: string
+  ): Promise<string | null> {
     const systemPrompt = this.resolveNamingPrompt()
     // A title is a throwaway 10-word summary: never carry the source assistant /
     // agent id, or buildAgentParams resolves its tool configuration (MCP tools,
@@ -363,6 +375,7 @@ export class TopicNamingService {
     // the renderer omits assistantId for the same reason.
     const request: AiGenerateRequest = {
       uniqueModelId,
+      chatId,
       system: systemPrompt,
       prompt,
       // A title is 10 words: never reason. Set this explicitly so the request builder does not

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -129,6 +129,7 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
+        chatId: 'topic-1',
         uniqueModelId: 'openai::gpt-4o-mini'
       })
     )
@@ -279,6 +280,7 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
+        chatId: 'session-1',
         uniqueModelId: 'openai::gpt-4o-mini'
       })
     )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

OpenCode Go automatic title-generation requests omitted the stable conversation identity, so `x-opencode-session` was absent even though the main inference request included it.

After this PR:

Topic and Agent-session title requests pass their existing IDs through `AiGenerateRequest.chatId`, reusing the provider routing that injects the OpenCode header while respecting an explicitly configured header.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19938

### Why we need it and why it was done in this way

OpenCode Go requires a stable per-conversation routing identity; the provider builder and header-precedence behavior were already correct, so the fix belongs at the title-request boundary where the identity was lost.

The following tradeoffs were made:

- `chatId` remains optional for unrelated one-shot text-generation requests.

The following alternatives were considered:

- Adding `x-opencode-session` directly in `TopicNamingService` was rejected because it would duplicate provider-specific policy and risk sending the header to unrelated providers.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19938

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A.

### Special notes for your reviewer

Validated with the focused topic-naming, request-parameter, and provider-config test suites (205 tests), plus `pnpm lint`; existing provider tests cover OpenCode-only injection and explicit-header precedence.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: N/A - this is a focused bug fix
- [x] Upgrade: Impact of this change on upgrade flows was considered and no migration is required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for correcting existing provider behavior
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
OpenCode Go automatic conversation titles now preserve session identity, preventing title generation failures when the provider requires `x-opencode-session`.
```
