### PR TITLE
fix(agent-workspace): reject filesystem roots

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -614,6 +614,15 @@ export class AgentSessionRuntimeService extends BaseService {
    */
   async primeConnection(sessionId: string): Promise<void> {
     try {
+      const liveEntry = this.entries.get(sessionId)
+      const liveConnection = liveEntry ? this.currentConnection(liveEntry) : undefined
+      if (liveEntry && liveConnection) {
+        // Re-prime of a live session (e.g. a second window opening it): re-read and republish the
+        // catalog without a fallible validation/reconcile pass over an already-running connection.
+        this.refreshSupportedCommands(liveEntry, liveConnection)
+        return
+      }
+
       const session = agentSessionService.getById(sessionId)
       if (!session?.agentId) return
       const agent = agentService.getAgent(session.agentId)
@@ -624,9 +633,6 @@ export class AgentSessionRuntimeService extends BaseService {
 
       const existing = this.entries.get(sessionId)
       if (existing) {
-        // Re-prime of a live session (e.g. a second window opening it): re-read and republish the
-        // catalog so a consumer that mounts after the initial publish still gets it — `ensureConnection`
-        // alone skips the read when the connection already exists.
         void this.ensureConnection(existing)
           .then((connected) => {
             if (connected) this.refreshSupportedCommands(existing)

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -614,6 +614,14 @@ export class AgentSessionRuntimeService extends BaseService {
    */
   async primeConnection(sessionId: string): Promise<void> {
     try {
+      const session = agentSessionService.getById(sessionId)
+      if (!session?.agentId) return
+      const agent = agentService.getAgent(session.agentId)
+      if (!agent?.model) return
+      const driver = runtimeDriverRegistry.getAgentSessionDriver(agent.type)
+      if (!driver) return
+      await driver.validateSession(session)
+
       const existing = this.entries.get(sessionId)
       if (existing) {
         // Re-prime of a live session (e.g. a second window opening it): re-read and republish the
@@ -626,12 +634,6 @@ export class AgentSessionRuntimeService extends BaseService {
           .catch((error) => logger.warn('Failed to re-prime agent session connection', { sessionId, error }))
         return
       }
-
-      const session = agentSessionService.getById(sessionId)
-      if (!session?.agentId) return
-      const agent = agentService.getAgent(session.agentId)
-      if (!agent?.model) return
-      if (!runtimeDriverRegistry.getAgentSessionDriver(agent.type)) return
 
       // Resolve the session's container trace id up front so the primed connection carries the same
       // trace context the first turn will. The connection is reused across turns, so without this its

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -3486,6 +3486,31 @@ describe('AgentSessionRuntimeService', () => {
   })
 
   describe('primeConnection — eager command load on session open', () => {
+    it('does not open a connection when session validation fails', async () => {
+      const session = {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { id: 'workspace-1', path: '/', type: 'user' }
+      }
+      const validateSession = vi.fn().mockRejectedValue(new Error('filesystem root is not allowed'))
+      const connect = vi.fn()
+      runtimeDriverRegistry.register({
+        type: 'test-runtime',
+        capabilities: ['agent-session'],
+        connect,
+        validateSession,
+        listAvailableTools: vi.fn().mockResolvedValue([])
+      })
+      mocks.getSessionById.mockReturnValue(session)
+
+      const service = new AgentSessionRuntimeService()
+      await service.primeConnection('session-1')
+
+      expect(validateSession).toHaveBeenCalledWith(session)
+      expect(connect).not.toHaveBeenCalled()
+      expect(service.inspect('session-1')).toBeUndefined()
+    })
+
     it('opens the connection without a turn and caches the slash-command catalog', async () => {
       const commands = [{ name: 'clear', description: 'Clear conversation' }]
       const events = createAsyncQueue<any>()

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -3586,8 +3586,9 @@ describe('AgentSessionRuntimeService', () => {
       expect(service.inspect('session-1')).toBeUndefined()
     })
 
-    it('re-priming a live session republishes the catalog without rebuilding the connection', async () => {
+    it('re-priming a live session republishes the catalog without revalidation or rebuilding', async () => {
       const commands = [{ name: 'clear', description: 'Clear conversation' }]
+      const validateSession = vi.fn()
       const connection = {
         events: createAsyncQueue<any>().iterable,
         send: vi.fn(),
@@ -3600,7 +3601,7 @@ describe('AgentSessionRuntimeService', () => {
         type: 'test-runtime',
         capabilities: ['agent-session'],
         connect,
-        validateSession: vi.fn(),
+        validateSession,
         listAvailableTools: vi.fn().mockResolvedValue([])
       })
       mocks.getSessionById.mockReturnValue({ id: 'session-1', agentId: 'agent-1' })
@@ -3614,15 +3615,17 @@ describe('AgentSessionRuntimeService', () => {
 
       mocks.cacheSetShared.mockClear()
       connection.getSupportedCommands.mockClear()
+      validateSession.mockRejectedValueOnce(new Error('transient validation failure'))
 
       // Second prime hits the existing-entry branch — it must re-read and republish (so a window
-      // mounting late still gets the catalog), not early-return on the live connection.
+      // mounting late still gets the catalog) without a fallible validation or reconciliation pass.
       await service.primeConnection('session-1')
       await vi.waitFor(() => {
         expect(connection.getSupportedCommands).toHaveBeenCalled()
         expect(mocks.cacheSetShared).toHaveBeenCalledWith('agent.session.slash_commands.session-1', commands)
       })
-      // The existing connection is reused — no second connect.
+      expect(validateSession).toHaveBeenCalledTimes(1)
+      expect(connection.reconcile).not.toHaveBeenCalled()
       expect(connect).toHaveBeenCalledTimes(1)
     })
 

--- a/src/main/ai/runtime/agentSessionWorkspace.test.ts
+++ b/src/main/ai/runtime/agentSessionWorkspace.test.ts
@@ -1,0 +1,58 @@
+import type * as MainFileUtils from '@main/utils/file'
+import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  ensureAgentStorageDirectory: vi.fn(),
+  getPathStatus: vi.fn(),
+  t: vi.fn((key: string, options?: { path?: string }) => `${key}:${options?.path ?? ''}`)
+}))
+
+vi.mock('@application', () => ({ application: { getPath: vi.fn() } }))
+vi.mock('@logger', () => ({
+  loggerService: { withContext: () => ({ warn: vi.fn() }) }
+}))
+vi.mock('@main/ai/agents/agentDataDirectory', () => ({
+  ensureAgentStorageDirectory: mocks.ensureAgentStorageDirectory
+}))
+vi.mock('@main/i18n', () => ({ t: mocks.t }))
+vi.mock('@main/utils/file', async (importActual) => ({
+  ...(await importActual<typeof MainFileUtils>()),
+  getPathStatus: mocks.getPathStatus
+}))
+
+const { AgentSessionWorkspaceError, prepareAgentSessionWorkspaceDirectory } = await import('./agentSessionWorkspace')
+
+function userSession(workspacePath: string): AgentSessionEntity {
+  return {
+    id: 'session-1',
+    workspace: { id: 'workspace-1', path: workspacePath, type: 'user' }
+  } as AgentSessionEntity
+}
+
+describe('prepareAgentSessionWorkspaceDirectory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getPathStatus.mockResolvedValue({ ok: true, kind: 'directory' })
+  })
+
+  it.each(['/', '/./', '/tmp/..'])(
+    'blocks a persisted user workspace that resolves to the filesystem root before probing it: %s',
+    async (workspacePath) => {
+      const promise = prepareAgentSessionWorkspaceDirectory(userSession(workspacePath))
+
+      await expect(promise).rejects.toBeInstanceOf(AgentSessionWorkspaceError)
+      await expect(promise).rejects.toMatchObject({
+        message: `agent.session.workspace_status.filesystem_root:${workspacePath}`,
+        retryable: false
+      })
+      expect(mocks.getPathStatus).not.toHaveBeenCalled()
+    }
+  )
+
+  it('allows a normal nested workspace directory', async () => {
+    await expect(prepareAgentSessionWorkspaceDirectory(userSession('/tmp/project'))).resolves.toBeUndefined()
+
+    expect(mocks.getPathStatus).toHaveBeenCalledWith('/tmp/project')
+  })
+})

--- a/src/main/ai/runtime/agentSessionWorkspace.test.ts
+++ b/src/main/ai/runtime/agentSessionWorkspace.test.ts
@@ -8,7 +8,10 @@ const mocks = vi.hoisted(() => ({
   t: vi.fn((key: string, options?: { path?: string }) => `${key}:${options?.path ?? ''}`)
 }))
 
-vi.mock('@application', () => ({ application: { getPath: vi.fn() } }))
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory()
+})
 vi.mock('@logger', () => ({
   loggerService: { withContext: () => ({ warn: vi.fn() }) }
 }))

--- a/src/main/ai/runtime/agentSessionWorkspace.ts
+++ b/src/main/ai/runtime/agentSessionWorkspace.ts
@@ -4,7 +4,7 @@ import { application } from '@application'
 import { loggerService } from '@logger'
 import { ensureAgentStorageDirectory } from '@main/ai/agents/agentDataDirectory'
 import { t } from '@main/i18n'
-import { getPathStatus, type PathStatus } from '@main/utils/file'
+import { getPathStatus, isFilesystemRoot, type PathStatus } from '@main/utils/file'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
 
@@ -29,6 +29,9 @@ export function isAgentSessionWorkspaceError(error: unknown): error is AgentSess
 
 export async function prepareAgentSessionWorkspaceDirectory(session: AgentSessionEntity): Promise<void> {
   const workspace = session.workspace
+  if (isFilesystemRoot(workspace.path)) {
+    throw new AgentSessionWorkspaceError(t('agent.session.workspace_status.filesystem_root', { path: workspace.path }))
+  }
   switch (workspace.type) {
     case AGENT_WORKSPACE_TYPE.SYSTEM:
       // System workspaces are app-owned session directories; user workspaces

--- a/src/main/ai/runtime/claudeCode/__tests__/buildMcpServers.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildMcpServers.test.ts
@@ -72,7 +72,8 @@ vi.mock('@application', async () => {
 })
 
 vi.mock('@main/utils/file', () => ({
-  getPathStatus: mockGetPathStatus
+  getPathStatus: mockGetPathStatus,
+  isFilesystemRoot: () => false
 }))
 
 vi.mock('@main/ai/agents/agentDataDirectory', () => ({

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -199,6 +199,7 @@ vi.mock('@main/utils/asar', () => ({
 
 vi.mock('@main/utils/file', () => ({
   getPathStatus: mocks.getPathStatus,
+  isFilesystemRoot: () => false,
   isPathInside: (child: string, parent: string) => {
     const relative = path.relative(path.resolve(parent), path.resolve(child))
     return relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)

--- a/src/main/ai/streamManager/context/__tests__/AgentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/AgentChatContextProvider.test.ts
@@ -160,6 +160,9 @@ describe('AgentChatContextProvider', () => {
     expect(mocks.runtimeValidateSession).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'session-1', workspace: { path: '/tmp' } })
     )
+    expect(mocks.runtimeValidateSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.runtimeBeginTurn.mock.invocationCallOrder[0]
+    )
     expect(mocks.saveMessagesTx).toHaveBeenCalledOnce()
     expect(mocks.saveMessage).not.toHaveBeenCalled()
     expect(provider.isPersistentConversation).toBe(true)

--- a/src/main/data/services/AgentWorkspaceService.ts
+++ b/src/main/data/services/AgentWorkspaceService.ts
@@ -7,6 +7,7 @@ import { agentChannelService } from '@data/services/AgentChannelService'
 import { getDataService } from '@data/services/dataServiceRegistry'
 import { applyMoves, insertWithOrderKey } from '@data/services/utils/orderKey'
 import { timestampToISO } from '@data/services/utils/rowMappers'
+import { isFilesystemRoot } from '@main/utils/file'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
 import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import {
@@ -73,6 +74,9 @@ export class AgentWorkspaceService {
     }
     if (!path.isAbsolute(trimmed)) {
       throw DataApiErrorFactory.validation({ path: ['Workspace path must be absolute'] })
+    }
+    if (isFilesystemRoot(trimmed)) {
+      throw DataApiErrorFactory.validation({ path: ['Filesystem roots cannot be used as Agent workspaces'] })
     }
     const normalized = path.normalize(trimmed)
     const root = path.parse(normalized).root

--- a/src/main/data/services/AgentWorkspaceService.ts
+++ b/src/main/data/services/AgentWorkspaceService.ts
@@ -7,6 +7,7 @@ import { agentChannelService } from '@data/services/AgentChannelService'
 import { getDataService } from '@data/services/dataServiceRegistry'
 import { applyMoves, insertWithOrderKey } from '@data/services/utils/orderKey'
 import { timestampToISO } from '@data/services/utils/rowMappers'
+import { t } from '@main/i18n'
 import { isFilesystemRoot } from '@main/utils/file'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
 import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
@@ -76,7 +77,9 @@ export class AgentWorkspaceService {
       throw DataApiErrorFactory.validation({ path: ['Workspace path must be absolute'] })
     }
     if (isFilesystemRoot(trimmed)) {
-      throw DataApiErrorFactory.validation({ path: ['Filesystem roots cannot be used as Agent workspaces'] })
+      throw DataApiErrorFactory.validation({
+        path: [t('agent.session.workspace_status.filesystem_root', { path: trimmed })]
+      })
     }
     const normalized = path.normalize(trimmed)
     const root = path.parse(normalized).root

--- a/src/main/data/services/AgentWorkspaceService.ts
+++ b/src/main/data/services/AgentWorkspaceService.ts
@@ -96,7 +96,9 @@ export class AgentWorkspaceService {
       .where(options.includeSystem ? undefined : eq(agentWorkspaceTable.type, AGENT_WORKSPACE_TYPE.USER))
       .orderBy(asc(agentWorkspaceTable.orderKey), asc(agentWorkspaceTable.id))
       .all()
-    return rows.map(rowToAgentWorkspace)
+    return rows
+      .filter((row) => row.type !== AGENT_WORKSPACE_TYPE.USER || !isFilesystemRoot(row.path))
+      .map(rowToAgentWorkspace)
   }
 
   getById(id: string, options: AgentWorkspaceLookupOptions = {}): AgentWorkspaceEntity {
@@ -115,7 +117,9 @@ export class AgentWorkspaceService {
       ? eq(agentWorkspaceTable.id, id)
       : and(eq(agentWorkspaceTable.id, id), eq(agentWorkspaceTable.type, AGENT_WORKSPACE_TYPE.USER))
     const [row] = tx.select().from(agentWorkspaceTable).where(predicate).limit(1).all()
-    if (!row) throw DataApiErrorFactory.notFound('Workspace', id)
+    if (!row || (row.type === AGENT_WORKSPACE_TYPE.USER && isFilesystemRoot(row.path))) {
+      throw DataApiErrorFactory.notFound('Workspace', id)
+    }
     return row
   }
 

--- a/src/main/data/services/__tests__/AgentWorkspaceService.test.ts
+++ b/src/main/data/services/__tests__/AgentWorkspaceService.test.ts
@@ -136,6 +136,17 @@ describe('AgentWorkspaceService', () => {
     })
   })
 
+  it.each(['/', '/./', '/tmp/..'])(
+    'rejects a user workspace that resolves to the filesystem root: %s',
+    async (value) => {
+      await expect(findOrCreateWorkspace(value)).rejects.toMatchObject({
+        code: ErrorCode.VALIDATION_ERROR
+      })
+
+      expect(await dbh.db.select().from(agentWorkspaceTable).where(eq(agentWorkspaceTable.path, '/'))).toEqual([])
+    }
+  )
+
   it('throws not found for missing workspaces', async () => {
     expect(captureError(() => agentWorkspaceService.getById('missing-workspace'))).toMatchObject({
       code: ErrorCode.NOT_FOUND

--- a/src/main/data/services/__tests__/AgentWorkspaceService.test.ts
+++ b/src/main/data/services/__tests__/AgentWorkspaceService.test.ts
@@ -3,6 +3,7 @@ import { agentWorkspaceTable } from '@data/db/schemas/agentWorkspace'
 import { AgentWorkspaceService, agentWorkspaceService } from '@data/services/AgentWorkspaceService'
 import { ErrorCode } from '@shared/data/api/errors'
 import { setupTestDatabase } from '@test-helpers/db'
+import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
 import { eq } from 'drizzle-orm'
 import { mkdtemp, rm, stat } from 'fs/promises'
 import { tmpdir } from 'os'
@@ -29,6 +30,7 @@ describe('AgentWorkspaceService', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks()
+    MockMainPreferenceServiceUtils.resetMocks()
     await Promise.all(tempRoots.splice(0).map((tempRoot) => rm(tempRoot, { recursive: true, force: true })))
   })
 
@@ -146,6 +148,19 @@ describe('AgentWorkspaceService', () => {
       expect(await dbh.db.select().from(agentWorkspaceTable).where(eq(agentWorkspaceTable.path, '/'))).toEqual([])
     }
   )
+
+  it('localizes the filesystem-root validation error for the current app language', () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'zh-CN')
+
+    expect(captureError(() => agentWorkspaceService.findOrCreateByPath('/'))).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: {
+        fieldErrors: {
+          path: ['文件系统根目录不能用作工作区，请选择一个子文件夹：/']
+        }
+      }
+    })
+  })
 
   it('throws not found for missing workspaces', async () => {
     expect(captureError(() => agentWorkspaceService.getById('missing-workspace'))).toMatchObject({

--- a/src/main/data/services/__tests__/AgentWorkspaceService.test.ts
+++ b/src/main/data/services/__tests__/AgentWorkspaceService.test.ts
@@ -149,6 +149,28 @@ describe('AgentWorkspaceService', () => {
     }
   )
 
+  it('hides persisted user filesystem roots from workspace lookup boundaries', async () => {
+    const rootWorkspaceId = 'workspace-persisted-root'
+    await dbh.db.insert(agentWorkspaceTable).values({
+      id: rootWorkspaceId,
+      name: 'Persisted Root',
+      path: '/',
+      type: 'user',
+      orderKey: 'a0'
+    })
+
+    expect(agentWorkspaceService.list()).toEqual([])
+    expect(agentWorkspaceService.list({ includeSystem: true })).toEqual([])
+    expect(captureError(() => agentWorkspaceService.getById(rootWorkspaceId))).toMatchObject({
+      code: ErrorCode.NOT_FOUND
+    })
+    expect(
+      captureError(() =>
+        dbh.db.transaction((tx) => agentWorkspaceService.getByIdTx(tx, rootWorkspaceId, { includeSystem: true }))
+      )
+    ).toMatchObject({ code: ErrorCode.NOT_FOUND })
+  })
+
   it('localizes the filesystem-root validation error for the current app language', () => {
     MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'zh-CN')
 

--- a/src/main/i18n/locales/de-de.json
+++ b/src/main/i18n/locales/de-de.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Neue Aufgabe",
   "agent.session.run_status.busy": "Die Agent-Sitzung ist beschäftigt. Bitte versuchen Sie es in Kürze erneut.",
   "agent.session.run_status.unavailable": "Die Agent-Sitzung ist nicht mehr verfügbar.",
+  "agent.session.workspace_status.filesystem_root": "Dateisystem-Stammverzeichnisse können nicht als Arbeitsbereiche verwendet werden. Wähle einen Unterordner: {{path}}",
   "agent.session.workspace_status.inaccessible": "Arbeitsbereichspfad ist nicht zugänglich: {{path}}",
   "agent.session.workspace_status.missing": "Arbeitsbereichspfad existiert nicht: {{path}}",
   "agent.session.workspace_status.not_directory": "Der Workspace-Pfad ist kein Verzeichnis: {{path}}",

--- a/src/main/i18n/locales/el-gr.json
+++ b/src/main/i18n/locales/el-gr.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Νέα εργασία",
   "agent.session.run_status.busy": "Η συνεδρία Agent είναι απασχολημένη. Δοκιμάστε ξανά σε λίγο.",
   "agent.session.run_status.unavailable": "Η συνεδρία Agent δεν είναι πλέον διαθέσιμη.",
+  "agent.session.workspace_status.filesystem_root": "Οι ρίζες του συστήματος αρχείων δεν μπορούν να χρησιμοποιηθούν ως χώροι εργασίας. Επιλέξτε έναν υποφάκελο: {{path}}",
   "agent.session.workspace_status.inaccessible": "Η διαδρομή του χώρου εργασίας δεν είναι προσβάσιμη: {{path}}",
   "agent.session.workspace_status.missing": "Η διαδρομή του χώρου εργασίας δεν υπάρχει: {{path}}",
   "agent.session.workspace_status.not_directory": "Η διαδρομή του χώρου εργασίας δεν είναι κατάλογος: {{path}}",

--- a/src/main/i18n/locales/en-us.json
+++ b/src/main/i18n/locales/en-us.json
@@ -4,6 +4,7 @@
   "agent.session.new": "New task",
   "agent.session.run_status.busy": "The Agent Session is busy. Please try again shortly.",
   "agent.session.run_status.unavailable": "The Agent Session is no longer available.",
+  "agent.session.workspace_status.filesystem_root": "Filesystem roots cannot be used as workspaces. Choose a subfolder: {{path}}",
   "agent.session.workspace_status.inaccessible": "Workspace path is not accessible: {{path}}",
   "agent.session.workspace_status.missing": "Workspace path does not exist: {{path}}",
   "agent.session.workspace_status.not_directory": "Workspace path is not a directory: {{path}}",

--- a/src/main/i18n/locales/es-es.json
+++ b/src/main/i18n/locales/es-es.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Nueva tarea",
   "agent.session.run_status.busy": "La sesión del Agent está ocupada. Inténtalo de nuevo en breve.",
   "agent.session.run_status.unavailable": "La sesión del Agent ya no está disponible.",
+  "agent.session.workspace_status.filesystem_root": "Las raíces del sistema de archivos no se pueden usar como espacios de trabajo. Elige una subcarpeta: {{path}}",
   "agent.session.workspace_status.inaccessible": "La ruta del espacio de trabajo no es accesible: {{path}}",
   "agent.session.workspace_status.missing": "La ruta del espacio de trabajo no existe: {{path}}",
   "agent.session.workspace_status.not_directory": "La ruta del espacio de trabajo no es una carpeta: {{path}}",

--- a/src/main/i18n/locales/fr-fr.json
+++ b/src/main/i18n/locales/fr-fr.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Nouvelle tâche",
   "agent.session.run_status.busy": "La session Agent est occupée. Veuillez réessayer dans quelques instants.",
   "agent.session.run_status.unavailable": "La session Agent n’est plus disponible.",
+  "agent.session.workspace_status.filesystem_root": "Les racines du système de fichiers ne peuvent pas servir d’espaces de travail. Choisissez un sous-dossier : {{path}}",
   "agent.session.workspace_status.inaccessible": "Le chemin de l'espace de travail n'est pas accessible : {{path}}",
   "agent.session.workspace_status.missing": "Le chemin de l'espace de travail n'existe pas : {{path}}",
   "agent.session.workspace_status.not_directory": "Le chemin de l’espace de travail n’est pas un répertoire : {{path}}",

--- a/src/main/i18n/locales/ja-jp.json
+++ b/src/main/i18n/locales/ja-jp.json
@@ -4,6 +4,7 @@
   "agent.session.new": "新しいタスク",
   "agent.session.run_status.busy": "Agent セッションは処理中です。しばらくしてからもう一度お試しください。",
   "agent.session.run_status.unavailable": "Agent セッションは利用できなくなりました。",
+  "agent.session.workspace_status.filesystem_root": "ファイルシステムのルートはワークスペースとして使用できません。サブフォルダーを選択してください: {{path}}",
   "agent.session.workspace_status.inaccessible": "ワークスペースパスにアクセスできません: {{path}}",
   "agent.session.workspace_status.missing": "ワークスペースパスが存在しません: {{path}}",
   "agent.session.workspace_status.not_directory": "ワークスペースパスがフォルダーではありません: {{path}}",

--- a/src/main/i18n/locales/pt-pt.json
+++ b/src/main/i18n/locales/pt-pt.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Nova tarefa",
   "agent.session.run_status.busy": "A sessão do Agent está ocupada. Tente novamente dentro de instantes.",
   "agent.session.run_status.unavailable": "A sessão do Agent já não está disponível.",
+  "agent.session.workspace_status.filesystem_root": "As raízes do sistema de ficheiros não podem ser usadas como espaços de trabalho. Escolha uma subpasta: {{path}}",
   "agent.session.workspace_status.inaccessible": "O caminho do espaço de trabalho não está acessível: {{path}}",
   "agent.session.workspace_status.missing": "O caminho do espaço de trabalho não existe: {{path}}",
   "agent.session.workspace_status.not_directory": "O caminho do espaço de trabalho não é uma pasta: {{path}}",

--- a/src/main/i18n/locales/ro-ro.json
+++ b/src/main/i18n/locales/ro-ro.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Sarcină nouă",
   "agent.session.run_status.busy": "Sesiunea Agent este ocupată. Încercați din nou în curând.",
   "agent.session.run_status.unavailable": "Sesiunea Agent nu mai este disponibilă.",
+  "agent.session.workspace_status.filesystem_root": "Rădăcinile sistemului de fișiere nu pot fi folosite ca spații de lucru. Alege un subfolder: {{path}}",
   "agent.session.workspace_status.inaccessible": "Calea către spațiul de lucru nu este accesibilă: {{path}}",
   "agent.session.workspace_status.missing": "Calea către spațiul de lucru nu există: {{path}}",
   "agent.session.workspace_status.not_directory": "Calea spațiului de lucru nu este un director: {{path}}",

--- a/src/main/i18n/locales/ru-ru.json
+++ b/src/main/i18n/locales/ru-ru.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Новая задача",
   "agent.session.run_status.busy": "Сеанс Agent занят. Повторите попытку чуть позже.",
   "agent.session.run_status.unavailable": "Сеанс Agent больше недоступен.",
+  "agent.session.workspace_status.filesystem_root": "Корни файловой системы нельзя использовать как рабочие пространства. Выберите подпапку: {{path}}",
   "agent.session.workspace_status.inaccessible": "Путь к рабочей области недоступен: {{path}}",
   "agent.session.workspace_status.missing": "Путь к рабочей области не существует: {{path}}",
   "agent.session.workspace_status.not_directory": "Путь к рабочей области не является каталогом: {{path}}",

--- a/src/main/i18n/locales/tr-tr.json
+++ b/src/main/i18n/locales/tr-tr.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Yeni görev",
   "agent.session.run_status.busy": "Ajan Oturumu meşgul. Lütfen kısa süre sonra tekrar deneyin.",
   "agent.session.run_status.unavailable": "Ajan Oturumu artık kullanılamıyor.",
+  "agent.session.workspace_status.filesystem_root": "Dosya sistemi kökleri çalışma alanı olarak kullanılamaz. Bir alt klasör seçin: {{path}}",
   "agent.session.workspace_status.inaccessible": "Çalışma alanı yoluna erişilemiyor: {{path}}",
   "agent.session.workspace_status.missing": "Çalışma alanı yolu mevcut değil: {{path}}",
   "agent.session.workspace_status.not_directory": "Çalışma alanı yolu bir dizin değil: {{path}}",

--- a/src/main/i18n/locales/vi-vn.json
+++ b/src/main/i18n/locales/vi-vn.json
@@ -4,6 +4,7 @@
   "agent.session.new": "Nhiệm vụ mới",
   "agent.session.run_status.busy": "Phiên Agent đang bận. Vui lòng thử lại sau ít phút.",
   "agent.session.run_status.unavailable": "Phiên Agent không còn khả dụng.",
+  "agent.session.workspace_status.filesystem_root": "Không thể dùng thư mục gốc của hệ thống tệp làm không gian làm việc. Hãy chọn một thư mục con: {{path}}",
   "agent.session.workspace_status.inaccessible": "Đường dẫn không gian làm việc không thể truy cập: {{path}}",
   "agent.session.workspace_status.missing": "Đường dẫn không gian làm việc không tồn tại: {{path}}",
   "agent.session.workspace_status.not_directory": "Đường dẫn không gian làm việc không phải là thư mục: {{path}}",

--- a/src/main/i18n/locales/zh-cn.json
+++ b/src/main/i18n/locales/zh-cn.json
@@ -4,6 +4,7 @@
   "agent.session.new": "新任务",
   "agent.session.run_status.busy": "Agent 会话正忙，请稍后重试。",
   "agent.session.run_status.unavailable": "Agent 会话已不可用。",
+  "agent.session.workspace_status.filesystem_root": "文件系统根目录不能用作工作区，请选择一个子文件夹：{{path}}",
   "agent.session.workspace_status.inaccessible": "工作区路径不可访问：{{path}}",
   "agent.session.workspace_status.missing": "工作区路径不存在：{{path}}",
   "agent.session.workspace_status.not_directory": "工作区路径不是目录：{{path}}",

--- a/src/main/i18n/locales/zh-tw.json
+++ b/src/main/i18n/locales/zh-tw.json
@@ -4,6 +4,7 @@
   "agent.session.new": "新任務",
   "agent.session.run_status.busy": "Agent 工作階段忙碌中，請稍後再試。",
   "agent.session.run_status.unavailable": "Agent 工作階段已無法使用。",
+  "agent.session.workspace_status.filesystem_root": "檔案系統根目錄不能用作工作區，請選擇一個子資料夾：{{path}}",
   "agent.session.workspace_status.inaccessible": "工作區路徑無法存取：{{path}}",
   "agent.session.workspace_status.missing": "工作區路徑不存在：{{path}}",
   "agent.session.workspace_status.not_directory": "工作區路徑不是資料夾：{{path}}",

--- a/src/main/utils/file/__tests__/path.test.ts
+++ b/src/main/utils/file/__tests__/path.test.ts
@@ -5,7 +5,20 @@ import path from 'node:path'
 import type { AbsoluteFilePath } from '@shared/types/file'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { canWrite, isOutsidePath, isPathInside, isSameOrInside } from '../path'
+import { canWrite, isFilesystemRoot, isOutsidePath, isPathInside, isSameOrInside } from '../path'
+
+describe('isFilesystemRoot', () => {
+  it.each(['/', '/./', '/tmp/..'])('identifies a path that resolves to the POSIX filesystem root: %s', (value) => {
+    expect(isFilesystemRoot(value)).toBe(true)
+  })
+
+  it.each(['/tmp', '/tmp/project', '/tmp/../workspace'])(
+    'does not reject a path that resolves below the POSIX filesystem root: %s',
+    (value) => {
+      expect(isFilesystemRoot(value)).toBe(false)
+    }
+  )
+})
 
 describe('isPathInside', () => {
   it('returns true when child is directly inside parent', () => {

--- a/src/main/utils/file/__tests__/path.win32.test.ts
+++ b/src/main/utils/file/__tests__/path.win32.test.ts
@@ -1,0 +1,26 @@
+import type * as NodePath from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof NodePath>('node:path')
+  return { ...actual.win32, default: actual.win32 }
+})
+
+describe('isFilesystemRoot on a Windows host', () => {
+  it.each(['C:\\', 'C:/', 'C:\\tmp\\..', '\\\\server\\share', '\\\\server\\share\\'])(
+    'identifies a path that resolves to a filesystem root: %s',
+    async (value) => {
+      const { isFilesystemRoot } = await import('../path')
+      expect(isFilesystemRoot(value)).toBe(true)
+    }
+  )
+
+  it.each(['C:\\work', 'C:/work/project', '\\\\server\\share\\project'])(
+    'does not reject a nested directory: %s',
+    async (value) => {
+      const { isFilesystemRoot } = await import('../path')
+      expect(isFilesystemRoot(value)).toBe(false)
+    }
+  )
+})

--- a/src/main/utils/file/__tests__/path.win32.test.ts
+++ b/src/main/utils/file/__tests__/path.win32.test.ts
@@ -8,7 +8,7 @@ vi.mock('node:path', async () => {
 })
 
 describe('isFilesystemRoot on a Windows host', () => {
-  it.each(['C:\\', 'C:/', 'C:\\tmp\\..', '\\\\server\\share', '\\\\server\\share\\'])(
+  it.each(['C:\\', 'C:/', 'C:\\tmp\\..', '\\\\server\\share', '\\\\server\\share\\', '//server/share'])(
     'identifies a path that resolves to a filesystem root: %s',
     async (value) => {
       const { isFilesystemRoot } = await import('../path')
@@ -16,7 +16,7 @@ describe('isFilesystemRoot on a Windows host', () => {
     }
   )
 
-  it.each(['C:\\work', 'C:/work/project', '\\\\server\\share\\project'])(
+  it.each(['C:\\work', 'C:/work/project', '\\\\server\\share\\project', '//server/share/project'])(
     'does not reject a nested directory: %s',
     async (value) => {
       const { isFilesystemRoot } = await import('../path')

--- a/src/main/utils/file/__tests__/path.win32.test.ts
+++ b/src/main/utils/file/__tests__/path.win32.test.ts
@@ -8,19 +8,29 @@ vi.mock('node:path', async () => {
 })
 
 describe('isFilesystemRoot on a Windows host', () => {
-  it.each(['C:\\', 'C:/', 'C:\\tmp\\..', '\\\\server\\share', '\\\\server\\share\\', '//server/share'])(
-    'identifies a path that resolves to a filesystem root: %s',
-    async (value) => {
-      const { isFilesystemRoot } = await import('../path')
-      expect(isFilesystemRoot(value)).toBe(true)
-    }
-  )
+  it.each([
+    'C:\\',
+    'C:/',
+    'C:\\tmp\\..',
+    '\\\\server\\share',
+    '\\\\server\\share\\',
+    '//server/share',
+    '\\\\?\\UNC\\server\\share',
+    '\\\\?\\UNC\\server\\share\\',
+    '\\\\?\\unc\\server\\share'
+  ])('identifies a path that resolves to a filesystem root: %s', async (value) => {
+    const { isFilesystemRoot } = await import('../path')
+    expect(isFilesystemRoot(value)).toBe(true)
+  })
 
-  it.each(['C:\\work', 'C:/work/project', '\\\\server\\share\\project', '//server/share/project'])(
-    'does not reject a nested directory: %s',
-    async (value) => {
-      const { isFilesystemRoot } = await import('../path')
-      expect(isFilesystemRoot(value)).toBe(false)
-    }
-  )
+  it.each([
+    'C:\\work',
+    'C:/work/project',
+    '\\\\server\\share\\project',
+    '//server/share/project',
+    '\\\\?\\UNC\\server\\share\\project'
+  ])('does not reject a nested directory: %s', async (value) => {
+    const { isFilesystemRoot } = await import('../path')
+    expect(isFilesystemRoot(value)).toBe(false)
+  })
 })

--- a/src/main/utils/file/index.ts
+++ b/src/main/utils/file/index.ts
@@ -88,6 +88,14 @@ export {
   write
 } from './fs'
 export { decodeTextBufferIfText, getFileType, isTextByContent, mimeToExt } from './metadata'
-export { canWrite, isNotEmptyDir, isOutsidePath, isPathInside, isSameOrInside, resolvePath } from './path'
+export {
+  canWrite,
+  isFilesystemRoot,
+  isNotEmptyDir,
+  isOutsidePath,
+  isPathInside,
+  isSameOrInside,
+  resolvePath
+} from './path'
 export { getPathStatus, type PathStatus, type PathStatusKind } from './pathStatus'
 export { open, showInFolder } from './shell'

--- a/src/main/utils/file/path.ts
+++ b/src/main/utils/file/path.ts
@@ -27,7 +27,8 @@ function normalizePathForComparison(value: string): string {
 /** True iff `candidate` resolves to the current filesystem volume root. */
 export function isFilesystemRoot(candidate: string): boolean {
   const resolved = path.resolve(candidate)
-  return resolved === path.parse(resolved).root
+  const normalized = path.normalize(resolved.replace(/^\\\\\?\\UNC\\/i, '\\\\'))
+  return normalized === path.parse(normalized).root
 }
 
 /**

--- a/src/main/utils/file/path.ts
+++ b/src/main/utils/file/path.ts
@@ -24,6 +24,12 @@ function normalizePathForComparison(value: string): string {
   return isMac || isWin ? resolved.toLowerCase() : resolved
 }
 
+/** True iff `candidate` resolves to the current filesystem volume root. */
+export function isFilesystemRoot(candidate: string): boolean {
+  const resolved = path.resolve(candidate)
+  return resolved === path.parse(resolved).root
+}
+
 /**
  * True iff `child` is a strict descendant of `parent`.
  *

--- a/src/renderer/components/chat/panes/ArtifactPane.tsx
+++ b/src/renderer/components/chat/panes/ArtifactPane.tsx
@@ -15,7 +15,7 @@ import { useFileSize } from '@renderer/hooks/useFileSize'
 import { useIsTextFile } from '@renderer/hooks/useIsTextFile'
 import { toast } from '@renderer/services/toast'
 import { getFileExtension } from '@renderer/utils/file'
-import { joinPath } from '@renderer/utils/path'
+import { isFilesystemRoot, joinPath } from '@renderer/utils/path'
 import { isWin } from '@renderer/utils/platform'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import { AlertCircle, ArrowLeft, Copy, CopySlash, Eye, RotateCw, Sparkles, SquarePen, X } from 'lucide-react'
@@ -170,8 +170,13 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
     () => (previewSelectionWorkspacePath ? AbsoluteFilePathSchema.safeParse(previewSelectionWorkspacePath) : null),
     [previewSelectionWorkspacePath]
   )
-  const hasInvalidPreviewSelection = Boolean(previewFileSelection && !parsedPreviewWorkspacePath?.success)
-  const validPreviewFileSelection = parsedPreviewWorkspacePath?.success ? previewFileSelection : null
+  const isPreviewWorkspaceRoot =
+    parsedPreviewWorkspacePath?.success && isFilesystemRoot(parsedPreviewWorkspacePath.data)
+  const hasInvalidPreviewSelection = Boolean(
+    previewFileSelection && (!parsedPreviewWorkspacePath?.success || isPreviewWorkspaceRoot)
+  )
+  const validPreviewFileSelection =
+    parsedPreviewWorkspacePath?.success && !isPreviewWorkspaceRoot ? previewFileSelection : null
   const effectiveTreeErrorKind: ArtifactFileTreeErrorKind | undefined = hasInvalidPreviewSelection
     ? 'invalid_path'
     : model.errorKind

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
@@ -834,6 +834,18 @@ describe('ArtifactPane', () => {
     }
   )
 
+  it('blocks a persisted relative artifact selection from a filesystem-root workspace', async () => {
+    render(<ArtifactPane workspacePath="/" previewFileSelection={{ workspacePath: '/', filePath: 'dist/report.md' }} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('empty-state')).toHaveTextContent('agent.preview_pane.tree_error.invalid_path.title')
+    )
+    expect(screen.queryByTestId('artifact-file-preview-overlay')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Open in Finder' })).not.toBeInTheDocument()
+    expect(mocks.treeCreate).not.toHaveBeenCalled()
+  })
+
   it('requests the workspace tree from DirectoryTreeBuilder', async () => {
     mockWorkspaceTree('/tmp/workspace', ['README.md', 'src/index.ts'])
 

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
@@ -821,6 +821,19 @@ describe('ArtifactPane', () => {
     expect(mocks.listDirectoryEntries).not.toHaveBeenCalled()
   })
 
+  it.each(['/', '/tmp/..'])(
+    'blocks a filesystem root before requesting its directory tree: %s',
+    async (workspacePath) => {
+      render(<ArtifactPane workspacePath={workspacePath} />)
+
+      await waitFor(() =>
+        expect(screen.getByTestId('empty-state')).toHaveTextContent('agent.preview_pane.tree_error.invalid_path.title')
+      )
+      expect(mocks.treeCreate).not.toHaveBeenCalled()
+      expect(mocks.listDirectoryEntries).not.toHaveBeenCalled()
+    }
+  )
+
   it('requests the workspace tree from DirectoryTreeBuilder', async () => {
     mockWorkspaceTree('/tmp/workspace', ['README.md', 'src/index.ts'])
 

--- a/src/renderer/components/chat/panes/useArtifactFileTreeModel.ts
+++ b/src/renderer/components/chat/panes/useArtifactFileTreeModel.ts
@@ -2,7 +2,7 @@ import { loggerService } from '@logger'
 import { type FileTreeNode } from '@renderer/components/FileTree'
 import { useDirectoryTree } from '@renderer/hooks/useDirectoryTree'
 import { ipcApi } from '@renderer/ipc'
-import { joinPath } from '@renderer/utils/path'
+import { isFilesystemRoot, joinPath } from '@renderer/utils/path'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import type { CreateTreeIpcResult, DirectoryTreeOptions, TreeDir, TreeDirRoot, TreeNode } from '@shared/utils/file'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
@@ -646,8 +646,9 @@ export function useArtifactFileTreeModel({
   onExpandedIdsChange
 }: UseArtifactFileTreeModelParams): ArtifactFileTreeModel {
   const workspacePathResult = workspacePath ? AbsoluteFilePathSchema.safeParse(workspacePath) : null
-  const validWorkspacePath = workspacePathResult?.success ? workspacePathResult.data : undefined
-  const invalidWorkspacePath = Boolean(workspacePath && !workspacePathResult?.success)
+  const rootWorkspacePath = workspacePathResult?.success && isFilesystemRoot(workspacePathResult.data)
+  const validWorkspacePath = workspacePathResult?.success && !rootWorkspacePath ? workspacePathResult.data : undefined
+  const invalidWorkspacePath = Boolean(workspacePath && (!workspacePathResult?.success || rootWorkspacePath))
 
   useEffect(() => {
     if (invalidWorkspacePath) {

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -62,6 +62,7 @@ import {
 } from '@renderer/utils/input'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import { resolveReasoningEffortForModel } from '@renderer/utils/model'
+import { isFilesystemRoot } from '@renderer/utils/path'
 import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
 import type { AgentEntity } from '@shared/data/types/agent'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
@@ -197,16 +198,16 @@ const buildAccessiblePathFilePart = (
 
 /**
  * `AgentWorkspacePathSchema` only guarantees a non-empty string, so the stored
- * workspace path is asserted to be an absolute filesystem path here, before it
- * reaches the path helpers. A malformed one yields no accessible paths, which
+ * workspace path is asserted to be a safe non-root absolute filesystem path here,
+ * before it reaches the path helpers. An unsafe one yields no accessible paths, which
  * degrades to inlining attachments instead of referencing them — still correct,
  * just less efficient.
  */
 const toAccessiblePaths = (workspacePath: string | undefined): AbsoluteFilePath[] => {
   if (!workspacePath) return []
   const parsed = AbsoluteFilePathSchema.safeParse(workspacePath)
-  if (!parsed.success) {
-    logger.warn('Ignoring agent workspace path that is not an absolute filesystem path', { path: workspacePath })
+  if (!parsed.success || isFilesystemRoot(parsed.data)) {
+    logger.warn('Ignoring unsafe agent workspace path', { path: workspacePath })
     return []
   }
   return [parsed.data]

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -2446,7 +2446,7 @@ describe('AgentComposer', () => {
     expect(items).toEqual([expect.objectContaining({ id: 'agent-resource:no-paths' })])
   })
 
-  it.each(['/', 'C:\\', '\\\\server\\share', '//server/share'])(
+  it.each(['/', 'C:\\', '\\\\server\\share'])(
     'does not search a persisted filesystem-root workspace: %s',
     async (workspacePath) => {
       mocks.sessionWorkspacePath = workspacePath
@@ -2468,6 +2468,25 @@ describe('AgentComposer', () => {
       expect(items).toEqual([expect.objectContaining({ id: 'agent-resource:no-paths' })])
     }
   )
+
+  it('searches a POSIX double-slash workspace instead of treating it as a Windows UNC root', async () => {
+    mocks.sessionWorkspacePath = '//server/share'
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const source = mocks.surfaceProps?.suggestionSources?.[0]
+    await source?.items({ query: 'notes', editor: {} as any })
+
+    expect(mocks.listDirectoryEntries).toHaveBeenCalledWith('//server/share', expect.any(Object))
+  })
 
   it('provides workspace file resources through the @ mention suggestion source', async () => {
     vi.useFakeTimers()

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -2446,6 +2446,29 @@ describe('AgentComposer', () => {
     expect(items).toEqual([expect.objectContaining({ id: 'agent-resource:no-paths' })])
   })
 
+  it.each(['/', 'C:\\', '\\\\server\\share', '//server/share'])(
+    'does not search a persisted filesystem-root workspace: %s',
+    async (workspacePath) => {
+      mocks.sessionWorkspacePath = workspacePath
+
+      render(
+        <AgentComposer
+          agentId="agent-1"
+          sessionId="session-1"
+          sendMessage={mocks.sendMessage}
+          stop={mocks.stop}
+          isStreaming={false}
+        />
+      )
+
+      const source = mocks.surfaceProps?.suggestionSources?.[0]
+      const items = await source?.items({ query: 'notes', editor: {} as any })
+
+      expect(mocks.listDirectoryEntries).not.toHaveBeenCalled()
+      expect(items).toEqual([expect.objectContaining({ id: 'agent-resource:no-paths' })])
+    }
+  )
+
   it('provides workspace file resources through the @ mention suggestion source', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/hooks/agent/__tests__/useAgentWorkspaceWarning.test.tsx
+++ b/src/renderer/hooks/agent/__tests__/useAgentWorkspaceWarning.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ ipcRequest: vi.fn() }))
+
+vi.mock('@logger', () => ({
+  loggerService: { withContext: () => ({ warn: vi.fn() }) }
+}))
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: mocks.ipcRequest } }))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, options: { path: string }) => `${key}:${options.path}` })
+}))
+
+const { useAgentWorkspaceWarning } = await import('../useAgentWorkspaceWarning')
+
+describe('useAgentWorkspaceWarning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.ipcRequest.mockResolvedValue({ kind: 'directory' })
+  })
+
+  it('reports an actionable warning for a filesystem root without probing its metadata', async () => {
+    const { result } = renderHook(() => useAgentWorkspaceWarning('/tmp/..'))
+
+    await waitFor(() => {
+      expect(result.current).toBe('agent.session.workspace_status.filesystem_root:/tmp/..')
+    })
+    expect(mocks.ipcRequest).not.toHaveBeenCalled()
+  })
+
+  it('continues checking a normal nested workspace', async () => {
+    const { result } = renderHook(() => useAgentWorkspaceWarning('/tmp/project'))
+
+    await waitFor(() => expect(mocks.ipcRequest).toHaveBeenCalledOnce())
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/src/renderer/hooks/agent/useAgentWorkspaceWarning.ts
+++ b/src/renderer/hooks/agent/useAgentWorkspaceWarning.ts
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger'
 import { ipcApi } from '@renderer/ipc'
+import { isFilesystemRoot } from '@renderer/utils/path'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import { createFilePathHandle } from '@shared/utils/file'
 import { useEffect, useState } from 'react'
@@ -15,6 +16,11 @@ export function useAgentWorkspaceWarning(workspacePath: string | undefined, enab
     if (!enabled) return
     if (!workspacePath) {
       setWarning(undefined)
+      return
+    }
+    const parsedWorkspacePath = AbsoluteFilePathSchema.safeParse(workspacePath)
+    if (parsedWorkspacePath.success && isFilesystemRoot(parsedWorkspacePath.data)) {
+      setWarning(t('agent.session.workspace_status.filesystem_root', { path: workspacePath }))
       return
     }
 

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Arbeitsverzeichnis auswählen",
   "agent.session.workspace_selector.search_placeholder": "Arbeitsverzeichnisse durchsuchen",
   "agent.session.workspace_selector.select_failed": "Ordnerauswahl fehlgeschlagen.",
+  "agent.session.workspace_status.filesystem_root": "Dateisystem-Stammverzeichnisse können nicht als Arbeitsbereiche verwendet werden. Wähle einen Unterordner: {{path}}",
   "agent.session.workspace_status.inaccessible": "Arbeitsbereichspfad ist nicht zugänglich: {{path}}",
   "agent.session_delivery.from": "Von {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Angenommen",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Επιλέξτε κατάλογο εργασίας",
   "agent.session.workspace_selector.search_placeholder": "Αναζήτηση καταλόγων εργασίας",
   "agent.session.workspace_selector.select_failed": "Αποτυχία επιλογής φακέλου.",
+  "agent.session.workspace_status.filesystem_root": "Οι ρίζες του συστήματος αρχείων δεν μπορούν να χρησιμοποιηθούν ως χώροι εργασίας. Επιλέξτε έναν υποφάκελο: {{path}}",
   "agent.session.workspace_status.inaccessible": "Η διαδρομή του χώρου εργασίας δεν είναι προσβάσιμη: {{path}}",
   "agent.session_delivery.from": "Από {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Αποδεκτό",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Select work directory",
   "agent.session.workspace_selector.search_placeholder": "Search work directories",
   "agent.session.workspace_selector.select_failed": "Failed to select folder.",
+  "agent.session.workspace_status.filesystem_root": "Filesystem roots cannot be used as workspaces. Choose a subfolder: {{path}}",
   "agent.session.workspace_status.inaccessible": "Workspace path is not accessible: {{path}}",
   "agent.session_delivery.from": "From {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Accepted",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Seleccionar carpeta de trabajo",
   "agent.session.workspace_selector.search_placeholder": "Buscar carpetas de trabajo",
   "agent.session.workspace_selector.select_failed": "Error al seleccionar la carpeta.",
+  "agent.session.workspace_status.filesystem_root": "Las raíces del sistema de archivos no se pueden usar como espacios de trabajo. Elige una subcarpeta: {{path}}",
   "agent.session.workspace_status.inaccessible": "La ruta del espacio de trabajo no es accesible: {{path}}",
   "agent.session_delivery.from": "De {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Aceptado",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Sélectionner le répertoire de travail",
   "agent.session.workspace_selector.search_placeholder": "Rechercher dans les répertoires de travail",
   "agent.session.workspace_selector.select_failed": "Échec de la sélection du dossier.",
+  "agent.session.workspace_status.filesystem_root": "Les racines du système de fichiers ne peuvent pas servir d’espaces de travail. Choisissez un sous-dossier : {{path}}",
   "agent.session.workspace_status.inaccessible": "Le chemin de l'espace de travail n'est pas accessible : {{path}}",
   "agent.session_delivery.from": "De {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Accepté",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "作業フォルダーを選択",
   "agent.session.workspace_selector.search_placeholder": "作業フォルダーを検索",
   "agent.session.workspace_selector.select_failed": "フォルダーを選択できませんでした。",
+  "agent.session.workspace_status.filesystem_root": "ファイルシステムのルートはワークスペースとして使用できません。サブフォルダーを選択してください: {{path}}",
   "agent.session.workspace_status.inaccessible": "ワークスペースパスにアクセスできません: {{path}}",
   "agent.session_delivery.from": "{{agent}} / {{session}} から",
   "agent.session_delivery.status.accepted": "受付済み",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Selecionar pasta de trabalho",
   "agent.session.workspace_selector.search_placeholder": "Pesquisar pastas de trabalho",
   "agent.session.workspace_selector.select_failed": "Falha ao selecionar pasta.",
+  "agent.session.workspace_status.filesystem_root": "As raízes do sistema de ficheiros não podem ser usadas como espaços de trabalho. Escolha uma subpasta: {{path}}",
   "agent.session.workspace_status.inaccessible": "O caminho do workspace não está acessível: {{path}}",
   "agent.session_delivery.from": "De {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Aceite",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Selectează directorul de lucru",
   "agent.session.workspace_selector.search_placeholder": "Caută în directoarele de lucru",
   "agent.session.workspace_selector.select_failed": "Nu s-a reușit selectarea directorului.",
+  "agent.session.workspace_status.filesystem_root": "Rădăcinile sistemului de fișiere nu pot fi folosite ca spații de lucru. Alege un subfolder: {{path}}",
   "agent.session.workspace_status.inaccessible": "Calea către spațiul de lucru nu este accesibilă: {{path}}",
   "agent.session_delivery.from": "De la {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Acceptat",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Выберите рабочий каталог",
   "agent.session.workspace_selector.search_placeholder": "Поиск рабочих каталогов",
   "agent.session.workspace_selector.select_failed": "Не удалось выбрать папку.",
+  "agent.session.workspace_status.filesystem_root": "Корни файловой системы нельзя использовать как рабочие пространства. Выберите подпапку: {{path}}",
   "agent.session.workspace_status.inaccessible": "Путь к рабочей области недоступен: {{path}}",
   "agent.session_delivery.from": "От {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Принято",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Çalışma dizini seç",
   "agent.session.workspace_selector.search_placeholder": "Çalışma dizinlerinde ara",
   "agent.session.workspace_selector.select_failed": "Klasör seçilemedi.",
+  "agent.session.workspace_status.filesystem_root": "Dosya sistemi kökleri çalışma alanı olarak kullanılamaz. Bir alt klasör seçin: {{path}}",
   "agent.session.workspace_status.inaccessible": "Çalışma alanı yoluna erişilemiyor: {{path}}",
   "agent.session_delivery.from": "Gönderen: {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Kabul edildi",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "Chọn thư mục làm việc",
   "agent.session.workspace_selector.search_placeholder": "Tìm kiếm thư mục làm việc",
   "agent.session.workspace_selector.select_failed": "Không thể chọn thư mục.",
+  "agent.session.workspace_status.filesystem_root": "Không thể dùng thư mục gốc của hệ thống tệp làm không gian làm việc. Hãy chọn một thư mục con: {{path}}",
   "agent.session.workspace_status.inaccessible": "Đường dẫn không gian làm việc không thể truy cập: {{path}}",
   "agent.session_delivery.from": "Từ {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "Đã tiếp nhận",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "选择工作目录",
   "agent.session.workspace_selector.search_placeholder": "搜索工作目录",
   "agent.session.workspace_selector.select_failed": "选择文件夹失败。",
+  "agent.session.workspace_status.filesystem_root": "文件系统根目录不能用作工作区，请选择一个子文件夹：{{path}}",
   "agent.session.workspace_status.inaccessible": "工作区路径不可访问：{{path}}",
   "agent.session_delivery.from": "来自 {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "已接受",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -246,6 +246,7 @@
   "agent.session.workspace_selector.placeholder": "選擇工作目錄",
   "agent.session.workspace_selector.search_placeholder": "搜尋工作目錄",
   "agent.session.workspace_selector.select_failed": "選擇資料夾失敗。",
+  "agent.session.workspace_status.filesystem_root": "檔案系統根目錄不能用作工作區，請選擇一個子資料夾：{{path}}",
   "agent.session.workspace_status.inaccessible": "工作區路徑無法存取：{{path}}",
   "agent.session_delivery.from": "來自 {{agent}} / {{session}}",
   "agent.session_delivery.status.accepted": "已接受",

--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -57,6 +57,7 @@ import { type Topic, TopicType, type TopicType as TopicTypeEnum } from '@rendere
 import { buildAgentFileWorkspaceKey, buildAgentSessionTopicId } from '@renderer/utils/agentSession'
 import { resolveInlineFilePath } from '@renderer/utils/filePath'
 import { openFileTarget } from '@renderer/utils/openFileTarget'
+import { isFilesystemRoot } from '@renderer/utils/path'
 import { cn } from '@renderer/utils/style'
 import type { AgentSessionBackgroundTasks } from '@shared/ai/agentSessionBackgroundTasks'
 import { isDeferredToolOutput } from '@shared/ai/transport'
@@ -129,6 +130,11 @@ function containsFile(root: TreeDirRoot | null): boolean {
     return false
   })
   return found
+}
+
+function isWorkspaceFilesystemRoot(workspacePath: string | undefined): boolean {
+  const parsedWorkspacePath = AbsoluteFilePathSchema.safeParse(workspacePath)
+  return parsedWorkspacePath.success && isFilesystemRoot(parsedWorkspacePath.data)
 }
 
 function getFlowTabValue(toolCallId: string): string {
@@ -317,7 +323,11 @@ function AgentRightPaneActionsProvider({
     }
   }, [artifactOpenRequestRef, sessionId, workspacePath])
   const canOpenAgentToolFlow = conversationState === 'ready' && Boolean(sessionId)
-  const canOpenArtifactFile = workspaceCurrent && Boolean(workspacePath) && panelActions.canOpen('files')
+  const canOpenArtifactFile =
+    workspaceCurrent &&
+    Boolean(workspacePath) &&
+    !isWorkspaceFilesystemRoot(workspacePath) &&
+    panelActions.canOpen('files')
   const openAgentToolFlow = useCallback(
     (input: AgentToolFlowOpenInput) => {
       if (!canOpenAgentToolFlow) return
@@ -1209,6 +1219,7 @@ function AgentTraceRightPanel({ active, scope }: RightPanelComponentProps<AgentR
 
 function resolveAgentFilesReadiness(scope: AgentRightPanelScope): RightPanelReadiness {
   if (scope.meta.conversationState !== 'ready') return scope.meta.conversationState
+  if (isWorkspaceFilesystemRoot(scope.meta.workspacePath)) return 'unavailable'
   if (scope.meta.workspaceType === AGENT_WORKSPACE_TYPE.SYSTEM && !scope.hasSystemWorkspaceFiles) {
     return 'unavailable'
   }

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -1491,7 +1491,7 @@ describe('AgentRightPane', () => {
     expect(screen.getByText('index.html')).toBeInTheDocument()
   })
 
-  it('hides the artifacts section when the workspace cannot open files', () => {
+  it('hides file-opening actions for a persisted filesystem-root workspace', () => {
     const parts = [
       {
         type: 'dynamic-tool',
@@ -1504,7 +1504,12 @@ describe('AgentRightPane', () => {
     const messages = [{ id: 'm1', role: 'assistant', parts, metadata: { status: 'pending' } }] as CherryUIMessage[]
 
     render(
-      <TestAgentRightPane sessionId="session-a" messages={messages} partsByMessageId={{ m1: parts }}>
+      <TestAgentRightPane
+        sessionId="session-a"
+        workspacePath="/tmp/.."
+        workspaceType="user"
+        messages={messages}
+        partsByMessageId={{ m1: parts }}>
         <AgentRightPane.Shortcuts />
         <AgentRightPane.Viewport />
       </TestAgentRightPane>
@@ -1512,6 +1517,7 @@ describe('AgentRightPane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.status' }))
 
     expect(screen.queryByText('agent.right_pane.info.artifacts')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'agent.right_pane.tabs.files' })).toBeNull()
   })
 
   it('restores the stop button and reports an error when the runtime cannot stop the task', async () => {

--- a/src/renderer/utils/__tests__/path.test.ts
+++ b/src/renderer/utils/__tests__/path.test.ts
@@ -2,10 +2,26 @@ import type { AbsoluteFilePath } from '@shared/types/file'
 import { PosixRelativeFilePathSchema } from '@shared/utils/file'
 import { describe, expect, it } from 'vitest'
 
-import { getRelativePath, isPathInside, isSamePath } from '../path'
+import { getRelativePath, isFilesystemRoot, isPathInside, isSamePath } from '../path'
 
 /** Fixture helper — these are shape-valid absolute paths, so the brand is safe to assert. */
 const p = (value: string) => value as AbsoluteFilePath
+
+describe('isFilesystemRoot', () => {
+  it.each(['/', '/./', '/tmp/..', 'C:\\', 'C:/', 'C:\\tmp\\..', '\\\\server\\share', '\\\\server\\share\\'])(
+    'identifies a path that resolves to a filesystem root: %s',
+    (value) => {
+      expect(isFilesystemRoot(p(value))).toBe(true)
+    }
+  )
+
+  it.each(['/tmp/project', 'C:\\work', '\\\\server\\share\\project'])(
+    'does not reject a nested directory: %s',
+    (value) => {
+      expect(isFilesystemRoot(p(value))).toBe(false)
+    }
+  )
+})
 
 describe('isSamePath', () => {
   it('treats a path as the same as itself', () => {

--- a/src/renderer/utils/__tests__/path.test.ts
+++ b/src/renderer/utils/__tests__/path.test.ts
@@ -8,12 +8,19 @@ import { getRelativePath, isFilesystemRoot, isPathInside, isSamePath } from '../
 const p = (value: string) => value as AbsoluteFilePath
 
 describe('isFilesystemRoot', () => {
-  it.each(['/', '/./', '/tmp/..', 'C:\\', 'C:/', 'C:\\tmp\\..', '\\\\server\\share', '\\\\server\\share\\'])(
-    'identifies a path that resolves to a filesystem root: %s',
-    (value) => {
-      expect(isFilesystemRoot(p(value))).toBe(true)
-    }
-  )
+  it.each([
+    '/',
+    '/./',
+    '/tmp/..',
+    '//tmp/..',
+    'C:\\',
+    'C:/',
+    'C:\\tmp\\..',
+    '\\\\server\\share',
+    '\\\\server\\share\\'
+  ])('identifies a path that resolves to a filesystem root: %s', (value) => {
+    expect(isFilesystemRoot(p(value))).toBe(true)
+  })
 
   it.each(['/tmp/project', 'C:\\work', '\\\\server\\share\\project', '//server/share/project'])(
     'does not reject a nested directory: %s',

--- a/src/renderer/utils/__tests__/path.test.ts
+++ b/src/renderer/utils/__tests__/path.test.ts
@@ -8,14 +8,22 @@ import { getRelativePath, isFilesystemRoot, isPathInside, isSamePath } from '../
 const p = (value: string) => value as AbsoluteFilePath
 
 describe('isFilesystemRoot', () => {
-  it.each(['/', '/./', '/tmp/..', 'C:\\', 'C:/', 'C:\\tmp\\..', '\\\\server\\share', '\\\\server\\share\\'])(
-    'identifies a path that resolves to a filesystem root: %s',
-    (value) => {
-      expect(isFilesystemRoot(p(value))).toBe(true)
-    }
-  )
+  it.each([
+    '/',
+    '/./',
+    '/tmp/..',
+    'C:\\',
+    'C:/',
+    'C:\\tmp\\..',
+    '\\\\server\\share',
+    '\\\\server\\share\\',
+    '//server/share',
+    '//server/share/project/..'
+  ])('identifies a path that resolves to a filesystem root: %s', (value) => {
+    expect(isFilesystemRoot(p(value))).toBe(true)
+  })
 
-  it.each(['/tmp/project', 'C:\\work', '\\\\server\\share\\project'])(
+  it.each(['/tmp/project', 'C:\\work', '\\\\server\\share\\project', '//server/share/project'])(
     'does not reject a nested directory: %s',
     (value) => {
       expect(isFilesystemRoot(p(value))).toBe(false)

--- a/src/renderer/utils/__tests__/path.test.ts
+++ b/src/renderer/utils/__tests__/path.test.ts
@@ -8,23 +8,22 @@ import { getRelativePath, isFilesystemRoot, isPathInside, isSamePath } from '../
 const p = (value: string) => value as AbsoluteFilePath
 
 describe('isFilesystemRoot', () => {
-  it.each([
-    '/',
-    '/./',
-    '/tmp/..',
-    'C:\\',
-    'C:/',
-    'C:\\tmp\\..',
-    '\\\\server\\share',
-    '\\\\server\\share\\',
-    '//server/share',
-    '//server/share/project/..'
-  ])('identifies a path that resolves to a filesystem root: %s', (value) => {
-    expect(isFilesystemRoot(p(value))).toBe(true)
-  })
+  it.each(['/', '/./', '/tmp/..', 'C:\\', 'C:/', 'C:\\tmp\\..', '\\\\server\\share', '\\\\server\\share\\'])(
+    'identifies a path that resolves to a filesystem root: %s',
+    (value) => {
+      expect(isFilesystemRoot(p(value))).toBe(true)
+    }
+  )
 
   it.each(['/tmp/project', 'C:\\work', '\\\\server\\share\\project', '//server/share/project'])(
     'does not reject a nested directory: %s',
+    (value) => {
+      expect(isFilesystemRoot(p(value))).toBe(false)
+    }
+  )
+
+  it.each(['//server/share', '//server/share/project/..'])(
+    'does not interpret a POSIX double-slash path as a Windows UNC root: %s',
     (value) => {
       expect(isFilesystemRoot(p(value))).toBe(false)
     }

--- a/src/renderer/utils/__tests__/path.win32.test.ts
+++ b/src/renderer/utils/__tests__/path.win32.test.ts
@@ -1,0 +1,21 @@
+import type { AbsoluteFilePath } from '@shared/types/file'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/utils/platform', () => ({ isWin: true }))
+
+const { isFilesystemRoot } = await import('../path')
+
+const p = (value: string) => value as AbsoluteFilePath
+
+describe('isFilesystemRoot on Windows', () => {
+  it.each(['//server/share', '//server/share/', '//server/share/project/..'])(
+    'identifies a forward-slash UNC root: %s',
+    (value) => {
+      expect(isFilesystemRoot(p(value))).toBe(true)
+    }
+  )
+
+  it('allows a nested forward-slash UNC directory', () => {
+    expect(isFilesystemRoot(p('//server/share/project'))).toBe(false)
+  })
+})

--- a/src/renderer/utils/__tests__/path.win32.test.ts
+++ b/src/renderer/utils/__tests__/path.win32.test.ts
@@ -8,14 +8,22 @@ const { isFilesystemRoot } = await import('../path')
 const p = (value: string) => value as AbsoluteFilePath
 
 describe('isFilesystemRoot on Windows', () => {
-  it.each(['//server/share', '//server/share/', '//server/share/project/..'])(
-    'identifies a forward-slash UNC root: %s',
-    (value) => {
-      expect(isFilesystemRoot(p(value))).toBe(true)
-    }
-  )
+  it.each([
+    '//server/share',
+    '//server/share/',
+    '//server/share/project/..',
+    '\\\\?\\UNC\\server\\share',
+    '\\\\?\\UNC\\server\\share\\',
+    '\\\\?\\unc\\server\\share'
+  ])('identifies a UNC root: %s', (value) => {
+    expect(isFilesystemRoot(p(value))).toBe(true)
+  })
 
   it('allows a nested forward-slash UNC directory', () => {
     expect(isFilesystemRoot(p('//server/share/project'))).toBe(false)
+  })
+
+  it('allows a nested extended-length UNC directory', () => {
+    expect(isFilesystemRoot(p('\\\\?\\UNC\\server\\share\\project'))).toBe(false)
   })
 })

--- a/src/renderer/utils/__tests__/path.win32.test.ts
+++ b/src/renderer/utils/__tests__/path.win32.test.ts
@@ -17,7 +17,13 @@ describe('isFilesystemRoot on Windows', () => {
     '\\\\?\\unc\\server\\share',
     '//?/UNC/server/share',
     '//?/UNC/server/share/',
-    '//?/unc/server/share'
+    '//?/unc/server/share',
+    '//server//share',
+    '//server/\\share',
+    '\\\\server\\\\share',
+    '\\\\server\\/share',
+    '//?/UNC/server//share',
+    '\\\\?\\UNC\\server\\\\share'
   ])('identifies a UNC root: %s', (value) => {
     expect(isFilesystemRoot(p(value))).toBe(true)
   })
@@ -29,5 +35,6 @@ describe('isFilesystemRoot on Windows', () => {
   it('allows a nested extended-length UNC directory', () => {
     expect(isFilesystemRoot(p('\\\\?\\UNC\\server\\share\\project'))).toBe(false)
     expect(isFilesystemRoot(p('//?/UNC/server/share/project'))).toBe(false)
+    expect(isFilesystemRoot(p('//?/UNC/server//share/project'))).toBe(false)
   })
 })

--- a/src/renderer/utils/__tests__/path.win32.test.ts
+++ b/src/renderer/utils/__tests__/path.win32.test.ts
@@ -23,7 +23,11 @@ describe('isFilesystemRoot on Windows', () => {
     '\\\\server\\\\share',
     '\\\\server\\/share',
     '//?/UNC/server//share',
-    '\\\\?\\UNC\\server\\\\share'
+    '\\\\?\\UNC\\server\\\\share',
+    '\\\\?\\UNC\\\\server\\share',
+    '\\\\?\\UNC\\/server\\share',
+    '//?/UNC//server/share',
+    '//?/UNC/\\server/share'
   ])('identifies a UNC root: %s', (value) => {
     expect(isFilesystemRoot(p(value))).toBe(true)
   })
@@ -34,7 +38,11 @@ describe('isFilesystemRoot on Windows', () => {
 
   it('allows a nested extended-length UNC directory', () => {
     expect(isFilesystemRoot(p('\\\\?\\UNC\\server\\share\\project'))).toBe(false)
+    expect(isFilesystemRoot(p('\\\\?\\UNC\\\\server\\share\\project'))).toBe(false)
+    expect(isFilesystemRoot(p('\\\\?\\UNC\\/server\\share\\project'))).toBe(false)
     expect(isFilesystemRoot(p('//?/UNC/server/share/project'))).toBe(false)
+    expect(isFilesystemRoot(p('//?/UNC//server/share/project'))).toBe(false)
+    expect(isFilesystemRoot(p('//?/UNC/\\server/share/project'))).toBe(false)
     expect(isFilesystemRoot(p('//?/UNC/server//share/project'))).toBe(false)
   })
 })

--- a/src/renderer/utils/__tests__/path.win32.test.ts
+++ b/src/renderer/utils/__tests__/path.win32.test.ts
@@ -27,7 +27,11 @@ describe('isFilesystemRoot on Windows', () => {
     '\\\\?\\UNC\\\\server\\share',
     '\\\\?\\UNC\\/server\\share',
     '//?/UNC//server/share',
-    '//?/UNC/\\server/share'
+    '//?/UNC/\\server/share',
+    '\\\\?\\\\UNC\\server\\share',
+    '\\\\?\\/UNC\\server\\share',
+    '//?//UNC/server/share',
+    '//?/\\UNC/server/share'
   ])('identifies a UNC root: %s', (value) => {
     expect(isFilesystemRoot(p(value))).toBe(true)
   })
@@ -44,5 +48,9 @@ describe('isFilesystemRoot on Windows', () => {
     expect(isFilesystemRoot(p('//?/UNC//server/share/project'))).toBe(false)
     expect(isFilesystemRoot(p('//?/UNC/\\server/share/project'))).toBe(false)
     expect(isFilesystemRoot(p('//?/UNC/server//share/project'))).toBe(false)
+    expect(isFilesystemRoot(p('\\\\?\\\\UNC\\server\\share\\project'))).toBe(false)
+    expect(isFilesystemRoot(p('\\\\?\\/UNC\\server\\share\\project'))).toBe(false)
+    expect(isFilesystemRoot(p('//?//UNC/server/share/project'))).toBe(false)
+    expect(isFilesystemRoot(p('//?/\\UNC/server/share/project'))).toBe(false)
   })
 })

--- a/src/renderer/utils/__tests__/path.win32.test.ts
+++ b/src/renderer/utils/__tests__/path.win32.test.ts
@@ -14,7 +14,10 @@ describe('isFilesystemRoot on Windows', () => {
     '//server/share/project/..',
     '\\\\?\\UNC\\server\\share',
     '\\\\?\\UNC\\server\\share\\',
-    '\\\\?\\unc\\server\\share'
+    '\\\\?\\unc\\server\\share',
+    '//?/UNC/server/share',
+    '//?/UNC/server/share/',
+    '//?/unc/server/share'
   ])('identifies a UNC root: %s', (value) => {
     expect(isFilesystemRoot(p(value))).toBe(true)
   })
@@ -25,5 +28,6 @@ describe('isFilesystemRoot on Windows', () => {
 
   it('allows a nested extended-length UNC directory', () => {
     expect(isFilesystemRoot(p('\\\\?\\UNC\\server\\share\\project'))).toBe(false)
+    expect(isFilesystemRoot(p('//?/UNC/server/share/project'))).toBe(false)
   })
 })

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -21,7 +21,7 @@ import { canonicalizeFilePath, parseWindowsPath, type PosixRelativeFilePath } fr
  * is a separator. On POSIX a backslash is an ordinary filename character.
  */
 const isWindowsDrivePath = (path: string) => /^[A-Za-z]:[/\\]/.test(path)
-const isWindowsUncPath = (path: string) => path.startsWith('\\\\')
+const isWindowsUncPath = (path: string) => path.startsWith('\\\\') || path.startsWith('//')
 
 function resolvesToParsedRoot(segments: string[]): boolean {
   let depth = 0
@@ -39,7 +39,7 @@ function resolvesToParsedRoot(segments: string[]): boolean {
 /** True iff `candidate` resolves to a POSIX, Windows drive, or UNC share root. */
 export const isFilesystemRoot = (candidate: AbsoluteFilePath): boolean => {
   if (isWindowsDrivePath(candidate) || isWindowsUncPath(candidate)) {
-    const parsed = parseWindowsPath(candidate)
+    const parsed = parseWindowsPath(candidate.startsWith('//') ? `\\\\${candidate.slice(2)}` : candidate)
     return parsed.isAbsolute && resolvesToParsedRoot(parsed.segments)
   }
   return toPathKey(candidate) === '/'

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -14,13 +14,36 @@
  */
 
 import type { AbsoluteFilePath } from '@shared/types/file'
-import { canonicalizeFilePath, type PosixRelativeFilePath } from '@shared/utils/file'
+import { canonicalizeFilePath, parseWindowsPath, type PosixRelativeFilePath } from '@shared/utils/file'
 
 /**
  * A Windows drive path (`C:\…` / `C:/…`) — the only shape in which a backslash
  * is a separator. On POSIX a backslash is an ordinary filename character.
  */
 const isWindowsDrivePath = (path: string) => /^[A-Za-z]:[/\\]/.test(path)
+const isWindowsUncPath = (path: string) => path.startsWith('\\\\')
+
+function resolvesToParsedRoot(segments: string[]): boolean {
+  let depth = 0
+  for (const segment of segments) {
+    if (segment === '.') continue
+    if (segment === '..') {
+      depth = Math.max(0, depth - 1)
+      continue
+    }
+    depth += 1
+  }
+  return depth === 0
+}
+
+/** True iff `candidate` resolves to a POSIX, Windows drive, or UNC share root. */
+export const isFilesystemRoot = (candidate: AbsoluteFilePath): boolean => {
+  if (isWindowsDrivePath(candidate) || isWindowsUncPath(candidate)) {
+    const parsed = parseWindowsPath(candidate)
+    return parsed.isAbsolute && resolvesToParsedRoot(parsed.segments)
+  }
+  return toPathKey(candidate) === '/'
+}
 
 /**
  * Byte-faithful canonical comparison form — or `null` when the path has no

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -40,8 +40,9 @@ function resolvesToParsedRoot(segments: string[]): boolean {
 /** True iff `candidate` resolves to a POSIX, Windows drive, or UNC share root. */
 export const isFilesystemRoot = (candidate: AbsoluteFilePath): boolean => {
   if (!isWin && candidate.startsWith('//')) return canonicalizeFilePath(candidate) === '/'
-  if (isWindowsDrivePath(candidate) || isWindowsUncPath(candidate)) {
-    const parsed = parseWindowsPath(candidate.startsWith('//') ? `\\\\${candidate.slice(2)}` : candidate)
+  const normalized = candidate.replace(/^\\\\\?\\UNC\\/i, '\\\\')
+  if (isWindowsDrivePath(normalized) || isWindowsUncPath(normalized)) {
+    const parsed = parseWindowsPath(normalized.startsWith('//') ? `\\\\${normalized.slice(2)}` : normalized)
     return parsed.isAbsolute && resolvesToParsedRoot(parsed.segments)
   }
   return toPathKey(candidate) === '/'

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -13,6 +13,7 @@
  * (`src/main/utils/file/fs.ts`) instead.
  */
 
+import { isWin } from '@renderer/utils/platform'
 import type { AbsoluteFilePath } from '@shared/types/file'
 import { canonicalizeFilePath, parseWindowsPath, type PosixRelativeFilePath } from '@shared/utils/file'
 
@@ -21,7 +22,7 @@ import { canonicalizeFilePath, parseWindowsPath, type PosixRelativeFilePath } fr
  * is a separator. On POSIX a backslash is an ordinary filename character.
  */
 const isWindowsDrivePath = (path: string) => /^[A-Za-z]:[/\\]/.test(path)
-const isWindowsUncPath = (path: string) => path.startsWith('\\\\') || path.startsWith('//')
+const isWindowsUncPath = (path: string) => path.startsWith('\\\\') || (isWin && path.startsWith('//'))
 
 function resolvesToParsedRoot(segments: string[]): boolean {
   let depth = 0

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -39,6 +39,7 @@ function resolvesToParsedRoot(segments: string[]): boolean {
 
 /** True iff `candidate` resolves to a POSIX, Windows drive, or UNC share root. */
 export const isFilesystemRoot = (candidate: AbsoluteFilePath): boolean => {
+  if (!isWin && candidate.startsWith('//')) return canonicalizeFilePath(candidate) === '/'
   if (isWindowsDrivePath(candidate) || isWindowsUncPath(candidate)) {
     const parsed = parseWindowsPath(candidate.startsWith('//') ? `\\\\${candidate.slice(2)}` : candidate)
     return parsed.isAbsolute && resolvesToParsedRoot(parsed.segments)

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -40,7 +40,7 @@ function resolvesToParsedRoot(segments: string[]): boolean {
 /** True iff `candidate` resolves to a POSIX, Windows drive, or UNC share root. */
 export const isFilesystemRoot = (candidate: AbsoluteFilePath): boolean => {
   if (!isWin && candidate.startsWith('//')) return canonicalizeFilePath(candidate) === '/'
-  const normalized = candidate.replace(/^\\\\\?\\UNC\\/i, '\\\\')
+  const normalized = candidate.replace(/^\\\\\?\\UNC\\/i, '\\\\').replace(/^\/\/\?\/UNC\//i, '//')
   if (isWindowsDrivePath(normalized) || isWindowsUncPath(normalized)) {
     const parsed = parseWindowsPath(normalized.startsWith('//') ? `\\\\${normalized.slice(2)}` : normalized)
     return parsed.isAbsolute && resolvesToParsedRoot(parsed.segments)

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -40,7 +40,7 @@ function resolvesToParsedRoot(segments: string[]): boolean {
 /** True iff `candidate` resolves to a POSIX, Windows drive, or UNC share root. */
 export const isFilesystemRoot = (candidate: AbsoluteFilePath): boolean => {
   if (!isWin && candidate.startsWith('//')) return canonicalizeFilePath(candidate) === '/'
-  const normalized = candidate.replace(/^\\\\\?\\UNC[\\/]+/i, '\\\\').replace(/^\/\/\?\/UNC[\\/]+/i, '//')
+  const normalized = candidate.replace(/^\\\\\?[\\/]+UNC[\\/]+/i, '\\\\').replace(/^\/\/\?[\\/]+UNC[\\/]+/i, '//')
   if (isWindowsDrivePath(normalized) || isWindowsUncPath(normalized)) {
     const parsed = parseWindowsPath(normalized.startsWith('//') ? `\\\\${normalized.slice(2)}` : normalized)
     return parsed.isAbsolute && resolvesToParsedRoot(parsed.segments)

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -40,7 +40,7 @@ function resolvesToParsedRoot(segments: string[]): boolean {
 /** True iff `candidate` resolves to a POSIX, Windows drive, or UNC share root. */
 export const isFilesystemRoot = (candidate: AbsoluteFilePath): boolean => {
   if (!isWin && candidate.startsWith('//')) return canonicalizeFilePath(candidate) === '/'
-  const normalized = candidate.replace(/^\\\\\?\\UNC\\/i, '\\\\').replace(/^\/\/\?\/UNC\//i, '//')
+  const normalized = candidate.replace(/^\\\\\?\\UNC[\\/]+/i, '\\\\').replace(/^\/\/\?\/UNC[\\/]+/i, '//')
   if (isWindowsDrivePath(normalized) || isWindowsUncPath(normalized)) {
     const parsed = parseWindowsPath(normalized.startsWith('//') ? `\\\\${normalized.slice(2)}` : normalized)
     return parsed.isAbsolute && resolvesToParsedRoot(parsed.segments)

--- a/src/shared/utils/file/__tests__/pathSpec.test.ts
+++ b/src/shared/utils/file/__tests__/pathSpec.test.ts
@@ -30,7 +30,8 @@ describe('parseWindowsPath', () => {
     ['C:/a', { isAbsolute: true, root: 'C:/', segments: ['a'] }],
     ['\\a', { isAbsolute: true, root: '\\', segments: ['a'] }],
     ['/a', { isAbsolute: true, root: '/', segments: ['a'] }],
-    ['\\\\server\\share\\a', { isAbsolute: true, root: '\\\\server\\share', segments: ['a'] }]
+    ['\\\\server\\share\\a', { isAbsolute: true, root: '\\\\server\\share', segments: ['a'] }],
+    ['\\\\server\\\\share/a', { isAbsolute: true, root: '\\\\server\\\\share', segments: ['a'] }]
   ])('parses %s', (value, expected) => {
     expect(parseWindowsPath(value)).toEqual(expected)
   })

--- a/src/shared/utils/file/pathSpec.ts
+++ b/src/shared/utils/file/pathSpec.ts
@@ -69,7 +69,7 @@ export interface ParsedPath {
  */
 const WINDOWS_DRIVE_PATTERN = /^[A-Za-z]:/
 /** `\\server\share` — both components required, matching `AbsoluteFilePathSchema`. */
-const WINDOWS_UNC_PATTERN = /^\\\\[^\\/]+[\\/][^\\/]+/
+const WINDOWS_UNC_PATTERN = /^\\\\[^\\/]+[\\/]+[^\\/]+/
 
 const toSegments = (body: string, separator: RegExp): string[] =>
   body.split(separator).filter((segment) => segment !== '')


### PR DESCRIPTION
### What this PR does

Before this PR:

Agent workspaces accepted filesystem roots such as `/`, Windows drive roots, and UNC share roots. A persisted root could reach runtime validation and renderer file-opening surfaces, causing whole-filesystem indexing and an unusable startup.

After this PR:

Agent workspace creation rejects paths that resolve lexically to a filesystem root. Existing persisted roots fail with an actionable, localized workspace error before runtime startup. The artifact tree, Files capability, keyboard shortcut, and artifact-open actions all stay unavailable without creating a directory tree or starting recursive search. Nested workspace directories remain unchanged.

Fixes #19862

### Why we need it and why it was done in this way

The guard uses the host `node:path` implementation in the main process, including navigation normalization such as `/tmp/..`. The renderer uses its existing pure-string path algebra so it can block indexing synchronously before IPC. Runtime dispatch validates the workspace before `beginTurn`, so Pi/DSH local skill snapshots and Claude workspace skill discovery occur only after the guard passes.

The following tradeoffs were made:

- This change rejects literal and navigation-normalized POSIX, Windows drive, and UNC share roots without adding filesystem I/O to the synchronous DataApi write transaction.
- Existing non-empty sessions retain readable history, but cannot be silently rebound because workspace binding is intentionally permanent after the first message. A migration or clone-based recovery flow needs a separate product contract so historical file references are not reinterpreted.
- A path that is itself a symlink to a filesystem root remains a residual risk. Closing that effective-root case requires an async `realpath` policy across workspace persistence and the generic directory-tree/search IPC boundaries; that broader filesystem-identity change is intentionally kept out of this focused fix.

The following alternatives were considered:

- Estimating workspace size and asking for confirmation does not prevent startup recovery failures for an already persisted root.
- Adding guards to each runtime skill scanner would duplicate policy and still leave renderer indexing exposed.

Links to places where the discussion took place: #19862

### Breaking changes

A filesystem root can no longer be selected as an Agent workspace. Existing affected sessions show a prompt to choose a subfolder.

### Special notes for your reviewer

Validation:

- Current head: `5783c09ab50f0af1ac56ef2630b329037c1b61f6`.
- New review regressions reproduced the persisted-root file-opening exposure, four extended-UNC share separator false negatives, and four mixed or repeated separators between the `?` and `UNC` markers before the fixes.
- Final affected suites: 123/123 passed (`AgentRightPane` 45, session workspace 4, renderer Windows paths 25, shared path specification 49).
- Earlier current-branch coverage: renderer path suites 70/70; shared file utility suites 239/239; broader main/renderer regression set 174 passed with one platform-specific skip.
- `pnpm lint` passed, including typecheck, 69,472 i18n checks, and formatting.
- `pnpm test:lint` passed.
- Exact-head GitHub CI is monitored asynchronously; local required gates passed.

Screenshots:

No credible Before/After screenshot could be produced. The only tracked Cherry Studio dev Electron instance is owned by `/Users/siin/conductor/workspaces/cherry-studio/doha-v1`; per the single-dev-app constraint, this isolated PR worktree did not start, replace, or borrow that instance. The user-visible result is covered by the workspace-warning hook test, ArtifactPane invalid-state integration test, and AgentRightPane file-action regression.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for this targeted safety fix
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Reject filesystem roots as Agent workspaces and prompt affected users to choose a subfolder.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace persistence, session startup/priming, and multiple file-browsing surfaces; incorrect root detection could block valid UNC/POSIX paths or leave unsafe roots reachable.
> 
> **Overview**
> **Blocks filesystem roots** (`/`, drive letters, UNC shares, and paths that normalize to them) from being used as Agent workspaces end-to-end, with localized errors and without probing the disk for roots.
> 
> **Persistence and runtime:** workspace creation validation rejects roots; persisted user workspaces at a root are omitted from list/lookup. Session workspace preparation fails fast before `getPathStatus`. `primeConnection` now runs `validateSession` before opening a connection (no connect on failure). Re-priming an **already live** connection only refreshes slash commands—no second validation, reconcile, or reconnect.
> 
> **Renderer:** artifact tree, @-mention file search, workspace warnings, and right-pane file actions treat root workspaces as invalid/unavailable so indexing and recursive search never start.
> 
> **Path handling:** adds shared `isFilesystemRoot` (main uses `node:path`; renderer uses pure-string rules, including POSIX `//` vs Windows UNC). UNC parsing tolerates extra slashes in `parseWindowsPath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5783c09ab50f0af1ac56ef2630b329037c1b61f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->