### PR TITLE
fix(mini-app): drop raw permission key from leaf tooltips

### DIFF
--- a/src/renderer/components/MiniApp/PermissionChecklist.tsx
+++ b/src/renderer/components/MiniApp/PermissionChecklist.tsx
@@ -20,7 +20,7 @@ export interface PermissionLeafItem {
 /**
  * The Android-style permission list shared by the consent card and the detail panel: one
  * namespace per row — title, an (i) for what it means, then its leaves inline, each a
- * checkbox + label unit. Technical names stay out of the text and appear on hover.
+ * checkbox + label unit.
  */
 export const PermissionChecklist: FC<{
   items: PermissionLeafItem[]
@@ -62,28 +62,27 @@ export const PermissionChecklist: FC<{
               {leaves.map((leaf) => {
                 const item = byKey.get(leaf)!
                 return (
-                  <Tooltip key={leaf} content={leaf}>
-                    <label
-                      className={cn(
-                        // Block-level on purpose: an inline-flex label sits on the line's baseline, and an empty
-                        // (unticked) checkbox has a different baseline from a ticked one — the row would jump.
-                        'flex items-center gap-1.5 text-sm',
-                        item.fixed ? 'cursor-not-allowed text-muted-foreground' : 'cursor-pointer'
-                      )}>
-                      <Checkbox
-                        size="sm"
-                        checked={item.checked}
-                        disabled={disabled || item.fixed}
-                        // The technical id would OVERRIDE the visible label for screen-reader
-                        // and voice-control users (WCAG 2.5.3), and the visible label alone is
-                        // ambiguous — "Read", "Write" and "Delete" each name two leaves in
-                        // different namespaces. The qualified form contains the visible word.
-                        aria-label={permissionLabel(t, leaf)}
-                        onCheckedChange={(checked) => onToggle(leaf, checked === true)}
-                      />
-                      <span>{permissionLeafLabel(t, leaf)}</span>
-                    </label>
-                  </Tooltip>
+                  <label
+                    key={leaf}
+                    className={cn(
+                      // Block-level on purpose: an inline-flex label sits on the line's baseline, and an empty
+                      // (unticked) checkbox has a different baseline from a ticked one — the row would jump.
+                      'flex items-center gap-1.5 text-sm',
+                      item.fixed ? 'cursor-not-allowed text-muted-foreground' : 'cursor-pointer'
+                    )}>
+                    <Checkbox
+                      size="sm"
+                      checked={item.checked}
+                      disabled={disabled || item.fixed}
+                      // The technical id would OVERRIDE the visible label for screen-reader
+                      // and voice-control users (WCAG 2.5.3), and the visible label alone is
+                      // ambiguous — "Read", "Write" and "Delete" each name two leaves in
+                      // different namespaces. The qualified form contains the visible word.
+                      aria-label={permissionLabel(t, leaf)}
+                      onCheckedChange={(checked) => onToggle(leaf, checked === true)}
+                    />
+                    <span>{permissionLeafLabel(t, leaf)}</span>
+                  </label>
                 )
               })}
             </div>


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The permission list shared by the install-consent dialog, the detail panel, and the update review rendered a hover tooltip on each leaf whose content was the bare technical capability key (e.g. `file.export`). To a user this reads exactly like a missing translation, and it carries no information the visible UI already provides.

After this PR:

The redundant leaf-level tooltip is gone. The visible label (`permissionLeafLabel`) already localizes every leaf, each namespace row already carries an `InfoTooltip` with the full localized description, and the checkbox `aria-label` keeps the qualified form (WCAG 2.5.3), so nothing informative is lost.

`key={leaf}` moves from the removed `Tooltip` wrapper onto the `<label>`, and the component's doc comment no longer claims technical names "appear on hover".

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

We considered whether this "technical name on hover" was an intentional design or simply a bug, and concluded that either way it should go: the tooltip is the only place in this component where an unlocalized key reaches the user, and it looks like broken i18n. Replacing it with the localized qualified label would only duplicate text already visible in the row (namespace title + leaf label) and the namespace `InfoTooltip`.

The following alternatives were considered:

- **Show the localized qualified label (`permissionLabel`) in the tooltip** — rejected: fully redundant with the visible row and the namespace `InfoTooltip`.
- **Show both a localized label and the technical key** — rejected: keeps the developer-facing key that reads as a translation bug, and the key is only meaningful to manifest authors, not to consenting users.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

The mini-app permission UI (`PermissionChecklist`) is shared by `InstallConsentDialog`, `MiniAppDetailPanel`, and `UpdateReviewCard`. Tests for all consumers plus the permission-copy contract pass; only this file changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Remove the permission tooltips in the mini-app install/detail dialogs that showed raw technical keys (e.g. file.export) and read as untranslated strings.
```
