### PR TITLE
fix(model-health): clear cached check results on unmount

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useHealthCheck.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/useHealthCheck.test.tsx
@@ -390,15 +390,15 @@ describe('useHealthCheck', () => {
     expect(readModelHealthStatus(rerankModel.id)).toMatchObject({ model: rerankModel })
   })
 
-  it('clears results left in the cache by a previous mount', async () => {
+  it('clears cached results on unmount so a later mount never renders them', async () => {
     checkModelsHealthMock.mockResolvedValue([okResult(chatModel), okResult(rerankModel)])
     const { result, unmount } = renderHook(() => useHealthCheck('openai', getCredentialsState()))
     await act(async () => {
       await result.current.startHealthCheck({ keySelection: { mode: 'all' }, isConcurrent: true, timeout: 15000 })
     })
-    unmount()
+    expect(readStatuses()).not.toEqual([])
 
-    renderHook(() => useHealthCheck('openai', getCredentialsState()))
+    unmount()
     expect(readStatuses()).toEqual([])
   })
 

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/useHealthCheck.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/useHealthCheck.ts
@@ -272,7 +272,10 @@ export function useHealthCheck(providerId: string, credentialsState: ModelCheckC
   // its results; the cleanup also covers unmount.
   useEffect(() => {
     publishStatuses([])
-    return abortInFlightCheck
+    return () => {
+      abortInFlightCheck()
+      publishStatuses([])
+    }
   }, [abortInFlightCheck, anthropicApiHost, apiHost, credentialChangeVersion, providerId, publishStatuses])
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: #19876 moved model health check results into the window memory cache (one key per model) so each row re-renders on its own, but the effect cleanup only aborted the in-flight run. Results written by a previous mount stayed in the cache: returning to a provider rendered the old statuses on the first frame (or indefinitely if the model list had not loaded yet when the mount-time clear ran), and every provider checked in the session kept its rows in memory.

After this PR: the same cleanup that aborts the run also clears the published statuses, so the cache lifetime matches the component lifetime as it did before #19876. Leaving the provider page, switching provider/endpoint/credentials, or unmounting all drop the results.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: results no longer survive a remount of the provider page. That is the pre-#19876 behavior, so it is a restoration rather than a new tradeoff.

The following alternatives were considered: a TTL on the cache entries was rejected because it does not prevent the first-frame flash of stale results and adds a knob nobody asked for. Deferring the mount-time clear until the model list loads was rejected because it only patches the same-provider case and still leaks results for every other provider.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The existing test "clears results left in the cache by a previous mount" only passed because the second mount did the clearing. It is rewritten to assert the cache is empty right after `unmount()`; it fails on `main` and passes with this fix.

Verified with `npx vitest run` on `useHealthCheck.test.tsx` (12 passed) plus the sibling `modelHealthStatusCache`, `modelListHealthContext`, and `ProviderModelList` tests (11 passed), and eslint/biome on the two touched files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Model health check results no longer linger after leaving the provider page.
```

