### PR TITLE
fix(kb_manage): persist absolute path as source for file items (fixes #19954)

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/cherryBuiltinTools.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/cherryBuiltinTools.test.ts
@@ -468,7 +468,7 @@ describe('cherryBuiltinTools', () => {
     expect(textOf(result)).toMatch(/no items/i)
   })
 
-  it('runs kb_manage add within the bound scope, building the add input from an absolute file path', async () => {
+  it('runs kb_manage add within the bound scope, storing the full path as source (REGRESSION #19954)', async () => {
     kbAddItems.mockResolvedValue({ status: 'added' })
 
     const result = await callCherryBuiltinTool(
@@ -478,10 +478,10 @@ describe('cherryBuiltinTools', () => {
     )
 
     expect(kbAddItems).toHaveBeenCalledWith('b1', [
-      { type: 'file', data: { source: 'report.pdf', path: '/Users/me/docs/report.pdf' } }
+      { type: 'file', data: { source: '/Users/me/docs/report.pdf', path: '/Users/me/docs/report.pdf' } }
     ])
     expect(result.isError).toBeFalsy()
-    expect(JSON.parse(textOf(result))).toEqual({ action: 'add', added: ['report.pdf'] })
+    expect(JSON.parse(textOf(result))).toEqual({ action: 'add', added: ['/Users/me/docs/report.pdf'] })
   })
 
   it('runs kb_manage delete within the bound scope, forwarding conceptIds and the applied/notFound split', async () => {

--- a/src/main/ai/tools/__tests__/knowledgeLookup.test.ts
+++ b/src/main/ai/tools/__tests__/knowledgeLookup.test.ts
@@ -4,13 +4,14 @@ vi.mock('@logger', () => ({
   loggerService: { withContext: () => ({ debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }
 }))
 
-const { knowledgeSearchMock } = vi.hoisted(() => ({
-  knowledgeSearchMock: vi.fn<() => Promise<unknown[]>>()
+const { knowledgeSearchMock, addItemsMock } = vi.hoisted(() => ({
+  knowledgeSearchMock: vi.fn<() => Promise<unknown[]>>(),
+  addItemsMock: vi.fn<() => Promise<unknown>>()
 }))
 vi.mock('@application', () => ({
   application: {
     get: (name: string) => {
-      if (name === 'KnowledgeService') return { search: knowledgeSearchMock }
+      if (name === 'KnowledgeService') return { search: knowledgeSearchMock, addItems: addItemsMock }
       throw new Error(`Unexpected application.get(${name})`)
     }
   }
@@ -21,6 +22,7 @@ import {
   knowledgeListModelOutput,
   knowledgeManageModelOutput,
   knowledgeReadModelOutput,
+  manageKnowledge,
   searchKnowledge
 } from '../knowledgeLookup'
 
@@ -107,5 +109,30 @@ describe('model output formatters on unreadable stored output', () => {
       type: 'text',
       value: KNOWLEDGE_UNREADABLE_OUTPUT_NOTE
     })
+  })
+})
+
+// kb_manage add with `type: file` stores the absolute path as the row's source
+// identifier, not the basename — reindex re-acquires from source, so a
+// basename-only source silently breaks every refresh (issue #19954).
+describe('manageKnowledge add for file type', () => {
+  it('persists the absolute path as source so kb_manage refresh can find it (REGRESSION #19954)', async () => {
+    addItemsMock.mockResolvedValueOnce({ status: 'added' })
+
+    const result = await manageKnowledge(
+      { action: 'add', baseId: 'base-1', type: 'file', path: 'D:\\AI_Model_tmp\\test.md' },
+      []
+    )
+
+    expect(result).toEqual({ action: 'add', added: ['D:\\AI_Model_tmp\\test.md'] })
+    expect(addItemsMock).toHaveBeenCalledWith('base-1', [
+      expect.objectContaining({
+        type: 'file',
+        data: expect.objectContaining({
+          source: 'D:\\AI_Model_tmp\\test.md',
+          path: 'D:\\AI_Model_tmp\\test.md'
+        })
+      })
+    ])
   })
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeManageTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeManageTool.test.ts
@@ -92,16 +92,16 @@ describe('kb_manage', () => {
     expect(deleteConcepts).not.toHaveBeenCalled()
   })
 
-  it('adds a file by absolute path, deriving the source name from the basename', async () => {
+  it('adds a file by absolute path, storing the full path as source (REGRESSION #19954)', async () => {
     const result = await callExecute(
       { baseId: 'kb-1', action: 'add', type: 'file', path: '/Users/me/docs/report.pdf' },
       { knowledgeBaseIds: ['kb-1'] }
     )
 
     expect(addItems).toHaveBeenCalledWith('kb-1', [
-      { type: 'file', data: { source: 'report.pdf', path: '/Users/me/docs/report.pdf' } }
+      { type: 'file', data: { source: '/Users/me/docs/report.pdf', path: '/Users/me/docs/report.pdf' } }
     ])
-    expect(result).toEqual({ action: 'add', added: ['report.pdf'] })
+    expect(result).toEqual({ action: 'add', added: ['/Users/me/docs/report.pdf'] })
   })
 
   it('rejects a non-absolute file path via schema validation and does not add', async () => {

--- a/src/main/ai/tools/knowledgeLookup.ts
+++ b/src/main/ai/tools/knowledgeLookup.ts
@@ -20,8 +20,6 @@
  * `WebSearchService` honours one). Add one here only once the service does.
  */
 
-import { basename } from 'node:path'
-
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { citeId, newCitePrefix } from '@main/ai/utils/citationIds'
@@ -563,7 +561,11 @@ function buildAddInput(input: ManageKnowledgeInput): AddInputResult {
       if (!input.path) {
         return { ok: false, error: 'kb_manage add with type "file" requires `path` — an absolute local file path.' }
       }
-      const source = basename(input.path)
+      // Source is the user-facing identifier stored on the row. Reindex rebuilds
+      // from this path; storing only the basename breaks every kb_manage refresh
+      // call after PR #19829 made reindex re-acquire from the real source
+      // (issue #19954).
+      const source = input.path
       return validateAddInput({ type: 'file', data: { source, path: input.path } }, source)
     }
     case 'url': {


### PR DESCRIPTION
## Bug

Fixes #19954

MCP `kb_manage add` for `type: file` accepted the absolute path but persisted only the basename as `data.source`. After PR #19829 changed reindex to re-acquire from the real source, every `kb_manage refresh` on such a row now fails with `Cannot reindex a knowledge item whose source file or folder no longer exists`, even though the file exists.

## Root cause

`buildAddInput` in `src/main/ai/tools/knowledgeLookup.ts` did `const source = basename(input.path)`. The url / note branches already persisted the user-supplied identifier (URL, derived title); file was the outlier. PR #19829's "re-acquire from the real source" means reindex reads `data.source` to locate the file — basename never resolves to an actual file path.

## Fix

Set `source = input.path` in the file branch. Same value lands in both `data.source` and `data.path`, matching the url branch's `source = url`. Drop the now-unused `basename` import.

Add a regression test that asserts `data.source === data.path === '<user-supplied absolute path>'` on the add call.

Signed-off-by: xxiaoxiong <2482929840@qq.com>