### PR TITLE
fix(updater): handle missing manifests without transient retries

### DIFF
--- a/docs/contrib/app-upgrade.md
+++ b/docs/contrib/app-upgrade.md
@@ -56,3 +56,5 @@ The selected electron-updater channel determines which edition-specific manifest
 ## Check Lifecycle
 
 Manual checks are available in development and packaged, non-portable builds. Portable builds do not perform update checks. Packaged, non-portable builds also schedule automatic checks in the main process. Successful checks return to the normal cadence, while failed scheduled checks use exponential backoff before retrying. Update events and download progress continue to reach the main window through IpcApi.
+
+A managed-feed HTTP 503 with the structured code `manifest_missing` keeps the normal four-hour schedule (with ±15% jitter), reducing repeated requests while a release manifest is unavailable. The check remains an error, and manual retry remains available; manual checks show the existing unpublished-update explanation instead of a generic error. Other failures, including `edition_mismatch` and 404 responses, retain their existing handling. Automatic discovery after the feed is repaired may take up to 4.6 hours; this does not repair release-service routing or rollout configuration.

--- a/src/main/services/AppUpdaterService.ts
+++ b/src/main/services/AppUpdaterService.ts
@@ -18,8 +18,9 @@ import {
   parseReleaseHistory,
   type ReleaseNotesEntry
 } from '@shared/utils/releaseNotes'
+import { isMissingUpdateManifest } from '@shared/utils/updateError'
 import type { ProgressInfo, UpdateInfo } from 'builder-util-runtime'
-import { CancellationToken } from 'builder-util-runtime'
+import { CancellationToken, HttpError } from 'builder-util-runtime'
 import { app, net } from 'electron'
 import type { Logger, NsisUpdater, UpdateCheckResult } from 'electron-updater'
 import { AppUpdater, autoUpdater } from 'electron-updater'
@@ -373,7 +374,13 @@ export class AppUpdaterService extends BaseService {
       }
       this.updateCheckFailures = 0
       this.scheduleNextUpdateCheck(this.nextUpdateCheckDelayMs())
