### PR TITLE
fix(filesystem-mcp): defer regex validation to fallback

### DIFF
--- a/src/main/ai/mcp/servers/filesystem/__tests__/grep.test.ts
+++ b/src/main/ai/mcp/servers/filesystem/__tests__/grep.test.ts
@@ -42,6 +42,28 @@ describe('grep MCP ripgrep integration', () => {
     expect(rgArgs[patternIndex - 1]).toBe('--')
   })
 
+  it('accepts ripgrep regex syntax that JavaScript does not support', async () => {
+    const workspaceRoot = await createTempDir('grep-ripgrep-regex-root-')
+    const pattern = '(?P<word>foo)'
+    const runRipgrepSpy = vi.spyOn(types, 'runRipgrep').mockResolvedValue({ ok: true, stdout: '', exitCode: 1 })
+
+    const result = await handleGrepTool({ pattern, path: workspaceRoot }, workspaceRoot)
+
+    expect(runRipgrepSpy).toHaveBeenCalledOnce()
+    expect(runRipgrepSpy.mock.calls[0][0]).toContain(pattern)
+    expect(result.content[0].text).toBe('No matches found')
+  })
+
+  it('rejects unsupported regex syntax when manual search is required', async () => {
+    const workspaceRoot = await createTempDir('grep-fallback-regex-root-')
+    const pattern = '(?P<word>foo)'
+    vi.spyOn(types, 'runRipgrep').mockResolvedValue({ ok: false, stdout: '', exitCode: null })
+
+    await expect(handleGrepTool({ pattern, path: workspaceRoot }, workspaceRoot)).rejects.toThrow(
+      `Invalid regex pattern: ${pattern}`
+    )
+  })
+
   it('parses structured match output for a single-file search', async () => {
     const workspaceRoot = await createTempDir('grep-output-root-')
     const matchedFile = path.join(workspaceRoot, 'match.txt')

--- a/src/main/ai/mcp/servers/filesystem/tools/grep.ts
+++ b/src/main/ai/mcp/servers/filesystem/tools/grep.ts
@@ -123,15 +123,6 @@ export async function handleGrepTool(args: unknown, baseDir: string) {
   // literal search pattern instead of the preprocessor flag (arg-injection → RCE).
   rgArgs.push('--', data.pattern, validPath)
 
-  try {
-    // No `g` flag: this regex is reused with `.test(line)` per line, and a global
-    // regex carries `lastIndex` across calls — that silently skips matches on
-    // subsequent lines. Case-insensitive matching only.
-    regex = new RegExp(data.pattern, 'i')
-  } catch (error) {
-    throw new Error(`Invalid regex pattern: ${data.pattern}`)
-  }
-
   async function searchFile(filePath: string): Promise<void> {
     if (matches.length >= MAX_GREP_MATCHES) {
       truncated = true
@@ -300,6 +291,15 @@ export async function handleGrepTool(args: unknown, baseDir: string) {
   }
 
   if (!usedRipgrep) {
+    try {
+      // No `g` flag: this regex is reused with `.test(line)` per line, and a global
+      // regex carries `lastIndex` across calls — that silently skips matches on
+      // subsequent lines. Case-insensitive matching only.
+      regex = new RegExp(data.pattern, 'i')
+    } catch {
+      throw new Error(`Invalid regex pattern: ${data.pattern}`)
+    }
+
     const stats = await fs.stat(validPath)
     if (stats.isFile()) {
       await searchFile(validPath)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The filesystem MCP `grep` tool validated every pattern with JavaScript `RegExp` before invoking ripgrep, rejecting syntax that ripgrep supports but JavaScript does not, such as `(?P<word>foo)`.

After this PR:

Ripgrep receives patterns without JavaScript pre-validation. JavaScript regex validation runs only when the manual fallback search is required.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The tool advertises and executes ripgrep regex searches, so ripgrep—not the fallback engine—should define the accepted syntax on the primary path. The fallback retains its existing validation and error message when ripgrep cannot be used.

The following tradeoffs were made:

Ripgrep-only syntax still cannot run in the JavaScript fallback and returns the existing invalid-pattern error when fallback is required.

The following alternatives were considered:

Removing fallback validation entirely was rejected because manual search still calls JavaScript `RegExp.test()` and must reject unsupported syntax explicitly.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Tests cover both accepting ripgrep-only syntax on the primary path and rejecting it when manual fallback is required.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Filesystem MCP] Allow grep searches to use regular expression syntax supported by ripgrep.
```
