### PR TITLE
fix(external-app): preserve localized Windows app names

### DIFF
--- a/src/main/services/externalApp/__tests__/defaultApplication.test.ts
+++ b/src/main/services/externalApp/__tests__/defaultApplication.test.ts
@@ -30,6 +30,16 @@ describe('resolveDefaultApplication', () => {
     })
   })
 
+  it('decodes a Base64 application name from NUL-interleaved PowerShell output', async () => {
+    const encodedName = Buffer.from('写字板', 'utf8').toString('base64')
+    mocks.execFileAsync.mockResolvedValue({ stdout: Buffer.from(`${encodedName}\r\n`, 'utf16le').toString('utf8') })
+    const { resolveDefaultApplication } = await import('../defaultApplication')
+
+    await expect(resolveDefaultApplication('C:\\Users\\Cherry\\报告.docx' as AbsoluteFilePath)).resolves.toEqual({
+      name: '写字板'
+    })
+  })
+
   it('does not expose replacement characters for invalid UTF-8 application names', async () => {
     mocks.execFileAsync.mockResolvedValue({ stdout: Buffer.from([0xff]).toString('base64') })
     const { resolveDefaultApplication } = await import('../defaultApplication')

--- a/src/main/services/externalApp/__tests__/defaultApplication.test.ts
+++ b/src/main/services/externalApp/__tests__/defaultApplication.test.ts
@@ -1,0 +1,39 @@
+import type { AbsoluteFilePath } from '@shared/types/file'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  execFileAsync: vi.fn(),
+  getFileIcon: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }))
+vi.mock('node:util', () => ({ promisify: () => mocks.execFileAsync }))
+
+vi.mock('@main/core/platform', () => ({ isLinux: false, isMac: false, isWin: true }))
+
+vi.mock('electron', () => ({
+  app: { getFileIcon: mocks.getFileIcon }
+}))
+
+describe('resolveDefaultApplication', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getFileIcon.mockResolvedValue({ isEmpty: () => true })
+  })
+
+  it('preserves localized application names across the PowerShell output boundary', async () => {
+    mocks.execFileAsync.mockResolvedValue({ stdout: `${Buffer.from('写字板', 'utf8').toString('base64')}\n` })
+    const { resolveDefaultApplication } = await import('../defaultApplication')
+
+    await expect(resolveDefaultApplication('C:\\Users\\Cherry\\报告.docx' as AbsoluteFilePath)).resolves.toEqual({
+      name: '写字板'
+    })
+  })
+
+  it('does not expose replacement characters for invalid UTF-8 application names', async () => {
+    mocks.execFileAsync.mockResolvedValue({ stdout: Buffer.from([0xff]).toString('base64') })
+    const { resolveDefaultApplication } = await import('../defaultApplication')
+
+    await expect(resolveDefaultApplication('C:\\Users\\Cherry\\report.docx' as AbsoluteFilePath)).resolves.toBeNull()
+  })
+})

--- a/src/main/services/externalApp/defaultApplication.ts
+++ b/src/main/services/externalApp/defaultApplication.ts
@@ -149,6 +149,6 @@ async function execute(command: string, args: string[]): Promise<string | null> 
     timeout: LOOKUP_TIMEOUT_MS,
     windowsHide: true
   })
-  const value = stdout.trim().replaceAll('\0', '')
+  const value = stdout.replaceAll('\0', '').trim()
   return value || null
 }

