### PR TITLE
fix(cherry-cloud): focus app after sign-in

### DIFF
--- a/src/main/services/cherryCloud/CherryCloudService.ts
+++ b/src/main/services/cherryCloud/CherryCloudService.ts
@@ -402,6 +402,7 @@ export class CherryCloudService extends BaseService {
         session
       }
       this.scheduleSessionExpiry(session)
+      application.get('MainWindowService').showMainWindow()
       void application
         .get('ApiGatewayService')
         .start()

--- a/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
+++ b/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
@@ -21,7 +21,8 @@ const mocks = vi.hoisted(() => ({
   savedDevice: null as { publicKey: string; privateKey: string } | null,
   savedSession: null as Record<string, unknown> | null,
   sessionClear: vi.fn(),
-  sessionReplace: vi.fn()
+  sessionReplace: vi.fn(),
+  showMainWindow: vi.fn()
 }))
 
 vi.mock('@data/dataApiDataChange', () => ({
@@ -71,6 +72,7 @@ vi.mock('@application', () => ({
     get: (name: string) => {
       if (name === 'ApiGatewayService') return { start: mocks.gatewayStart }
       if (name === 'IpcApiService') return { broadcast: mocks.broadcast }
+      if (name === 'MainWindowService') return { showMainWindow: mocks.showMainWindow }
       throw new Error(`Unexpected service: ${name}`)
     }
   }
@@ -354,6 +356,7 @@ describe('CherryCloudService', () => {
     )
     expect(await service.getStatus()).toEqual({ phase: 'signed-in', displayName: 'Sora' })
     expect(mocks.gatewayStart).toHaveBeenCalledOnce()
+    expect(mocks.showMainWindow).toHaveBeenCalledOnce()
 
     const exchangeRequest = requestCalls(`/api/v1/desktop/authorizations/${authorizationId}/exchange`)[0]
     expect(exchangeRequest[0]).toBe(`http://127.0.0.1:8084/api/v1/desktop/authorizations/${authorizationId}/exchange`)
@@ -441,6 +444,7 @@ describe('CherryCloudService', () => {
 
     expect(await service.getStatus()).toEqual({ phase: 'signed-out', displayName: null })
     expect(mocks.savedSession).toBeNull()
+    expect(mocks.showMainWindow).not.toHaveBeenCalled()
   })
 
   it.each([


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Completing Cherry Cloud authorization in the external browser left Cherry Studio in the background.

After this PR: Once the callback exchange succeeds and the session is persisted, Cherry Studio restores, shows, and focuses its main window; service tests cover successful sign-in and persistence failure.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: The existing `MainWindowService.showMainWindow()` path is reused so platform-specific restoration and focus behavior stays centralized.

The following alternatives were considered: Renderer-side focus handling was rejected because DOM focus cannot reliably activate the native application after browser authorization.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Verified with `pnpm test:main src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts` and `pnpm lint`; no user-guide update is required because the behavior is automatic.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Cherry Cloud] Bring Cherry Studio to the foreground after sign-in completes.
```
