### PR TITLE
fix(release-workflow): restore generated notes and add downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,11 +347,17 @@ jobs:
 
       - name: Prepare bilingual release notes
         shell: bash
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           node scripts/release/compose-release-body.js \
             electron-builder.yml \
             - \
-            "$RUNNER_TEMP/release-body.md"
+            "$RUNNER_TEMP/release-body.md" \
+            "$REPO" \
+            "$TAG" \
+            "Cherry Studio"
 
       - name: Create or update draft release
         id: draft-release
@@ -468,11 +474,16 @@ jobs:
           TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           # every release branch forks from main, so GitHub cannot infer the previous tag by ancestry
-          PREVIOUS_TAG="$(gh api "repos/$REPO/releases?per_page=100" | jq -r \
+          RELEASE_PAGES="$(gh api --paginate --slurp "repos/$REPO/releases?per_page=100")"
+          PREVIOUS_TAG="$(jq -r \
             --arg tag "$TAG" \
             --argjson includePrereleases "$PRERELEASE" \
-            '[.[] | select(.draft | not) | select(.tag_name != $tag) | select($includePrereleases or (.prerelease | not))]
-             | sort_by(.published_at) | last | .tag_name')
+            '[.[][] | select(.draft | not) | select(.tag_name != $tag) | select($includePrereleases or (.prerelease | not))]
+             | sort_by(.published_at) | (last | .tag_name) // empty' <<< "$RELEASE_PAGES")"
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "No published release is available as the previous tag for $TAG" >&2
+            exit 1
+          fi
           echo "Generating changes since $PREVIOUS_TAG"
           gh api --method POST "repos/$REPO/releases/generate-notes" \
             -f tag_name="$TAG" \
@@ -481,7 +492,10 @@ jobs:
           node scripts/release/compose-release-body.js \
             electron-builder.yml \
             "$RUNNER_TEMP/generated-release-notes.md" \
-            "$RUNNER_TEMP/release-body.md"
+            "$RUNNER_TEMP/release-body.md" \
+            "$REPO" \
+            "$TAG" \
+            "Cherry Studio"
           # PATCH without tag_name resets a draft to untagged-<sha>
           jq -Rs --arg tag "$TAG" '{tag_name: $tag, body: .}' < "$RUNNER_TEMP/release-body.md" > "$RUNNER_TEMP/release-body.json"
           RELEASE="$(gh api --method PATCH "repos/$REPO/releases/$RELEASE_ID" \