--- a/src/main/services/externalApp/defaultApplication.ts
+++ b/src/main/services/externalApp/defaultApplication.ts
@@ -68,16 +68,29 @@ async function resolveDefaultApplicationName(targetPath: AbsoluteFilePath): Prom
   if (isWin) {
     const extension = path.extname(targetPath)
     if (!extension) return null
-    return execute('powershell.exe', [
+    const encodedName = await execute('powershell.exe', [
       '-NoLogo',
       '-NoProfile',
       '-NonInteractive',
       '-EncodedCommand',
       createWindowsLookupCommand(extension)
     ])
+    return encodedName ? decodeBase64Utf8(encodedName) : null
   }
   if (isLinux) return resolveLinuxDefaultApplicationName(targetPath)
   return null
+}
+
+function decodeBase64Utf8(value: string): string | null {
+  const bytes = Buffer.from(value, 'base64')
+  if (bytes.toString('base64') !== value) return null
+
+  try {
+    const decoded = new TextDecoder('utf-8', { fatal: true }).decode(bytes).trim()
+    return decoded || null
+  } catch {
+    return null
+  }
 }
 
 function createWindowsLookupCommand(extension: string): string {
@@ -85,7 +98,8 @@ function createWindowsLookupCommand(extension: string): string {
   const script = [
     WINDOWS_DEFAULT_APPLICATION_SCRIPT,
     `$extension = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${extensionBase64}'))`,
-    '[AssociationQuery]::GetFriendlyAppName($extension)'
+    '$name = [AssociationQuery]::GetFriendlyAppName($extension)',
+    'if ($name) { [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($name)) }'
   ].join('\n')
   return Buffer.from(script, 'utf16le').toString('base64')
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Windows PowerShell wrote the localized default-application name directly to stdout. The main process decoded those bytes as UTF-8 and removed NUL characters afterward, so non-ASCII names could already contain replacement characters by the time they reached the Open with menu.

![Before: localized default application name rendered with replacement characters](https://github.com/user-attachments/assets/407839a8-3175-4ba5-8315-b065555299d5)

After this PR:

PowerShell encodes the application name as UTF-8 and transports it as Base64-only ASCII. The main process validates the Base64 payload and decodes UTF-8 strictly, preserving localized names and omitting malformed metadata instead of rendering replacement characters.

No After screenshot is included because the reported path is Windows-specific and the available development host is macOS; a simulated result would not be credible runtime evidence. The Windows boundary is covered by focused regression tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19819

### Why we need it and why it was done in this way

The feedback screenshot identifies the platform through the File Explorer label; macOS would show Finder. Encoding inside PowerShell prevents its host or console output encoding from altering the Unicode name before Node receives it. A strict decoder also ensures malformed bytes cannot leak replacement glyphs into the menu.

The following tradeoffs were made:

- If PowerShell returns malformed Base64 or invalid UTF-8, the optional application metadata is omitted and the existing default-app fallback remains available.
- The macOS and Linux lookup paths are unchanged because the evidence only reproduces the Windows boundary.

The following alternatives were considered:

- Decoding raw PowerShell stdout with a fixed legacy code page was rejected because the correct code page varies by Windows locale and host configuration.
- Replacing replacement characters after decoding was rejected because the original application name cannot be recovered after lossy decoding.

Links to places where the discussion took place: #19819

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- The issue title and `macos` label conflict with the attached UI evidence: the screenshot shows the Windows-only File Explorer translation (`资源管理器`), while macOS renders Finder as `访达`.
- Regression test red state: both new tests failed against the previous direct-output implementation by exposing the encoded payload as the label.
- Validation: `pnpm exec vitest run --project main src/main/services/externalApp/__tests__/defaultApplication.test.ts src/main/services/externalApp/__tests__/ExternalAppService.test.ts` (11 tests passed); focused Biome check and `git diff --check` passed.
- Windows runtime verification is unavailable on the current macOS development host.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix garbled localized default application names in the Open with menu on Windows.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Windows default-app name resolution with safe fallback on decode failure; no auth or data-handling changes.
> 
> **Overview**
> Fixes garbled labels in the **Open with** menu on Windows when the system default app has a non-ASCII friendly name (e.g. Chinese).
> 
> **Windows lookup** no longer treats PowerShell stdout as plain UTF-8 text. The embedded script now Base64-encodes the friendly app name in UTF-8, and the main process validates and decodes that payload with strict UTF-8 (`fatal`) instead of showing replacement characters. Invalid Base64 or UTF-8 yields no default-app metadata so existing fallbacks still apply. Stdout handling strips NULs before trimming to cope with interleaved PowerShell output.
> 
> Adds **regression tests** for plain Base64 stdout, NUL/UTF-16le-shaped output, and invalid UTF-8 returning `null`. macOS and Linux paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ff469e1ac091a58a28293bafe9c5d80b088257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->