### PR TITLE
fix(ai): probe edit-only image models via edit mode

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -1178,17 +1178,24 @@ export class AiService extends BaseService {
       // Edit-only models (qwen-image-edit / wan2.5-i2i / qwen-mt-image …) serve no
       // `generate` mode: the bare default leaves the job path without a transport
       // descriptor, failing before any provider request. Probe their first declared
-      // mode with a tiny inline PNG instead.
+      // mode with a tiny inline PNG and the mode's registry defaults instead — the
+      // vendor bag must carry required params (qwen-mt-image langs, wanx2.1 function)
+      // that main never materializes on its own.
       const imageSupport = providerRegistryService.getImageGenerationSupport(provider.id, model.apiModelId ?? model.id)
       const editOnly = imageSupport != null && !('generate' in imageSupport.modes)
+      const probeMode = editOnly ? (Object.keys(imageSupport!.modes)[0] as ImageGenerationMode) : undefined
+      const probeSupports = probeMode ? imageSupport!.modes[probeMode]?.supports : undefined
+      const probeParams: ParamValues = {}
+      for (const [key, spec] of Object.entries(probeSupports ?? {})) {
+        if (spec && typeof spec === 'object' && 'default' in spec && spec.default !== undefined) {
+          probeParams[key] = spec.default
+        }
+      }
       probe = this.generateImage({
         ...probeRequest,
         prompt: 'a red circle',
-        ...(editOnly && {
-          mode: Object.keys(imageSupport!.modes)[0] as ImageGenerationMode,
-          inputImages: [PROBE_INPUT_IMAGE_DATA_URL]
-        }),
-        paramValues: {},
+        ...(editOnly && { mode: probeMode, inputImages: [PROBE_INPUT_IMAGE_DATA_URL] }),
+        paramValues: probeParams,
         cleanupPolicy: 'delete_when_unreferenced'
       })
     } else {

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -86,6 +86,10 @@ const logger = loggerService.withContext('AiService')
 const EMBEDDING_MAX_PARALLEL_CALLS = 5
 
 const NO_NATIVE_FILE_REQUIREMENTS: NativeFileSupport = { image: false, pdf: false, audio: false, video: false }
+
+/** 64x64 white PNG — edit-mode health-check input so the probe needs no user image. */
+const PROBE_INPUT_IMAGE_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAXklEQVR4nO3PMQ0AMAzAsPInvYLYYVWKESTzjhsd8KsBrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BbQHKU9LC7/CP1AAAAABJRU5ErkJggg=='
 type MutableNativeFileSupport = { -readonly [K in keyof NativeFileSupport]: NativeFileSupport[K] }
 
 /** Native attachment shapes preserved for the primary and therefore replayed unchanged to a fallback. */
@@ -1171,9 +1175,19 @@ export class AiService extends BaseService {
       probe = this.embedMany({ ...probeRequest, values: ['test'] })
     } else if (isGenerateImageModel(model) && !hasChatPrimaryEndpoint) {
       // Image-only models reject /chat/completions with a 400 — probe the image endpoint.
+      // Edit-only models (qwen-image-edit / wan2.5-i2i / qwen-mt-image …) serve no
+      // `generate` mode: the bare default leaves the job path without a transport
+      // descriptor, failing before any provider request. Probe their first declared
+      // mode with a tiny inline PNG instead.
+      const imageSupport = providerRegistryService.getImageGenerationSupport(provider.id, model.apiModelId ?? model.id)
+      const editOnly = imageSupport != null && !('generate' in imageSupport.modes)
       probe = this.generateImage({
         ...probeRequest,
         prompt: 'a red circle',
+        ...(editOnly && {
+          mode: Object.keys(imageSupport!.modes)[0] as ImageGenerationMode,
+          inputImages: [PROBE_INPUT_IMAGE_DATA_URL]
+        }),
         paramValues: {},
         cleanupPolicy: 'delete_when_unreferenced'
       })

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -51,11 +51,13 @@ import { createAiUsagePlugin } from './hooks/billingHook'
 import { resolveAttachmentBudget } from './messages/attachmentBudget'
 import { prepareChatMessages } from './messages/attachmentRouting'
 import { resolveMediaCapabilities, resolveToolResultMediaCapabilities } from './messages/messageCapabilities'
-import { hasImageTransport } from './provider/custom/imageTransportRegistry'
+import { resolveProviderAiSdkConfig } from './provider/config'
+import { hasImageTransport, resolveImageTransport } from './provider/custom/imageTransportRegistry'
 import { deleteImageInputEntries, imageGenerationJobHandler } from './provider/custom/tasks/imageGenerationJobHandler'
 import type { ImageGenerationJobOutput, ImageGenerationJobPayload } from './provider/custom/tasks/jobTypes'
 import { buildVendorProviderOptions } from './provider/custom/wire/buildImageRequest'
 import { DEFAULT_DIFFUSION_REGISTRATION, WIRE_REGISTRY } from './provider/custom/wire/wireProfile'
+import { resolveEffectiveEndpoint, resolveWireModelId } from './provider/endpoint'
 import { listModels as listModelsFromProvider, probeOllamaModel } from './provider/listModels'
 import type { AgentLoopHooks, NativeFileSupport, RequestFeature } from './runtime/aiSdk'
 import { Agent, buildAgentParams, buildFallbackModels, createRetryableWrap, readRetryPolicy } from './runtime/aiSdk'
@@ -90,6 +92,10 @@ const NO_NATIVE_FILE_REQUIREMENTS: NativeFileSupport = { image: false, pdf: fals
 /** 64x64 white PNG — edit-mode health-check input so the probe needs no user image. */
 const PROBE_INPUT_IMAGE_DATA_URL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAXklEQVR4nO3PMQ0AMAzAsPInvYLYYVWKESTzjhsd8KsBrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BbQHKU9LC7/CP1AAAAABJRU5ErkJggg=='
+const PROBE_INPUT_IMAGE_BASE64 = PROBE_INPUT_IMAGE_DATA_URL.slice('data:image/png;base64,'.length)
+
+/** Edit-only probes pick the first mode the model declares, in painting-tab preference order. */
+const EDIT_ONLY_PROBE_FALLBACK_MODES: readonly ImageGenerationMode[] = ['edit', 'remix', 'upscale', 'merge']
 type MutableNativeFileSupport = { -readonly [K in keyof NativeFileSupport]: NativeFileSupport[K] }
 
 /** Native attachment shapes preserved for the primary and therefore replayed unchanged to a fallback. */
@@ -1183,21 +1189,58 @@ export class AiService extends BaseService {
       // that main never materializes on its own.
       const imageSupport = providerRegistryService.getImageGenerationSupport(provider.id, model.apiModelId ?? model.id)
       const editOnly = imageSupport != null && !('generate' in imageSupport.modes)
-      const probeMode = editOnly ? (Object.keys(imageSupport!.modes)[0] as ImageGenerationMode) : undefined
-      const probeSupports = probeMode ? imageSupport!.modes[probeMode]?.supports : undefined
+      const probeMode: ImageGenerationMode = editOnly
+        ? (EDIT_ONLY_PROBE_FALLBACK_MODES.find((mode) => mode in imageSupport.modes) ?? 'edit')
+        : 'generate'
+      const probeSupports = imageSupport?.modes?.[probeMode]?.supports
       const probeParams: ParamValues = {}
       for (const [key, spec] of Object.entries(probeSupports ?? {})) {
         if (spec && typeof spec === 'object' && 'default' in spec && spec.default !== undefined) {
           probeParams[key] = spec.default
         }
       }
-      probe = this.generateImage({
-        ...probeRequest,
-        prompt: 'a red circle',
-        ...(editOnly && { mode: probeMode, inputImages: [PROBE_INPUT_IMAGE_DATA_URL] }),
-        paramValues: probeParams,
-        cleanupPolicy: 'delete_when_unreferenced'
-      })
+      const transportProviderId = provider.presetProviderId ?? provider.id
+      if (request.uniqueModelId && hasImageTransport(transportProviderId, model.apiModelId ?? model.id)) {
+        // Transport models run their submit/poll loop on the job system, whose
+        // handler re-selects a serving key — dropping the health check's
+        // `apiKeyOverride` and possibly probing a different rotated credential
+        // than the one being reported. A check needs no restart survival, so
+        // probe inline: one submit (accepted = credential + endpoint + model OK)
+        // with the caller's key, no job row, no result download.
+        const vendorTransport = imageSupport?.modes?.[probeMode]?.vendorTransport
+        probe = (async () => {
+          const { config } = await resolveProviderAiSdkConfig(provider, model, {
+            apiKeyOverride: request.apiKeyOverride
+          })
+          const wireModelId = resolveWireModelId(model, resolveEffectiveEndpoint(provider, model).endpointType)
+          const transport = resolveImageTransport(config.providerId, wireModelId, config.providerSettings)
+          if (!transport) {
+            throw new Error(`Image health check: no transport for '${config.providerId}' (model '${wireModelId}')`)
+          }
+          await transport.submit({
+            modelId: wireModelId,
+            prompt: 'a red circle',
+            n: 1,
+            size: undefined,
+            seed: undefined,
+            files: editOnly ? [{ type: 'file', mediaType: 'image/png', data: PROBE_INPUT_IMAGE_BASE64 }] : undefined,
+            mask: undefined,
+            modelDescriptor: vendorTransport
+              ? { id: wireModelId, endpoint: vendorTransport.endpoint, isSync: vendorTransport.isSync, mode: probeMode }
+              : undefined,
+            providerParams: probeParams,
+            signal: controller.signal
+          })
+        })()
+      } else {
+        probe = this.generateImage({
+          ...probeRequest,
+          prompt: 'a red circle',
+          ...(editOnly && { mode: probeMode, inputImages: [PROBE_INPUT_IMAGE_DATA_URL] }),
+          paramValues: probeParams,
+          cleanupPolicy: 'delete_when_unreferenced'
+        })
+      }
     } else {
       // Latency is the probe's measured output — thinking tokens would pollute it
       // for reasoning-capable models whose provider default enables reasoning.

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -1639,6 +1639,61 @@ describe('AiService tool approval', () => {
     expect(imageSpy).not.toHaveBeenCalled()
   })
 
+  // Edit-only image models (qwen-image-edit / wan2.5-i2i / qwen-mt-image …) serve no
+  // `generate` mode — the bare default leaves the job path without a transport
+  // descriptor and the check failed before any provider request.
+  it('probes edit-only image models with their declared mode and an inline input image', async () => {
+    const service = createService()
+    const imageSpy = vi.spyOn(service, 'generateImage').mockResolvedValue({ files: [] })
+    mockModelGetByKey.mockReturnValue({
+      id: 'test-provider::test-edit-image',
+      providerId: 'test-provider',
+      apiModelId: 'test-edit-image',
+      name: 'Test Edit Image',
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+      supportsStreaming: false,
+      isEnabled: true,
+      isHidden: false
+    })
+    mockGetImageGenerationSupport.mockReturnValueOnce({
+      modes: { edit: { vendorTransport: { endpoint: '/api/v1/services/aigc/multimodal-generation/generation' } } }
+    })
+
+    await service.checkModel({ uniqueModelId: 'test-provider::test-edit-image' })
+
+    expect(mockGetImageGenerationSupport).toHaveBeenCalledWith('test-provider', 'test-edit-image')
+    expect(imageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'edit',
+        inputImages: [expect.stringContaining('data:image/png;base64,')]
+      })
+    )
+  })
+
+  it('keeps generate-capable image probes mode-less', async () => {
+    const service = createService()
+    const imageSpy = vi.spyOn(service, 'generateImage').mockResolvedValue({ files: [] })
+    mockModelGetByKey.mockReturnValue({
+      id: 'test-provider::test-image',
+      providerId: 'test-provider',
+      apiModelId: 'test-image',
+      name: 'Test Image',
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION],
+      supportsStreaming: false,
+      isEnabled: true,
+      isHidden: false
+    })
+    mockGetImageGenerationSupport.mockReturnValueOnce({
+      modes: { generate: { vendorTransport: { endpoint: '/v1/images/generations' } } }
+    })
+
+    await service.checkModel({ uniqueModelId: 'test-provider::test-image' })
+
+    expect(imageSpy).toHaveBeenCalledWith(expect.not.objectContaining({ mode: expect.anything() }))
+    expect(imageSpy).toHaveBeenCalledWith(expect.not.objectContaining({ inputImages: expect.anything() }))
+  })
+
   it('fails rerank health checks when the probe returns an empty ranking', async () => {
     const service = createService()
     vi.spyOn(service, 'rerank').mockResolvedValue({ ranking: [] })

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -3,6 +3,7 @@ import { ENDPOINT_TYPE, type Model, MODEL_CAPABILITY } from '@shared/data/types/
 import { isGatewayRoutableModel } from '@shared/utils/model'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as ImageTransportRegistryModule from '../provider/custom/imageTransportRegistry'
 import type * as ListModelsModule from '../provider/listModels'
 import { makeProvider } from './fixtures/provider'
 
@@ -36,6 +37,7 @@ const mockReadRetryPolicy = vi.fn(() => ({
   fallbackModelIds: ['fallback::model']
 }))
 const mockGetImageGenerationSupport = vi.fn()
+const mockResolveImageTransport = vi.fn()
 const mockListProviderRegistryModels = vi.fn()
 const mockListModelsFromProvider = vi.fn()
 const mockInstallBuiltinSkills = vi.fn()
@@ -79,7 +81,10 @@ vi.mock('../tools/adapters/aiSdk/builtin/registerBuiltinTools', () => ({
 }))
 
 vi.mock('../utils/customFetch', () => ({
-  installProviderUserAgentInterceptor: () => mockInstallProviderUserAgentInterceptor()
+  installProviderUserAgentInterceptor: () => mockInstallProviderUserAgentInterceptor(),
+  // The inline health-check probe resolves the real provider config, which
+  // defaults providerSettings.fetch to customFetch — a stub keeps it inert.
+  customFetch: vi.fn()
 }))
 
 vi.mock('@main/data/services/ProviderService', () => ({
@@ -102,6 +107,17 @@ vi.mock('@data/services/ProviderRegistryService', () => ({
     listProviderRegistryModels: (...args: unknown[]) => mockListProviderRegistryModels(...args)
   }
 }))
+
+// Inline health-check probes resolve the transport through this module. Keep
+// `hasImageTransport` real (routing tests depend on the true registry) and stub
+// only the transport resolution so submit never reaches the network.
+vi.mock('../provider/custom/imageTransportRegistry', async (importOriginal) => {
+  const actual = await importOriginal<typeof ImageTransportRegistryModule>()
+  return {
+    ...actual,
+    resolveImageTransport: (...args: unknown[]) => mockResolveImageTransport(...args)
+  }
+})
 
 vi.mock('../provider/listModels', async (importOriginal) => {
   const actual = await importOriginal<typeof ListModelsModule>()
@@ -1679,6 +1695,57 @@ describe('AiService tool approval', () => {
         mode: 'edit',
         inputImages: [expect.stringContaining('data:image/png;base64,')],
         paramValues: { addWatermark: false, sourceLang: 'auto', targetLang: 'en' }
+      })
+    )
+  })
+
+  // Transport models route their job through a handler that re-selects a serving
+  // key, dropping the health check's apiKeyOverride — the probe could run with a
+  // different rotated credential than the one being reported. The check probes
+  // inline instead, resolving the config WITH the caller's key.
+  it('probes transport image models inline with the caller API-key override', async () => {
+    const service = createService()
+    mockProviderGetByProviderId.mockReturnValueOnce(makeProvider({ id: 'ppio', name: 'PPIO' }))
+    mockModelGetByKey.mockReturnValue({
+      id: 'ppio::qwen-image-edit',
+      providerId: 'ppio',
+      apiModelId: 'qwen-image-edit',
+      name: 'Qwen Image Edit',
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+      supportsStreaming: false,
+      isEnabled: true,
+      isHidden: false
+    })
+    mockGetImageGenerationSupport.mockReturnValueOnce({
+      modes: {
+        edit: {
+          supports: { sourceLang: { default: 'auto', options: ['auto', 'en'], type: 'enum' } },
+          vendorTransport: { endpoint: '/api/v1/services/aigc/multimodal-generation/generation', isSync: true }
+        }
+      }
+    })
+    const submit = vi.fn().mockResolvedValue({ imageUrls: ['https://example.test/img.png'] })
+    mockResolveImageTransport.mockReturnValueOnce({ submit })
+
+    await service.checkModel({
+      uniqueModelId: 'ppio::qwen-image-edit',
+      apiKeyOverride: 'sk-selected'
+    })
+
+    expect(mockProviderResolveApiKey).toHaveBeenCalledWith('ppio', 'sk-selected')
+    expect(mockResolveImageTransport).toHaveBeenCalled()
+    expect(submit).toHaveBeenCalledTimes(1)
+    expect(submit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: 'qwen-image-edit',
+        modelDescriptor: {
+          id: 'qwen-image-edit',
+          endpoint: '/api/v1/services/aigc/multimodal-generation/generation',
+          isSync: true,
+          mode: 'edit'
+        },
+        providerParams: { sourceLang: 'auto' },
+        files: [{ type: 'file', mediaType: 'image/png', data: expect.any(String) }]
       })
     )
   })

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -1733,7 +1733,7 @@ describe('AiService tool approval', () => {
     })
 
     expect(mockProviderResolveApiKey).toHaveBeenCalledWith('ppio', 'sk-selected')
-    expect(mockResolveImageTransport).toHaveBeenCalled()
+    expect(mockResolveImageTransport).toHaveBeenCalledWith('ppio', 'qwen-image-edit', expect.anything())
     expect(submit).toHaveBeenCalledTimes(1)
     expect(submit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1765,13 +1765,20 @@ describe('AiService tool approval', () => {
       isHidden: false
     })
     mockGetImageGenerationSupport.mockReturnValueOnce({
-      modes: { generate: { vendorTransport: { endpoint: '/v1/images/generations' } } }
+      modes: {
+        generate: {
+          supports: { numImages: { default: 1, max: 4, min: 1, type: 'range' } },
+          vendorTransport: { endpoint: '/v1/images/generations' }
+        }
+      }
     })
 
     await service.checkModel({ uniqueModelId: 'test-provider::test-image' })
 
     expect(imageSpy).toHaveBeenCalledWith(expect.not.objectContaining({ mode: expect.anything() }))
     expect(imageSpy).toHaveBeenCalledWith(expect.not.objectContaining({ inputImages: expect.anything() }))
+    // Generate-capable models still materialize their generate-mode defaults.
+    expect(imageSpy).toHaveBeenCalledWith(expect.objectContaining({ paramValues: { numImages: 1 } }))
   })
 
   it('fails rerank health checks when the probe returns an empty ranking', async () => {

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -1642,7 +1642,7 @@ describe('AiService tool approval', () => {
   // Edit-only image models (qwen-image-edit / wan2.5-i2i / qwen-mt-image …) serve no
   // `generate` mode — the bare default leaves the job path without a transport
   // descriptor and the check failed before any provider request.
-  it('probes edit-only image models with their declared mode and an inline input image', async () => {
+  it('probes edit-only image models with their declared mode, an inline input image, and materialized param defaults', async () => {
     const service = createService()
     const imageSpy = vi.spyOn(service, 'generateImage').mockResolvedValue({ files: [] })
     mockModelGetByKey.mockReturnValue({
@@ -1655,8 +1655,20 @@ describe('AiService tool approval', () => {
       isEnabled: true,
       isHidden: false
     })
+    // Defaults must be materialized main-side: qwen-mt-image's source/target langs and
+    // wanx2.1-imageedit's function are REQUIRED vendor params the transport omits
+    // when the bag is empty, so a bare `paramValues: {}` probe still fails server-side.
     mockGetImageGenerationSupport.mockReturnValueOnce({
-      modes: { edit: { vendorTransport: { endpoint: '/api/v1/services/aigc/multimodal-generation/generation' } } }
+      modes: {
+        edit: {
+          supports: {
+            addWatermark: { default: false, type: 'switch' },
+            sourceLang: { default: 'auto', options: ['auto', 'en'], type: 'enum' },
+            targetLang: { default: 'en', options: ['en', 'zh'], type: 'enum' }
+          },
+          vendorTransport: { endpoint: '/api/v1/services/aigc/image2image/image-synthesis' }
+        }
+      }
     })
 
     await service.checkModel({ uniqueModelId: 'test-provider::test-edit-image' })
@@ -1665,7 +1677,8 @@ describe('AiService tool approval', () => {
     expect(imageSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: 'edit',
-        inputImages: [expect.stringContaining('data:image/png;base64,')]
+        inputImages: [expect.stringContaining('data:image/png;base64,')],
+        paramValues: { addWatermark: false, sourceLang: 'auto', targetLang: 'en' }
       })
     )
   })


### PR DESCRIPTION
## Problem

Edit-only image models — `qwen-image-edit`, `qwen-mt-image`, `wan2.5-i2i-preview`, `wanx2.1-imageedit` on DashScope, and the same lines on QwenCloud — declare only `modes.edit` in the registry. The model health check (`checkModel`) probes image-only models through `generateImage` without a `mode`, and the job path defaults to `'generate'`:

- `modes['generate']` is `undefined` for these models → no `vendorTransport` descriptor is derived
- `DashScopeTransport.submit` throws `Missing modelDescriptor` **before any provider request**

So checking these models always failed with an opaque error, even with a valid key. This is a pre-existing gap on `main` (surfaced by the QwenCloud PR review, #19810).

## Fix

`checkModel`'s image probe now resolves the model's declared modes and parameter specs from the registry:

1. **Mode**: when `generate` is absent, probe the first declared mode in painting-tab preference order (`edit` → `remix` → `upscale` → `merge`).
2. **Input image**: edit-mode probes carry an inline 64×64 PNG — a real edit request exercising the same endpoint/credential path the painting tab uses.
3. **Param defaults**: the probe's `paramValues` materialize the mode's registry defaults, mirroring what the painting UI stamps on model selection. Without this, models whose edit mode has *required* vendor params (qwen-mt-image `source_lang`/`target_lang`, wanx2.1-imageedit `function`) still failed server-side on an empty bag.
4. **Transport models probe inline**: the job system's handler re-selects a serving key, dropping the health check's `apiKeyOverride` — the probe could run with a different rotated credential than the one being reported. A check needs no restart survival, so transport models are probed with a single inline `submit` using the caller's key: acceptance = credential + endpoint + model OK. No job row, no result download.

`generate`-capable non-transport models keep the mode-less `generateImage` probe (with their generate-mode defaults materialized). Rerank/embedding/text probes are untouched.

### Known trade-off

For async transports (PPIO / DashScope async / ModelScope / TokenHub), inline acceptance means the remote task is no longer polled to completion — a task rejected *after* submission (e.g. content moderation) would read as a pass. The old job path awaited completion but 15 s was often too short anyway and DashScope has no remote cancel endpoint; within the check's timeout budget, submit-acceptance is the reliable signal.

## Testing

- `probes edit-only image models …` — mode + PNG input + materialized param defaults
- `probes transport image models inline with the caller API-key override` — `resolveApiKey` receives the override; `resolveImageTransport` is keyed on the expected provider/model; submit receives descriptor, defaults, and the PNG
- `keeps generate-capable image probes mode-less` — no mode/inputImages, generate defaults materialized
- Full `AiService` suite: 61/61; `pnpm test:lint`, typecheck, i18n check clean