### PR TITLE
fix(launchpad): keep mini apps attached when opening

### DIFF
--- a/src/renderer/pages/launchpad/LaunchpadPage.tsx
+++ b/src/renderer/pages/launchpad/LaunchpadPage.tsx
@@ -14,6 +14,7 @@ import translateIcon from '@renderer/assets/images/apps/launchpad-translate.svg'
 import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
 import App from '@renderer/components/MiniApp/MiniApp'
 import Scrollbar from '@renderer/components/Scrollbar'
+import { useCurrentTab, useTabs } from '@renderer/hooks/tab'
 import { useLaunchpadAppOrder } from '@renderer/hooks/useLaunchpadAppOrder'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
 import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
@@ -66,6 +67,8 @@ export default function LaunchpadPage() {
   } = useMiniApps()
   const { appFavorites, miniAppFavoriteIds, setAppPinned, toggleMiniApp } = useSidebarFavorites()
   const { orderedAppIds, reorderApps } = useLaunchpadAppOrder()
+  const currentTab = useCurrentTab()
+  const { openTab, updateTab } = useTabs()
   const suppressClickUntilRef = useRef(0)
   const draggedItemIdRef = useRef<string | null>(null)
 
@@ -120,12 +123,21 @@ export default function LaunchpadPage() {
   }
 
   const openMiniApp = useCallback(
-    (appId: string) => {
+    (appId: string, displayName: string, icon?: string) => {
       if (shouldSuppressLaunchClick(appId)) return
 
-      void navigateToUrl(`/app/mini-app/${appId}`)
+      const url = `/app/mini-app/${appId}`
+      if (!currentTab) {
+        void navigateToUrl(url)
+        return
+      }
+      if (currentTab.isPinned) {
+        openTab(url, { title: displayName, icon })
+        return
+      }
+      updateTab(currentTab.id, { url, title: displayName, icon, metadata: undefined })
     },
-    [navigateToUrl, shouldSuppressLaunchClick]
+    [currentTab, navigateToUrl, openTab, shouldSuppressLaunchClick, updateTab]
   )
 
   const openDeepSeekHarness = () => {

--- a/src/renderer/pages/launchpad/__tests__/LaunchpadPage.test.tsx
+++ b/src/renderer/pages/launchpad/__tests__/LaunchpadPage.test.tsx
@@ -11,6 +11,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
+  openTab: vi.fn(),
+  updateTab: vi.fn(),
+  currentTab: {
+    id: 'launchpad-tab',
+    type: 'route' as const,
+    url: '/app/launchpad',
+    title: 'Launchpad',
+    isPinned: false
+  },
   pinnedMiniApps: [] as any[],
   openedMiniApps: [] as any[],
   reorderMiniAppsByStatus: vi.fn(() => Promise.resolve()),
@@ -76,8 +85,14 @@ vi.mock('@renderer/components/command', () => ({
 }))
 
 vi.mock('@renderer/components/MiniApp/MiniApp', () => ({
-  default: ({ app, onOpen }: { app: { appId: string; name: string }; onOpen?: (appId: string) => void }) => (
-    <button type="button" onClick={() => onOpen?.(app.appId)}>
+  default: ({
+    app,
+    onOpen
+  }: {
+    app: { appId: string; name: string; logo?: string }
+    onOpen?: (appId: string, displayName: string, icon?: string) => void
+  }) => (
+    <button type="button" onClick={() => onOpen?.(app.appId, app.name, app.logo)}>
       {app.name}
     </button>
   )
@@ -99,6 +114,11 @@ vi.mock('@renderer/hooks/useMiniApps', () => ({
     pinned: mocks.pinnedMiniApps,
     reorderMiniAppsByStatus: mocks.reorderMiniAppsByStatus
   })
+}))
+
+vi.mock('@renderer/hooks/tab', () => ({
+  useCurrentTab: () => mocks.currentTab,
+  useTabs: () => ({ openTab: mocks.openTab, updateTab: mocks.updateTab })
 }))
 
 vi.mock('@renderer/services/toast', () => ({
@@ -186,6 +206,13 @@ describe('LaunchpadPage', () => {
   beforeEach(() => {
     mocks.pinnedMiniApps = []
     mocks.openedMiniApps = []
+    mocks.currentTab = {
+      id: 'launchpad-tab',
+      type: 'route',
+      url: '/app/launchpad',
+      title: 'Launchpad',
+      isPinned: false
+    }
     mocks.sidebarFavorites = [appFavorite('assistants')]
     mocks.appOrder = []
     mocks.sortableCalls.length = 0
@@ -321,7 +348,7 @@ describe('LaunchpadPage', () => {
     expect(mocks.navigate).toHaveBeenCalledWith({ to: '/app/agents' })
   })
 
-  it('navigates concrete mini apps inside the current launchpad tab', async () => {
+  it('retargets the current launchpad tab before opening a mini app', async () => {
     const user = userEvent.setup()
     mocks.pinnedMiniApps = [createMiniApp('calculator')]
 
@@ -329,7 +356,30 @@ describe('LaunchpadPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Calculator' }))
 
-    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/app/mini-app/calculator' })
+    expect(mocks.updateTab).toHaveBeenCalledWith('launchpad-tab', {
+      url: '/app/mini-app/calculator',
+      title: 'Calculator',
+      icon: 'calculator-logo',
+      metadata: undefined
+    })
+    expect(mocks.navigate).not.toHaveBeenCalled()
+  })
+
+  it('keeps a pinned launchpad tab and opens or reuses the mini app tab', async () => {
+    const user = userEvent.setup()
+    mocks.pinnedMiniApps = [createMiniApp('calculator')]
+    mocks.currentTab = { ...mocks.currentTab, isPinned: true }
+
+    render(<LaunchpadPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Calculator' }))
+
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/mini-app/calculator', {
+      title: 'Calculator',
+      icon: 'calculator-logo'
+    })
+    expect(mocks.updateTab).not.toHaveBeenCalled()
+    expect(mocks.navigate).not.toHaveBeenCalled()
   })
 
   it('sorts every pinned mini app by order key and persists to order keys, not favorites', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Opening a mini-app from an unpinned Launchpad tab navigated through the router before the owning tab URL changed. The mini-app pool could therefore treat the new view as orphaned and leave the page waiting for its webview attachment.

After this PR:

An unpinned Launchpad tab is retargeted to the mini-app URL immediately, keeping the pooled view attached to its owning tab. A pinned Launchpad tab remains intact and opens or reuses a separate mini-app tab.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19827

### Why we need it and why it was done in this way

The tab must own the mini-app URL before `MiniAppPage` mounts so the pool cannot evict the view as orphaned. The implementation uses the existing tab operations and preserves the established pinned-tab behavior.

The following tradeoffs were made:

The Launchpad now depends directly on the tab context for mini-app activation. It retains router navigation only as a fallback when no owning tab exists.

The following alternatives were considered:

Always replacing the current tab was rejected because it would overwrite a pinned Launchpad tab. Always opening a new tab was rejected because unpinned Launchpad tabs are intended to be reused.

Links to places where the discussion took place: #19827, #19834

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

- Regression coverage verifies both unpinned-tab retargeting and pinned Launchpad preservation.
- Local verification: `pnpm lint`; `pnpm test:lint`; `pnpm test:renderer src/renderer/pages/launchpad/__tests__/LaunchpadPage.test.tsx` (20 tests passed).
- UI verification and the required result screenshot are pending because the single allowed Electron instance is currently owned by another workspace. This PR remains draft and review is not requested until that instance is released and the screenshot is embedded here.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed mini-apps opened from Launchpad getting stuck while attaching their webview.
```
