### PR TITLE
fix(deepseek-harness): support authenticated ready URLs

### DIFF
--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -352,19 +352,52 @@ function sanitizeDiagnostic(value: string, secret?: string): string {
 }
 
 function parseReadyUrl(output: string): string | undefined {
-  const match = /^dsh web: (http:\/\/127\.0\.0\.1:(\d{1,5}))(?:\s|$)/m.exec(output)
-  if (!match) return undefined
-  const port = Number(match[2])
-  if (!Number.isInteger(port) || port < 1 || port > 65535) return undefined
-  const url = new URL(match[1])
-  if (url.protocol !== 'http:' || url.hostname !== '127.0.0.1' || url.pathname !== '/') return undefined
-  return url.toString().replace(/\/$/, '')
+  for (const match of output.matchAll(/^dsh web: (\S+)\r?\n/gm)) {
+    const candidate = match[1]
+    const address = /^http:\/\/127\.0\.0\.1:([1-9]\d{0,4})/.exec(candidate)
+    if (!address) continue
+    const port = Number(address[1])
+    if (port > 65535) continue
+
+    try {
+      const url = new URL(candidate)
+      if (
+        url.protocol !== 'http:' ||
+        url.hostname !== '127.0.0.1' ||
+        url.username ||
+        url.password ||
+        url.pathname !== '/' ||
+        url.hash
+      ) {
+        continue
+      }
+
+      const baseUrl = `http://127.0.0.1:${address[1]}`
+      if (!url.search) {
+        if (candidate !== baseUrl && candidate !== `${baseUrl}/`) continue
+        return baseUrl
+      }
+
+      const params = [...url.searchParams]
+      const token = params.length === 1 && params[0][0] === 'token' ? params[0][1] : undefined
+      if (!token || !/^[A-Za-z0-9_-]{43}$/.test(token) || candidate !== `${baseUrl}/?token=${token}`) continue
+      return candidate
+    } catch {
+      continue
+    }
+  }
+  return undefined
 }
 
 async function assertWebReady(url: string): Promise<void> {
-  const response = await fetch(`${url}/`, { redirect: 'manual', signal: AbortSignal.timeout(5000) })
+  const readyUrl = new URL(url)
+  const response = await fetch(readyUrl.toString(), { redirect: 'manual', signal: AbortSignal.timeout(5000) })
   await response.body?.cancel()
-  if (response.status !== 200) throw new Error(`DeepSeek Harness Web UI returned HTTP ${response.status}`)
+  const exchangedToken =
+    readyUrl.searchParams.has('token') && response.status === 303 && response.headers.get('location') === '/'
+  if (response.status !== 200 && !exchangedToken) {
+    throw new Error(`DeepSeek Harness Web UI returned HTTP ${response.status}`)
+  }
 }
 
 function waitForReady(child: ChildProcess, secret: string, signal: AbortSignal): Promise<string> {

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -25,7 +25,8 @@ const mocks = vi.hoisted(() => ({
   gatewayStart: vi.fn(),
   gatewayEnsureKey: vi.fn(),
   gatewayGetConfig: vi.fn(),
-  broadcast: vi.fn()
+  broadcast: vi.fn(),
+  loggerWarn: vi.fn()
 }))
 
 vi.mock('node:child_process', async (importOriginal) => ({
@@ -56,7 +57,7 @@ vi.mock('@main/utils/shellEnv', () => ({
   refreshShellEnv: vi.fn(async () => ({ PATH: '/managed/bin' }))
 }))
 vi.mock('@logger', () => ({
-  loggerService: { withContext: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) }
+  loggerService: { withContext: () => ({ info: vi.fn(), warn: mocks.loggerWarn, error: vi.fn(), debug: vi.fn() }) }
 }))
 vi.mock('../config', async () => {
   const actual = await vi.importActual<typeof DeepSeekHarnessConfigModule>('../config')
@@ -220,6 +221,80 @@ describe('DeepSeekHarnessService', () => {
     expect(mocks.spawn.mock.calls[0][2].env).toHaveProperty('DSH_PERMISSION_MODE', 'workspace-write')
     expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:43123/', expect.anything())
     await service.stop()
+  })
+
+  it('probes and returns the complete authenticated URL printed by dsh 0.1.2-rc.1', async () => {
+    vi.useFakeTimers()
+    const token = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ'
+    const readyUrl = `http://127.0.0.1:43123/?token=${token}`
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 303,
+      headers: new Headers({ location: '/' }),
+      body: { cancel: vi.fn(async () => undefined) }
+    } as unknown as Response)
+    spawnChild((child) => {
+      child.stdout.write('dsh web: http://127.0.0.1:43123/?token=abcdefghijklmnop')
+      child.stdout.write('qrstuvwxyzABCDEFGHIJKLMNOPQ\n')
+    })
+    const service = new DeepSeekHarnessService()
+    const start = service.start(startInput)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    await expect(start).resolves.toEqual({ success: true, url: readyUrl })
+    expect(fetch).toHaveBeenCalledWith(readyUrl, expect.objectContaining({ redirect: 'manual' }))
+    await service.stop()
+  })
+
+  it.each([
+    'https://127.0.0.1:43123/?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ',
+    'http://localhost:43123/?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ',
+    'http://2130706433:43123/?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ',
+    'http://127.0.0.1:0/?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ',
+    'http://127.0.0.1:65536/?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ',
+    'http://127.0.0.1:43123/admin?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ',
+    'http://127.0.0.1:43123/?token=',
+    'http://127.0.0.1:43123/?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&token=duplicate',
+    'http://127.0.0.1:43123/?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&debug=true',
+    'http://127.0.0.1:43123/?token=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ#fragment'
+  ])('rejects an unsafe ready URL: %s', async (readyUrl) => {
+    spawnChild((child) => {
+      child.stdout.write(`dsh web: ${readyUrl}\n`)
+      queueMicrotask(() => child.close(1, null))
+    })
+
+    await expect(new DeepSeekHarnessService().start(startInput)).resolves.toMatchObject({ success: false })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not accept an unauthenticated 401 response as readiness', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 401,
+      body: { cancel: vi.fn(async () => undefined) }
+    } as unknown as Response)
+    spawnChild((child) => child.stdout.write('dsh web: http://127.0.0.1:43123\n'))
+
+    const result = await new DeepSeekHarnessService().start(startInput)
+
+    expect(result).toEqual({
+      success: false,
+      message: expect.stringContaining('Web UI returned HTTP 401')
+    })
+  })
+
+  it('redacts the launch token from startup diagnostics and process-error logs', async () => {
+    const token = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ'
+    const readyUrl = `http://127.0.0.1:43123/?token=${token}`
+    vi.mocked(fetch).mockRejectedValueOnce(new Error(`request failed for ${readyUrl}`))
+    const child = spawnChild((process) => process.stdout.write(`dsh web: ${readyUrl}\n`))
+    const result = await new DeepSeekHarnessService().start(startInput)
+    child.emit('error', new Error(`socket failed for ${readyUrl}`))
+
+    expect(result).toEqual({ success: false, message: expect.stringContaining('<redacted>') })
+    expect(JSON.stringify(result)).not.toContain(token)
+    const logged = JSON.stringify(mocks.loggerWarn.mock.calls)
+    expect(logged).toContain('<redacted>')
+    expect(logged).not.toContain(token)
   })
 
   it('restarts only the managed child when its launch permission changes', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Cherry only parsed a bare `http://127.0.0.1:<port>` ready URL from `dsh web` and probed the unauthenticated root. DeepSeek Harness 0.1.2-rc.1 prints a token-bearing URL and rejects anonymous requests, so managed startup always timed out.

After this PR:

Cherry preserves the authenticated loopback URL printed by DeepSeek Harness, probes that exact URL, accepts its documented token exchange redirect, and returns the same URL to the embedded UI. Legacy tokenless ready URLs remain supported.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20000

### Why we need it and why it was done in this way

DeepSeek Harness 0.1.2-rc.1 emits a 43-character base64url process token as the sole query parameter. Its first authenticated root request responds with `303 Location: /` while setting the browser cookie; an anonymous root request returns 401.

The following tradeoffs were made:

- Ready URLs are limited to HTTP on the literal `127.0.0.1`, an explicit valid port, the root path, and either no query or exactly one valid launch token.
- The readiness probe recognizes the authenticated 303 exchange without treating an anonymous 401 as success.
- Tokenless HTTP 200 behavior remains available for older DeepSeek Harness versions.

The following alternatives were considered:

- Treating HTTP 401 as ready was rejected because it would return an unusable tokenless URL to the UI.
- Removing query validation was rejected because the child process output crosses into an embedded browser navigation boundary.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

- https://github.com/CherryHQ/cherry-studio/issues/20000
- https://github.com/deepseek-ai/deepseek-harness

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Validation completed:

- Regression test failed before the implementation because the rc.1 token URL timed out, then passed after the fix.
- `pnpm test:main src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts` (35 tests)
- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`

The tests cover split stdout chunks, the authenticated 303 exchange, rejection of non-loopback/HTTPS/invalid-port/non-root/invalid-query URLs, refusal of anonymous 401 responses, and token redaction from diagnostics and process-error logs.

This changes only the main-process startup handshake and has no visual layout change, so an Electron instance and UI screenshots are not applicable.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
DeepSeek Harness Web sessions now start correctly when the runtime requires its token-authenticated URL.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes loopback URL validation and the embedded-browser navigation boundary at harness startup; mistakes could block launches or accept unsafe URLs, though scope is limited to main-process handshake logic with strong test coverage.
> 
> **Overview**
> **Fixes DeepSeek Harness startup when `dsh` prints a token-authenticated loopback URL** (e.g. 0.1.2-rc.1), which previously caused managed launches to time out because Cherry only accepted a bare `http://127.0.0.1:<port>` and probed an unauthenticated root.
> 
> `parseReadyUrl` now scans `dsh web:` lines and returns either the legacy base URL or a strictly validated `/?token=<43-char base64url>` URL (HTTP, literal `127.0.0.1`, root path only—rejecting HTTPS, localhost aliases, bad ports, extra query params, and fragments). `assertWebReady` probes that exact URL and treats the documented **303 → `/` token exchange** as ready while still requiring **HTTP 200** for tokenless URLs; **401** no longer counts as success.
> 
> Tests cover split stdout chunks, the authenticated flow, unsafe URL rejection, 401 handling, and launch-token redaction in failure diagnostics and process-error logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deda4236b4557f1e08ea6dbe53e9fb368d38ea60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->