### PR TITLE
fix(agent-workspace): open folders with the preferred editor

### DIFF
--- a/src/main/services/externalApp/__tests__/ExternalAppService.test.ts
+++ b/src/main/services/externalApp/__tests__/ExternalAppService.test.ts
@@ -182,6 +182,17 @@ describe('ExternalAppService', () => {
     await expect(service.openTarget('/tmp/report.pdf', 'known:wt', 'file')).rejects.toThrow('is not available')
   })
 
+  it('encodes spaces and non-ASCII directory names in editor URLs', async () => {
+    mocks.statSync.mockReturnValue({ isDirectory: () => true })
+    const { ExternalAppService } = await import('../ExternalAppService')
+
+    await new ExternalAppService().openTarget('/tmp/My Workspace/开发', 'known:vscode', 'directory')
+
+    expect(mocks.openExternal).toHaveBeenCalledWith(
+      'vscode://file//tmp/My%20Workspace/%E5%BC%80%E5%8F%91?windowId=_blank'
+    )
+  })
+
   it('validates generated editor URLs before opening them externally', async () => {
     mocks.isSafeExternalUrl.mockReturnValue(false)
     const { ExternalAppService } = await import('../ExternalAppService')

--- a/src/renderer/components/OpenTarget/OpenTargetButton.tsx
+++ b/src/renderer/components/OpenTarget/OpenTargetButton.tsx
@@ -27,14 +27,25 @@ const SPLIT_BUTTON_CLASS = 'h-full rounded-none p-0'
 export interface OpenTargetButtonProps {
   targetPath: string
   pathKind: ExternalOpenTargetPathKind
-  menuTrigger?: ReactNode
+  primaryContent?: ReactNode
+  primaryClassName?: string
+  menuClassName?: string
   tooltip?: string
   className?: string
 }
 
-export function OpenTargetButton({ targetPath, pathKind, menuTrigger, tooltip, className }: OpenTargetButtonProps) {
+export function OpenTargetButton({
+  targetPath,
+  pathKind,
+  primaryContent,
+  primaryClassName,
+  menuClassName,
+  tooltip,
+  className
+}: OpenTargetButtonProps) {
   const { t } = useTranslation()
   const [menuOpen, setMenuOpen] = useState(false)
+  const hasCustomPrimary = primaryContent !== undefined
   const { targets, selectedTarget, openTarget } = usePreferredExternalOpenTarget(targetPath, pathKind)
 
   const handleOpen = useCallback(
@@ -54,7 +65,7 @@ export function OpenTargetButton({ targetPath, pathKind, menuTrigger, tooltip, c
     : t('agent.preview_pane.default_app')
   const primaryIcon = selectedTarget ? <OpenTargetIcon target={selectedTarget} /> : <FolderOpen size={16} />
   const menu = (
-    <PopoverContent className="w-56 p-1" align={menuTrigger ? 'start' : 'end'}>
+    <PopoverContent className="w-56 p-1" align={hasCustomPrimary ? 'start' : 'end'}>
       <MenuList>
         {targets.map((target) => (
           <MenuItem
@@ -73,51 +84,48 @@ export function OpenTargetButton({ targetPath, pathKind, menuTrigger, tooltip, c
     </PopoverContent>
   )
 
-  if (menuTrigger) {
-    const trigger = <PopoverTrigger asChild>{menuTrigger}</PopoverTrigger>
-    return (
-      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-        {tooltip ? <NormalTooltip content={tooltip}>{trigger}</NormalTooltip> : trigger}
-        {menu}
-      </Popover>
-    )
-  }
-
   if (targets.length <= 1) {
     return (
       <NormalTooltip content={tooltip ?? primaryLabel} delayDuration={500}>
         <Button
           type="button"
           variant="ghost"
-          size="icon-sm"
+          size={hasCustomPrimary ? 'sm' : 'icon-sm'}
           disabled={!selectedTarget}
-          className={cn(TOOLBAR_BUTTON_CLASS, className)}
-          aria-label={primaryLabel}
+          className={cn(hasCustomPrimary ? primaryClassName : TOOLBAR_BUTTON_CLASS, className)}
+          aria-label={hasCustomPrimary ? tooltip : primaryLabel}
           onClick={() => void handleOpen()}>
-          {primaryIcon}
+          {primaryContent ?? primaryIcon}
         </Button>
       </NormalTooltip>
     )
   }
 
   return (
-    <ButtonGroup attached={false} className={cn(SPLIT_BUTTON_GROUP_CLASS, 'gap-0', className)}>
+    <ButtonGroup
+      attached={hasCustomPrimary}
+      className={cn(!hasCustomPrimary && SPLIT_BUTTON_GROUP_CLASS, 'gap-0', className)}>
       <NormalTooltip content={tooltip ?? primaryLabel} delayDuration={500}>
         <Button
           type="button"
-          className={cn('w-8 min-w-8', SPLIT_BUTTON_CLASS, TOOLBAR_BUTTON_CLASS)}
+          className={cn(
+            hasCustomPrimary ? primaryClassName : cn('w-8 min-w-8', SPLIT_BUTTON_CLASS, TOOLBAR_BUTTON_CLASS)
+          )}
           variant="ghost"
-          size="icon-sm"
-          aria-label={primaryLabel}
+          size={hasCustomPrimary ? 'sm' : 'icon-sm'}
+          aria-label={hasCustomPrimary ? tooltip : primaryLabel}
           onClick={() => void handleOpen()}>
-          {primaryIcon}
+          {primaryContent ?? primaryIcon}
         </Button>
       </NormalTooltip>
       <Popover open={menuOpen} onOpenChange={setMenuOpen}>
         <PopoverTrigger asChild>
           <Button
             type="button"
-            className={cn('w-6 min-w-6', SPLIT_BUTTON_CLASS, TOOLBAR_BUTTON_CLASS)}
+            className={cn(
+              'w-6 min-w-6',
+              hasCustomPrimary ? menuClassName : cn(SPLIT_BUTTON_CLASS, TOOLBAR_BUTTON_CLASS)
+            )}
             variant="ghost"
             size="icon-sm"
             aria-label={t('common.more')}>

--- a/src/renderer/components/OpenTarget/__tests__/OpenTargetButton.test.tsx
+++ b/src/renderer/components/OpenTarget/__tests__/OpenTargetButton.test.tsx
@@ -37,6 +37,11 @@ const selectedTarget: ExternalOpenTarget = {
   kind: 'application'
 }
 
+const fileManagerTarget: ExternalOpenTarget = {
+  id: 'file_manager',
+  kind: 'file_manager'
+}
+
 describe('OpenTargetButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -55,6 +60,25 @@ describe('OpenTargetButton', () => {
     await user.click(screen.getByRole('button', { name: 'Open in Visual Studio Code' }))
 
     expect(mocks.openTarget).toHaveBeenCalledWith(selectedTarget)
+  })
+
+  it('keeps a custom workspace trigger as the primary action with a separate target menu', async () => {
+    const user = userEvent.setup()
+    mocks.usePreferredExternalOpenTarget.mockReturnValue({
+      targets: [fileManagerTarget, selectedTarget],
+      selectedTarget,
+      openTarget: mocks.openTarget
+    })
+    render(<OpenTargetButton targetPath="/tmp/My Workspace" pathKind="directory" primaryContent="Open workspace" />)
+
+    await user.click(screen.getByRole('button', { name: 'Open workspace' }))
+
+    expect(mocks.openTarget).toHaveBeenCalledWith(selectedTarget)
+
+    await user.click(screen.getByRole('button', { name: 'common.more' }))
+    await user.click(screen.getByRole('button', { name: /agent\.session\.file_manager/ }))
+
+    expect(mocks.openTarget).toHaveBeenLastCalledWith(fileManagerTarget)
   })
 
   it('reports a launch failure', async () => {

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -296,9 +296,9 @@ vi.mock('@data/CacheService', () => ({
 }))
 
 vi.mock('@renderer/components/OpenTarget', () => ({
-  OpenTargetButton: ({ targetPath, menuTrigger }: { targetPath: string; menuTrigger?: ReactNode }) => (
+  OpenTargetButton: ({ targetPath, primaryContent }: { targetPath: string; primaryContent?: ReactNode }) => (
     <div data-testid="workspace-open-button" data-workdir={targetPath}>
-      {menuTrigger}
+      <button type="button">{primaryContent}</button>
     </div>
   )
 }))

--- a/src/renderer/components/composer/variants/agent/AgentConversationControls.tsx
+++ b/src/renderer/components/composer/variants/agent/AgentConversationControls.tsx
@@ -241,18 +241,8 @@ function WorkspaceControl({
     : (workspace?.name ?? selectWorkspaceLabel)
   const canQuickClearWorkspace = Boolean(onWorkspaceChange && workspace && !iconOnly)
   if (!onWorkspaceChange && workspace?.type === 'user' && workspace.path) {
-    const openMenuTrigger = (
-      <Button
-        variant="ghost"
-        size="sm"
-        type="button"
-        className={cn(
-          baseTriggerClassName,
-          'relative',
-          iconOnly && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS,
-          hasWarning && 'text-warning hover:text-warning'
-        )}
-        aria-label={workspaceWarning}>
+    const openButtonContent = (
+      <>
         {hasWarning ? (
           <TriangleAlert size={20} aria-hidden />
         ) : (
@@ -261,14 +251,24 @@ function WorkspaceControl({
           </span>
         )}
         <span className={cn('max-w-40 truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)}>{workspaceLabel}</span>
-        <ChevronDown size={14} aria-hidden className={cn('text-muted-foreground', iconOnly && 'hidden')} />
-      </Button>
+      </>
     )
     return (
       <OpenTargetButton
         targetPath={workspace.path}
         pathKind="directory"
-        menuTrigger={openMenuTrigger}
+        primaryContent={openButtonContent}
+        primaryClassName={cn(
+          baseTriggerClassName,
+          'relative',
+          iconOnly && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS,
+          hasWarning && 'text-warning hover:text-warning'
+        )}
+        menuClassName={cn(
+          baseTriggerClassName,
+          'px-0 text-muted-foreground',
+          hasWarning && 'text-warning hover:text-warning'
+        )}
         tooltip={workspaceWarning}
       />
     )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The Agent workspace button always opened the target picker, so it could not directly launch the user's preferred editor.

After this PR:

The workspace name is the primary action and opens the selected editor. A separate chevron keeps the file manager and other detected applications available.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19638

### Why we need it and why it was done in this way

The existing external-app service already discovers supported editors, stores the path-scoped preference, validates deep links, and falls back to the file manager. This change reuses that contract and only separates the custom workspace control into primary and menu actions.

The following tradeoffs were made:

The compact workspace control uses two small attached actions when multiple targets exist so both direct open and Open With remain reachable.

The following alternatives were considered:

Duplicating editor selection and launch logic in the Agent composer was rejected because it would bypass the shared preference and error handling.

Links to places where the discussion took place: #19638

### Breaking changes

None.

### Special notes for your reviewer

UI screenshot is pending. The sole tracked development Electron currently belongs to another worktree (`edinburgh-v1`), so this draft intentionally does not request review until that instance exits and a result-state screenshot is embedded and independently verified.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent workspace folders can now open directly in the selected external editor while keeping other open targets available.
```