--- a/scripts/__tests__/release-workflow.test.ts
+++ b/scripts/__tests__/release-workflow.test.ts
@@ -668,7 +668,7 @@ describe('release publication state', () => {
     target_commitish: workflowSha
   }
 
-  it('combines curated bilingual notes with GitHub generated changes', () => {
+  it('builds a compact release page with user downloads and generated changes', () => {
     const builderContent = [
       'releaseInfo:',
       '  releaseNotes: |',
@@ -680,24 +680,41 @@ describe('release publication state', () => {
       ''
     ].join('\n')
 
-    expect(composeReleaseBody({ builderContent, generatedNotes: "## What's Changed\n- Fix one\n" })).toBe(
-      [
-        '<!--LANG:en-->',
-        'English notes',
-        '<!--LANG:zh-CN-->',
-        '中文说明',
-        '<!--LANG:END-->',
-        '',
-        '---',
-        '',
-        "## What's Changed",
-        '- Fix one',
-        ''
-      ].join('\n')
+    const body = composeReleaseBody({
+      builderContent,
+      generatedNotes: "## What's Changed\n- Fix one\n\n## New Contributors\n- @new",
+      productName: 'Cherry Studio',
+      repository: 'CherryHQ/cherry-studio',
+      tag: 'v1.2.0'
+    })
+
+    expect(body).toContain('## Downloads / 下载 (v1.2.0)')
+    expect(body.match(/^\| (Windows|macOS|Linux) \|/gm)).toHaveLength(6)
+    expect(body.match(/https:\/\/github\.com\/CherryHQ\/cherry-studio\/releases\/download\/v1\.2\.0\//g)).toHaveLength(
+      28
     )
-    expect(composeReleaseBody({ builderContent, generatedNotes: '' })).toBe(
-      '<!--LANG:en-->\nEnglish notes\n<!--LANG:zh-CN-->\n中文说明\n<!--LANG:END-->\n'
+    expect(body).toContain(
+      '[Installer](https://github.com/CherryHQ/cherry-studio/releases/download/v1.2.0/Cherry-Studio-1.2.0-win-x64-setup.exe)'
     )
+    expect(body).toContain(
+      '[RPM](https://github.com/CherryHQ/cherry-studio/releases/download/v1.2.0/Cherry-Studio-CN-1.2.0-linux-arm64.rpm)'
+    )
+    expect(body).not.toMatch(/\.(?:blockmap|ya?ml|json)\)/)
+    expect(body).toContain('<summary>English</summary>\n\nEnglish notes\n\n</details>')
+    expect(body).toContain('<summary>简体中文</summary>\n\n中文说明\n\n</details>')
+    expect(body).not.toContain('<!--LANG:')
+    expect(body.indexOf('## Release Notes / 发布说明')).toBeLessThan(body.indexOf("## What's Changed"))
+    expect(body).toContain("## What's Changed\n- Fix one\n\n## New Contributors\n- @new\n")
+
+    const bodyWithoutChanges = composeReleaseBody({
+      builderContent,
+      generatedNotes: '',
+      productName: 'Cherry Studio',
+      repository: 'CherryHQ/cherry-studio',
+      tag: 'v1.2.0'
+    })
+    expect(bodyWithoutChanges).not.toContain("## What's Changed")
+    expect(bodyWithoutChanges).toContain('<summary>English</summary>\n\nEnglish notes\n\n</details>')
   })
 
   it('accepts only an exact-head all-platform build with artifacts and no open release pull request', () => {
@@ -1000,7 +1017,10 @@ describe('release workflow gates', () => {
       expect(step.with.name).toContain('${{ matrix.edition }}')
       expect(step.with.path).toContain('dist/${{ steps.release-channel.outputs.channel }}*.yml')
     }
+    expect(stagingSteps[0].with.path).toContain('dist/*.blockmap')
+    expect(stagingSteps[1].with.path).toContain('dist/*.blockmap')
     expect(historyStep.if).toContain("matrix.edition == 'global'")
+    expect(historyStep.with.path).toBe('resources/cherry-studio/release-history.json')
   })
 
   it('revalidates the selected release branch head before draft mutation and tag movement', () => {
@@ -1015,6 +1035,10 @@ describe('release workflow gates', () => {
       (step: { name?: string }) => step.name === 'Move draft tag with lease after artifact upload'
     )
     const draftStep = finalizeSteps.find((step: { name?: string }) => step.name === 'Create or update draft release')
+    const notesStep = finalizeSteps.find(
+      (step: { name?: string }) => step.name === 'Add generated changes to release notes'
+    )
+    const notesSyntax = spawnSync('bash', ['-n'], { encoding: 'utf8', input: notesStep.run })
 
     expect(finalizeSteps.indexOf(headStep)).toBeLessThan(releaseIndex)
     expect(headStep.run).toContain('BRANCH_SHA="$BRANCH_SHA"')
@@ -1026,6 +1050,10 @@ describe('release workflow gates', () => {
     expect(tagStep.run).toContain('node scripts/release/validate-release-state.js build-completion')
     expect(tagStep.run).toContain('gh api --method POST "repos/$REPO/git/refs"')
     expect(tagStep.run).toContain('beforeOid: $beforeOid')
+    expect(notesSyntax.status, notesSyntax.stderr).toBe(0)
+    expect(notesStep.run).toContain('gh api --paginate --slurp')
+    expect(notesStep.run).toContain('-f previous_tag_name="$PREVIOUS_TAG"')
+    expect(notesStep.run).toContain('if [ -z "$PREVIOUS_TAG" ]')
   })
 
   it('requires environment approval before validating and publishing the exact build', () => {

--- a/scripts/release/compose-release-body.js
+++ b/scripts/release/compose-release-body.js
@@ -1,26 +1,83 @@
 const fs = require('node:fs')
 
+const { EDITIONS, getReleaseDownloadGroups } = require('./edition')
 const { readBuilderReleaseNotes } = require('./hotfix-release-notes')
 
-function composeReleaseBody({ builderContent, generatedNotes }) {
+const LANGUAGES = [
+  { end: '<!--LANG:zh-CN-->', label: 'English', start: '<!--LANG:en-->' },
+  { end: '<!--LANG:END-->', label: '简体中文', start: '<!--LANG:zh-CN-->' }
+]
+const PLATFORMS = [
+  { id: 'windows', label: 'Windows' },
+  { id: 'mac', label: 'macOS' },
+  { id: 'linux', label: 'Linux' }
+]
+
+function createDownloadTable({ productName, repository, tag }) {
+  const version = tag.startsWith('v') ? tag.slice(1) : tag
+  const lines = [
+    `## Downloads / 下载 (${tag})`,
+    '',
+    '| Platform | Architecture | Global | China Edition |',
+    '| --- | --- | --- | --- |'
+  ]
+
+  for (const platform of PLATFORMS) {
+    const editionGroups = EDITIONS.map((edition) =>
+      getReleaseDownloadGroups({ edition, platform: platform.id, productName, version })
+    )
+
+    for (let index = 0; index < editionGroups[0].length; index += 1) {
+      const architecture = editionGroups[0][index].architecture
+      const downloads = editionGroups.map((groups) =>
+        groups[index].artifacts
+          .map(({ fileName, label }) => {
+            const url = `https://github.com/${repository}/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(fileName)}`
+            return `[${label}](${url})`
+          })
+          .join(' · ')
+      )
+      lines.push(`| ${platform.label} | ${architecture} | ${downloads[0]} | ${downloads[1]} |`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function createReleaseNotes(curatedNotes) {
+  const sections = LANGUAGES.map(({ end, label, start }) => {
+    const content = curatedNotes.slice(curatedNotes.indexOf(start) + start.length, curatedNotes.indexOf(end)).trim()
+    return `<details>\n<summary>${label}</summary>\n\n${content}\n\n</details>`
+  })
+
+  return `## Release Notes / 发布说明\n\n${sections.join('\n\n')}`
+}
+
+function composeReleaseBody({ builderContent, generatedNotes, productName, repository, tag }) {
   const curatedNotes = readBuilderReleaseNotes(builderContent).releaseNotes.trim()
   const changes = generatedNotes?.trim() || ''
 
   if (!curatedNotes) throw new Error('electron-builder.yml release notes are empty')
-  if (!changes) return `${curatedNotes}\n`
+  const body = `${createDownloadTable({ productName, repository, tag })}\n\n${createReleaseNotes(curatedNotes)}`
+  if (!changes) return `${body}\n`
 
-  return `${curatedNotes}\n\n---\n\n${changes}\n`
+  return `${body}\n\n---\n\n${changes}\n`
 }
 
 function main() {
-  const [builderPath, generatedNotesPath, outputPath] = process.argv.slice(2)
-  if (!builderPath || !generatedNotesPath || !outputPath) {
-    throw new Error('Usage: compose-release-body.js <electron-builder.yml> <generated-notes.md> <output.md>')
+  const [builderPath, generatedNotesPath, outputPath, repository, tag, productName] = process.argv.slice(2)
+  if (!builderPath || !generatedNotesPath || !outputPath || !repository || !tag || !productName) {
+    throw new Error(
+      'Usage: compose-release-body.js <electron-builder.yml> <generated-notes.md> <output.md> <repository> <tag> <product-name>'
+    )
   }
 
   const body = composeReleaseBody({
     builderContent: fs.readFileSync(builderPath, 'utf8'),
-    generatedNotes: generatedNotesPath === '-' ? '' : fs.readFileSync(generatedNotesPath, 'utf8')
+    generatedNotes: generatedNotesPath === '-' ? '' : fs.readFileSync(generatedNotesPath, 'utf8'),
+    productName,
+    repository,
+    tag
   })
   fs.writeFileSync(outputPath, body)
 }

--- a/scripts/release/edition.js
+++ b/scripts/release/edition.js
@@ -1,8 +1,7 @@
-const semver = require('semver')
-
 const CHINA_EDITION = 'cn'
 const GLOBAL_EDITION = 'global'
 const EDITIONS = [GLOBAL_EDITION, CHINA_EDITION]
+const RELEASE_ARCHITECTURES = ['x64', 'arm64']
 
 function assertEdition(edition) {
   if (!EDITIONS.includes(edition)) {
@@ -12,6 +11,7 @@ function assertEdition(edition) {
 
 function getReleaseChannel(version, edition) {
   assertEdition(edition)
+  const semver = require('semver')
   const prerelease = semver.prerelease(version)
   if (prerelease === null && !semver.valid(version)) {
     throw new Error(`Invalid release version: ${version}`)
@@ -26,50 +26,85 @@ function getReleaseProductName(productName, edition) {
   return edition === CHINA_EDITION ? 'Cherry Studio CN' : productName
 }
 
-function getExpectedReleaseArtifacts({ edition, platform, productName, version }) {
+function getReleaseDownloadGroups({ edition, platform, productName, version }) {
   assertEdition(edition)
   const artifactProductName = getReleaseProductName(productName, edition).replace(/ /g, '-')
+  const platformName = platform === 'windows' ? 'win' : platform
+
+  if (!['windows', 'mac', 'linux'].includes(platform)) {
+    throw new Error(`Unsupported release platform: ${platform}`)
+  }
+
+  return RELEASE_ARCHITECTURES.map((architecture) => {
+    const baseName = `${artifactProductName}-${version}-${platformName}-${architecture}`
+    let artifacts
+
+    if (platform === 'windows') {
+      artifacts = [
+        { fileName: `${baseName}-setup.exe`, label: 'Installer' },
+        { fileName: `${baseName}-portable.exe`, label: 'Portable' }
+      ]
+    } else if (platform === 'mac') {
+      artifacts = [
+        { fileName: `${baseName}.dmg`, label: 'DMG' },
+        { fileName: `${baseName}.zip`, label: 'ZIP' }
+      ]
+    } else {
+      artifacts = [
+        { fileName: `${baseName}.AppImage`, label: 'AppImage' },
+        { fileName: `${baseName}.deb`, label: 'DEB' },
+        { fileName: `${baseName}.rpm`, label: 'RPM' }
+      ]
+    }
+
+    return { architecture, artifacts }
+  })
+}
+
+function getExpectedReleaseArtifacts({ edition, platform, productName, version }) {
+  const downloadGroups = getReleaseDownloadGroups({ edition, platform, productName, version })
   const channel = getReleaseChannel(version, edition)
+  const fileName = (architecture, label) =>
+    downloadGroups
+      .find((group) => group.architecture === architecture)
+      .artifacts.find((artifact) => artifact.label === label).fileName
 
   if (platform === 'windows') {
-    const baseName = `${artifactProductName}-${version}-win`
-    const x64Setup = `${baseName}-x64-setup.exe`
-    const arm64Setup = `${baseName}-arm64-setup.exe`
+    const x64Setup = fileName('x64', 'Installer')
+    const arm64Setup = fileName('arm64', 'Installer')
     return {
-      files: [x64Setup, arm64Setup, `${baseName}-x64-portable.exe`, `${baseName}-arm64-portable.exe`],
+      files: [x64Setup, arm64Setup, fileName('x64', 'Portable'), fileName('arm64', 'Portable')],
       manifests: [{ file: `${channel}.yml`, urls: [x64Setup, arm64Setup] }]
     }
   }
 
   if (platform === 'mac') {
-    const baseName = `${artifactProductName}-${version}-mac`
-    const x64Zip = `${baseName}-x64.zip`
-    const arm64Zip = `${baseName}-arm64.zip`
+    const x64Zip = fileName('x64', 'ZIP')
+    const arm64Zip = fileName('arm64', 'ZIP')
     return {
       files: [
         x64Zip,
         `${x64Zip}.blockmap`,
         arm64Zip,
         `${arm64Zip}.blockmap`,
-        `${baseName}-x64.dmg`,
-        `${baseName}-arm64.dmg`
+        fileName('x64', 'DMG'),
+        fileName('arm64', 'DMG')
       ],
       manifests: [{ file: `${channel}-mac.yml`, urls: [x64Zip, arm64Zip] }]
     }
   }
 
   if (platform === 'linux') {
-    const baseName = `${artifactProductName}-${version}-linux`
-    const x64AppImage = `${baseName}-x64.AppImage`
-    const arm64AppImage = `${baseName}-arm64.AppImage`
+    const x64AppImage = fileName('x64', 'AppImage')
+    const arm64AppImage = fileName('arm64', 'AppImage')
     return {
       files: [
         x64AppImage,
-        `${baseName}-x64.deb`,
-        `${baseName}-x64.rpm`,
+        fileName('x64', 'DEB'),
+        fileName('x64', 'RPM'),
         arm64AppImage,
-        `${baseName}-arm64.deb`,
-        `${baseName}-arm64.rpm`
+        fileName('arm64', 'DEB'),
+        fileName('arm64', 'RPM')
       ],
       manifests: [
         { file: `${channel}-linux.yml`, urls: [x64AppImage] },
@@ -86,6 +121,7 @@ module.exports = {
   EDITIONS,
   GLOBAL_EDITION,
   getExpectedReleaseArtifacts,
+  getReleaseDownloadGroups,
   getReleaseChannel,
   getReleaseProductName
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The release finalization step had an unmatched quote, so it failed before adding GitHub-generated changes; GitHub also could not infer the previous tag across independent release branches, and the release page exposed 41 assets without a compact package selector.

After this PR:

The workflow explicitly selects the previous published tag from all release pages, passes it to `generate-notes`, and fails closed if none exists; the release body adds a six-row platform/architecture/edition download matrix for 28 installable packages, collapses bilingual curated notes, and retains `What's Changed`, `New Contributors`, and all support assets in the release.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The download table deliberately omits updater metadata (`.yml`, `.blockmap`, and `release-history.json`) while leaving the complete 41-asset upload unchanged.

The following alternatives were considered:

GitHub's automatic previous-tag inference was rejected because release branches do not share tag ancestry, while listing all assets in the table was rejected because updater metadata is not a user-installable package.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

https://github.com/CherryHQ/cherry-studio/actions/runs/33725643926/job/100561107334

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

The current `v2.0.11` draft requires this fix to be backported and rebuilt; rerunning the old failed job would still use the broken workflow definition.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
