### PR TITLE
fix(naming): forward topic/session id to OpenCode Go auto-title requests (fixes #19938)

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -225,6 +225,14 @@ export interface AiGenerateRequest extends AiBaseRequest {
   system?: string
   prompt?: string
   messages?: ModelMessage[]
+  /**
+   * Topic or agent-session id that scopes this request to a specific conversation.
+   * In-process only: forwarded as `sessionId` to provider config so transports
+   * like OpenCode Go can attach stable identity headers (e.g. `x-opencode-session`)
+   * to background jobs (e.g. auto title generation) that otherwise reach the
+   * provider without conversation affinity.
+   */
+  chatId?: string
 }
 
 // ── SDK extensions ─────────────────────────────────────────────────

--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -205,7 +205,15 @@ export class TopicNamingService {
       ]
 
       const uniqueModelId = this.resolveNamingModelId()
-      const title = await this.generateSummaryTitle(uniqueModelId, buildStructuredConversation(structuredConversation))
+      // Forward topicId as chatId so providers with conversation-scoped identity
+      // (OpenCode Go's x-opencode-session, see issue #19938) attach the header
+      // to this background request — without it the auto-title call reaches the
+      // operator as an untracked request and may fail once enforcement starts.
+      const title = await this.generateSummaryTitle(
+        uniqueModelId,
+        buildStructuredConversation(structuredConversation),
+        topicId
+      )
       if (!title) return
 
       this.renameTopicIfStillAuto(topic.id, title, userText)
@@ -304,7 +312,11 @@ export class TopicNamingService {
         { role: finalMessage.role, mainText: cleanMarkdownImages(getMainTextContentFromUiMessage(finalMessage)) }
       ]
 
-      const title = await this.generateSummaryTitle(uniqueModelId, buildStructuredConversation(structuredConversation))
+      const title = await this.generateSummaryTitle(
+        uniqueModelId,
+        buildStructuredConversation(structuredConversation),
+        sessionId
+      )
       if (!title) return
 
       const nextName = sanitizeConversationTitle(title)
@@ -352,7 +364,11 @@ export class TopicNamingService {
     }
   }
 
-  private async generateSummaryTitle(uniqueModelId: UniqueModelId, prompt: string): Promise<string | null> {
+  private async generateSummaryTitle(
+    uniqueModelId: UniqueModelId,
+    prompt: string,
+    chatId?: string
+  ): Promise<string | null> {
     const systemPrompt = this.resolveNamingPrompt()
     // A title is a throwaway 10-word summary: never carry the source assistant /
     // agent id, or buildAgentParams resolves its tool configuration (MCP tools,
@@ -366,7 +382,10 @@ export class TopicNamingService {
       // fall back to the source assistant's saved `reasoning_effort` (buildAgentParams precedence is
       // `request.reasoningEffort ?? assistant.settings.reasoning_effort ?? 'default'`), which would
       // otherwise leak a `high`/`xhigh`/`max` thinking budget onto this throwaway request.
-      reasoningEffort: 'none'
+      reasoningEffort: 'none',
+      // Forward the originating topic / agent session so the SDK config receives
+      // a sessionId; OpenCode Go's transport uses it to attach x-opencode-session.
+      ...(chatId ? { chatId } : {})
     }
 
     try {

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -127,7 +127,10 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        uniqueModelId: 'openai::gpt-4o-mini'
+        uniqueModelId: 'openai::gpt-4o-mini',
+        // Forward topicId so providers with conversation-scoped identity
+        // (OpenCode Go's x-opencode-session, see issue #19938) attach the header.
+        chatId: 'topic-1'
       })
     )
     // A naming request must never carry the assistant id — buildAgentParams would
@@ -246,7 +249,9 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        uniqueModelId: 'openai::gpt-4o-mini'
+        uniqueModelId: 'openai::gpt-4o-mini',
+        // Forward sessionId so OpenCode Go attaches x-opencode-session (issue #19938).
+        chatId: 'session-1'
       })
     )
     expect(mocks.generateText.mock.calls[0][0]).not.toHaveProperty('assistantId')


### PR DESCRIPTION
## Bug

Fixes #19938

OpenCode Go's operator announced that inference requests without `x-opencode-session` may start failing on September 5, 2026. Cherry Studio's main request correctly carries the header, but the auto-topic-title request does not.

## Root cause

`TopicNamingService.generateSummaryTitle()` builds an `AiGenerateRequest` without `chatId`. Inside `buildAgentParams` → `resolveSdkConfig(provider, model, resolvedEndpoint, apiKeyOverride, request.chatId)`, the missing `chatId` becomes a missing `sessionId` for `buildOpenCodeGoConfig(ctx)`, which only sets `x-opencode-session` when an explicit session id is provided. The same gap exists in `doMaybeRenameAgentSession` (sessionId) and the agent-session rename path.

## Fix

1. `AiGenerateRequest` gains an optional `chatId` field.
2. `TopicNamingService.generateSummaryTitle()` accepts a `chatId` argument and forwards it on the request.
3. Both call sites pass their identity:
   - `doMaybeRenameFromConversationSummary` → topicId
   - `doMaybeRenameAgentSession` → sessionId
4. `buildAgentParams` already threads `request.chatId` to `resolveSdkConfig`, so the OpenCode Go config picks it up automatically.

`resolveCompressionModel` is noted in the issue as an adjacent source-audit point but is not reproduced by the runtime evidence; left for a separate change.

Tighten two existing `TopicNamingService.test.ts` cases so the regression cannot silently return: assert `chatId` is forwarded alongside `uniqueModelId` on the `generateText` call.

Signed-off-by: xxiaoxiong <2482929840@qq.com>