### PR TITLE
fix(message-tokens): distinguish unavailable usage

### DIFF
--- a/src/renderer/components/chat/messages/frame/MessageTokenDetailsCard.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokenDetailsCard.tsx
@@ -218,7 +218,9 @@ const MessageTokenDetailsCard = ({
   const createdAtLabel = Number.isFinite(createdAt) ? dateFormatter.format(new Date(createdAt)) : undefined
   const formatTokens = (value: number) =>
     t('chat.message.token_details.tokens', { value: numberFormatter.format(value) })
-  const formatOptionalTokens = (value: number | undefined) => (value === undefined ? '—' : formatTokens(value))
+  const unavailableLabel = t('chat.message.token_details.unavailable')
+  const formatOptionalTokens = (value: number | undefined) =>
+    value === undefined ? unavailableLabel : formatTokens(value)
   const formatMilliseconds = durationFormatter
   const costLabel = stats.costs
     ?.map((cost) =>
@@ -243,7 +245,7 @@ const MessageTokenDetailsCard = ({
         : undefined
   const speedLabel =
     performance.modelTokensPerSecond === undefined
-      ? '—'
+      ? unavailableLabel
       : t('chat.message.token_details.tokens_per_second_value', {
           value: decimalFormatter.format(performance.modelTokensPerSecond)
         })

--- a/src/renderer/components/chat/messages/frame/MessageTokenDetailsCard.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokenDetailsCard.tsx
@@ -12,6 +12,7 @@ import type { MessageListItem } from '../types'
 import { getMessageListItemModel } from '../utils/messageListItem'
 import {
   buildMessagePerformanceViewModel,
+  getMessageTokenUsage,
   type MessagePerformanceLaneId,
   type MessagePerformanceViewModel
 } from './messagePerformance'
@@ -207,9 +208,8 @@ const MessageTokenDetailsCard = ({
     return null
   }
 
-  const inputTokens = stats.inputTokens ?? 0
-  const outputTokens = stats.outputTokens ?? 0
-  const reasoningTokens = Math.min(Math.max(stats.outputTokenDetails?.reasoningTokens ?? 0, 0), outputTokens)
+  const { inputTokens, outputTokens } = getMessageTokenUsage(stats)
+  const reasoningTokens = Math.min(Math.max(stats.outputTokenDetails?.reasoningTokens ?? 0, 0), outputTokens ?? 0)
   const cacheReadTokens = stats.inputTokenDetails?.cacheReadTokens ?? 0
   const cacheWriteTokens = stats.inputTokenDetails?.cacheWriteTokens ?? 0
   const noCacheTokens = stats.inputTokenDetails?.noCacheTokens ?? 0
@@ -218,6 +218,7 @@ const MessageTokenDetailsCard = ({
   const createdAtLabel = Number.isFinite(createdAt) ? dateFormatter.format(new Date(createdAt)) : undefined
   const formatTokens = (value: number) =>
     t('chat.message.token_details.tokens', { value: numberFormatter.format(value) })
+  const formatOptionalTokens = (value: number | undefined) => (value === undefined ? '—' : formatTokens(value))
   const formatMilliseconds = durationFormatter
   const costLabel = stats.costs
     ?.map((cost) =>
@@ -346,12 +347,12 @@ const MessageTokenDetailsCard = ({
           <PrimaryMetric
             testId="message-metric-input"
             label={t('chat.message.token_details.input')}
-            value={formatTokens(inputTokens)}
+            value={formatOptionalTokens(inputTokens)}
           />
           <PrimaryMetric
             testId="message-metric-output"
             label={t('chat.message.token_details.output')}
-            value={formatTokens(outputTokens)}
+            value={formatOptionalTokens(outputTokens)}
           />
           <PrimaryMetric
             testId="message-metric-speed"

--- a/src/renderer/components/chat/messages/frame/MessageTokens.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokens.tsx
@@ -156,7 +156,8 @@ const MessageTokens: FC<MessageTokensProps> = ({ message }) => {
 
   const totalTokens = getMessageTokenUsage(stats).totalTokens
   const tokenLabel = t('chat.message.token_details.tokens', {
-    value: totalTokens === undefined ? '—' : compactFormatter.format(totalTokens)
+    value:
+      totalTokens === undefined ? t('chat.message.token_details.unavailable') : compactFormatter.format(totalTokens)
   })
   const locateMessage = () => actions.locateMessage?.(message.id, false)
 

--- a/src/renderer/components/chat/messages/frame/MessageTokens.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokens.tsx
@@ -1,21 +1,16 @@
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@cherrystudio/ui'
 import { useInfiniteFlatItems, useInfiniteQuery } from '@renderer/data/hooks/useDataApi'
-import type { MessageStats } from '@shared/data/types/message'
 import type { FC, MouseEvent } from 'react'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useMessageListActions, useMessageListMeta } from '../MessageListProvider'
 import type { MessageListItem } from '../types'
-import { getMessageModelTokensPerSecond } from './messagePerformance'
+import { getMessageModelTokensPerSecond, getMessageTokenUsage } from './messagePerformance'
 import MessageTokenDetailsCard from './MessageTokenDetailsCard'
 
 interface MessageTokensProps {
   message: MessageListItem
-}
-
-function getTotalTokens(stats: MessageStats): number {
-  return stats.totalTokens ?? (stats.inputTokens ?? 0) + (stats.outputTokens ?? 0)
 }
 
 function UserMessageTokens({ label, onLocate }: { label: string; onLocate: () => void }) {
@@ -159,8 +154,10 @@ const MessageTokens: FC<MessageTokensProps> = ({ message }) => {
     return null
   }
 
-  const totalTokens = getTotalTokens(stats)
-  const tokenLabel = t('chat.message.token_details.tokens', { value: compactFormatter.format(totalTokens) })
+  const totalTokens = getMessageTokenUsage(stats).totalTokens
+  const tokenLabel = t('chat.message.token_details.tokens', {
+    value: totalTokens === undefined ? '—' : compactFormatter.format(totalTokens)
+  })
   const locateMessage = () => actions.locateMessage?.(message.id, false)
 
   if (message.role === 'user') {

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
@@ -63,6 +63,7 @@ const translations: Record<string, string> = {
   'chat.message.token_details.tokens_per_second_value': '{{value}} Tokens/s',
   'chat.message.token_details.total_duration': 'End-to-end duration',
   'chat.message.token_details.uncached': 'Uncached',
+  'chat.message.token_details.unavailable': 'Not available',
   'chat.message.token_details.usage': 'Token usage',
   'chat.message.token_details.waiting_first_token': 'Waiting',
   'common.loading': 'Loading...'
@@ -190,7 +191,7 @@ describe('MessageTokens', () => {
     expect(screen.getByRole('button', { name: '3.3K Tokens' })).toHaveClass('message-tokens')
   })
 
-  it('shows unavailable instead of a false zero when a completed runtime reports empty token counters', () => {
+  it('shows localized unavailable values without false throughput for empty runtime token counters', () => {
     renderWithProvider(
       createMessage('assistant', {
         inputTokens: 0,
@@ -200,8 +201,10 @@ describe('MessageTokens', () => {
       })
     )
 
-    expect(screen.getByRole('button', { name: '— Tokens' })).toHaveClass('message-tokens')
+    expect(screen.getByRole('button', { name: 'Not available Tokens' })).toHaveClass('message-tokens')
     expect(screen.queryByRole('button', { name: '0 Tokens' })).not.toBeInTheDocument()
+    openDetails()
+    expect(getDetailsCard()).not.toHaveTextContent('End-to-end throughput')
   })
 
   it('shows unavailable after reloading an Agent message with cost but no token counts', () => {
@@ -237,9 +240,9 @@ describe('MessageTokens', () => {
 
     openDetails()
 
-    expect(screen.getByRole('button', { name: '— Tokens' })).toHaveClass('message-tokens')
-    expect(screen.getByTestId('message-metric-input')).toHaveTextContent('Input—')
-    expect(screen.getByTestId('message-metric-output')).toHaveTextContent('Output—')
+    expect(screen.getByRole('button', { name: 'Not available Tokens' })).toHaveClass('message-tokens')
+    expect(screen.getByTestId('message-metric-input')).toHaveTextContent('InputNot available')
+    expect(screen.getByTestId('message-metric-output')).toHaveTextContent('OutputNot available')
     expect(screen.getByTestId('message-cost')).toHaveTextContent('$0.0123')
   })
 
@@ -406,7 +409,7 @@ describe('MessageTokens', () => {
     const trigger = screen.getByRole('button', { name: '12 Tokens' })
     expect(trigger).toHaveClass('message-tokens')
 
-    expect(screen.getByTestId('message-metric-speed')).toHaveTextContent('Model generation TPS—')
+    expect(screen.getByTestId('message-metric-speed')).toHaveTextContent('Model generation TPSNot available')
     expect(getDetailsCard()).not.toHaveTextContent(/Tokens\/s/)
   })
 

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
@@ -1,12 +1,15 @@
 import '@testing-library/jest-dom/vitest'
 
 import type * as CherryStudioUi from '@cherrystudio/ui'
+import { toAgentSessionUIMessage } from '@renderer/hooks/useAgentSessionParts'
 import type { Topic } from '@renderer/types/topic'
+import type { AgentSessionMessageEntity } from '@shared/data/types/agent'
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MessageListProvider } from '../../MessageListProvider'
 import { defaultMessageRenderConfig, type MessageListItem, type MessageListProviderValue } from '../../types'
+import { toMessageListItem } from '../../utils/messageListItem'
 import MessageTokens from '../MessageTokens'
 
 const dataApiMocks = vi.hoisted(() => ({
@@ -35,6 +38,9 @@ vi.mock('@renderer/hooks/useProvider', () => ({
 const translations: Record<string, string> = {
   'chat.message.token_details.cache_read': 'Cache read',
   'chat.message.token_details.cache_write': 'Cache write',
+  'chat.message.token_details.cost': 'Cost',
+  'chat.message.token_details.cost_billed': 'Billed by provider',
+  'chat.message.token_details.cost_estimated': 'Estimated',
   'chat.message.token_details.end_to_end_throughput': 'End-to-end throughput',
   'chat.message.token_details.input': 'Input',
   'chat.message.token_details.input_breakdown': 'Input breakdown',
@@ -177,12 +183,64 @@ describe('MessageTokens', () => {
     renderWithProvider(
       createMessage('assistant', {
         inputTokens: 1234,
-        outputTokens: 2048,
-        totalTokens: 3282
+        outputTokens: 2048
       })
     )
 
     expect(screen.getByRole('button', { name: '3.3K Tokens' })).toHaveClass('message-tokens')
+  })
+
+  it('shows unavailable instead of a false zero when a completed runtime reports empty token counters', () => {
+    renderWithProvider(
+      createMessage('assistant', {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        runtimeTiming: { startedAt: 1_000, completedAt: 2_000, spans: [] }
+      })
+    )
+
+    expect(screen.getByRole('button', { name: '— Tokens' })).toHaveClass('message-tokens')
+    expect(screen.queryByRole('button', { name: '0 Tokens' })).not.toBeInTheDocument()
+  })
+
+  it('shows unavailable after reloading an Agent message with cost but no token counts', () => {
+    const row = {
+      id: 'agent-message-1',
+      sessionId: 'agent-session-1',
+      role: 'assistant',
+      data: { parts: [{ type: 'text', text: 'Completed' }] },
+      searchableText: 'Completed',
+      status: 'success',
+      modelId: 'claude-code::claude-sonnet-4-5',
+      messageSnapshot: null,
+      stats: {
+        requestCount: 1,
+        costs: [
+          {
+            currency: 'USD',
+            amount: 0.0123,
+            providerReportedRequestCount: 1,
+            computedRequestCount: 0
+          }
+        ],
+        runtimeTiming: { startedAt: 1_000, completedAt: 2_000, spans: [] }
+      },
+      runtimeResumeToken: 'claude-session-1',
+      delivery: null,
+      createdAt: '2026-09-04T00:00:00.000Z',
+      updatedAt: '2026-09-04T00:00:01.000Z'
+    } as AgentSessionMessageEntity
+    const reloadedMessage = toMessageListItem(toAgentSessionUIMessage(row), { topicId: row.sessionId })
+
+    renderWithProvider(reloadedMessage, 'agent-session')
+
+    openDetails()
+
+    expect(screen.getByRole('button', { name: '— Tokens' })).toHaveClass('message-tokens')
+    expect(screen.getByTestId('message-metric-input')).toHaveTextContent('Input—')
+    expect(screen.getByTestId('message-metric-output')).toHaveTextContent('Output—')
+    expect(screen.getByTestId('message-cost')).toHaveTextContent('$0.0123')
   })
 
   it('loads the first invocation page when the card opens and defers full pagination until expansion', () => {

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
@@ -197,6 +197,7 @@ describe('MessageTokens', () => {
         inputTokens: 0,
         outputTokens: 0,
         totalTokens: 0,
+        providerPerformance: { measuredOutputTokens: 0, generationDurationMs: 1_000 },
         runtimeTiming: { startedAt: 1_000, completedAt: 2_000, spans: [] }
       })
     )
@@ -204,6 +205,8 @@ describe('MessageTokens', () => {
     expect(screen.getByRole('button', { name: 'Not available Tokens' })).toHaveClass('message-tokens')
     expect(screen.queryByRole('button', { name: '0 Tokens' })).not.toBeInTheDocument()
     openDetails()
+    expect(getDetailsCard()).not.toHaveTextContent('0 Tokens/s')
+    expect(screen.getByTestId('message-metric-speed')).toHaveTextContent('Model generation TPSNot available')
     expect(getDetailsCard()).not.toHaveTextContent('End-to-end throughput')
   })
 

--- a/src/renderer/components/chat/messages/frame/__tests__/messagePerformance.test.ts
+++ b/src/renderer/components/chat/messages/frame/__tests__/messagePerformance.test.ts
@@ -98,6 +98,20 @@ describe('message performance view model', () => {
     expect(view.intervals.some((interval) => interval.id.endsWith('2'))).toBe(false)
   })
 
+  it('omits end-to-end throughput when the runtime produced no output tokens', () => {
+    const view = buildMessagePerformanceViewModel({
+      inputTokens: 100,
+      outputTokens: 0,
+      runtimeTiming: {
+        startedAt: 1_000,
+        completedAt: 2_000,
+        spans: []
+      }
+    })
+
+    expect(view.endToEndTokensPerSecond).toBeUndefined()
+  })
+
   it('keeps parallel spans overlapping instead of adding them into percentages', () => {
     const view = buildMessagePerformanceViewModel({
       runtimeTiming: {

--- a/src/renderer/components/chat/messages/frame/messagePerformance.ts
+++ b/src/renderer/components/chat/messages/frame/messagePerformance.ts
@@ -21,6 +21,17 @@ export interface MessagePerformanceViewModel {
   intervals: MessagePerformanceInterval[]
 }
 
+export function getMessageTokenUsage(stats: MessageStats) {
+  const inputTokens = stats.inputTokens
+  const outputTokens = stats.outputTokens
+  const componentTotal =
+    inputTokens !== undefined || outputTokens !== undefined ? (inputTokens ?? 0) + (outputTokens ?? 0) : undefined
+  const totalTokens = stats.totalTokens !== undefined && stats.totalTokens > 0 ? stats.totalTokens : componentTotal
+
+  if (![inputTokens, outputTokens, totalTokens].some((value) => value !== undefined && value > 0)) return {}
+  return { inputTokens, outputTokens, totalTokens }
+}
+
 function intervalFromRuntimeSpan(span: MessageRuntimeSpan, rangeEnd: number): MessagePerformanceInterval | undefined {
   const completedAt = span.completedAt ?? rangeEnd
   if (completedAt <= span.startedAt) return undefined

--- a/src/renderer/components/chat/messages/frame/messagePerformance.ts
+++ b/src/renderer/components/chat/messages/frame/messagePerformance.ts
@@ -125,7 +125,10 @@ function buildRuntimeViewModel(
   )
   const timeFirstTokenMs = firstTokenRecord?.timeFirstTokenMs ?? undefined
   const modelTokensPerSecond =
-    measuredOutputTokens !== undefined && generationDuration !== undefined && generationDuration > 0
+    measuredOutputTokens !== undefined &&
+    measuredOutputTokens > 0 &&
+    generationDuration !== undefined &&
+    generationDuration > 0
       ? measuredOutputTokens / (generationDuration / 1000)
       : undefined
   const totalDurationMs =
@@ -216,7 +219,7 @@ export function getMessageModelTokensPerSecond(stats: MessageStats): number | un
   if (stats.runtimeTiming) {
     const outputTokens = stats.providerPerformance?.measuredOutputTokens
     const durationMs = stats.providerPerformance?.generationDurationMs
-    return outputTokens !== undefined && durationMs !== undefined && durationMs > 0
+    return outputTokens !== undefined && outputTokens > 0 && durationMs !== undefined && durationMs > 0
       ? outputTokens / (durationMs / 1000)
       : undefined
   }

--- a/src/renderer/components/chat/messages/frame/messagePerformance.ts
+++ b/src/renderer/components/chat/messages/frame/messagePerformance.ts
@@ -130,9 +130,10 @@ function buildRuntimeViewModel(
       : undefined
   const totalDurationMs =
     runtime.completedAt !== undefined ? Math.max(0, runtime.completedAt - runtime.startedAt) : undefined
+  const outputTokens = getMessageTokenUsage(stats).outputTokens
   const endToEndTokensPerSecond =
-    totalDurationMs !== undefined && totalDurationMs > 0 && stats.outputTokens !== undefined
-      ? stats.outputTokens / (totalDurationMs / 1000)
+    totalDurationMs !== undefined && totalDurationMs > 0 && outputTokens !== undefined
+      ? outputTokens / (totalDurationMs / 1000)
       : undefined
   const measuredIntervals = [...modelIntervals, ...runtimeIntervals]
 

--- a/src/renderer/components/chat/messages/frame/messagePerformance.ts
+++ b/src/renderer/components/chat/messages/frame/messagePerformance.ts
@@ -135,7 +135,7 @@ function buildRuntimeViewModel(
     runtime.completedAt !== undefined ? Math.max(0, runtime.completedAt - runtime.startedAt) : undefined
   const outputTokens = getMessageTokenUsage(stats).outputTokens
   const endToEndTokensPerSecond =
-    totalDurationMs !== undefined && totalDurationMs > 0 && outputTokens !== undefined
+    totalDurationMs !== undefined && totalDurationMs > 0 && outputTokens !== undefined && outputTokens > 0
       ? outputTokens / (totalDurationMs / 1000)
       : undefined
   const measuredIntervals = [...modelIntervals, ...runtimeIntervals]

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/s",
   "chat.message.token_details.total_duration": "Gesamtdauer",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Nicht zwischengespeichert",
   "chat.message.token_details.usage": "Token-Nutzung",
   "chat.message.token_details.waiting_first_token": "Wartend",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "Μάρκες {{value}}",
   "chat.message.token_details.tokens_per_second_value": "{{value}} token/δ",
   "chat.message.token_details.total_duration": "Διάρκεια από άκρο σε άκρο",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Χωρίς προσωρινή αποθήκευση",
   "chat.message.token_details.usage": "Χρήση token",
   "chat.message.token_details.waiting_first_token": "Αναμονή",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Tokens/s",
   "chat.message.token_details.total_duration": "End-to-end duration",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Uncached",
   "chat.message.token_details.usage": "Token usage",
   "chat.message.token_details.waiting_first_token": "Waiting",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Tokens/s",
   "chat.message.token_details.total_duration": "Duración de extremo a extremo",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Sin caché",
   "chat.message.token_details.usage": "Uso de tokens",
   "chat.message.token_details.waiting_first_token": "Esperando",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Jetons",
   "chat.message.token_details.tokens_per_second_value": "{{value}} jetons/s",
   "chat.message.token_details.total_duration": "Durée de bout en bout",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Non mis en cache",
   "chat.message.token_details.usage": "Utilisation des jetons",
   "chat.message.token_details.waiting_first_token": "En attente",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} トークン",
   "chat.message.token_details.tokens_per_second_value": "{{value}} トークン/秒",
   "chat.message.token_details.total_duration": "エンドツーエンドの期間",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "キャッシュされていない",
   "chat.message.token_details.usage": "トークン使用量",
   "chat.message.token_details.waiting_first_token": "待機",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Tokens/s",
   "chat.message.token_details.total_duration": "Duração de ponta a ponta",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Não em cache",
   "chat.message.token_details.usage": "Uso de tokens",
   "chat.message.token_details.waiting_first_token": "A aguardar",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Jetoane",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Tokeni/s",
   "chat.message.token_details.total_duration": "Durată de la capăt la capăt",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Necached/Necacheuit",
   "chat.message.token_details.usage": "Utilizare token-uri",
   "chat.message.token_details.waiting_first_token": "Așteptare",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Токенов",
   "chat.message.token_details.tokens_per_second_value": "{{value}} токенов/с",
   "chat.message.token_details.total_duration": "Продолжительность от начала до конца",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Не кэшированный",
   "chat.message.token_details.usage": "Использование токенов",
   "chat.message.token_details.waiting_first_token": "Ожидание",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Token",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/s",
   "chat.message.token_details.total_duration": "Uçtan uca süre",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Önbelleğe alınmamış",
   "chat.message.token_details.usage": "Token kullanımı",
   "chat.message.token_details.waiting_first_token": "Bekleme",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Mã thông báo",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/giây",
   "chat.message.token_details.total_duration": "Thời lượng từ đầu đến cuối",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "Chưa lưu vào bộ nhớ đệm",
   "chat.message.token_details.usage": "Sử dụng token",
   "chat.message.token_details.waiting_first_token": "Đang chờ",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Tokens",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/秒",
   "chat.message.token_details.total_duration": "端到端耗时",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "未缓存",
   "chat.message.token_details.usage": "Token 使用",
   "chat.message.token_details.waiting_first_token": "等待",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -728,6 +728,7 @@
   "chat.message.token_details.tokens": "{{value}} Token",
   "chat.message.token_details.tokens_per_second_value": "{{value}} Token/秒",
   "chat.message.token_details.total_duration": "端到端持續時間",
+  "chat.message.token_details.unavailable": "—",
   "chat.message.token_details.uncached": "未快取",
   "chat.message.token_details.usage": "Token 使用量",
   "chat.message.token_details.waiting_first_token": "等待",


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Completed Claude Code Agent messages displayed `0 Tokens` when the runtime emitted empty token counters or when a reloaded usage projection contained cost but no token counts. The token detail card also presented missing input and output counts as confirmed zeros.

After this PR:

The message footer and detail card distinguish unavailable token usage from real reported counts. Empty counters and missing persisted token fields render as an em dash, while non-zero and partial input/output reports continue to use their actual or derived total. Recorded cost remains visible and is never converted into an estimated token count.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19965

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix stays in the shared token presentation path because both live Claude Code metadata and durable Agent-session rows can legitimately lack token counts. A single normalization keeps the compact label and exact detail metrics consistent without changing persisted usage facts.

The following alternatives were considered:

- Deriving token counts from the recorded model cost was rejected because pricing and cache behavior do not provide a reliable inverse calculation.
- Writing synthetic token values during persistence was rejected because it would turn unavailable data into durable false facts and would not repair existing rows after restart.

Links to places where the discussion took place: #19965

### Breaking changes

None.

### Special notes for your reviewer

- Regression proof: both the completed-runtime zero-counter case and the DataApi-reloaded Agent message case failed before the production fix.
- Focused renderer tests: 36/36 passed across `MessageTokens`, message performance, Agent-session projection, and the Agent message-list adapter.
- `pnpm lint` and `pnpm test:lint` passed.
- Commit `0077b76342` is signed, DCO-signed-off, and GitHub reports `Verified`.
- UI verification completed in the isolated `CherryStudioPR20011Visual` profile against the same persisted Agent message on the parent and PR head.

### UI verification

#### Before

<img width="960" height="600" alt="Before: unavailable usage incorrectly renders as 0 Tokens" src="https://github.com/user-attachments/assets/4e8f2e37-969f-40f4-b3a6-cf6de267ed67" />

#### After

<img width="960" height="600" alt="After: unavailable usage renders as an em dash" src="https://github.com/user-attachments/assets/3defff47-bf31-474e-ab75-cf7ea7c07403" />

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Completed Agent sessions now show unavailable token usage instead of a misleading zero when the runtime did not report token counts.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in chat token/performance UI with no persistence or billing logic changes.
> 
> **Overview**
> Message token labels and the detail card now treat **missing or all-zero** usage as unavailable (localized em dash) instead of showing **0 Tokens** or implied throughput.
> 
> A shared **`getMessageTokenUsage`** helper centralizes this in the message footer and hover card; **recorded cost still displays** when token counts are absent (e.g. reloaded Agent session rows). **Model and end-to-end TPS** are suppressed when measured or reported output is zero, so empty runtime counters no longer produce **0 Tokens/s**.
> 
> New **`chat.message.token_details.unavailable`** strings were added across locales; tests cover zero-counter runtimes and Agent reload-with-cost scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f955e4a961172efcc444a0c06d775664fdf756a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->