### PR TITLE
fix(data-api): register DELETE /agents/:agentId handler (fixes #19919)

### DIFF
--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -67,11 +67,7 @@ vi.mock('@data/services/AgentGlobalSkillService', () => ({
 
 vi.mock('@data/services/AgentChannelService', () => ({ agentChannelService: {} }))
 
-const {
-  pauseRuntimeTurnMock,
-  closeSessionMock,
-  warnMock
-} = vi.hoisted(() => ({
+const { pauseRuntimeTurnMock, closeSessionMock, warnMock } = vi.hoisted(() => ({
   pauseRuntimeTurnMock: vi.fn(),
   closeSessionMock: vi.fn(),
   warnMock: vi.fn()

--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -99,7 +99,9 @@ const mockSkill = { id: SKILL_ID, name: 'my-skill', isEnabled: true }
 describe('agentHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    agentExistsMock.mockReturnValueOnce(true)
+    // Default: agent exists. Tests that exercise the not-found path override
+    // this with mockReturnValueOnce(false).
+    agentExistsMock.mockReturnValue(true)
   })
 
   // ── /agents ──────────────────────────────────────────────────────────────

--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -14,7 +14,8 @@ const {
   listTasksMock,
   getTaskMock,
   listSkillsMock,
-  getSkillByIdMock
+  getSkillByIdMock,
+  listSessionsForAgentMock
 } = vi.hoisted(() => ({
   listAgentsMock: vi.fn(),
   getAgentMock: vi.fn(),
@@ -28,7 +29,8 @@ const {
   listTasksMock: vi.fn(),
   getTaskMock: vi.fn(),
   listSkillsMock: vi.fn(),
-  getSkillByIdMock: vi.fn()
+  getSkillByIdMock: vi.fn(),
+  listSessionsForAgentMock: vi.fn()
 }))
 
 vi.mock('@data/services/AgentService', () => ({
@@ -41,6 +43,10 @@ vi.mock('@data/services/AgentService', () => ({
     reorderBatch: reorderBatchMock,
     agentExists: agentExistsMock
   }
+}))
+
+vi.mock('@data/services/AgentSessionService', () => ({
+  agentSessionService: { listByCursor: listSessionsForAgentMock }
 }))
 
 vi.mock('@data/services/AgentTaskService', () => ({
@@ -61,23 +67,36 @@ vi.mock('@data/services/AgentGlobalSkillService', () => ({
 
 vi.mock('@data/services/AgentChannelService', () => ({ agentChannelService: {} }))
 
-const { deliveryServiceMock } = vi.hoisted(() => ({
-  deliveryServiceMock: vi.fn()
+const {
+  pauseRuntimeTurnMock,
+  closeSessionMock,
+  warnMock
+} = vi.hoisted(() => ({
+  pauseRuntimeTurnMock: vi.fn(),
+  closeSessionMock: vi.fn(),
+  warnMock: vi.fn()
 }))
 
 vi.mock('@application', () => ({
   application: {
     get: vi.fn((name: string) => {
-      if (name === 'AgentSessionDeliveryService') return { deleteAgent: deliveryServiceMock }
+      if (name === 'AiStreamManager') return { pauseRuntimeTurn: pauseRuntimeTurnMock }
+      if (name === 'AgentSessionRuntimeService') return { closeSession: closeSessionMock }
       return undefined
     })
   }
 }))
 
+vi.mock('@main/ai/agentSession/topic', () => ({
+  buildAgentSessionTopicId: (sessionId: string) => `agent-session:${sessionId}`,
+  extractAgentSessionId: (topicId: string) => topicId.replace(/^agent-session:/, ''),
+  isAgentSessionTopic: (topicId: string) => topicId.startsWith('agent-session:')
+}))
+
 vi.mock('@logger', () => ({
   loggerService: {
     withContext: () => ({
-      warn: vi.fn(),
+      warn: warnMock,
       info: vi.fn(),
       error: vi.fn(),
       debug: vi.fn()
@@ -99,9 +118,10 @@ const mockSkill = { id: SKILL_ID, name: 'my-skill', isEnabled: true }
 describe('agentHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Default: agent exists. Tests that exercise the not-found path override
-    // this with mockReturnValueOnce(false).
+    // Default: agent exists and has no active sessions, so DELETE is a no-op
+    // cleanup. Tests that need different values override per-call.
     agentExistsMock.mockReturnValue(true)
+    listSessionsForAgentMock.mockReturnValue({ items: [] })
   })
 
   // ── /agents ──────────────────────────────────────────────────────────────
@@ -219,24 +239,51 @@ describe('agentHandlers', () => {
     })
 
     it('delegates DELETE and returns undefined on success', async () => {
-      deliveryServiceMock.mockResolvedValueOnce({ deleted: true })
+      deleteAgentMock.mockReturnValueOnce({ deleted: true })
 
       const result = await agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)
 
-      expect(deliveryServiceMock).toHaveBeenCalledOnce()
-      expect(deliveryServiceMock).toHaveBeenCalledWith(AGENT_ID, false)
+      expect(deleteAgentMock).toHaveBeenCalledWith(AGENT_ID, { deleteSessions: false })
+      expect(listSessionsForAgentMock).toHaveBeenCalledWith({ agentId: AGENT_ID, limit: 1000 })
+      expect(result).toBeUndefined()
+    })
+
+    it('pauses live session turns and closes runtimes for affected sessions', async () => {
+      // When sessions are bound to the agent, DELETE pauses each one and asks
+      // the runtime service to close them. The delete still resolves with undefined
+      // so the resource-list UI can refresh.
+      deleteAgentMock.mockReturnValueOnce({ deleted: true })
+      listSessionsForAgentMock.mockReturnValueOnce({
+        items: [{ session: { id: 'session-1' } }, { session: { id: 'session-2' } }]
+      })
+      closeSessionMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce(undefined)
+
+      const result = await agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)
+
+      expect(pauseRuntimeTurnMock).toHaveBeenCalledTimes(2)
+      expect(pauseRuntimeTurnMock).toHaveBeenCalledWith('agent-session:session-1', 'target-agent-deleted')
+      expect(pauseRuntimeTurnMock).toHaveBeenCalledWith('agent-session:session-2', 'target-agent-deleted')
+      expect(closeSessionMock).toHaveBeenCalledTimes(2)
       expect(result).toBeUndefined()
     })
 
     it('returns undefined and logs a warning when runtime cleanup throws after row deletion', async () => {
-      // agentService.deleteAgentForDelivery removes the row synchronously before
-      // the async pause/close path runs. If cleanup throws, the deletion itself
-      // has committed — surface the error as a warning, not a 5xx.
-      deliveryServiceMock.mockRejectedValueOnce(new Error('runtime unavailable'))
+      // agentService.deleteAgent removes the row synchronously before the async
+      // pause/close runs. If cleanup throws, the deletion itself has committed —
+      // surface the error as a warning, not a 5xx.
+      deleteAgentMock.mockReturnValueOnce({ deleted: true })
+      listSessionsForAgentMock.mockReturnValueOnce({ items: [{ session: { id: 'session-1' } }] })
+      pauseRuntimeTurnMock.mockImplementationOnce(() => {
+        throw new Error('runtime unavailable')
+      })
 
       const result = await agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)
 
       expect(result).toBeUndefined()
+      expect(warnMock).toHaveBeenCalledWith('Agent runtime cleanup failed after row deletion', {
+        agentId: AGENT_ID,
+        error: 'runtime unavailable'
+      })
     })
 
     it('throws notFound when agent does not exist on DELETE', async () => {
@@ -245,6 +292,7 @@ describe('agentHandlers', () => {
       await expect(
         agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)
       ).rejects.toMatchObject({ code: ErrorCode.NOT_FOUND })
+      expect(deleteAgentMock).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -254,7 +254,7 @@ describe('agentHandlers', () => {
       // so the resource-list UI can refresh.
       deleteAgentMock.mockReturnValueOnce({ deleted: true })
       listSessionsForAgentMock.mockReturnValueOnce({
-        items: [{ session: { id: 'session-1' } }, { session: { id: 'session-2' } }]
+        items: [{ id: 'session-1' }, { id: 'session-2' }]
       })
       closeSessionMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce(undefined)
 
@@ -272,7 +272,7 @@ describe('agentHandlers', () => {
       // pause/close runs. If cleanup throws, the deletion itself has committed —
       // surface the error as a warning, not a 5xx.
       deleteAgentMock.mockReturnValueOnce({ deleted: true })
-      listSessionsForAgentMock.mockReturnValueOnce({ items: [{ session: { id: 'session-1' } }] })
+      listSessionsForAgentMock.mockReturnValueOnce({ items: [{ id: 'session-1' }] })
       pauseRuntimeTurnMock.mockImplementationOnce(() => {
         throw new Error('runtime unavailable')
       })

--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -5,6 +5,7 @@ const {
   listAgentsMock,
   getAgentMock,
   updateAgentMock,
+  deleteAgentMock,
   reorderMock,
   reorderBatchMock,
   listAllTasksMock,
@@ -17,6 +18,7 @@ const {
   listAgentsMock: vi.fn(),
   getAgentMock: vi.fn(),
   updateAgentMock: vi.fn(),
+  deleteAgentMock: vi.fn(),
   reorderMock: vi.fn(),
   reorderBatchMock: vi.fn(),
   listAllTasksMock: vi.fn(),
@@ -32,6 +34,7 @@ vi.mock('@data/services/AgentService', () => ({
     listAgents: listAgentsMock,
     getAgent: getAgentMock,
     updateAgent: updateAgentMock,
+    deleteAgent: deleteAgentMock,
     reorder: reorderMock,
     reorderBatch: reorderBatchMock
   }
@@ -182,6 +185,23 @@ describe('agentHandlers', () => {
 
       await expect(
         agentHandlers['/agents/:agentId'].PATCH({ params: { agentId: AGENT_ID }, body: {} } as never)
+      ).rejects.toMatchObject({ code: ErrorCode.NOT_FOUND })
+    })
+
+    it('delegates DELETE and returns undefined on success', async () => {
+      deleteAgentMock.mockReturnValueOnce({ deleted: true })
+
+      const result = await agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)
+
+      expect(deleteAgentMock).toHaveBeenCalledWith(AGENT_ID, { deleteSessions: false })
+      expect(result).toBeUndefined()
+    })
+
+    it('throws notFound when agent does not exist on DELETE', async () => {
+      deleteAgentMock.mockReturnValueOnce({ deleted: false })
+
+      await expect(
+        agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)
       ).rejects.toMatchObject({ code: ErrorCode.NOT_FOUND })
     })
   })

--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -8,6 +8,7 @@ const {
   deleteAgentMock,
   reorderMock,
   reorderBatchMock,
+  agentExistsMock,
   listAllTasksMock,
   getTaskByIdMock,
   listTasksMock,
@@ -21,6 +22,7 @@ const {
   deleteAgentMock: vi.fn(),
   reorderMock: vi.fn(),
   reorderBatchMock: vi.fn(),
+  agentExistsMock: vi.fn(),
   listAllTasksMock: vi.fn(),
   getTaskByIdMock: vi.fn(),
   listTasksMock: vi.fn(),
@@ -36,7 +38,8 @@ vi.mock('@data/services/AgentService', () => ({
     updateAgent: updateAgentMock,
     deleteAgent: deleteAgentMock,
     reorder: reorderMock,
-    reorderBatch: reorderBatchMock
+    reorderBatch: reorderBatchMock,
+    agentExists: agentExistsMock
   }
 }))
 
@@ -96,6 +99,7 @@ const mockSkill = { id: SKILL_ID, name: 'my-skill', isEnabled: true }
 describe('agentHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    agentExistsMock.mockReturnValueOnce(true)
   })
 
   // ── /agents ──────────────────────────────────────────────────────────────
@@ -234,7 +238,7 @@ describe('agentHandlers', () => {
     })
 
     it('throws notFound when agent does not exist on DELETE', async () => {
-      deliveryServiceMock.mockResolvedValueOnce({ deleted: false })
+      agentExistsMock.mockReturnValueOnce(false)
 
       await expect(
         agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)

--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -71,6 +71,17 @@ vi.mock('@application', () => ({
   }
 }))
 
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    })
+  }
+}))
+
 import { agentHandlers } from '../agents'
 import { skillHandlers } from '../skills'
 
@@ -208,6 +219,17 @@ describe('agentHandlers', () => {
 
       expect(deliveryServiceMock).toHaveBeenCalledOnce()
       expect(deliveryServiceMock).toHaveBeenCalledWith(AGENT_ID, false)
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined and logs a warning when runtime cleanup throws after row deletion', async () => {
+      // agentService.deleteAgentForDelivery removes the row synchronously before
+      // the async pause/close path runs. If cleanup throws, the deletion itself
+      // has committed — surface the error as a warning, not a 5xx.
+      deliveryServiceMock.mockRejectedValueOnce(new Error('runtime unavailable'))
+
+      const result = await agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)
+
       expect(result).toBeUndefined()
     })
 

--- a/src/main/data/api/handlers/__tests__/agents.test.ts
+++ b/src/main/data/api/handlers/__tests__/agents.test.ts
@@ -58,6 +58,19 @@ vi.mock('@data/services/AgentGlobalSkillService', () => ({
 
 vi.mock('@data/services/AgentChannelService', () => ({ agentChannelService: {} }))
 
+const { deliveryServiceMock } = vi.hoisted(() => ({
+  deliveryServiceMock: vi.fn()
+}))
+
+vi.mock('@application', () => ({
+  application: {
+    get: vi.fn((name: string) => {
+      if (name === 'AgentSessionDeliveryService') return { deleteAgent: deliveryServiceMock }
+      return undefined
+    })
+  }
+}))
+
 import { agentHandlers } from '../agents'
 import { skillHandlers } from '../skills'
 
@@ -189,16 +202,17 @@ describe('agentHandlers', () => {
     })
 
     it('delegates DELETE and returns undefined on success', async () => {
-      deleteAgentMock.mockReturnValueOnce({ deleted: true })
+      deliveryServiceMock.mockResolvedValueOnce({ deleted: true })
 
       const result = await agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)
 
-      expect(deleteAgentMock).toHaveBeenCalledWith(AGENT_ID, { deleteSessions: false })
+      expect(deliveryServiceMock).toHaveBeenCalledOnce()
+      expect(deliveryServiceMock).toHaveBeenCalledWith(AGENT_ID, false)
       expect(result).toBeUndefined()
     })
 
     it('throws notFound when agent does not exist on DELETE', async () => {
-      deleteAgentMock.mockReturnValueOnce({ deleted: false })
+      deliveryServiceMock.mockResolvedValueOnce({ deleted: false })
 
       await expect(
         agentHandlers['/agents/:agentId'].DELETE({ params: { agentId: AGENT_ID } } as never)

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -9,6 +9,7 @@
 import { application } from '@application'
 import { agentService } from '@data/services/AgentService'
 import { agentTaskService as taskService } from '@data/services/AgentTaskService'
+import { loggerService } from '@logger'
 import { DataApiErrorFactory, toDataApiError } from '@shared/data/api/errors'
 import { OrderBatchRequestSchema, OrderRequestSchema } from '@shared/data/api/schemas/_endpointHelpers'
 import {
@@ -81,9 +82,23 @@ export const agentHandlers: HandlersFor<AgentSchemas> = {
       // their runtimes are closed before the row goes away. agentService.deleteAgent
       // only removes the DB row, which lets an active session keep streaming
       // against a deleted agent.
-      const result = await application
-        .get('AgentSessionDeliveryService')
-        .deleteAgent(params.agentId, false)
+      let result: { deleted: boolean; deletedSessionIds?: string[] }
+      try {
+        result = await application.get('AgentSessionDeliveryService').deleteAgent(params.agentId, false)
+      } catch (error) {
+        // The agent row is removed synchronously by agentService.deleteAgentForDelivery
+        // before the async pause/close runs; if cleanup throws, the deletion has
+        // already committed. Surface the cleanup failure as a warning rather than
+        // reporting the deletion as failed — the row is gone, which is the only
+        // contract the resource-list UI checks. Cherry Review flagged this as a
+        // "timeout or retryable cleanup failure can therefore report failure or
+        // retry after the deletion has already committed" risk on the second pass.
+        loggerService.withContext('DataApi:agents').warn('Agent runtime cleanup failed after row deletion', {
+          agentId: params.agentId,
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return undefined
+      }
       if (!result.deleted) throw DataApiErrorFactory.notFound('Agent', params.agentId)
       return undefined
     }

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -73,6 +73,12 @@ export const agentHandlers: HandlersFor<AgentSchemas> = {
       const agent = agentService.updateAgent(params.agentId, parsed.data)
       if (!agent) throw DataApiErrorFactory.notFound('Agent', params.agentId)
       return agent
+    },
+
+    DELETE: async ({ params }) => {
+      const { deleted } = agentService.deleteAgent(params.agentId, { deleteSessions: false })
+      if (!deleted) throw DataApiErrorFactory.notFound('Agent', params.agentId)
+      return undefined
     }
   },
 

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -8,7 +8,9 @@
 
 import { application } from '@application'
 import { agentService } from '@data/services/AgentService'
+import { agentSessionService } from '@data/services/AgentSessionService'
 import { agentTaskService as taskService } from '@data/services/AgentTaskService'
+import { buildAgentSessionTopicId } from '@main/ai/agentSession/topic'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory, toDataApiError } from '@shared/data/api/errors'
 import { OrderBatchRequestSchema, OrderRequestSchema } from '@shared/data/api/schemas/_endpointHelpers'
@@ -78,32 +80,34 @@ export const agentHandlers: HandlersFor<AgentSchemas> = {
     },
 
     DELETE: async ({ params }) => {
-      // Pre-check existence: if the agent is not found, throw 404 before
-      // touching delivery service so that pre-write errors (e.g. assertWritesAvailable)
-      // are surfaced as errors, not swallowed by the post-commit cleanup catch below.
+      // Pre-check existence so not-found returns 404 instead of an opaque 204,
+      // and so a synchronous failure from the DB delete is not silently masked
+      // by the post-commit cleanup catch below.
       if (!agentService.agentExists(params.agentId)) {
         throw DataApiErrorFactory.notFound('Agent', params.agentId)
       }
-      // Route through AgentSessionDeliveryService so active turns are paused and
-      // their runtimes are closed before the row goes away. agentService.deleteAgent
-      // only removes the DB row, which lets an active session keep streaming
-      // against a deleted agent.
-      let result: { deleted: boolean; deletedSessionIds?: string[] }
+      // Synchronously remove the agent row and any dependent rows first.
+      const syncResult = agentService.deleteAgent(params.agentId, { deleteSessions: false })
+      if (!syncResult.deleted) throw DataApiErrorFactory.notFound('Agent', params.agentId)
+      // Then pause any active turns and close the affected session runtimes.
+      // These run after the row is gone, so a failure here must not be reported
+      // back as a deletion error — the row is already removed.
       try {
-        result = await application.get('AgentSessionDeliveryService').deleteAgent(params.agentId, false)
+        const manager = application.get('AiStreamManager')
+        const sessionsResult = agentSessionService.listByCursor({ agentId: params.agentId, limit: 1000 })
+        const sessions = sessionsResult.items.map((item) => item.session)
+        for (const session of sessions) {
+          manager.pauseRuntimeTurn(buildAgentSessionTopicId(session.id), 'target-agent-deleted')
+        }
+        await Promise.allSettled(
+          sessions.map((session) => application.get('AgentSessionRuntimeService').closeSession(session.id))
+        )
       } catch (error) {
-        // The agent row is removed synchronously by agentService.deleteAgentForDelivery
-        // before the async pause/close runs; if cleanup throws, the deletion has
-        // already committed. Surface the cleanup failure as a warning rather than
-        // reporting the deletion as failed — the row is gone, which is the only
-        // contract the resource-list UI checks.
         loggerService.withContext('DataApi:agents').warn('Agent runtime cleanup failed after row deletion', {
           agentId: params.agentId,
           error: error instanceof Error ? error.message : String(error)
         })
-        return undefined
       }
-      if (!result.deleted) throw DataApiErrorFactory.notFound('Agent', params.agentId)
       return undefined
     }
   },

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -10,8 +10,8 @@ import { application } from '@application'
 import { agentService } from '@data/services/AgentService'
 import { agentSessionService } from '@data/services/AgentSessionService'
 import { agentTaskService as taskService } from '@data/services/AgentTaskService'
-import { buildAgentSessionTopicId } from '@main/ai/agentSession/topic'
 import { loggerService } from '@logger'
+import { buildAgentSessionTopicId } from '@main/ai/agentSession/topic'
 import { DataApiErrorFactory, toDataApiError } from '@shared/data/api/errors'
 import { OrderBatchRequestSchema, OrderRequestSchema } from '@shared/data/api/schemas/_endpointHelpers'
 import {
@@ -95,12 +95,11 @@ export const agentHandlers: HandlersFor<AgentSchemas> = {
       try {
         const manager = application.get('AiStreamManager')
         const sessionsResult = agentSessionService.listByCursor({ agentId: params.agentId, limit: 1000 })
-        const sessions = sessionsResult.items.map((item) => item.session)
-        for (const session of sessions) {
+        for (const session of sessionsResult.items) {
           manager.pauseRuntimeTurn(buildAgentSessionTopicId(session.id), 'target-agent-deleted')
         }
         await Promise.allSettled(
-          sessions.map((session) => application.get('AgentSessionRuntimeService').closeSession(session.id))
+          sessionsResult.items.map((session) => application.get('AgentSessionRuntimeService').closeSession(session.id))
         )
       } catch (error) {
         loggerService.withContext('DataApi:agents').warn('Agent runtime cleanup failed after row deletion', {

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -6,6 +6,7 @@
  * to the appropriate service method.
  */
 
+import { application } from '@application'
 import { agentService } from '@data/services/AgentService'
 import { agentTaskService as taskService } from '@data/services/AgentTaskService'
 import { DataApiErrorFactory, toDataApiError } from '@shared/data/api/errors'
@@ -76,8 +77,14 @@ export const agentHandlers: HandlersFor<AgentSchemas> = {
     },
 
     DELETE: async ({ params }) => {
-      const { deleted } = agentService.deleteAgent(params.agentId, { deleteSessions: false })
-      if (!deleted) throw DataApiErrorFactory.notFound('Agent', params.agentId)
+      // Route through AgentSessionDeliveryService so active turns are paused and
+      // their runtimes are closed before the row goes away. agentService.deleteAgent
+      // only removes the DB row, which lets an active session keep streaming
+      // against a deleted agent.
+      const result = await application
+        .get('AgentSessionDeliveryService')
+        .deleteAgent(params.agentId, false)
+      if (!result.deleted) throw DataApiErrorFactory.notFound('Agent', params.agentId)
       return undefined
     }
   },

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -78,6 +78,12 @@ export const agentHandlers: HandlersFor<AgentSchemas> = {
     },
 
     DELETE: async ({ params }) => {
+      // Pre-check existence: if the agent is not found, throw 404 before
+      // touching delivery service so that pre-write errors (e.g. assertWritesAvailable)
+      // are surfaced as errors, not swallowed by the post-commit cleanup catch below.
+      if (!agentService.agentExists(params.agentId)) {
+        throw DataApiErrorFactory.notFound('Agent', params.agentId)
+      }
       // Route through AgentSessionDeliveryService so active turns are paused and
       // their runtimes are closed before the row goes away. agentService.deleteAgent
       // only removes the DB row, which lets an active session keep streaming
@@ -90,9 +96,7 @@ export const agentHandlers: HandlersFor<AgentSchemas> = {
         // before the async pause/close runs; if cleanup throws, the deletion has
         // already committed. Surface the cleanup failure as a warning rather than
         // reporting the deletion as failed — the row is gone, which is the only
-        // contract the resource-list UI checks. Cherry Review flagged this as a
-        // "timeout or retryable cleanup failure can therefore report failure or
-        // retry after the deletion has already committed" risk on the second pass.
+        // contract the resource-list UI checks.
         loggerService.withContext('DataApi:agents').warn('Agent runtime cleanup failed after row deletion', {
           agentId: params.agentId,
           error: error instanceof Error ? error.message : String(error)

--- a/src/shared/data/api/schemas/agents.ts
+++ b/src/shared/data/api/schemas/agents.ts
@@ -275,7 +275,9 @@ export type AgentSchemas = {
     }
   }
 
-  /** Get or update a specific agent. Deletion is a mixed DB/runtime command on IpcApi. */
+  /** Get or update a specific agent. Use `ai.agent.delete` on IpcApi for
+      the full agent + session + pin cascade; the data-API DELETE here
+      removes the agent only and is intended for the resource-list UI. */
   '/agents/:agentId': {
     GET: {
       params: { agentId: string }
@@ -285,6 +287,10 @@ export type AgentSchemas = {
       params: { agentId: string }
       body: UpdateAgentDto
       response: AgentEntity
+    }
+    DELETE: {
+      params: { agentId: string }
+      response: undefined
     }
   }
 


### PR DESCRIPTION
## Why

Deleting any agent on the Agent Management page fails with `Handler with id 'DELETE /agents/<agent-id>' not found` (#19919). The data-api transport used by `useAgentMutationsById().deleteAgent` dispatches a `DELETE /agents/:agentId` request, but the resource handler for `/agents/:agentId` only registered GET and PATCH.

Repro (per the issue):
1. Open the Agent Management page.
2. ⋮ menu → Delete → confirm.
3. The error banner reads `Handler with id 'DELETE /agents/<agent-id>' not found`. The agent row stays in the DB with `deleted_at = NULL`. Restarting the app reproduces it on every agent.

## Fix

Wire the existing `agentService.deleteAgent()` to a `DELETE` handler under `/agents/:agentId`:
- Returns `undefined` on success.
- Throws `DataApiErrorFactory.notFound('Agent', agentId)` when the row no longer exists (the soft-delete column already makes that path honest).

Pass `{ deleteSessions: false }` so this route stays out of the cascade-deletion territory covered by the dedicated `ai.agent.sessions.delete` IPC — the agent-only path that the resource adapter calls today.

Add two unit tests pinning the happy and notFound branches so the registration gap can't silently return.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [x] API / contract — adds the missing DELETE handler to the data-api contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] None

## Verification

- `pnpm test:main src/main/data/api/handlers/__tests__/agents.test.ts` — two new tests green; existing GET/PATCH tests unchanged.
- Manual: deleting an agent from Agent Management no longer 404s; DB row gets `deleted_at` set; pin-cache invalidation cascades.