### PR TITLE
fix(topic-naming): preserve OpenCode session affinity

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -232,6 +232,8 @@ export type AsInProcess<T extends AiBaseRequest> = Omit<T, 'requestOptions'> & {
 
 /** Non-streaming text generation request — pure transport data. */
 export interface AiGenerateRequest extends AiBaseRequest {
+  /** Stable conversation identity for provider affinity on non-streaming requests. */
+  chatId?: string
   system?: string
   prompt?: string
   messages?: ModelMessage[]

--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -208,7 +208,11 @@ export class TopicNamingService {
       ]
 
       const uniqueModelId = this.resolveNamingModelId()
-      const title = await this.generateSummaryTitle(uniqueModelId, buildStructuredConversation(structuredConversation))
+      const title = await this.generateSummaryTitle(
+        uniqueModelId,
+        buildStructuredConversation(structuredConversation),
+        topicId
+      )
       if (!title) return
 
       this.renameTopicIfStillAuto(topic.id, title, userText)
@@ -307,7 +311,11 @@ export class TopicNamingService {
         { role: finalMessage.role, mainText: cleanMarkdownImages(getMainTextContentFromUiMessage(finalMessage)) }
       ]
 
-      const title = await this.generateSummaryTitle(uniqueModelId, buildStructuredConversation(structuredConversation))
+      const title = await this.generateSummaryTitle(
+        uniqueModelId,
+        buildStructuredConversation(structuredConversation),
+        sessionId
+      )
       if (!title) return
 
       const nextName = sanitizeConversationTitle(title)
@@ -355,7 +363,11 @@ export class TopicNamingService {
     }
   }
 
-  private async generateSummaryTitle(uniqueModelId: UniqueModelId, prompt: string): Promise<string | null> {
+  private async generateSummaryTitle(
+    uniqueModelId: UniqueModelId,
+    prompt: string,
+    chatId: string
+  ): Promise<string | null> {
     const systemPrompt = this.resolveNamingPrompt()
     // A title is a throwaway 10-word summary: never carry the source assistant /
     // agent id, or buildAgentParams resolves its tool configuration (MCP tools,
@@ -363,6 +375,7 @@ export class TopicNamingService {
     // the renderer omits assistantId for the same reason.
     const request: AiGenerateRequest = {
       uniqueModelId,
+      chatId,
       system: systemPrompt,
       prompt,
       // A title is 10 words: never reason. Set this explicitly so the request builder does not

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -129,7 +129,8 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        uniqueModelId: 'openai::gpt-4o-mini'
+        uniqueModelId: 'openai::gpt-4o-mini',
+        chatId: 'topic-1'
       })
     )
     // A naming request must never carry the assistant id — buildAgentParams would
@@ -279,7 +280,8 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        uniqueModelId: 'openai::gpt-4o-mini'
+        uniqueModelId: 'openai::gpt-4o-mini',
+        chatId: 'session-1'
       })
     )
     expect(mocks.generateText.mock.calls[0][0]).not.toHaveProperty('assistantId')


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

OpenCode Go/Zen automatic topic-title requests omitted the conversation identity, so the provider-specific `x-opencode-session` header was absent even though normal chat requests included it. Agent-session title requests had the same gap.

After this PR:

Non-streaming title requests carry the existing topic or Agent session identity through `AiService` to the provider configuration path. OpenCode Go/Zen can therefore add `x-opencode-session`; unrelated providers remain unchanged, and an explicitly configured header still wins in the existing provider builder.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19938

### Why we need it and why it was done in this way

OpenCode Go/Zen uses `x-opencode-session` for required conversation affinity. `TopicNamingService` already owns the stable topic/session identity, but its `AiGenerateRequest` discarded that context before `buildAgentParams` resolved provider configuration.

The request now models an optional `chatId`, matching the existing parameter pipeline used by streaming requests. Topic naming passes the existing topic ID, while Agent naming passes the raw Agent session ID established as the provider-facing identity by #18184. The source assistant/agent ID remains intentionally absent so title generation cannot inherit tools.

The following tradeoffs were made:

The identity is optional because non-conversation generation calls, such as model probes, do not have a stable conversation.

The following alternatives were considered:

- Injecting `x-opencode-session` directly in `TopicNamingService` was rejected because provider-specific headers belong in the existing provider builder and explicit user headers must retain precedence.
- Passing `assistantId` was rejected because it would attach the source assistant's MCP, web-search, and knowledge-base tools to a throwaway title request.

Links to places where the discussion took place: #19938

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A.

### Special notes for your reviewer

Verification completed:

- `pnpm exec vitest run --project main src/main/services/__tests__/TopicNamingService.test.ts src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts src/main/ai/provider/__tests__/config.test.ts --reporter=dot` (206 passed)
- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`

This is a non-UI provider request-context fix, so no screenshot is applicable.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
OpenCode Go/Zen automatic conversation titles now preserve the required session affinity.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, optional request-field change on background title generation; provider header behavior is already established for streaming chatId.
> 
> **Overview**
> **Automatic title generation** now forwards the stable conversation id on non-streaming `generateText` calls, so OpenCode Go/Zen can attach `x-opencode-session` the same way normal chat streams already do.
> 
> `AiGenerateRequest` gains an optional `chatId`. `TopicNamingService` passes the **topic id** for chat summary naming and the **agent session id** for agent session naming into `generateSummaryTitle`; `assistantId` is still omitted so throwaway title requests do not inherit MCP/tools. Other providers and probes without a conversation id are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75b00a0c1ba0bdcc31f36495d714e0431f943df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->