### PR TITLE
feat(doctor): open the doctor from the Help menu and route the assistant diagnose tool through it

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/assistant.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/assistant.test.ts
@@ -18,11 +18,16 @@ const mocks = vi.hoisted(() => ({
   applicationGetPath: vi.fn(),
   mcpList: vi.fn(),
   modelGetByKey: vi.fn(),
-  providerGetById: vi.fn()
+  providerGetById: vi.fn(),
+  diagnoseEndpoint: vi.fn(),
+  doctorRun: vi.fn()
 }))
 
 vi.mock('@application', async () => {
-  const base = (await import('@test-mocks/main/application')).mockApplicationFactory()
+  const base = (await import('@test-mocks/main/application')).mockApplicationFactory({
+    NetworkService: { diagnoseEndpoint: mocks.diagnoseEndpoint },
+    DoctorService: { run: mocks.doctorRun }
+  } as never)
   return {
     ...base,
     application: {
@@ -644,6 +649,7 @@ describe('diagnose config', () => {
 
 describe('diagnose health', () => {
   const endpoint = 'https://endpoint-user:endpoint-pass@api.example:8443/v1/chat?endpoint-token=secret#fragment'
+  const ok = { status: 'ok', durationMs: 12 }
 
   function mockProvider() {
     mocks.providerGetById.mockReturnValue({
@@ -662,74 +668,125 @@ describe('diagnose health', () => {
     ).diagnoseHealth(providerId)
   }
 
-  it('returns only the endpoint origin after a successful health check', async () => {
+  it('reports the layered verdict with only the endpoint origin', async () => {
     mockProvider()
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => ({ ok: true, status: 200 }))
-    )
-    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+    mocks.diagnoseEndpoint.mockResolvedValue({
+      endpointId: 'provider:health-success',
+      host: 'api.example',
+      dns: ok,
+      tls: ok,
+      proxy: { effective: 'PROXY corp-proxy.internal:3128', configuredMode: 'system' },
+      http: { ...ok, data: { status: 401 } },
+      verdict: 'reachable'
+    })
 
     const result = await diagnoseHealth('health-success')
     const text = result.content[0].text
-    const health = JSON.parse(text) as { host: string }
-
-    expect(health.host).toBe('https://api.example:8443')
-    expect(clearTimeoutSpy).toHaveBeenCalled()
-    for (const secret of ['endpoint-user', 'endpoint-pass', '/v1/chat', 'endpoint-token=secret']) {
-      expect(text).not.toContain(secret)
+    const health = JSON.parse(text) as {
+      status: string
+      host: string
+      http: { httpStatus: number }
+      proxy: { mode: string }
     }
-  })
 
-  it('uses a structural connection failure without leaking endpoint or fetch-error URLs', async () => {
-    mockProvider()
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        throw new Error('connect https://error-user:error-pass@error.example:9443/private?error-token=secret')
-      })
+    expect(health).toMatchObject({
+      status: 'reachable',
+      host: 'https://api.example:8443',
+      http: { httpStatus: 401 },
+      proxy: { mode: 'system' }
+    })
+    expect(mocks.diagnoseEndpoint).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'provider:health-success', url: endpoint }),
+      expect.any(AbortSignal)
     )
-    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
-
-    const result = await diagnoseHealth('health-connection-failure')
-    const text = result.content[0].text
-    const health = JSON.parse(text) as { host: string; error: string }
-
-    expect(health).toMatchObject({ host: 'https://api.example:8443', error: 'connection failure' })
-    expect(clearTimeoutSpy).toHaveBeenCalled()
     for (const secret of [
       'endpoint-user',
       'endpoint-pass',
       '/v1/chat',
       'endpoint-token=secret',
-      'error-user',
-      'error-pass',
-      'error.example',
-      '/private',
-      'error-token=secret'
+      'corp-proxy.internal'
     ]) {
       expect(text).not.toContain(secret)
     }
   })
 
-  it('reports timeouts structurally and clears the timeout', async () => {
+  it('surfaces the failing layer and its code without leaking the URL', async () => {
     mockProvider()
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        throw Object.assign(new Error('https://error-user:error-pass@error.example/private?error-token=secret'), {
-          name: 'AbortError'
-        })
-      })
-    )
-    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+    mocks.diagnoseEndpoint.mockResolvedValue({
+      endpointId: 'provider:health-connection-failure',
+      host: 'api.example',
+      dns: { status: 'failed', durationMs: 5, kind: 'dns', code: 'ENOTFOUND' },
+      tls: { status: 'skipped', durationMs: 0, skippedBecause: 'dns_failed' },
+      proxy: { effective: 'DIRECT', configuredMode: 'none' },
+      http: { status: 'skipped', durationMs: 0, skippedBecause: 'dns_failed' },
+      verdict: 'unreachable'
+    })
 
-    const result = await diagnoseHealth('health-timeout')
-    const text = result.content[0].text
-    const health = JSON.parse(text) as { error: string }
+    const health = JSON.parse((await diagnoseHealth('health-connection-failure')).content[0].text) as {
+      status: string
+      dns: { kind: string; code: string }
+    }
+    expect(health).toMatchObject({ status: 'unreachable', dns: { kind: 'dns', code: 'ENOTFOUND' } })
+  })
 
-    expect(health.error).toBe('timeout')
-    expect(clearTimeoutSpy).toHaveBeenCalled()
-    expect(text).not.toContain('error-token=secret')
+  it('does not probe a provider without an API key', async () => {
+    mocks.providerGetById.mockReturnValue({ apiKeys: [], endpointConfigs: { chat: { baseUrl: endpoint } } })
+    const health = JSON.parse((await diagnoseHealth('health-no-key')).content[0].text) as { error: string }
+    expect(health.error).toBe('No API key configured')
+    expect(mocks.diagnoseEndpoint).not.toHaveBeenCalled()
+  })
+})
+
+describe('diagnose doctor', () => {
+  it('returns the upload projection of the report, dropping local-only data', async () => {
+    mocks.doctorRun.mockResolvedValue({
+      status: 'completed',
+      report: {
+        schemaVersion: 1,
+        runId: 'r1',
+        tier: 'quick',
+        startedAt: 's',
+        finishedAt: 'f',
+        expiresAt: 'e',
+        basics: { version: '2.0.0', userDataPath: '/Users/alice/secret' },
+        results: [
+          {
+            id: 'storage-userdata-location',
+            status: 'warn',
+            durationMs: 1,
+            attribution: 'user-fixable',
+            detail: { variant: 'fallback_to_default' },
+            actions: [],
+            evidence: [
+              { key: 'actual', value: '/Users/alice/secret', dataClass: 'local_only' },
+              { key: 'configuredUsableNow', value: false, dataClass: 'public' }
+            ]
+          }
+        ],
+        summary: { pass: 0, warn: 1, fail: 0, skip: 0, error: 0 }
+      }
+    })
+    const server = new AssistantServer()
+    const text = (
+      await (
+        server as unknown as { diagnoseDoctor: (tier: string) => Promise<{ content: Array<{ text: string }> }> }
+      ).diagnoseDoctor('quick')
+    ).content[0].text
+
+    expect(mocks.doctorRun).toHaveBeenCalledWith({ tier: 'quick' })
+    expect(JSON.parse(text)).toMatchObject({ summary: { warn: 1 } })
+    expect(text).not.toContain('/Users/alice/secret')
+    expect(text).toContain('configuredUsableNow')
+  })
+
+  it('passes a busy outcome through so the model can retry later', async () => {
+    mocks.doctorRun.mockResolvedValue({ status: 'busy', runId: 'r9' })
+    const server = new AssistantServer()
+    const text = (
+      await (
+        server as unknown as { diagnoseDoctor: (tier: string) => Promise<{ content: Array<{ text: string }> }> }
+      ).diagnoseDoctor('live')
+    ).content[0].text
+    expect(JSON.parse(text)).toEqual({ status: 'busy', runId: 'r9' })
   })
 })

--- a/src/main/ai/mcp/servers/assistant.ts
+++ b/src/main/ai/mcp/servers/assistant.ts
@@ -15,6 +15,7 @@ import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } fr
 import { ErrorCode as DataApiErrorCode, isDataApiError } from '@shared/data/api/errors'
 import { ThemeMode } from '@shared/data/preference/preferenceTypes'
 import { parseUniqueModelId, type UniqueModelId, UniqueModelIdSchema } from '@shared/data/types/model'
+import { type DoctorRunTier, projectDoctorReport } from '@shared/types/doctor'
 import {
   DIAGNOSTIC_DESCRIPTION_MAX_BYTES,
   diagnosticDescriptionByteLength,
@@ -101,13 +102,18 @@ const DIAGNOSE_TOOL: Tool = {
     properties: {
       action: {
         type: 'string',
-        enum: ['info', 'providers', 'health', 'logs', 'errors', 'mcp_status', 'read_source', 'config'],
+        enum: ['info', 'providers', 'health', 'doctor', 'logs', 'errors', 'mcp_status', 'read_source', 'config'],
         description:
-          'info: app version/paths/system. providers: list configured providers. health: test provider connectivity (cached 30s). logs: read recent log entries. errors: extract only ERROR/WARN entries from logs. mcp_status: check MCP server states. read_source: read a source file (read-only). config: read user settings (theme, language, proxy, default model, etc).'
+          'info: app version/paths/system. providers: list configured providers. health: layered reachability of a provider endpoint (DNS/TLS/proxy/HTTP, cached 30s). doctor: run the System Doctor checks and return the report (quick = local checks, live = quick + network probes). logs: read recent log entries. errors: extract only ERROR/WARN entries from logs. mcp_status: check MCP server states. read_source: read a source file (read-only). config: read user settings (theme, language, proxy, default model, etc).'
       },
       provider_id: {
         type: 'string',
         description: 'Provider ID for the health action'
+      },
+      tier: {
+        type: 'string',
+        enum: ['quick', 'live'],
+        description: 'Doctor tier for the doctor action (default quick)'
       },
       lines: {
         type: 'number',
@@ -280,6 +286,7 @@ const ASSISTANT_TOOLS = {
 // Health check cache: { providerId -> { result, timestamp } }
 const healthCache = new Map<string, { result: unknown; timestamp: number }>()
 const HEALTH_CACHE_TTL = 30_000 // 30 seconds
+const HEALTH_TIMEOUT_MS = 10_000
 
 class AssistantServer {
   public mcpServer: McpServer
@@ -591,6 +598,8 @@ class AssistantServer {
         return this.diagnoseProviders()
       case 'health':
         return await this.diagnoseHealth(args.provider_id as string | undefined)
+      case 'doctor':
+        return await this.diagnoseDoctor(args.tier === 'live' ? 'live' : 'quick')
       case 'logs':
         return this.diagnoseLogs(args.lines as number | undefined)
       case 'errors':
@@ -707,88 +716,42 @@ class AssistantServer {
         (provider.defaultChatEndpoint && endpointConfigs[provider.defaultChatEndpoint]?.baseUrl) ||
         Object.values(endpointConfigs)[0]?.baseUrl ||
         ''
+      const host = redactUrlToOrigin(apiHost)
 
       if (provider.apiKeys.length === 0) {
-        const result = {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify(
-                {
-                  providerId,
-                  status: 'error',
-                  error: 'No API key configured'
-                },
-                null,
-                2
-              )
-            }
-          ]
-        }
+        const result = this.jsonResult({ providerId, status: 'error', error: 'No API key configured', host })
         healthCache.set(providerId, { result, timestamp: Date.now() })
         return result
       }
 
-      // Simple connectivity test — try to reach the API host
-      const startTime = Date.now()
-      const host = redactUrlToOrigin(apiHost)
-      let timeout: ReturnType<typeof setTimeout> | undefined
-      try {
-        const testUrl = apiHost.startsWith('http') ? apiHost : `https://${apiHost}`
-        const controller = new AbortController()
-        timeout = setTimeout(() => controller.abort(), 10000)
-        const response = await fetch(testUrl, {
-          method: 'HEAD',
-          signal: controller.signal
-        })
-        const latency = Date.now() - startTime
-
-        const result = {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify(
-                {
-                  providerId,
-                  status: response.ok || response.status === 401 || response.status === 403 ? 'reachable' : 'error',
-                  httpStatus: response.status,
-                  latencyMs: latency,
-                  host
-                },
-                null,
-                2
-              )
-            }
-          ]
+      // Same layered probe the System Doctor uses; only the origin and the layer verdicts leave here.
+      const testUrl = apiHost.startsWith('http') ? apiHost : `https://${apiHost}`
+      const diagnosis = await application
+        .get('NetworkService')
+        .diagnoseEndpoint({ id: `provider:${providerId}`, url: testUrl }, AbortSignal.timeout(HEALTH_TIMEOUT_MS))
+      const layer = (result: { status: string; kind?: string; code?: string; durationMs: number }) => ({
+        status: result.status,
+        ...(result.kind ? { kind: result.kind } : {}),
+        ...(result.code ? { code: result.code } : {}),
+        latencyMs: Math.round(result.durationMs)
+      })
+      const result = this.jsonResult({
+        providerId,
+        status: diagnosis.verdict,
+        host,
+        dns: layer(diagnosis.dns),
+        tls: layer(diagnosis.tls),
+        proxy: {
+          mode: diagnosis.proxy.configuredMode,
+          ...(diagnosis.proxy.mismatch ? { mismatch: diagnosis.proxy.mismatch } : {})
+        },
+        http: {
+          ...layer(diagnosis.http),
+          ...(diagnosis.http.status === 'ok' ? { httpStatus: diagnosis.http.data.status } : {})
         }
-        healthCache.set(providerId, { result, timestamp: Date.now() })
-        return result
-      } catch (fetchError) {
-        const latency = Date.now() - startTime
-        const result = {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify(
-                {
-                  providerId,
-                  status: 'unreachable',
-                  error:
-                    fetchError instanceof Error && fetchError.name === 'AbortError' ? 'timeout' : 'connection failure',
-                  latencyMs: latency,
-                  host
-                },
-                null,
-                2
-              )
-            }
-          ]
-        }
-        healthCache.set(providerId, { result, timestamp: Date.now() })
-        return result
-      } finally {
-        if (timeout !== undefined) clearTimeout(timeout)
-      }
+      })
+      healthCache.set(providerId, { result, timestamp: Date.now() })
+      return result
     } catch (error) {
       return {
         content: [
@@ -800,6 +763,17 @@ class AssistantServer {
         isError: true
       }
     }
+  }
+
+  /** The System Doctor report in its `upload` projection: nothing local-only reaches the model. */
+  private async diagnoseDoctor(tier: DoctorRunTier) {
+    const outcome = await application.get('DoctorService').run({ tier })
+    if (outcome.status !== 'completed') return this.jsonResult(outcome)
+    return this.jsonResult(projectDoctorReport(outcome.report, 'upload'))
+  }
+
+  private jsonResult(value: unknown) {
+    return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] }
   }
 
   private diagnoseLogs(requestedLines?: number) {

--- a/src/main/i18n/locales/de-de.json
+++ b/src/main/i18n/locales/de-de.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Kopieren",
   "appMenu.cut": "Schneiden",
   "appMenu.delete": "Löschen",
+  "appMenu.doctor": "Systemdiagnose",
   "appMenu.documentation": "Dokumentation",
   "appMenu.edit": "Bearbeiten",
   "appMenu.feedback": "Rückmeldung",

--- a/src/main/i18n/locales/el-gr.json
+++ b/src/main/i18n/locales/el-gr.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Αντιγραφή",
   "appMenu.cut": "Αποκοπή",
   "appMenu.delete": "Διαγραφή",
+  "appMenu.doctor": "Διαγνωστικά συστήματος",
   "appMenu.documentation": "Τεκμηρίωση",
   "appMenu.edit": "Επεξεργασία",
   "appMenu.feedback": "Σχόλια",

--- a/src/main/i18n/locales/en-us.json
+++ b/src/main/i18n/locales/en-us.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Copy",
   "appMenu.cut": "Cut",
   "appMenu.delete": "Delete",
+  "appMenu.doctor": "System Diagnostics",
   "appMenu.documentation": "Documentation",
   "appMenu.edit": "Edit",
   "appMenu.feedback": "Feedback",

--- a/src/main/i18n/locales/es-es.json
+++ b/src/main/i18n/locales/es-es.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Copiar",
   "appMenu.cut": "Cortar",
   "appMenu.delete": "Eliminar",
+  "appMenu.doctor": "Diagnóstico del sistema",
   "appMenu.documentation": "Documentación",
   "appMenu.edit": "Editar",
   "appMenu.feedback": "Retroalimentación",

--- a/src/main/i18n/locales/fr-fr.json
+++ b/src/main/i18n/locales/fr-fr.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Copier",
   "appMenu.cut": "Couper",
   "appMenu.delete": "Supprimer",
+  "appMenu.doctor": "Diagnostic système",
   "appMenu.documentation": "Documentation",
   "appMenu.edit": "Modifier",
   "appMenu.feedback": "Retour d'information",

--- a/src/main/i18n/locales/ja-jp.json
+++ b/src/main/i18n/locales/ja-jp.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "コピー",
   "appMenu.cut": "切り取り",
   "appMenu.delete": "削除",
+  "appMenu.doctor": "システム診断",
   "appMenu.documentation": "ドキュメント",
   "appMenu.edit": "編集",
   "appMenu.feedback": "フィードバック",

--- a/src/main/i18n/locales/pt-pt.json
+++ b/src/main/i18n/locales/pt-pt.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Copiar",
   "appMenu.cut": "Cortar",
   "appMenu.delete": "Eliminar",
+  "appMenu.doctor": "Diagnóstico do sistema",
   "appMenu.documentation": "Documentação",
   "appMenu.edit": "Editar",
   "appMenu.feedback": "Comentários",

--- a/src/main/i18n/locales/ro-ro.json
+++ b/src/main/i18n/locales/ro-ro.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Copiază",
   "appMenu.cut": "Decupează",
   "appMenu.delete": "Șterge",
+  "appMenu.doctor": "Diagnosticare sistem",
   "appMenu.documentation": "Documentație",
   "appMenu.edit": "Editare",
   "appMenu.feedback": "Feedback",

--- a/src/main/i18n/locales/ru-ru.json
+++ b/src/main/i18n/locales/ru-ru.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Копировать",
   "appMenu.cut": "Вырезать",
   "appMenu.delete": "Удалить",
+  "appMenu.doctor": "Диагностика системы",
   "appMenu.documentation": "Документация",
   "appMenu.edit": "Редактировать",
   "appMenu.feedback": "Обратная связь",

--- a/src/main/i18n/locales/tr-tr.json
+++ b/src/main/i18n/locales/tr-tr.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Kopyala",
   "appMenu.cut": "Kes",
   "appMenu.delete": "Sil",
+  "appMenu.doctor": "Sistem Tanılama",
   "appMenu.documentation": "Belgeler",
   "appMenu.edit": "Düzenle",
   "appMenu.feedback": "Geri Bildirim",

--- a/src/main/i18n/locales/vi-vn.json
+++ b/src/main/i18n/locales/vi-vn.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "Sao chép",
   "appMenu.cut": "Cắt",
   "appMenu.delete": "Xóa",
+  "appMenu.doctor": "Chẩn đoán hệ thống",
   "appMenu.documentation": "Tài liệu",
   "appMenu.edit": "Chỉnh sửa",
   "appMenu.feedback": "Phản hồi",

--- a/src/main/i18n/locales/zh-cn.json
+++ b/src/main/i18n/locales/zh-cn.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "复制",
   "appMenu.cut": "剪切",
   "appMenu.delete": "删除",
+  "appMenu.doctor": "系统诊断",
   "appMenu.documentation": "文档",
   "appMenu.edit": "编辑",
   "appMenu.feedback": "反馈",

--- a/src/main/i18n/locales/zh-tw.json
+++ b/src/main/i18n/locales/zh-tw.json
@@ -32,6 +32,7 @@
   "appMenu.copy": "複製",
   "appMenu.cut": "剪下",
   "appMenu.delete": "刪除",
+  "appMenu.doctor": "系統診斷",
   "appMenu.documentation": "說明文件",
   "appMenu.edit": "編輯",
   "appMenu.feedback": "回饋",

--- a/src/main/services/AppMenuService.ts
+++ b/src/main/services/AppMenuService.ts
@@ -6,6 +6,7 @@ import type { NativeCommandMenuItem, NativeMenuItem } from '@main/services/menu/
 import { toElectronMenuTemplate } from '@main/services/menu/adapters/nativeMenuAdapter'
 import type { PreferenceShortcutType } from '@shared/data/preference/preferenceTypes'
 import type { SupportedPlatform } from '@shared/types/command'
+import { doctorSettingsPath } from '@shared/types/doctor'
 import {
   type CommandId,
   evaluateContextExpr,
@@ -158,6 +159,13 @@ export class AppMenuService extends BaseService {
             label: t('appMenu.documentation'),
             click: () => {
               void shell.openExternal('https://cherry-ai.com/docs')
+            }
+          },
+          {
+            type: 'custom',
+            label: t('appMenu.doctor'),
+            click: () => {
+              openSettingsInMainWindow(doctorSettingsPath('checks'))
             }
           },
           {

--- a/src/main/services/network/types.ts
+++ b/src/main/services/network/types.ts
@@ -70,8 +70,11 @@ export interface ProxyInUse {
 export const NETWORK_ENDPOINT_IDS = ['update', 'registry', 'cloud', 'diagnostics'] as const
 export type NetworkEndpointId = (typeof NETWORK_ENDPOINT_IDS)[number]
 
+/** Built-in ids plus ad-hoc targets (a provider's API host, a user-supplied URL). */
+export type NetworkEndpointRef = NetworkEndpointId | `provider:${string}` | 'custom'
+
 export interface NetworkEndpoint {
-  readonly id: NetworkEndpointId
+  readonly id: NetworkEndpointRef
   readonly url: string
   readonly method?: 'HEAD' | 'GET'
 }
@@ -82,7 +85,7 @@ export interface TlsPeerInfo {
 }
 
 export interface EndpointDiagnosis {
-  readonly endpointId: NetworkEndpointId | `provider:${string}` | 'custom'
+  readonly endpointId: NetworkEndpointRef
   /** Hostname only; `local_only` when it leaves the machine. */
   readonly host: string
   readonly dns: NetworkLayerResult<{ readonly addresses: readonly string[] }>

--- a/src/shared/types/doctor.ts
+++ b/src/shared/types/doctor.ts
@@ -1,3 +1,4 @@
+import type { SettingsPath } from '../data/types/settingsPath'
 import type { AppEdition } from './appEdition'
 
 /**
@@ -347,6 +348,18 @@ export function projectDoctorReport(
     return { ...result, evidence: result.evidence.filter((item) => allowed.has(item.dataClass)) }
   })
   return { ...report, basics, results }
+}
+
+export type DoctorPanel = 'checks' | 'export' | 'report'
+
+/**
+ * The dialog is opened from outside the renderer (Help menu, protocol links) by navigating to
+ * the About settings route with this query param; the About page mounts the dialog on it.
+ */
+export const DOCTOR_OPEN_QUERY_PARAM = 'doctor'
+
+export function doctorSettingsPath(panel: DoctorPanel = 'checks'): SettingsPath {
+  return `/settings/about?${DOCTOR_OPEN_QUERY_PARAM}=${panel}`
 }
 
 export function doctorCheckTitleKey<Id extends DoctorCheckId>(id: Id) {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Stacked on #19985 (base `network-service`), which is stacked on #19982. Retarget to `main` as the bases merge.

Before this PR:

The System Doctor could only be reached from the renderer. The assistant's `diagnose` MCP tool carried its own HEAD-request probe for provider hosts and had no way to hand the model a doctor report.

After this PR:

- Help menu → "System Diagnostics" (`appMenu.doctor`, translated in all 13 main locales) opens the main window on `/settings/about?doctor=checks` through the existing `openSettingsInMainWindow`, which already handles the live-window and cold-start cases. The route helper `doctorSettingsPath()` and the query-param constant live in `@shared/types/doctor` so the About page mounts the dialog on the same contract; no new IPC event.
- `diagnose` tool, `health` action: now calls `NetworkService.diagnoseEndpoint` and reports the layered verdict (DNS / TLS / proxy / HTTP) with the endpoint origin only; the effective proxy address is deliberately not included because the model may be cloud-hosted.
- `diagnose` tool, new `doctor` action with `tier: quick | live`: runs `DoctorService.run` and returns `projectDoctorReport(report, 'upload')`, so `local_only` and `consent_required` evidence never reach the model; `busy` passes through so the model can retry.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Route-param opening instead of a dedicated `open_requested` event: reuses the navigation delivery that already survives a missing or booting main window, and gives the frontend one contract for menu, protocol links and future deep links.
- The `upload` projection for the model: the assistant's model may be remote, so the same data boundary as an upload applies.

The following alternatives were considered:

- Keeping the assistant's own HEAD probe: rejected; two probes would explain the same failure differently.

Links to places where the discussion took place: System Doctor PRD §5 / §6.7 (internal Feishu doc).

### Breaking changes

None.

### Special notes for your reviewer

- Targeted checks only (the full `pnpm lint` was skipped for time): eslint + biome on the changed files, `pnpm i18n:check`, `tsgo` node typecheck; assistant, AppMenuService and doctor suites green (73 tests).
- The `prepare_diagnostic_report` tool's card still opens the upload dialog from the renderer; switching it to the doctor's report panel belongs to the dialog PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
