### PR TITLE
fix(file): compare inodes as bigint in isSameFile

### DIFF
--- a/src/main/utils/file/fs.ts
+++ b/src/main/utils/file/fs.ts
@@ -161,7 +161,9 @@ export async function probeReadable(path: AbsoluteFilePath): Promise<PathReadabi
  */
 export async function isSameFile(a: AbsoluteFilePath, b: AbsoluteFilePath): Promise<boolean> {
   try {
-    const [sa, sb] = await Promise.all([fsStat(a), fsStat(b)])
+    // bigint: Windows NTFS file reference numbers exceed 2^53, so as doubles
+    // two adjacent files can round to the same ino.
+    const [sa, sb] = await Promise.all([fsStat(a, { bigint: true }), fsStat(b, { bigint: true })])
     return sa.dev === sb.dev && sa.ino === sb.ino
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`isSameFile` compares `dev` + `ino` from `fs.stat()` as JS numbers. On Windows, `ino` is the 64-bit NTFS file reference number (48-bit MFT record index plus a 16-bit sequence number in the high bits). Once that value exceeds 2^53 it loses precision as a double, so two files created back to back with adjacent MFT records can round to the same `ino` and `isSameFile` reports them as identical. This is what makes the `main-test (windows-2022)` job flake on `fs.test.ts > isSameFile > returns false for two distinct files even with identical content` (e.g. https://github.com/CherryHQ/cherry-studio/actions/runs/33832148194/job/100897240348).

After this PR:

Both stats are taken with `{ bigint: true }`, so `dev` / `ino` are compared at full 64-bit precision. The comparison logic is unchanged.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

Only `isSameFile` is changed. `openReadableFileSnapshot` also compares `dev` / `ino`, but it compares a path stat against a handle stat of the same file, so rounding cannot make equal values unequal, and its `ino: number` is part of a public interface. It is left as is.

The following alternatives were considered:

- Retrying the CI job: it passes most of the time, but the underlying comparison is wrong and would keep flaking.
- Switching the whole module to bigint stats: widens the change for no benefit.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Locally verified with `npx vitest run --project main src/main/utils/file/__tests__/fs.test.ts` (76 passed), `tsgo --noEmit -p tsconfig.node.json`, and `biome check` on the changed file. The flake only reproduces on Windows when NTFS sequence numbers are high, which is why CI runners hit it intermittently.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
