### PR TITLE
fix(web-search): tolerate incomplete items in Querit search responses (fixes #19933)

### DIFF
--- a/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
@@ -1431,6 +1431,60 @@ describe('main web search API providers', () => {
     )
   })
 
+  it('survives a Querit search response where some result items lack title/url (REGRESSION #19933)', async () => {
+    // Querit declares every per-result field as Optional in its contract; one
+    // incomplete item must not invalidate the whole response.
+    fetchMock.mockResolvedValue(
+      createJsonResponse({
+        error_code: 200,
+        error_msg: '',
+        query_context: { query: 'hello' },
+        results: {
+          result: [
+            {
+              title: 'Complete',
+              snippet: 'Top hit snippet',
+              url: 'https://example.com/full'
+            },
+            // Item missing url — should be filtered out.
+            { title: 'No URL', snippet: 'snippet' },
+            // Item missing title — title should fall back to site_name / snippet / url.
+            { snippet: 'Snippet only', url: 'https://example.com/no-title', site_name: 'example.com' },
+            // Item missing both — also filtered out.
+            { snippet: 'orphan' }
+          ]
+        }
+      })
+    )
+
+    const provider = createProviderDriver(
+      QueritProvider,
+      createProvider({
+        id: 'querit',
+        name: 'Querit',
+        apiKeys: ['querit-key'],
+        apiHost: 'https://api.querit.ai'
+      })
+    )
+
+    const result = await provider.searchKeywords('hello', runtimeConfig)
+
+    expect(result.results).toEqual([
+      {
+        title: 'Complete',
+        content: 'Top hit snippet',
+        url: 'https://example.com/full',
+        sourceInput: 'hello'
+      },
+      {
+        title: 'example.com',
+        content: 'Snippet only',
+        url: 'https://example.com/no-title',
+        sourceInput: 'hello'
+      }
+    ])
+  })
+
   it('matches Zhipu request and normalized response snapshots from fixtures', async () => {
     fetchMock.mockResolvedValue(createJsonResponse(loadFixtureJson('zhipu-response.json')))
 

--- a/src/main/services/webSearch/providers/api/QueritProvider.ts
+++ b/src/main/services/webSearch/providers/api/QueritProvider.ts
@@ -27,12 +27,18 @@ const QueritSearchResponseSchema = z.object({
     query: z.string()
   }),
   results: z.object({
+    // Querit declares every per-result field as Optional in its contract
+    // (https://www.querit.ai/en/docs/reference/post); one incomplete item
+    // must not invalidate the whole response.
     result: z
       .array(
-        z.object({
-          title: z.string(),
+        z.looseObject({
+          title: z.string().optional(),
           snippet: z.string().optional(),
-          url: z.string()
+          url: z.string().optional(),
+          site_name: z.string().optional(),
+          page_age: z.string().optional(),
+          site_icon: z.string().optional()
         })
       )
       .default([])
@@ -156,12 +162,16 @@ export class QueritProvider extends BaseWebSearchProvider {
       providerId: this.provider.id,
       capability: 'searchKeywords',
       inputs: [context.query],
-      results: (searchPayload.results?.result || []).map((result) => ({
-        title: result.title,
-        content: result.snippet || '',
-        url: result.url,
-        sourceInput: context.query
-      }))
+      results: (searchPayload.results?.result || [])
+        // Drop items that have no usable URL — without one the caller can't
+        // open the result, so it's better to omit than to surface a broken row.
+        .filter((result) => typeof result.url === 'string' && result.url.length > 0)
+        .map((result) => ({
+          title: result.title ?? result.site_name ?? result.snippet ?? result.url ?? '',
+          content: result.snippet || '',
+          url: result.url ?? '',
+          sourceInput: context.query
+        }))
     }
   }
 


### PR DESCRIPTION
## Bug

Fixes #19933

When Querit is the web search provider, every search fails if
Settings → Web Search → "Number of search results" is greater than 3.
With a value of 3 or less the same search works. The provider "Check"
button in Settings also fails.

## Root cause

`QueritSearchResponseSchema` in `src/main/services/webSearch/providers/api/QueritProvider.ts`
required `title` and `url` as non-optional strings, but the Querit API contract
(POST /v1/search, https://www.querit.ai/en/docs/reference/post) declares **all**
per-result fields as Optional. One incomplete result item rejected the whole
response via zod, so searches with larger `count` values hit an incomplete item
and broke.

## Fix

1. Switch the per-result object from `z.object` to `z.looseObject` with all documented
   fields optional (`title`, `url`, `snippet`, `site_name`, `page_age`, `site_icon`).
2. In `buildFinalResponse`, drop items that have no usable URL (they can't be opened)
   and fall back `title` to `site_name → snippet → url` when `title` is missing.
3. Add a regression test that exercises a response with mixed complete/incomplete items.

The existing fixture-based snapshot test (`matches Querit request and normalized response snapshots from fixtures`) is unaffected because its single result still has a `title` and `url`.