-    } catch {
+    } catch (error) {
+      if (error instanceof HttpError && isMissingUpdateManifest(error)) {
+        this.updateCheckFailures = 0
+        logger.warn('scheduled update check hit manifest_missing, keeping normal cadence')
+        this.scheduleNextUpdateCheck(this.nextUpdateCheckDelayMs())
+        return
+      }
       this.updateCheckFailures++
       const backoffMs = computeBackoff(CHECK_RETRY_POLICY, this.updateCheckFailures)
       logger.warn(`scheduled update check failed, backing off for ${backoffMs}ms`)

--- a/src/main/services/AppUpdaterService.ts
+++ b/src/main/services/AppUpdaterService.ts
@@ -20,7 +20,7 @@ import {
 } from '@shared/utils/releaseNotes'
 import { isMissingUpdateManifest } from '@shared/utils/updateError'
 import type { ProgressInfo, UpdateInfo } from 'builder-util-runtime'
-import { CancellationToken, HttpError } from 'builder-util-runtime'
+import { CancellationToken } from 'builder-util-runtime'
 import { app, net } from 'electron'
 import type { Logger, NsisUpdater, UpdateCheckResult } from 'electron-updater'
 import { AppUpdater, autoUpdater } from 'electron-updater'
@@ -375,7 +375,7 @@ export class AppUpdaterService extends BaseService {
       this.updateCheckFailures = 0
       this.scheduleNextUpdateCheck(this.nextUpdateCheckDelayMs())
     } catch (error) {
-      if (error instanceof HttpError && isMissingUpdateManifest(error)) {
+      if (isMissingUpdateManifest(error)) {
         this.updateCheckFailures = 0
         logger.warn('scheduled update check hit manifest_missing, keeping normal cadence')
         this.scheduleNextUpdateCheck(this.nextUpdateCheckDelayMs())

--- a/src/main/services/__tests__/AppUpdaterService.scheduler.test.ts
+++ b/src/main/services/__tests__/AppUpdaterService.scheduler.test.ts
@@ -10,10 +10,14 @@
  * cleanup on stop.
  */
 
+import { IncomingMessage } from 'node:http'
+import { Socket } from 'node:net'
+
 import { application } from '@application'
 import { BaseService } from '@main/core/lifecycle/BaseService'
 import { SchedulerService } from '@main/core/scheduler/SchedulerService'
 import { regionService } from '@main/services/RegionService'
+import { createHttpError, HttpError } from 'builder-util-runtime'
 import { app } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -82,6 +86,16 @@ const SCHEDULE_ID = 'app-updater:auto-check'
 const INITIAL_DELAY = 5_000
 const INTERVAL = 4 * 60 * 60 * 1000
 const BACKOFF_FIRST = 5 * 60 * 1000
+
+const releaseError = (body: string, statusCode = 503) => {
+  const response = new IncomingMessage(new Socket())
+  response.statusCode = statusCode
+  response.statusMessage = 'Service Unavailable'
+  return createHttpError(
+    response,
+    `method: GET url: https://releases.cherry-ai.com/beta-cn-mac.yml\n\n          Data:\n          ${body}\n          `
+  )
+}
 
 const setPackaged = (value: boolean) => {
   ;(app as unknown as { isPackaged: boolean }).isPackaged = value
@@ -219,6 +233,56 @@ describe('AppUpdaterService — auto update-check scheduling', () => {
     expect(scheduler.has(SCHEDULE_ID)).toBe(false)
     await vi.advanceTimersByTimeAsync(INITIAL_DELAY + INTERVAL)
     expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled()
+  })
+
+  it('checks missing manifests on the normal cadence without preventing manual retries', async () => {
+    vi.mocked(autoUpdater.checkForUpdates).mockRejectedValue(releaseError('{"error":{"code":"manifest_missing"}}'))
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    await appUpdater._doAllReady()
+
+    await vi.advanceTimersByTimeAsync(INITIAL_DELAY)
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    await appUpdater.checkForUpdates()
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+    expect(autoUpdater.downloadUpdate).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(INTERVAL - 60 * 60 * 1000)
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(INTERVAL)
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(4)
+  })
+
+  it('restarts transient backoff after an intervening missing-manifest response', async () => {
+    vi.mocked(autoUpdater.checkForUpdates)
+      .mockRejectedValueOnce(new Error('network'))
+      .mockRejectedValueOnce(releaseError('{"error":{"code":"manifest_missing"}}'))
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValue(null)
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    await appUpdater._doAllReady()
+
+    await vi.advanceTimersByTimeAsync(INITIAL_DELAY + BACKOFF_FIRST)
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(INTERVAL)
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(BACKOFF_FIRST)
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(4)
+  })
+
+  it.each([
+    ['HTML mentioning the code', releaseError('<html>manifest_missing</html>')],
+    ['unknown structured code', releaseError('{"error":{"code":"upstream_timeout"}}')],
+    ['edition mismatch', releaseError('{"error":{"code":"edition_mismatch"}}', 400)],
+    ['404 without its response body', new HttpError(404, '404 Not Found', 'method: GET url: https://example.test')]
+  ])('keeps transient backoff for %s', async (_label, error) => {
+    vi.mocked(autoUpdater.checkForUpdates).mockRejectedValue(error)
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    await appUpdater._doAllReady()
+
+    await vi.advanceTimersByTimeAsync(INITIAL_DELAY + BACKOFF_FIRST)
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
   })
 
   it('unregisters the schedule on stop and stops checking', async () => {

--- a/src/main/services/__tests__/AppUpdaterService.scheduler.test.ts
+++ b/src/main/services/__tests__/AppUpdaterService.scheduler.test.ts
@@ -235,8 +235,11 @@ describe('AppUpdaterService — auto update-check scheduling', () => {
     expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled()
   })
 
-  it('checks missing manifests on the normal cadence without preventing manual retries', async () => {
-    vi.mocked(autoUpdater.checkForUpdates).mockRejectedValue(releaseError('{"error":{"code":"manifest_missing"}}'))
+  it.each([
+    ['HttpError', releaseError('{"error":{"code":"manifest_missing"}}')],
+    ['plain Error', new Error(releaseError('{"error":{"code":"manifest_missing"}}').message)]
+  ])('keeps normal cadence and manual retries for a missing manifest in %s', async (_label, error) => {
+    vi.mocked(autoUpdater.checkForUpdates).mockRejectedValue(error)
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
     await appUpdater._doAllReady()
 
@@ -274,6 +277,11 @@ describe('AppUpdaterService — auto update-check scheduling', () => {
   it.each([
     ['HTML mentioning the code', releaseError('<html>manifest_missing</html>')],
     ['unknown structured code', releaseError('{"error":{"code":"upstream_timeout"}}')],
+    ['non-Error rejection', null],
+    [
+      'oversized response',
+      releaseError(JSON.stringify({ error: { code: 'manifest_missing', message: 'x'.repeat(64 * 1024) } }))
+    ],
     ['edition mismatch', releaseError('{"error":{"code":"edition_mismatch"}}', 400)],
     ['404 without its response body', new HttpError(404, '404 Not Found', 'method: GET url: https://example.test')]
   ])('keeps transient backoff for %s', async (_label, error) => {

--- a/src/renderer/windows/main/hooks/__tests__/useAppUpdateHandler.test.ts
+++ b/src/renderer/windows/main/hooks/__tests__/useAppUpdateHandler.test.ts
@@ -1,6 +1,10 @@
+import { IncomingMessage } from 'node:http'
+import { Socket } from 'node:net'
+
 import type { AppEventSchemas } from '@shared/ipc/schemas/app'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import type { ProgressInfo, UpdateInfo } from 'builder-util-runtime'
+import { createHttpError } from 'builder-util-runtime'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -75,6 +79,13 @@ const progress: ProgressInfo = {
   percent: 100,
   total: 2048,
   transferred: 2048
+}
+
+const releaseError = (body: string, url = 'https://releases.cherry-ai.com/beta-cn-mac.yml') => {
+  const response = new IncomingMessage(new Socket())
+  response.statusCode = 503
+  response.statusMessage = 'Service Unavailable'
+  return createHttpError(response, `method: GET url: ${url}\n\n          Data:\n          ${body}\n          `)
 }
 
 function emit<E extends keyof AppEventSchemas>(event: E, payload: AppEventSchemas[E]) {
@@ -180,9 +191,53 @@ describe('useAppUpdateHandler', () => {
       icon: null
     })
   })
+
+  it('explains a missing manifest only for a manual check without reporting success', () => {
+    const { rerender } = renderHook(() => useAppUpdateHandler())
+    // Electron transports Error.message, not the HttpError subclass or its custom fields.
+    const error = new Error(releaseError('{"error":{"code":"manifest_missing","message":"missing"}}').message)
+    emit('app.updater.error', error)
+    expect(mocks.popupInfo).not.toHaveBeenCalled()
+
+    mocks.appUpdateState.manualCheck = true
+    rerender()
+    emit('app.updater.error', error)
+    expect(mocks.popupInfo).toHaveBeenCalledExactlyOnceWith({
+      title: 'settings.about.updateError',
+      content: 'settings.about.updateNotPublished',
+      icon: null
+    })
+    expect(mocks.updateAppUpdateState).toHaveBeenLastCalledWith({
+      checking: false,
+      downloading: false,
+      downloadProgress: 0,
+      manualCheck: false
+    })
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+  })
 })
 
 describe('getManualUpdateErrorMessageKey', () => {
+  it.each([
+    '<html>manifest_missing</html>',
+    '{"error":{"code":"upstream_timeout","message":"previous manifest_missing"}}',
+    '{"error":{"code":"edition_mismatch"}}',
+    '{"error":"manifest_missing"}',
+    'null',
+    '{broken json'
+  ])('does not treat an unrelated response body as a missing manifest: %s', (body) => {
+    expect(getManualUpdateErrorMessageKey(releaseError(body))).toBe('settings.about.updateError')
+  })
+
+  it('does not classify an unrelated host or free-form message by a matching substring', () => {
+    expect(
+      getManualUpdateErrorMessageKey(
+        releaseError('{"error":{"code":"manifest_missing"}}', 'https://example.test/beta-cn-mac.yml')
+      )
+    ).toBe('settings.about.updateError')
+    expect(getManualUpdateErrorMessageKey(new Error('503 manifest_missing'))).toBe('settings.about.updateError')
+  })
+
   it('classifies unpublished release artifacts without exposing the updater body', () => {
     expect(getManualUpdateErrorMessageKey(new Error('503 not_published'))).toBe('settings.about.updateNotPublished')
     expect(getManualUpdateErrorMessageKey(new Error('HttpError: 503 Cannot find latest.yml'))).toBe(

--- a/src/renderer/windows/main/hooks/useAppUpdateHandler.ts
+++ b/src/renderer/windows/main/hooks/useAppUpdateHandler.ts
@@ -5,6 +5,7 @@ import { notificationService } from '@renderer/services/notification'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
 import { uuid } from '@renderer/utils/uuid'
+import { isMissingUpdateManifest } from '@shared/utils/updateError'
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -13,7 +14,7 @@ const logger = loggerService.withContext('useAppUpdateHandler')
 /** Map updater failures to i18n keys. Never surface the raw HTTP body. */
 export function getManualUpdateErrorMessageKey(error: { message?: string } | null | undefined): string {
   const message = error?.message ?? ''
-  if (isUnpublishedReleaseError(message)) {
+  if (isMissingUpdateManifest(error) || isUnpublishedReleaseError(message)) {
     return 'settings.about.updateNotPublished'
   }
   return 'settings.about.updateError'

--- a/src/shared/utils/__tests__/updateError.test.ts
+++ b/src/shared/utils/__tests__/updateError.test.ts
@@ -1,0 +1,43 @@
+import { IncomingMessage } from 'node:http'
+import { Socket } from 'node:net'
+
+import { createHttpError } from 'builder-util-runtime'
+import { describe, expect, it } from 'vitest'
+
+import { isMissingUpdateManifest } from '../updateError'
+
+const releaseError = (body = '{"error":{"code":"manifest_missing"}}') => {
+  const response = new IncomingMessage(new Socket())
+  response.statusCode = 503
+  response.statusMessage = 'Service Unavailable'
+  return createHttpError(
+    response,
+    `method: GET url: https://releases.cherry-ai.com/beta-cn-mac.yml\n\n          Data:\n          ${body}\n          `
+  )
+}
+
+describe('isMissingUpdateManifest', () => {
+  it('recognizes SDK messages without relying on the error class', () => {
+    const error = releaseError()
+    expect(isMissingUpdateManifest(error)).toBe(true)
+    expect(isMissingUpdateManifest(new Error(error.message))).toBe(true)
+    expect(isMissingUpdateManifest({ message: error.message })).toBe(true)
+  })
+
+  it.each([null, undefined, 503, '503 manifest_missing', {}, { message: null }, { message: 503 }])(
+    'ignores a rejection without a string message: %j',
+    (error) => {
+      expect(isMissingUpdateManifest(error)).toBe(false)
+    }
+  )
+
+  it.each([
+    [64 * 1024, true],
+    [64 * 1024 + 1, false]
+  ])('classifies a %i-character message within the parsing limit: %s', (length, expected) => {
+    const body = (message: string) => JSON.stringify({ error: { code: 'manifest_missing', message } })
+    const overhead = releaseError(body('')).message.length
+    const error = releaseError(body('x'.repeat(length - overhead)))
+    expect(isMissingUpdateManifest(error)).toBe(expected)
+  })
+})

--- a/src/shared/utils/updateError.ts
+++ b/src/shared/utils/updateError.ts
@@ -1,0 +1,26 @@
+/** Recognize the managed feed's missing-manifest response without exposing its HTTP body. */
+export function isMissingUpdateManifest(error: { message?: string } | null | undefined): boolean {
+  const message = error?.message ?? ''
+  if (!message.startsWith('503 ')) return false
+
+  const descriptionStart = message.indexOf('\n')
+  const descriptionEnd = message.indexOf('\nHeaders: ')
+  if (descriptionStart === -1 || descriptionEnd <= descriptionStart) return false
+
+  try {
+    // builder-util-runtime JSON-encodes the description in message; unlike custom
+    // HttpError fields, message survives Electron's Error serialization.
+    const description: unknown = JSON.parse(message.slice(descriptionStart + 1, descriptionEnd))
+    if (typeof description !== 'string') return false
+
+    const match = /^method: GET url: https:\/\/releases\.cherry-ai\.com\/[^\s]+\n\s*Data:\s*([\s\S]+)$/.exec(
+      description
+    )
+    if (!match) return false
+
+    const body = JSON.parse(match[1]) as { error?: { code?: unknown } } | null
+    return body?.error?.code === 'manifest_missing'
+  } catch {
+    return false
+  }
+}

--- a/src/shared/utils/updateError.ts
+++ b/src/shared/utils/updateError.ts
@@ -1,6 +1,10 @@
+const MAX_UPDATE_ERROR_MESSAGE_LENGTH = 64 * 1024
+
 /** Recognize the managed feed's missing-manifest response without exposing its HTTP body. */
-export function isMissingUpdateManifest(error: { message?: string } | null | undefined): boolean {
-  const message = error?.message ?? ''
+export function isMissingUpdateManifest(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('message' in error)) return false
+  const message = error.message
+  if (typeof message !== 'string' || message.length > MAX_UPDATE_ERROR_MESSAGE_LENGTH) return false
   if (!message.startsWith('503 ')) return false
 
   const descriptionStart = message.indexOf('\n')

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-04-missing-update-manifest-handling.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-04-missing-update-manifest-handling.md
@@ -1,0 +1,19 @@
+---
+title: Update checks explain missing release manifests
+category: changed
+severity: notice
+introduced_in_pr: "#20003"
+date: 2026-09-04
+---
+
+## What changed
+
+When the managed update feed returns `manifest_missing`, automatic checks use the normal four-hour cadence with existing jitter. Manual checks explain that a published update is unavailable; they do not report the installation as up to date.
+
+## Why this matters to the user
+
+The client makes fewer requests while release metadata is unavailable. Automatic discovery after the feed is repaired can take up to 4.6 hours; other errors retain their existing retry behavior.
+
+## What the user should do
+
+Nothing — automatic. Use Check for Updates to retry immediately. Release-service configuration still needs to be corrected by its operator.


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Managed-feed `503 / manifest_missing` failures enter the 5–60 minute retry loop. Manual checks on the reproduced CN Beta/macOS path show the generic update error because the real error message misses the existing unpublished-release heuristic.

After this PR:

- Confirmed managed-feed `manifest_missing` responses keep the normal four-hour schedule with existing jitter. Manual retries and error reporting remain available; no “up to date” event is emitted.
- Manual checks reuse the existing unpublished-update explanation. Background checks continue to avoid popups.
- A shared, dependency-free predicate recognizes the structured response in the `HttpError.message` envelope preserved across Electron IPC. HTML, incidental mentions of the code, other hosts and unrelated errors do not qualify.
- `edition_mismatch`, 404s, network failures and other error codes retain their existing retry handling.

Related to #19999. This is a client-side follow-up, not a fix for release-service target selection. Please keep the issue open for the server-side work.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Fewer repeated requests while release metadata is missing, at the cost of automatic discovery taking up to 4.6 hours after the feed is repaired. Manual checks remain immediate.
- Parse the SDK's encoded description and exact JSON error code instead of matching a substring. Both processes use the same predicate; no IPC schema, dependency, setting or service is added.
- Retain the existing error event and logging. A missing manifest is not a successful “no update” result.

The following alternatives were considered:

- Cross-edition/website-policy fallback: outside the client contract; the release service owns rollout and target selection.
- Classify every 503, or also change 404/`edition_mismatch`: outside this narrow scope. In particular, the current SDK discards 404 response bodies.
- Post-publish feed monitoring: useful separate follow-up, not included here.

Links to places where the discussion took place: #19999. This PR proposes the client scope for maintainer feedback; it does not imply prior approval.

### Breaking changes

None to configuration or APIs. Automatic retry timing changes only for recognized `manifest_missing` responses; the recovery-latency tradeoff is documented in `docs/contrib/app-upgrade.md` and the user-facing change notice.

### Special notes for your reviewer

Validation on Node 24.14.0 / pnpm 11.8.0:

- RED: the new scheduler/hook regressions produced 3 intended failures and 23 passes before the fix. RED/GREEN evidence is preserved in the squashed commit message.
- GREEN: 50 tests pass across `AppUpdaterService.test.ts`, `AppUpdaterService.scheduler.test.ts`, `useAppUpdateHandler.test.ts` and `useAppUpdateHandler.lazy.test.ts`.
- Affected-file coverage: 98.14% lines, 88.4% branches; the new predicate has 100% line coverage.
- `pnpm lint` passes, including typecheck, i18n and formatting; it reports existing warnings in untouched files. `pnpm docs:check` and `pnpm build:cn` pass.
- A live managed-feed error produced by `builder-util-runtime@9.5.0` is recognized before and after `structuredClone`; its custom `description` field is lost, but `message` survives.

The pre-fix issue was reproduced in the official CN 2.0.11 GUI. Post-change verification here consists of regression tests, the live-error serialization check and the CN build; a new packaged-GUI run and successful update installation are not claimed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Updates] Explain missing release manifests during manual checks and use the normal automatic-check interval while they are unavailable. Manual retry remains available.
```
