### PR TITLE
fix(claude-code): validate bundled executable

### DIFF
--- a/scripts/__tests__/before-pack.test.ts
+++ b/scripts/__tests__/before-pack.test.ts
@@ -46,6 +46,21 @@ describe('assertPrebuiltPackages', () => {
 })
 
 describe('keepPackages', () => {
+  it.each(['arm64', 'x64'])('ships the matching Windows %s Claude executable outside ASAR', (arch) => {
+    const packageManifest = JSON.parse(readFileSync('package.json', 'utf8')) as {
+      dependencies: Record<string, string>
+      optionalDependencies: Record<string, string>
+    }
+    const builderConfig = parse(readFileSync('electron-builder.yml', 'utf8')) as { asarUnpack: string[] }
+    const packageName = `@anthropic-ai/claude-agent-sdk-win32-${arch}`
+
+    expect(packageManifest.optionalDependencies[packageName]).toBe(
+      packageManifest.dependencies['@anthropic-ai/claude-agent-sdk']
+    )
+    expect(keepPackages('win32', arch)).toContain(packageName)
+    expect(builderConfig.asarUnpack).toContain('node_modules/@anthropic-ai/claude-agent-sdk-*/**')
+  })
+
   it.each([
     ['x64', '@deepseek-ai/node-addon-landlock-run-linux-x64', '@deepseek-ai/node-addon-landlock-run-linux-arm64'],
     ['arm64', '@deepseek-ai/node-addon-landlock-run-linux-arm64', '@deepseek-ai/node-addon-landlock-run-linux-x64']

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -1,3 +1,4 @@
+import type * as NodeFs from 'node:fs'
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import type * as NodeModule from 'node:module'
 import os from 'node:os'
@@ -68,9 +69,19 @@ const mocks = vi.hoisted(() => ({
   createAgentsMdLoader: vi.fn(),
   loadAgentsMdInitialContext: vi.fn(),
   agentsMdHook: vi.fn(async () => ({})),
+  existsSync: vi.fn(() => true),
+  toAsarUnpackedPath: vi.fn((input: string) => input),
   platform: { isMac: false },
   isWin: false
 }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  return {
+    ...actual,
+    existsSync: mocks.existsSync
+  }
+})
 
 vi.mock('node:module', async (importOriginal) => {
   const actual = await importOriginal<typeof NodeModule>()
@@ -194,7 +205,7 @@ vi.mock('@main/services/proxy/proxyEnv', () => ({
 }))
 
 vi.mock('@main/utils/asar', () => ({
-  toAsarUnpackedPath: (input: string) => input
+  toAsarUnpackedPath: mocks.toAsarUnpackedPath
 }))
 
 vi.mock('@main/utils/file', () => ({
@@ -253,7 +264,8 @@ const {
   buildClaudeCodeSessionSettings,
   disposeToolPolicySnapshot,
   prepareClaudeCodeWorkspaceDirectory,
-  registerMcpSessionCatalogSync
+  registerMcpSessionCatalogSync,
+  resolveClaudeExecutablePath
 } = await import('../settingsBuilder')
 const { ClaudeCodeSessionStateService } = await import('../ClaudeCodeSessionStateService')
 // One real instance per test file — the facade resolves it via application.get, and the real Maps
@@ -352,6 +364,46 @@ describe('buildClaudeCodeSessionSettings', () => {
     mocks.checkSkillRuntimeDependencies.mockResolvedValue({})
     mocks.getBuiltinAgentPluginDirectory.mockReturnValue(undefined)
     mocks.loadBuiltinAgentDefinition.mockReturnValue(undefined)
+    mocks.existsSync.mockReturnValue(true)
+    mocks.toAsarUnpackedPath.mockImplementation((input: string) => input)
+  })
+
+  it('directs packaged installs to the official installer when the unpacked Claude executable is missing', () => {
+    mocks.isWin = true
+    mocks.resolveRequire.mockImplementation((specifier: string) => {
+      if (specifier === '@anthropic-ai/claude-agent-sdk') return 'C:\\app\\resources\\app.asar\\node_modules\\sdk.mjs'
+      return 'C:\\app\\resources\\app.asar\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+    })
+    mocks.toAsarUnpackedPath.mockImplementation((input: string) => input.replace('app.asar', 'app.asar.unpacked'))
+    mocks.existsSync.mockReturnValue(false)
+
+    expect(() => resolveClaudeExecutablePath()).toThrow(
+      /Bundled Claude Code executable is missing.*Reinstall Cherry Studio from the official installer/
+    )
+  })
+
+  it('returns an existing unpacked Claude executable', () => {
+    mocks.isWin = true
+    mocks.resolveRequire.mockImplementation((specifier: string) => {
+      if (specifier === '@anthropic-ai/claude-agent-sdk') return 'C:\\app\\resources\\app.asar\\node_modules\\sdk.mjs'
+      return 'C:\\app\\resources\\app.asar\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+    })
+    mocks.toAsarUnpackedPath.mockImplementation((input: string) => input.replace('app.asar', 'app.asar.unpacked'))
+
+    expect(resolveClaudeExecutablePath()).toBe(
+      'C:\\app\\resources\\app.asar.unpacked\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+    )
+  })
+
+  it('keeps the dependency repair message when the native package cannot be resolved', () => {
+    mocks.resolveRequire.mockImplementation((specifier: string) => {
+      if (specifier === '@anthropic-ai/claude-agent-sdk') return '/app/node_modules/sdk.mjs'
+      throw new Error(`Cannot resolve ${specifier}`)
+    })
+
+    expect(() => resolveClaudeExecutablePath()).toThrow(
+      /Reinstall @anthropic-ai\/claude-agent-sdk with optional dependencies/
+    )
   })
 
   it('preserves managed CLI paths from the login-shell environment', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -10,7 +10,10 @@ import {
   toMcpRuntimeName
 } from '@main/ai/toolApproval/builtinToolPolicy'
 import { KB_MANAGE_TOOL_NAME } from '@shared/ai/builtinTools'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const REAL_PLATFORM = process.platform
+const REAL_ARCH = process.arch
 
 const APPROVAL_REQUIRED_RUNTIME_NAMES = listBuiltinToolPolicies({ approval: 'required' }).map(toMcpRuntimeName)
 const BYPASSABLE_APPROVAL_REQUIRED_RUNTIME_NAMES = listBuiltinToolPolicies({
@@ -283,6 +286,11 @@ function systemPromptText(systemPrompt: unknown): string {
 }
 
 describe('buildClaudeCodeSessionSettings', () => {
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: REAL_PLATFORM, configurable: true })
+    Object.defineProperty(process, 'arch', { value: REAL_ARCH, configurable: true })
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.approvalRegister.mockReturnValue(true)
@@ -369,10 +377,15 @@ describe('buildClaudeCodeSessionSettings', () => {
   })
 
   it('directs packaged installs to the official installer when the unpacked Claude executable is missing', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    Object.defineProperty(process, 'arch', { value: 'x64', configurable: true })
     mocks.isWin = true
     mocks.resolveRequire.mockImplementation((specifier: string) => {
       if (specifier === '@anthropic-ai/claude-agent-sdk') return 'C:\\app\\resources\\app.asar\\node_modules\\sdk.mjs'
-      return 'C:\\app\\resources\\app.asar\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+      if (specifier === '@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe') {
+        return 'C:\\app\\resources\\app.asar\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+      }
+      throw new Error(`Unexpected specifier: ${specifier}`)
     })
     mocks.toAsarUnpackedPath.mockImplementation((input: string) => input.replace('app.asar', 'app.asar.unpacked'))
     mocks.existsSync.mockReturnValue(false)
@@ -383,10 +396,15 @@ describe('buildClaudeCodeSessionSettings', () => {
   })
 
   it('returns an existing unpacked Claude executable', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    Object.defineProperty(process, 'arch', { value: 'x64', configurable: true })
     mocks.isWin = true
     mocks.resolveRequire.mockImplementation((specifier: string) => {
       if (specifier === '@anthropic-ai/claude-agent-sdk') return 'C:\\app\\resources\\app.asar\\node_modules\\sdk.mjs'
-      return 'C:\\app\\resources\\app.asar\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+      if (specifier === '@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe') {
+        return 'C:\\app\\resources\\app.asar\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe'
+      }
+      throw new Error(`Unexpected specifier: ${specifier}`)
     })
     mocks.toAsarUnpackedPath.mockImplementation((input: string) => input.replace('app.asar', 'app.asar.unpacked'))
 

--- a/src/main/ai/runtime/claudeCode/environment.ts
+++ b/src/main/ai/runtime/claudeCode/environment.ts
@@ -4,6 +4,7 @@
  * derives the auto-compact window and per-request output cap from the model catalog.
  */
 
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 
@@ -113,13 +114,23 @@ export function resolveClaudeExecutablePath(): string {
         `@anthropic-ai/claude-agent-sdk-linux-${process.arch}`
       ]
     : [`@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`]
+  let missingUnpackedPath: string | undefined
 
   for (const packageName of nativePackages) {
     try {
-      return toAsarUnpackedPath(sdkRequire.resolve(`${packageName}/claude${extension}`))
+      const resolvedPath = sdkRequire.resolve(`${packageName}/claude${extension}`)
+      const executablePath = toAsarUnpackedPath(resolvedPath)
+      if (existsSync(executablePath)) return executablePath
+      if (executablePath !== resolvedPath) missingUnpackedPath = executablePath
     } catch {
       // Optional native packages are platform-specific; try the next candidate.
     }
+  }
+
+  if (missingUnpackedPath) {
+    throw new Error(
+      `Bundled Claude Code executable is missing at ${missingUnpackedPath}. Reinstall Cherry Studio from the official installer to restore it.`
+    )
   }
 
   throw new Error(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

When a packaged Cherry Studio installation was missing the unpacked Claude Code executable, the runtime passed the nonexistent path to the SDK. Windows Agent startup then failed with a generic optional-dependency message that did not identify the correct recovery action.

After this PR:

Cherry Studio validates the resolved unpacked executable before starting Claude Code. A damaged packaged installation now fails early with the missing path and directs the user to reinstall from the official installer, while development dependency failures keep their existing package-repair guidance. Packaging tests also pin the Windows native packages and ASAR unpack contract.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19948

### Why we need it and why it was done in this way

The SDK checks the executable only after Cherry converts its ASAR path to `app.asar.unpacked`. Validating that final filesystem path at Cherry's runtime boundary distinguishes a damaged packaged installation from a missing development dependency and produces the appropriate recovery guidance.

The following tradeoffs were made:

The fix reports the packaging failure instead of attempting an in-app binary repair. This keeps executable installation within the signed application installer and avoids downloading or mutating runtime binaries implicitly.

The following alternatives were considered:

Automatically downloading the missing executable was rejected because it would bypass the normal signed installer and add integrity, permission, and lifecycle concerns. Changing only the generic SDK error text was rejected because Cherry can identify the missing unpacked artifact precisely before invoking the SDK.

Links to places where the discussion took place: #19948

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The official v2.0.11 Windows x64 installer contains the expected `@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe`; the affected diagnostic reports that exact unpacked path as missing. Focused runtime tests (131 cases), packaging tests (12 cases), `pnpm lint`, and `pnpm test:lint` pass locally.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Windows Claude Code Agent startup diagnostics when the bundled executable is missing.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized path resolution and error messaging at Claude Code launch; no auth or data-path changes beyond failing fast with clearer diagnostics.
> 
> **Overview**
> **Claude Code startup** now checks that the resolved **ASAR-unpacked** native `claude` binary exists on disk before the Agent SDK runs. If the module resolves inside `app.asar` but the unpacked file is missing (typical broken Windows installer), startup fails early with the **missing path** and tells users to **reinstall Cherry Studio from the official installer**; unresolved optional native packages still get the existing **`pnpm`/optional-deps** repair message.
> 
> **Tests** add Windows packaging guards (`keepPackages`, `optionalDependencies`, `asarUnpack` for `@anthropic-ai/claude-agent-sdk-win32-*`) and unit cases for missing vs present unpacked executables and unresolved natives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fa4c42486f70f34d2ebe223d2ae6514340fb15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->