### PR TITLE
fix(cherry-cloud): support model capabilities and OpenAI chat

### DIFF
--- a/src/main/ai/provider/__tests__/cherryCloud.test.ts
+++ b/src/main/ai/provider/__tests__/cherryCloud.test.ts
@@ -1,3 +1,5 @@
+import { CHERRY_CLOUD_PROVIDER_ID } from '@shared/data/presets/cherryai'
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -23,21 +25,38 @@ describe('Cherry Cloud provider transport', () => {
     mocks.authenticatedFetch.mockResolvedValue(new Response('{}', { status: 200 }))
   })
 
-  it('delegates only the configured Cloud path and strips caller credentials', async () => {
-    const config = buildCherryCloudProviderConfig('messages')
+  it.each([
+    {
+      endpointType: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+      providerId: 'anthropic',
+      path: '/v1/messages'
+    },
+    {
+      endpointType: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      providerId: 'openai-compatible',
+      path: '/v1/chat/completions'
+    }
+  ])('routes $endpointType through $path and strips caller credentials', async ({ endpointType, providerId, path }) => {
+    const config = buildCherryCloudProviderConfig(endpointType, 'messages')
     const settings = config.providerSettings as {
       apiKey?: string
       baseURL?: string
       fetch?: typeof globalThis.fetch
+      includeUsage?: boolean
+      name?: string
     }
     const controller = new AbortController()
 
-    expect(config.providerId).toBe('anthropic')
+    expect(config.providerId).toBe(providerId)
     expect(config.endpoint).toBe('messages')
     expect(settings.baseURL).toBe('https://cloud.cherryai.com.cn/v1')
     expect(settings.apiKey).toBeTruthy()
+    if (endpointType === ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS) {
+      expect(settings.name).toBe(CHERRY_CLOUD_PROVIDER_ID)
+      expect(settings.includeUsage).toBe(true)
+    }
 
-    const response = await settings.fetch!(new URL('https://cloud.cherryai.com.cn/v1/messages?beta=true'), {
+    const response = await settings.fetch!(new URL(`https://cloud.cherryai.com.cn${path}?beta=true`), {
       method: 'POST',
       headers: {
         Authorization: 'Bearer caller-token',
@@ -57,9 +76,9 @@ describe('Cherry Cloud provider transport', () => {
 
     expect(response.status).toBe(200)
     expect(mocks.authenticatedFetch).toHaveBeenCalledOnce()
-    const [path, init] = mocks.authenticatedFetch.mock.calls[0]
+    const [requestPath, init] = mocks.authenticatedFetch.mock.calls[0]
     const headers = new Headers(init.headers)
-    expect(path).toBe('/v1/messages?beta=true')
+    expect(requestPath).toBe(`${path}?beta=true`)
     expect(init).toMatchObject({ method: 'POST', body: '{"model":"claude"}' })
     expect(headers.get('content-type')).toBe('application/json')
     expect(headers.get('idempotency-key')).toBe('request-1')
@@ -76,16 +95,19 @@ describe('Cherry Cloud provider transport', () => {
     expect(init.signal?.aborted).toBe(true)
   })
 
-  it('rejects requests outside the configured Cloud message route', async () => {
-    const config = buildCherryCloudProviderConfig()
+  it.each([
+    [ENDPOINT_TYPE.ANTHROPIC_MESSAGES, '/v1/chat/completions'],
+    [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, '/v1/messages']
+  ])('rejects requests outside the configured %s route', async (endpointType, mismatchedPath) => {
+    const config = buildCherryCloudProviderConfig(endpointType)
     const fetch = (config.providerSettings as { fetch?: typeof globalThis.fetch }).fetch!
 
-    await expect(fetch('https://example.com/v1/messages', { method: 'POST', body: '{}' })).rejects.toThrow(
+    await expect(fetch(`https://example.com${mismatchedPath}`, { method: 'POST', body: '{}' })).rejects.toThrow(
       'configured Cherry Cloud API origin'
     )
-    await expect(fetch('https://cloud.cherryai.com.cn/api/v1/account', { method: 'GET' })).rejects.toThrow(
-      'configured Cherry Cloud API origin'
-    )
+    await expect(
+      fetch(`https://cloud.cherryai.com.cn${mismatchedPath}`, { method: 'POST', body: '{}' })
+    ).rejects.toThrow('configured Cherry Cloud API origin')
     expect(mocks.authenticatedFetch).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -82,23 +82,25 @@ afterEach(() => {
 })
 
 describe('providerToAiSdkConfig — builder dispatch matrix', () => {
-  it('routes managed Cherry Cloud models through Anthropic without selecting a provider API key', async () => {
-    const provider = makeProvider({ id: CHERRY_CLOUD_PROVIDER_ID, presetProviderId: CHERRYAI_PROVIDER_ID })
-    const model = makeModel({
-      id: `${CHERRY_CLOUD_PROVIDER_ID}::deepseek-go`,
-      apiModelId: 'deepseek-go',
-      providerId: CHERRY_CLOUD_PROVIDER_ID,
-      group: CHERRY_CLOUD_MODEL_GROUP,
-      endpointTypes: [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
-    })
+  it.each([ENDPOINT_TYPE.ANTHROPIC_MESSAGES, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS])(
+    'passes managed Cherry Cloud %s models to its credential-free transport',
+    async (endpointType) => {
+      const provider = makeProvider({ id: CHERRY_CLOUD_PROVIDER_ID, presetProviderId: CHERRYAI_PROVIDER_ID })
+      const model = makeModel({
+        id: `${CHERRY_CLOUD_PROVIDER_ID}::deepseek-go`,
+        apiModelId: 'deepseek-go',
+        providerId: CHERRY_CLOUD_PROVIDER_ID,
+        group: CHERRY_CLOUD_MODEL_GROUP,
+        endpointTypes: [endpointType]
+      })
 
-    const resolved = await resolveProviderAiSdkConfig(provider, model)
+      const resolved = await resolveProviderAiSdkConfig(provider, model)
 
-    expect(resolved.config.providerId).toBe('anthropic')
-    expect(resolved.credentialReceipt).toEqual({ attribution: 'unknown' })
-    expect(buildCherryCloudProviderConfigMock).toHaveBeenCalledOnce()
-    expect(resolveApiKeyMock).not.toHaveBeenCalled()
-  })
+      expect(resolved.credentialReceipt).toEqual({ attribution: 'unknown' })
+      expect(buildCherryCloudProviderConfigMock.mock.calls[0][0]).toBe(endpointType)
+      expect(resolveApiKeyMock).not.toHaveBeenCalled()
+    }
+  )
 
   it('does not route an ordinary CherryAI model from its display group', async () => {
     const provider = makeProvider({ id: CHERRYAI_PROVIDER_ID })

--- a/src/main/ai/provider/cherryCloud.ts
+++ b/src/main/ai/provider/cherryCloud.ts
@@ -1,8 +1,11 @@
 import { application } from '@application'
+import { CHERRY_CLOUD_PROVIDER_ID } from '@shared/data/presets/cherryai'
+import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
 
 import type { ProviderConfig } from '../types'
 
 const CHERRY_CLOUD_MESSAGES_PATH = '/v1/messages'
+const CHERRY_CLOUD_CHAT_COMPLETIONS_PATH = '/v1/chat/completions'
 const SDK_API_KEY_PLACEHOLDER = 'managed-by-cherry-cloud'
 const UNSAFE_FORWARD_HEADERS = new Set([
   'authorization',
@@ -34,30 +37,45 @@ function forwardedHeaders(source: Headers): Headers {
   return headers
 }
 
-export function buildCherryCloudProviderConfig(endpoint?: string): ProviderConfig<'anthropic'> {
+export function buildCherryCloudProviderConfig(
+  endpointType: EndpointType | undefined,
+  endpoint?: string
+): ProviderConfig {
   const service = application.get('CherryCloudService')
   const apiOrigin = new URL(service.getApiOrigin()).origin
+  const requestPath =
+    endpointType === ENDPOINT_TYPE.ANTHROPIC_MESSAGES
+      ? CHERRY_CLOUD_MESSAGES_PATH
+      : endpointType === ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS
+        ? CHERRY_CLOUD_CHAT_COMPLETIONS_PATH
+        : undefined
+  if (!requestPath) throw new Error(`Unsupported Cherry Cloud endpoint type: ${endpointType ?? 'undefined'}`)
 
-  return {
-    providerId: 'anthropic',
-    endpoint,
-    providerSettings: {
-      apiKey: SDK_API_KEY_PLACEHOLDER,
-      baseURL: new URL('/v1', `${apiOrigin}/`).toString(),
-      fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-        const request = new Request(input, init)
-        const url = new URL(request.url)
-        if (url.origin !== apiOrigin || url.pathname !== CHERRY_CLOUD_MESSAGES_PATH) {
-          throw new Error('Cherry Cloud requests must stay on the configured Cherry Cloud API origin')
-        }
-
-        return service.authenticatedFetch(`${url.pathname}${url.search}`, {
-          method: request.method,
-          headers: forwardedHeaders(request.headers),
-          body: request.body ? await request.text() : undefined,
-          signal: request.signal
-        })
+  const providerSettings = {
+    apiKey: SDK_API_KEY_PLACEHOLDER,
+    baseURL: new URL('/v1', `${apiOrigin}/`).toString(),
+    fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init)
+      const url = new URL(request.url)
+      if (url.origin !== apiOrigin || url.pathname !== requestPath) {
+        throw new Error('Cherry Cloud requests must stay on the configured Cherry Cloud API origin')
       }
+
+      return service.authenticatedFetch(`${url.pathname}${url.search}`, {
+        method: request.method,
+        headers: forwardedHeaders(request.headers),
+        body: request.body ? await request.text() : undefined,
+        signal: request.signal
+      })
     }
+  }
+
+  if (endpointType === ENDPOINT_TYPE.ANTHROPIC_MESSAGES) {
+    return { providerId: 'anthropic', endpoint, providerSettings }
+  }
+  return {
+    providerId: 'openai-compatible',
+    endpoint,
+    providerSettings: { ...providerSettings, name: CHERRY_CLOUD_PROVIDER_ID, includeUsage: true }
   }
 }

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -223,7 +223,7 @@ export async function resolveProviderAiSdkConfig(
     { match: (p) => p.id === GROK_CLI_PROVIDER_ID, build: withProviderAuth('oauth', buildGrokCliConfig) },
     {
       match: (p) => isManagedCherryCloudModel(p.id),
-      build: withoutCredential((ctx) => buildCherryCloudProviderConfig(ctx.endpoint))
+      build: withoutCredential((ctx) => buildCherryCloudProviderConfig(ctx.endpointType, ctx.endpoint))
     },
     { match: (p) => p.id === CHERRYAI_PROVIDER_ID, build: withSelectedApiKey(buildCherryAIConfig) },
     // Local embedding runs fully in-process (transformers.js in a worker): no

--- a/src/main/services/cherryCloud/CherryCloudService.ts
+++ b/src/main/services/cherryCloud/CherryCloudService.ts
@@ -1,6 +1,7 @@
 import { application } from '@application'
 import { notifyDataApiDataChange } from '@data/dataApiDataChange'
 import { modelService } from '@data/services/ModelService'
+import { providerRegistryService } from '@data/services/ProviderRegistryService'
 import { loggerService } from '@logger'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { getAppEdition } from '@main/utils/appEdition'
@@ -612,13 +613,44 @@ export class CherryCloudService extends BaseService {
       endpoint_type: EndpointType
       context_window: number
       max_output_tokens: number
-      capabilities: ModelCapability[]
+      capabilities?: ModelCapability[]
     }>
   ): void {
     const current = modelService.list({ providerId: CHERRY_CLOUD_PROVIDER_ID })
     const currentByModelId = new Map(current.map((model) => [parseUniqueModelId(model.id).modelId, model]))
-    const remoteByModelId = new Map(models.map((model) => [model.id, model]))
-    const missing = models.filter((model) => !currentByModelId.has(model.id))
+    const missingCapabilityModelIds = models
+      .filter((model) => model.capabilities === undefined)
+      .map((model) => model.id)
+    const registryCapabilitiesByModelId = new Map<string, ModelCapability[]>()
+
+    if (missingCapabilityModelIds.length > 0) {
+      try {
+        for (const model of providerRegistryService.resolveModels(
+          CHERRY_CLOUD_PROVIDER_ID,
+          missingCapabilityModelIds
+        )) {
+          if (!model.presetModelId) continue
+          const modelId = model.apiModelId ?? parseUniqueModelId(model.id).modelId
+          registryCapabilitiesByModelId.set(modelId, model.capabilities)
+        }
+      } catch (error) {
+        logger.warn('Cherry Cloud registry capability fallback failed', {
+          modelCount: missingCapabilityModelIds.length,
+          reason: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+
+    const reconciledModels = models.map((model) => ({
+      ...model,
+      capabilities:
+        model.capabilities ??
+        registryCapabilitiesByModelId.get(model.id) ??
+        currentByModelId.get(model.id)?.capabilities ??
+        []
+    }))
+    const remoteByModelId = new Map(reconciledModels.map((model) => [model.id, model]))
+    const missing = reconciledModels.filter((model) => !currentByModelId.has(model.id))
     const updates = current.flatMap((model) => {
       const modelId = parseUniqueModelId(model.id).modelId
       const remote = remoteByModelId.get(modelId)

--- a/src/main/services/cherryCloud/CherryCloudService.ts
+++ b/src/main/services/cherryCloud/CherryCloudService.ts
@@ -5,7 +5,12 @@ import { loggerService } from '@logger'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { getAppEdition } from '@main/utils/appEdition'
 import { CHERRY_CLOUD_MODEL_GROUP, CHERRY_CLOUD_PROVIDER_ID } from '@shared/data/presets/cherryai'
-import { createUniqueModelId, type EndpointType, parseUniqueModelId } from '@shared/data/types/model'
+import {
+  createUniqueModelId,
+  type EndpointType,
+  type ModelCapability,
+  parseUniqueModelId
+} from '@shared/data/types/model'
 import type { CherryCloudModelSyncResult, CherryCloudStatus } from '@shared/ipc/schemas/cherryCloud'
 import { app, net, shell } from 'electron'
 import type { ZodType } from 'zod'
@@ -607,6 +612,7 @@ export class CherryCloudService extends BaseService {
       endpoint_type: EndpointType
       context_window: number
       max_output_tokens: number
+      capabilities: ModelCapability[]
     }>
   ): void {
     const current = modelService.list({ providerId: CHERRY_CLOUD_PROVIDER_ID })
@@ -624,6 +630,8 @@ export class CherryCloudService extends BaseService {
         model.endpointTypes[0] === remote.endpoint_type &&
         model.contextWindow === remote.context_window &&
         model.maxOutputTokens === remote.max_output_tokens &&
+        model.capabilities.length === remote.capabilities.length &&
+        model.capabilities.every((capability) => remote.capabilities.includes(capability)) &&
         model.supportsStreaming &&
         model.isEnabled
       ) {
@@ -638,6 +646,7 @@ export class CherryCloudService extends BaseService {
             endpointTypes: [remote.endpoint_type],
             contextWindow: remote.context_window,
             maxOutputTokens: remote.max_output_tokens,
+            capabilities: remote.capabilities,
             supportsStreaming: true,
             isEnabled: true
           }
@@ -656,6 +665,7 @@ export class CherryCloudService extends BaseService {
             endpointTypes: [model.endpoint_type],
             contextWindow: model.context_window,
             maxOutputTokens: model.max_output_tokens,
+            capabilities: model.capabilities,
             supportsStreaming: true
           }
         }))
@@ -688,7 +698,9 @@ export class CherryCloudService extends BaseService {
     const url = this.resolveRequestUrl(path)
     const headers = new Headers(init?.headers)
     const idempotencyKey =
-      url.pathname === '/v1/messages' ? (headers.get('Idempotency-Key') ?? createIdempotencyKey()) : undefined
+      url.pathname === '/v1/messages' || url.pathname === '/v1/chat/completions'
+        ? (headers.get('Idempotency-Key') ?? createIdempotencyKey())
+        : undefined
     const response = await this.signedFetch(url, init, session, { bearer: true, idempotencyKey })
     if (response.status === 401) await this.clearSession(session)
     return response

--- a/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
+++ b/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
@@ -1,3 +1,4 @@
+import type { Model } from '@shared/data/types/model'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -94,7 +95,11 @@ vi.mock('../CherryCloudLoopbackCallback', () => ({
   CherryCloudLoopbackCallback: { open: mocks.loopbackOpen }
 }))
 
+import { providerRegistryService } from '@data/services/ProviderRegistryService'
+
 import { CherryCloudLoginUnavailableError, CherryCloudService } from '../CherryCloudService'
+
+const resolveRegistryModels = vi.spyOn(providerRegistryService, 'resolveModels')
 
 const authorizationId = '00000000-0000-4000-8000-000000000001'
 const sessionId = '00000000-0000-4000-8000-000000000010'
@@ -305,6 +310,7 @@ describe('CherryCloudService', () => {
     mocks.modelList.mockReturnValue([])
     mocks.modelCreate.mockReturnValue([])
     mocks.modelBulkUpdate.mockReturnValue([])
+    resolveRegistryModels.mockReturnValue([])
     mocks.gatewayStart.mockResolvedValue(undefined)
     mocks.openExternal.mockResolvedValue(undefined)
     mocks.loopbackOpen.mockResolvedValue(mocks.loopbackReceiver)
@@ -818,6 +824,7 @@ describe('CherryCloudService', () => {
       }
     ])
     expect(mocks.modelBulkUpdate).not.toHaveBeenCalled()
+    expect(resolveRegistryModels).not.toHaveBeenCalled()
     expect(mocks.modelList).toHaveBeenCalledWith({ providerId: 'cherryai-subscription' })
     expect(mocks.notifyDataChange).toHaveBeenCalledWith([{ endpoint: '/models', kind: 'membership' }])
     for (const [, init] of mocks.netFetch.mock.calls) {
@@ -872,6 +879,110 @@ describe('CherryCloudService', () => {
         }
       }
     ])
+  })
+
+  it('falls back to registry capabilities when the Cloud catalog omits them', async () => {
+    const service = await createSignedInService()
+    resolveRegistryModels.mockReturnValue([
+      {
+        id: 'cherryai-subscription::deepseek-free',
+        providerId: 'cherryai-subscription',
+        apiModelId: 'deepseek-free',
+        presetModelId: 'deepseek-free',
+        name: 'DeepSeek Free',
+        capabilities: ['function-call', 'reasoning'],
+        supportsStreaming: true,
+        isEnabled: true,
+        isHidden: false
+      } satisfies Model
+    ])
+    const modelWithoutCapabilities = { ...cloudModelCatalog.data[0], capabilities: undefined }
+    mockModelSync(
+      {
+        ...accountSnapshot,
+        entitlements: [accountSnapshot.entitlements[0]]
+      },
+      { data: [modelWithoutCapabilities] }
+    )
+
+    await service['syncEntitledModels']()
+
+    expect(resolveRegistryModels).toHaveBeenCalledWith('cherryai-subscription', ['deepseek-free'])
+    expect(mocks.modelCreate).toHaveBeenCalledWith([
+      {
+        dto: {
+          providerId: 'cherryai-subscription',
+          modelId: 'deepseek-free',
+          name: 'DeepSeek Free',
+          group: 'Cherry Cloud',
+          endpointTypes: ['anthropic-messages'],
+          contextWindow: 128_000,
+          maxOutputTokens: 8_192,
+          capabilities: ['function-call', 'reasoning'],
+          supportsStreaming: true
+        }
+      }
+    ])
+  })
+
+  it.each([
+    {
+      failure: 'does not recognize the Cloud SKU',
+      arrange: () =>
+        resolveRegistryModels.mockReturnValue([
+          {
+            id: 'cherryai-subscription::deepseek-free',
+            providerId: 'cherryai-subscription',
+            apiModelId: 'deepseek-free',
+            presetModelId: null,
+            name: 'DeepSeek Free',
+            capabilities: [],
+            supportsStreaming: true,
+            isEnabled: true,
+            isHidden: false
+          } satisfies Model
+        ])
+    },
+    {
+      failure: 'is unavailable',
+      arrange: () =>
+        resolveRegistryModels.mockImplementation(() => {
+          throw new Error('registry unavailable')
+        })
+    }
+  ])('preserves existing capabilities when the Registry $failure', async ({ arrange }) => {
+    const service = await createSignedInService()
+    mocks.modelList.mockReturnValue([
+      {
+        id: 'cherryai-subscription::deepseek-free',
+        providerId: 'cherryai-subscription',
+        apiModelId: 'deepseek-free',
+        name: 'DeepSeek Free',
+        group: 'Cherry Cloud',
+        endpointTypes: ['anthropic-messages'],
+        contextWindow: 128_000,
+        maxOutputTokens: 8_192,
+        capabilities: ['function-call'],
+        supportsStreaming: true,
+        isEnabled: true
+      }
+    ])
+    arrange()
+    const modelWithoutCapabilities = { ...cloudModelCatalog.data[0], capabilities: undefined }
+    mockModelSync(
+      {
+        ...accountSnapshot,
+        entitlements: [accountSnapshot.entitlements[0]]
+      },
+      { data: [modelWithoutCapabilities] }
+    )
+
+    await expect(service['syncEntitledModels']()).resolves.toEqual({
+      entitledModelIds: ['cherryai-subscription::deepseek-free'],
+      quotaExhaustedModelIds: []
+    })
+    expect(mocks.modelCreate).not.toHaveBeenCalled()
+    expect(mocks.modelBulkUpdate).not.toHaveBeenCalled()
   })
 
   it('rejects model protocols outside the Cherry Cloud contract', async () => {

--- a/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
+++ b/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
@@ -136,21 +136,24 @@ const cloudModelCatalog = {
       display_name: 'DeepSeek Free',
       endpoint_type: 'anthropic-messages',
       context_window: 128_000,
-      max_output_tokens: 8_192
+      max_output_tokens: 8_192,
+      capabilities: ['function-call']
     },
     {
       id: 'deepseek-go',
       display_name: 'DeepSeek GO',
       endpoint_type: 'anthropic-messages',
       context_window: 256_000,
-      max_output_tokens: 16_384
+      max_output_tokens: 16_384,
+      capabilities: ['function-call', 'reasoning']
     },
     {
       id: 'deepseek-inactive',
       display_name: 'DeepSeek Inactive',
       endpoint_type: 'anthropic-messages',
       context_window: 64_000,
-      max_output_tokens: 4_096
+      max_output_tokens: 4_096,
+      capabilities: []
     }
   ]
 }
@@ -776,7 +779,7 @@ describe('CherryCloudService', () => {
       },
       {
         data: cloudModelCatalog.data.map((model) =>
-          model.id === 'deepseek-go' ? { ...model, endpoint_type: 'openai-responses' } : model
+          model.id === 'deepseek-go' ? { ...model, endpoint_type: 'openai-chat-completions' } : model
         )
       }
     )
@@ -796,6 +799,7 @@ describe('CherryCloudService', () => {
           endpointTypes: ['anthropic-messages'],
           contextWindow: 128_000,
           maxOutputTokens: 8_192,
+          capabilities: ['function-call'],
           supportsStreaming: true
         }
       },
@@ -805,9 +809,10 @@ describe('CherryCloudService', () => {
           modelId: 'deepseek-go',
           name: 'DeepSeek GO',
           group: 'Cherry Cloud',
-          endpointTypes: ['openai-responses'],
+          endpointTypes: ['openai-chat-completions'],
           contextWindow: 256_000,
           maxOutputTokens: 16_384,
+          capabilities: ['function-call', 'reasoning'],
           supportsStreaming: true
         }
       }
@@ -821,6 +826,63 @@ describe('CherryCloudService', () => {
       expect(headers.get('Cherry-Device-ID')).toBe(deviceId)
       expect(headers.get('Cherry-Signature')).toMatch(/^[A-Za-z0-9_-]{86}$/)
     }
+  })
+
+  it('updates capabilities for an existing managed model', async () => {
+    const service = await createSignedInService()
+    mocks.modelList.mockReturnValue([
+      {
+        id: 'cherryai-subscription::deepseek-free',
+        providerId: 'cherryai-subscription',
+        apiModelId: 'deepseek-free',
+        name: 'DeepSeek Free',
+        group: 'Cherry Cloud',
+        endpointTypes: ['anthropic-messages'],
+        contextWindow: 128_000,
+        maxOutputTokens: 8_192,
+        capabilities: [],
+        supportsStreaming: true,
+        isEnabled: true
+      }
+    ])
+    mockModelSync(
+      {
+        ...accountSnapshot,
+        entitlements: [accountSnapshot.entitlements[0]]
+      },
+      { data: [cloudModelCatalog.data[0]] }
+    )
+
+    await service['syncEntitledModels']()
+
+    expect(mocks.modelCreate).not.toHaveBeenCalled()
+    expect(mocks.modelBulkUpdate).toHaveBeenCalledWith([
+      {
+        providerId: 'cherryai-subscription',
+        modelId: 'deepseek-free',
+        patch: {
+          name: 'DeepSeek Free',
+          group: 'Cherry Cloud',
+          endpointTypes: ['anthropic-messages'],
+          contextWindow: 128_000,
+          maxOutputTokens: 8_192,
+          capabilities: ['function-call'],
+          supportsStreaming: true,
+          isEnabled: true
+        }
+      }
+    ])
+  })
+
+  it('rejects model protocols outside the Cherry Cloud contract', async () => {
+    const service = await createSignedInService()
+    mockModelSync(accountSnapshot, {
+      data: [{ ...cloudModelCatalog.data[0], endpoint_type: 'openai-responses' }]
+    })
+
+    await expect(service['syncEntitledModels']()).rejects.toThrow()
+    expect(mocks.modelCreate).not.toHaveBeenCalled()
+    expect(mocks.modelBulkUpdate).not.toHaveBeenCalled()
   })
 
   it('keeps managed models while signed out', async () => {
@@ -1207,6 +1269,22 @@ describe('CherryCloudService', () => {
     expect(headers.get('Cherry-Body-SHA256')).toBe('f24394a04116608ee41330b7fd6511ff8e44f65e29f6cfc44bb7c8393de7e5ea')
     expect(init.redirect).toBe('error')
     expect(init.signal).toBeUndefined()
+  })
+
+  it('adds an idempotency key to signed OpenAI chat completion requests', async () => {
+    const service = await createSignedInService()
+    mockCloudRoute('/v1/chat/completions', jsonResponse({ object: 'chat.completion' }))
+
+    await service.authenticatedFetch('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"model":"deepseek-go","messages":[]}'
+    })
+
+    const init = requestCalls('/v1/chat/completions')[0][1]
+    const headers = new Headers(init.headers)
+    expect(headers.get('Idempotency-Key')).toMatch(/^[A-Za-z0-9_-]{42}[AEIMQUYcgkosw048]$/)
+    expect(headers.get('Cherry-Signature')).toMatch(/^[A-Za-z0-9_-]{86}$/)
   })
 
   it('clears the local login before waiting for remote Product Session revocation', async () => {

--- a/src/main/services/cherryCloud/__tests__/contracts.test.ts
+++ b/src/main/services/cherryCloud/__tests__/contracts.test.ts
@@ -83,23 +83,33 @@ describe('Cherry Cloud response contracts', () => {
           {
             id: 'claude-test',
             display_name: 'Claude Test',
-            endpoint_type: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
             context_window: 200_000,
             max_output_tokens: 8_192
           }
         ]
       }).success
     ).toBe(false)
+  })
+
+  it('defaults missing capabilities and ignores unknown capability values', () => {
+    const model = {
+      id: 'claude-test',
+      display_name: 'Claude Test',
+      endpoint_type: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+      context_window: 200_000,
+      max_output_tokens: 8_192
+    }
+
+    expect(cloudModelListSchema.parse({ data: [model] }).data[0].capabilities).toEqual([])
+    expect(
+      cloudModelListSchema.parse({
+        data: [{ ...model, capabilities: [MODEL_CAPABILITY.FUNCTION_CALL, 'future-capability'] }]
+      }).data[0].capabilities
+    ).toEqual([MODEL_CAPABILITY.FUNCTION_CALL])
+    expect(cloudModelListSchema.safeParse({ data: [{ ...model, capabilities: null }] }).success).toBe(false)
     expect(
       cloudModelListSchema.safeParse({
-        data: [
-          {
-            id: 'claude-test',
-            display_name: 'Claude Test',
-            context_window: 200_000,
-            max_output_tokens: 8_192
-          }
-        ]
+        data: [{ ...model, capabilities: [MODEL_CAPABILITY.FUNCTION_CALL, 1] }]
       }).success
     ).toBe(false)
   })

--- a/src/main/services/cherryCloud/__tests__/contracts.test.ts
+++ b/src/main/services/cherryCloud/__tests__/contracts.test.ts
@@ -91,7 +91,7 @@ describe('Cherry Cloud response contracts', () => {
     ).toBe(false)
   })
 
-  it('defaults missing capabilities and ignores unknown capability values', () => {
+  it('preserves missing capabilities for client fallback and ignores unknown capability values', () => {
     const model = {
       id: 'claude-test',
       display_name: 'Claude Test',
@@ -100,7 +100,7 @@ describe('Cherry Cloud response contracts', () => {
       max_output_tokens: 8_192
     }
 
-    expect(cloudModelListSchema.parse({ data: [model] }).data[0].capabilities).toEqual([])
+    expect(cloudModelListSchema.parse({ data: [model] }).data[0].capabilities).toBeUndefined()
     expect(
       cloudModelListSchema.parse({
         data: [{ ...model, capabilities: [MODEL_CAPABILITY.FUNCTION_CALL, 'future-capability'] }]

--- a/src/main/services/cherryCloud/__tests__/contracts.test.ts
+++ b/src/main/services/cherryCloud/__tests__/contracts.test.ts
@@ -1,4 +1,4 @@
-import { ENDPOINT_TYPE } from '@cherrystudio/provider-registry'
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@cherrystudio/provider-registry'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -60,6 +60,7 @@ describe('Cherry Cloud response contracts', () => {
             endpoint_type: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
             context_window: 200_000,
             max_output_tokens: 8_192,
+            capabilities: [MODEL_CAPABILITY.FUNCTION_CALL],
             model_metadata: { tier: 'work' }
           }
         ],
@@ -82,6 +83,19 @@ describe('Cherry Cloud response contracts', () => {
           {
             id: 'claude-test',
             display_name: 'Claude Test',
+            endpoint_type: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+            context_window: 200_000,
+            max_output_tokens: 8_192
+          }
+        ]
+      }).success
+    ).toBe(false)
+    expect(
+      cloudModelListSchema.safeParse({
+        data: [
+          {
+            id: 'claude-test',
+            display_name: 'Claude Test',
             context_window: 200_000,
             max_output_tokens: 8_192
           }
@@ -95,7 +109,8 @@ describe('Cherry Cloud response contracts', () => {
       display_name: 'Claude Test',
       endpoint_type: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
       context_window: 200_000,
-      max_output_tokens: 8_192
+      max_output_tokens: 8_192,
+      capabilities: [MODEL_CAPABILITY.FUNCTION_CALL]
     }
 
     expect(cloudModelListSchema.safeParse({ data: [{ ...model, id: 'claude?test' }] }).success).toBe(false)

--- a/src/main/services/cherryCloud/contracts.ts
+++ b/src/main/services/cherryCloud/contracts.ts
@@ -1,4 +1,4 @@
-import { ENDPOINT_TYPE, objectValues } from '@cherrystudio/provider-registry'
+import { ENDPOINT_TYPE, MODEL_CAPABILITY, objectValues } from '@cherrystudio/provider-registry'
 import { CHERRY_CLOUD_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import { createUniqueModelId } from '@shared/data/types/model'
 import * as z from 'zod'
@@ -84,14 +84,17 @@ const cloudModelIdSchema = z
     { message: 'model ID cannot contain reserved route characters' }
   )
 
+const cloudEndpointTypeSchema = z.enum([ENDPOINT_TYPE.ANTHROPIC_MESSAGES, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS])
+
 export const cloudModelListSchema = z.looseObject({
   data: z.array(
     z.looseObject({
       id: cloudModelIdSchema,
       display_name: z.string().min(1),
-      endpoint_type: z.enum(objectValues(ENDPOINT_TYPE)),
+      endpoint_type: cloudEndpointTypeSchema,
       context_window: z.number().int().positive(),
-      max_output_tokens: z.number().int().positive()
+      max_output_tokens: z.number().int().positive(),
+      capabilities: z.array(z.enum(objectValues(MODEL_CAPABILITY)))
     })
   )
 })

--- a/src/main/services/cherryCloud/contracts.ts
+++ b/src/main/services/cherryCloud/contracts.ts
@@ -88,10 +88,10 @@ const cloudEndpointTypeSchema = z.enum([ENDPOINT_TYPE.ANTHROPIC_MESSAGES, ENDPOI
 const KNOWN_MODEL_CAPABILITIES = new Set<string>(objectValues(MODEL_CAPABILITY))
 const cloudModelCapabilitiesSchema = z
   .array(z.string())
-  .default([])
   .transform((capabilities) =>
     capabilities.filter((capability): capability is ModelCapability => KNOWN_MODEL_CAPABILITIES.has(capability))
   )
+  .optional()
 
 export const cloudModelListSchema = z.looseObject({
   data: z.array(

--- a/src/main/services/cherryCloud/contracts.ts
+++ b/src/main/services/cherryCloud/contracts.ts
@@ -1,4 +1,4 @@
-import { ENDPOINT_TYPE, MODEL_CAPABILITY, objectValues } from '@cherrystudio/provider-registry'
+import { ENDPOINT_TYPE, MODEL_CAPABILITY, type ModelCapability, objectValues } from '@cherrystudio/provider-registry'
 import { CHERRY_CLOUD_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import { createUniqueModelId } from '@shared/data/types/model'
 import * as z from 'zod'
@@ -85,6 +85,13 @@ const cloudModelIdSchema = z
   )
 
 const cloudEndpointTypeSchema = z.enum([ENDPOINT_TYPE.ANTHROPIC_MESSAGES, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS])
+const KNOWN_MODEL_CAPABILITIES = new Set<string>(objectValues(MODEL_CAPABILITY))
+const cloudModelCapabilitiesSchema = z
+  .array(z.string())
+  .default([])
+  .transform((capabilities) =>
+    capabilities.filter((capability): capability is ModelCapability => KNOWN_MODEL_CAPABILITIES.has(capability))
+  )
 
 export const cloudModelListSchema = z.looseObject({
   data: z.array(
@@ -94,7 +101,7 @@ export const cloudModelListSchema = z.looseObject({
       endpoint_type: cloudEndpointTypeSchema,
       context_window: z.number().int().positive(),
       max_output_tokens: z.number().int().positive(),
-      capabilities: z.array(z.enum(objectValues(MODEL_CAPABILITY)))
+      capabilities: cloudModelCapabilitiesSchema
     })
   )
 })

--- a/src/renderer/components/chat/messages/frame/MessageTokenDetailsCard.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokenDetailsCard.tsx
@@ -275,6 +275,13 @@ const MessageTokenDetailsCard = ({
           value: formatTokens(noCacheTokens)
         }
       : undefined,
+    performance.timeFirstTokenMs !== undefined
+      ? {
+          id: 'time-to-first-token',
+          label: t('chat.message.token_details.time_to_first_token'),
+          value: formatMilliseconds(performance.timeFirstTokenMs)
+        }
+      : undefined,
     performance.endToEndTokensPerSecond !== undefined
       ? {
           id: 'end-to-end-throughput',

--- a/src/renderer/components/chat/messages/frame/MessageTokens.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokens.tsx
@@ -44,7 +44,7 @@ function AssistantMessageTokens({
   const contentId = useId()
   const messageKind = useMessageListMeta().aiUsageMessageKind ?? 'chat'
   const { pages, isLoading, isRefreshing, hasNext, loadNext } = useInfiniteQuery('/ai-usage-records', {
-    enabled: showMoreDetails && isDetailsOpen && message.stats?.runtimeTiming !== undefined,
+    enabled: isDetailsOpen && message.stats?.runtimeTiming !== undefined,
     query: {
       messageKind,
       messageId: message.id,

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
@@ -52,6 +52,7 @@ const translations: Record<string, string> = {
   'chat.message.token_details.runtime_breakdown': 'Runtime breakdown',
   'chat.message.token_details.text_generation': 'Text generation',
   'chat.message.token_details.text_output': 'Text output',
+  'chat.message.token_details.time_to_first_token': 'Time to first token',
   'chat.message.token_details.tokens': '{{value}} Tokens',
   'chat.message.token_details.tokens_per_second_value': '{{value}} Tokens/s',
   'chat.message.token_details.total_duration': 'End-to-end duration',
@@ -184,7 +185,7 @@ describe('MessageTokens', () => {
     expect(screen.getByRole('button', { name: '3.3K Tokens' })).toHaveClass('message-tokens')
   })
 
-  it('loads invocation details only after the user explicitly expands more information', () => {
+  it('loads the first invocation page when the card opens and defers full pagination until expansion', () => {
     renderWithProvider(
       createMessage(
         'assistant',
@@ -205,7 +206,13 @@ describe('MessageTokens', () => {
     openDetails()
     expect(dataApiMocks.useInfiniteQuery).toHaveBeenLastCalledWith(
       '/ai-usage-records',
-      expect.objectContaining({ enabled: false })
+      expect.objectContaining({
+        enabled: true,
+        query: expect.objectContaining({
+          messageKind: 'agent-session',
+          messageId: 'agent-message-1'
+        })
+      })
     )
 
     expandMoreDetails()
@@ -263,6 +270,7 @@ describe('MessageTokens', () => {
     expect(screen.getByTestId('message-metric-input')).toHaveTextContent('Input100 Tokens')
     expect(screen.getByTestId('message-metric-output')).toHaveTextContent('Output100 Tokens')
     expect(screen.getByTestId('message-metric-speed')).toHaveTextContent('Model generation TPS10 Tokens/s')
+    expect(screen.getByTestId('message-secondary-metrics')).toHaveTextContent('Time to first token4s')
     expect(screen.getByTestId('message-secondary-metrics')).toHaveTextContent('End-to-end throughput7.1 Tokens/s')
     expect(screen.getByTestId('message-secondary-metrics')).toHaveTextContent('End-to-end duration14s')
     expect(screen.queryByTestId('message-performance-breakdown')).not.toBeInTheDocument()

--- a/src/renderer/components/chat/messages/frame/__tests__/messagePerformance.test.ts
+++ b/src/renderer/components/chat/messages/frame/__tests__/messagePerformance.test.ts
@@ -94,6 +94,7 @@ describe('message performance view model', () => {
     expect(view.modelTokensPerSecond).toBe(30)
     expect(view.endToEndTokensPerSecond).toBe(20)
     expect(view.totalDurationMs).toBe(5_000)
+    expect(view.timeFirstTokenMs).toBe(500)
     expect(view.intervals.some((interval) => interval.id.endsWith('2'))).toBe(false)
   })
 
@@ -137,6 +138,7 @@ describe('message performance view model', () => {
     expect(getMessageModelTokensPerSecond(stats)).toBe(25)
     expect(buildMessagePerformanceViewModel(stats)).toMatchObject({
       totalDurationMs: 5_000,
+      timeFirstTokenMs: 1_000,
       modelTokensPerSecond: 25,
       endToEndTokensPerSecond: 20
     })

--- a/src/renderer/components/chat/messages/frame/messagePerformance.ts
+++ b/src/renderer/components/chat/messages/frame/messagePerformance.ts
@@ -15,6 +15,7 @@ export interface MessagePerformanceViewModel {
   startedAt?: number
   completedAt?: number
   totalDurationMs?: number
+  timeFirstTokenMs?: number
   modelTokensPerSecond?: number
   endToEndTokensPerSecond?: number
   intervals: MessagePerformanceInterval[]
@@ -108,6 +109,10 @@ function buildRuntimeViewModel(
 
   const measuredOutputTokens = stats.providerPerformance?.measuredOutputTokens
   const generationDuration = stats.providerPerformance?.generationDurationMs
+  const firstTokenRecord = records.find(
+    (record) => record.recordKind === 'invocation' && record.timeFirstTokenMs !== null
+  )
+  const timeFirstTokenMs = firstTokenRecord?.timeFirstTokenMs ?? undefined
   const modelTokensPerSecond =
     measuredOutputTokens !== undefined && generationDuration !== undefined && generationDuration > 0
       ? measuredOutputTokens / (generationDuration / 1000)
@@ -124,6 +129,7 @@ function buildRuntimeViewModel(
     startedAt: runtime.startedAt,
     completedAt: rangeEnd,
     totalDurationMs,
+    ...(timeFirstTokenMs !== undefined ? { timeFirstTokenMs } : {}),
     modelTokensPerSecond,
     endToEndTokensPerSecond,
     intervals: [...measuredIntervals, ...complementIntervals(runtime.startedAt, rangeEnd, measuredIntervals)]
@@ -134,7 +140,7 @@ function buildLegacyViewModel(stats: MessageStats): MessagePerformanceViewModel 
   const completion = stats.timeCompletionMs
   if (completion === undefined || completion <= 0) return { intervals: [] }
 
-  const firstToken = Math.min(stats.timeFirstTokenMs ?? 0, completion)
+  const firstToken = Math.min(Math.max(stats.timeFirstTokenMs ?? 0, 0), completion)
   const reasoning = Math.min(Math.max(stats.timeThinkingMs ?? 0, 0), completion)
   const waiting = Math.max(0, firstToken - Math.min(reasoning, firstToken))
   const outputTokens = stats.outputTokens
@@ -179,6 +185,7 @@ function buildLegacyViewModel(stats: MessageStats): MessagePerformanceViewModel 
     startedAt: 0,
     completedAt: completion,
     totalDurationMs: completion,
+    ...(stats.timeFirstTokenMs !== undefined ? { timeFirstTokenMs: firstToken } : {}),
     modelTokensPerSecond,
     endToEndTokensPerSecond,
     intervals

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Laufzeitaufschlüsselung",
   "chat.message.token_details.text_generation": "Textgenerierung",
   "chat.message.token_details.text_output": "Textausgabe",
+  "chat.message.token_details.time_to_first_token": "Zeit bis zum ersten Token",
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/s",
   "chat.message.token_details.total_duration": "Gesamtdauer",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Ανάλυση χρόνου εκτέλεσης",
   "chat.message.token_details.text_generation": "Δημιουργία κειμένου",
   "chat.message.token_details.text_output": "Έξοδος κειμένου",
+  "chat.message.token_details.time_to_first_token": "Χρόνος έως το πρώτο token",
   "chat.message.token_details.tokens": "Μάρκες {{value}}",
   "chat.message.token_details.tokens_per_second_value": "{{value}} token/δ",
   "chat.message.token_details.total_duration": "Διάρκεια από άκρο σε άκρο",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Runtime breakdown",
   "chat.message.token_details.text_generation": "Text generation",
   "chat.message.token_details.text_output": "Text output",
+  "chat.message.token_details.time_to_first_token": "Time to first token",
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Tokens/s",
   "chat.message.token_details.total_duration": "End-to-end duration",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Desglose del tiempo de ejecución",
   "chat.message.token_details.text_generation": "Generación de texto",
   "chat.message.token_details.text_output": "Salida de texto",
+  "chat.message.token_details.time_to_first_token": "Tiempo hasta el primer token",
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Tokens/s",
   "chat.message.token_details.total_duration": "Duración de extremo a extremo",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Répartition du temps d’exécution",
   "chat.message.token_details.text_generation": "Génération de texte",
   "chat.message.token_details.text_output": "Sortie de texte",
+  "chat.message.token_details.time_to_first_token": "Temps avant le premier token",
   "chat.message.token_details.tokens": "{{value}} Jetons",
   "chat.message.token_details.tokens_per_second_value": "{{value}} jetons/s",
   "chat.message.token_details.total_duration": "Durée de bout en bout",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "実行時間の内訳",
   "chat.message.token_details.text_generation": "テキスト生成",
   "chat.message.token_details.text_output": "テキスト出力",
+  "chat.message.token_details.time_to_first_token": "最初のトークンまでの時間",
   "chat.message.token_details.tokens": "{{value}} トークン",
   "chat.message.token_details.tokens_per_second_value": "{{value}} トークン/秒",
   "chat.message.token_details.total_duration": "エンドツーエンドの期間",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Distribuição do tempo de execução",
   "chat.message.token_details.text_generation": "Geração de texto",
   "chat.message.token_details.text_output": "Saída de texto",
+  "chat.message.token_details.time_to_first_token": "Tempo até ao primeiro token",
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Tokens/s",
   "chat.message.token_details.total_duration": "Duração de ponta a ponta",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Defalcarea timpului de execuție",
   "chat.message.token_details.text_generation": "Generarea de text",
   "chat.message.token_details.text_output": "Ieșire text",
+  "chat.message.token_details.time_to_first_token": "Timp până la primul token",
   "chat.message.token_details.tokens": "{{value}} Jetoane",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Tokeni/s",
   "chat.message.token_details.total_duration": "Durată de la capăt la capăt",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Распределение времени выполнения",
   "chat.message.token_details.text_generation": "Генерация текста",
   "chat.message.token_details.text_output": "Вывод текста",
+  "chat.message.token_details.time_to_first_token": "Время до первого токена",
   "chat.message.token_details.tokens": "{{value}} Токенов",
   "chat.message.token_details.tokens_per_second_value": "{{value}} токенов/с",
   "chat.message.token_details.total_duration": "Продолжительность от начала до конца",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Çalışma süresi dökümü",
   "chat.message.token_details.text_generation": "Metin oluşturma",
   "chat.message.token_details.text_output": "Metin çıktısı",
+  "chat.message.token_details.time_to_first_token": "İlk tokene kadar geçen süre",
   "chat.message.token_details.tokens": "{{value}} Token",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/s",
   "chat.message.token_details.total_duration": "Uçtan uca süre",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "Phân bổ thời gian chạy",
   "chat.message.token_details.text_generation": "Tạo văn bản",
   "chat.message.token_details.text_output": "Đầu ra văn bản",
+  "chat.message.token_details.time_to_first_token": "Thời gian đến token đầu tiên",
   "chat.message.token_details.tokens": "{{value}} Mã thông báo",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/giây",
   "chat.message.token_details.total_duration": "Thời lượng từ đầu đến cuối",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "运行时间分布",
   "chat.message.token_details.text_generation": "文本生成",
   "chat.message.token_details.text_output": "文本输出",
+  "chat.message.token_details.time_to_first_token": "首 Token 耗时",
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/秒",
   "chat.message.token_details.total_duration": "端到端耗时",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -708,6 +708,7 @@
   "chat.message.token_details.runtime_breakdown": "執行時間分布",
   "chat.message.token_details.text_generation": "文字產生",
   "chat.message.token_details.text_output": "文字輸出",
+  "chat.message.token_details.time_to_first_token": "首 Token 耗時",
   "chat.message.token_details.tokens": "{{value}} Token",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/秒",
   "chat.message.token_details.total_duration": "端到端持續時間",


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Cherry Cloud assumed Anthropic Messages and ignored server-declared model capabilities, causing OpenAI Chat Completions models to fail and eligible tool schemas to be omitted.

After this PR: Cherry Cloud chooses the transport by endpoint type, persists server-declared capabilities, falls back to matched client Registry metadata when legacy model-list responses omit `capabilities`, and ignores unknown future capability names. An explicit empty capability list remains authoritative.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Server-declared capabilities take precedence, including an explicit empty list. When legacy responses omit the field, only preset-linked Registry matches may supply capabilities; unmatched new SKUs remain capability-free, while existing models retain their last-known-good capabilities if Registry resolution is unavailable.

The following alternatives were considered: Treating every omitted field as an explicit empty list was rejected because it would silently remove known capabilities from legacy deployments. Unbounded Registry inference was also rejected because Cloud product SKU IDs do not always map to canonical models.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None. Explicit empty capability lists remain authoritative, while clients stay compatible with older responses that omit the field and with future responses containing unknown capability names.

### Special notes for your reviewer

<!-- optional -->

The shared `FUNCTION_CALL` capability gate is unchanged. Missing and explicitly empty capability declarations are intentionally distinct; malformed capability fields still reject the response.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Cherry Cloud models now honor server-declared capabilities, support configured OpenAI Chat Completions routes, and remain compatible with older model-list responses. Message token details now also show time to first token without requiring the expanded runtime breakdown.
```
