### PR TITLE
ci(github-actions): add workflow lint gate

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - windows-signing

--- a/.github/workflows/auto-update-catalog.yml
+++ b/.github/workflows/auto-update-catalog.yml
@@ -53,7 +53,7 @@ jobs:
       - name: 🔍 Check for changes
         id: git_status
         run: |
-          git diff --exit-code --quiet -- packages/provider-registry/data || echo "::set-output name=has_changes::true"
+          git diff --exit-code --quiet -- packages/provider-registry/data || echo "has_changes=true" >> "$GITHUB_OUTPUT"
           git status --porcelain -- packages/provider-registry/data
 
       - name: 📅 Set current date for PR title

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
           # The PR merge commit and its parents are enough for changeset comparison.
           fetch-depth: ${{ github.event_name == 'pull_request' && '2' || '1' }}
 
+      - name: Lint GitHub Actions workflows
+        uses: docker://rhysd/actionlint:1.7.12
+        env:
+          SHELLCHECK_OPTS: --severity=error
+        with:
+          args: -color
+
       - name: Prepare base reference
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

GitHub Actions workflows were parsed and some release steps had targeted tests, but no repository-wide validator checked Actions expressions and every Bash `run:` block before merge.

After this PR:

The existing `basic-checks` job runs pinned actionlint 1.7.12 with ShellCheck error diagnostics across all workflows, recognizes the `windows-signing` self-hosted runner, and migrates catalog output away from the deprecated `set-output` command.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

ShellCheck is gated at error severity so parsing and high-confidence failures block CI without making this PR repair existing style and informational findings.

The following alternatives were considered:

A release-only `bash -n` check was rejected because it would miss malformed scripts and Actions expressions in other workflows.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

https://github.com/CherryHQ/cherry-studio/pull/19970

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

This PR is stacked on #19970 and should be reviewed against `fix-release-notes-download-table`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
