### PR TITLE
fix(notes): keep rename editor focused

### DIFF
--- a/src/renderer/pages/notes/__tests__/useNotesMenu.test.tsx
+++ b/src/renderer/pages/notes/__tests__/useNotesMenu.test.tsx
@@ -1,0 +1,82 @@
+import type { NotesTreeNode } from '@renderer/types/note'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useNotesMenu } from '../hooks/useNotesMenu'
+
+vi.mock('@data/hooks/usePreference', () => ({
+  useMultiplePreferences: () => [{}]
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ error: vi.fn() })
+  }
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: vi.fn() }
+}))
+
+vi.mock('@renderer/services/popup', () => ({
+  popup: { confirm: vi.fn() }
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+const node: NotesTreeNode = {
+  id: 'note-1',
+  name: 'Example',
+  type: 'file',
+  treePath: 'Example.md',
+  externalPath: '/notes/Example.md',
+  createdAt: '2026-09-04T00:00:00.000Z',
+  updatedAt: '2026-09-04T00:00:00.000Z'
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useNotesMenu', () => {
+  it('starts inline rename after the context-menu focus restoration frame', () => {
+    let frameCallback: FrameRequestCallback | undefined
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallback = callback
+      return 1
+    })
+    const handleStartEdit = vi.fn()
+    const { result } = renderHook(() =>
+      useNotesMenu({
+        renamingNodeIds: new Set(),
+        onCreateNote: vi.fn(),
+        onCreateFolder: vi.fn(),
+        onRenameNode: vi.fn(),
+        onToggleStar: vi.fn(),
+        onDeleteNode: vi.fn(),
+        onSelectNode: vi.fn(),
+        handleStartEdit,
+        handleAutoRename: vi.fn()
+      })
+    )
+    const renameItem = result.current
+      .getMenuItems(node)
+      .find((item) => item.type === 'item' && item.id === 'notes.rename')
+
+    if (!renameItem || renameItem.type !== 'item') {
+      throw new Error('Rename menu item not found')
+    }
+
+    act(() => renameItem.onSelect())
+    expect(handleStartEdit).not.toHaveBeenCalled()
+
+    act(() => frameCallback?.(0))
+    expect(handleStartEdit).toHaveBeenCalledWith(node)
+  })
+})

--- a/src/renderer/pages/notes/hooks/useNotesMenu.tsx
+++ b/src/renderer/pages/notes/hooks/useNotesMenu.tsx
@@ -168,7 +168,9 @@ export const useNotesMenu = ({
           id: 'notes.rename',
           label: t('notes.rename'),
           icon: <Edit3 size={14} />,
-          onSelect: () => handleStartEdit(node)
+          onSelect: () => {
+            window.requestAnimationFrame(() => handleStartEdit(node))
+          }
         },
         {
           type: 'item',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Selecting **Rename** for a note or folder briefly opened the inline editor, but context-menu focus restoration immediately blurred and closed it before the user could type.

After this PR:

Inline rename starts after context-menu focus restoration completes, so the editor remains focused and accepts a new note or folder name.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19816

### Why we need it and why it was done in this way

The following tradeoffs were made:

The additional animation-frame delay is scoped to the Notes rename action. This avoids changing timing for unrelated context-menu and popup actions across the application.

The following alternatives were considered:

Changing the shared menu action scheduler was tested and rejected because it would alter every Cherry menu action for a Notes-specific focus race.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19816

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

The regression test verifies that Notes rename waits for the focus-restoration frame before starting inline editing. Manual Electron verification covered both note and folder rename, persistence after reload, and Escape cancellation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Notes] Fixed note and folder rename fields closing before users could enter a new name.
```
