### PR TITLE
fix(protocol): register portable launcher for deep links

### DIFF
--- a/src/main/services/protocol/ProtocolService.ts
+++ b/src/main/services/protocol/ProtocolService.ts
@@ -8,7 +8,7 @@ import { application } from '@application'
 import { mcpServerService } from '@data/services/McpServerService'
 import { loggerService } from '@logger'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
-import { isLinux } from '@main/core/platform'
+import { isLinux, isPortable, isWin } from '@main/core/platform'
 import { WindowType } from '@main/core/window/types'
 import { openSettingsInMainWindow } from '@main/services/mainWindowNavigation'
 import type { ProtocolMcpInstallRequest } from '@shared/data/types/mcpProtocolInstall'
@@ -148,6 +148,8 @@ export class ProtocolService extends BaseService {
         const absoluteEntry = path.isAbsolute(entry) ? entry : path.resolve(process.cwd(), entry)
         app.setAsDefaultProtocolClient(CHERRY_STUDIO_PROTOCOL, process.execPath, [absoluteEntry])
       }
+    } else if (isWin && isPortable && process.env.PORTABLE_EXECUTABLE_FILE) {
+      app.setAsDefaultProtocolClient(CHERRY_STUDIO_PROTOCOL, process.env.PORTABLE_EXECUTABLE_FILE, [])
     } else {
       app.setAsDefaultProtocolClient(CHERRY_STUDIO_PROTOCOL)
     }

--- a/src/main/services/protocol/__tests__/ProtocolService.test.ts
+++ b/src/main/services/protocol/__tests__/ProtocolService.test.ts
@@ -11,6 +11,7 @@ const {
   mcpServerServiceMock,
   openSettingsInMainWindowMock,
   oauthRuntimeServiceMock,
+  platformMock,
   windowManagerMock
 } = vi.hoisted(() => {
   const appMock = {
@@ -41,6 +42,11 @@ const {
   const oauthRuntimeServiceMock = {
     handleDeepLinkCallback: vi.fn()
   }
+  const platformMock = {
+    isLinux: false,
+    isPortable: false,
+    isWin: false
+  }
   const windowManagerMock = {
     getWindowType: vi.fn(() => 'main'),
     onWindowCreatedByType: vi.fn<(type: string, listener: unknown) => () => void>(() => vi.fn()),
@@ -55,6 +61,7 @@ const {
     mcpServerServiceMock,
     openSettingsInMainWindowMock,
     oauthRuntimeServiceMock,
+    platformMock,
     windowManagerMock
   }
 })
@@ -102,6 +109,8 @@ vi.mock('@main/services/mainWindowNavigation', () => ({
   openSettingsInMainWindow: openSettingsInMainWindowMock
 }))
 
+vi.mock('@main/core/platform', () => platformMock)
+
 vi.mock('../handlers/mcpInstall', () => ({
   parseMcpInstallProtocolUrl: handlersMock.parseMcpInstallProtocolUrl
 }))
@@ -138,6 +147,9 @@ describe('ProtocolService', () => {
     originalArgv = process.argv
     originalDefaultApp = (process as NodeJS.Process & { defaultApp?: boolean }).defaultApp
     vi.clearAllMocks()
+    platformMock.isLinux = false
+    platformMock.isPortable = false
+    platformMock.isWin = false
     oauthRuntimeServiceMock.handleDeepLinkCallback.mockResolvedValue(undefined)
     service = new ProtocolService()
   })
@@ -145,6 +157,7 @@ describe('ProtocolService', () => {
   afterEach(() => {
     process.argv = originalArgv
     setDefaultApp(originalDefaultApp)
+    vi.unstubAllEnvs()
   })
 
   it('logs malformed protocol URLs instead of throwing', async () => {
@@ -163,6 +176,22 @@ describe('ProtocolService', () => {
 
     expect(appMock.setAsDefaultProtocolClient).toHaveBeenCalledTimes(1)
     expect(appMock.setAsDefaultProtocolClient).toHaveBeenCalledWith('cherrystudio')
+  })
+
+  it('registers the stable launcher for packaged Windows portable builds', async () => {
+    setDefaultApp(false)
+    platformMock.isPortable = true
+    platformMock.isWin = true
+    vi.stubEnv('PORTABLE_EXECUTABLE_FILE', 'D:\\Apps\\Cherry Studio Portable.exe')
+
+    await (service as any).onInit()
+
+    expect(appMock.setAsDefaultProtocolClient).toHaveBeenCalledTimes(1)
+    expect(appMock.setAsDefaultProtocolClient).toHaveBeenCalledWith(
+      'cherrystudio',
+      'D:\\Apps\\Cherry Studio Portable.exe',
+      []
+    )
   })
 
   it('registers the dev protocol handler with an absolute app entry', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Windows portable builds registered the temporary extracted executable as the `cherrystudio://` protocol handler. Opening a deep link could therefore start the inner executable without the portable environment, use a different `userData` directory, bypass the existing portable instance lock, and keep running after NSIS removed its resource directory.

After this PR:

Windows portable builds register `PORTABLE_EXECUTABLE_FILE`, the stable outer launcher, as the protocol handler. The launcher restores the portable environment and forwards the URL to the existing instance through the same `userData`-scoped lock.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19990

### Why we need it and why it was done in this way

The following tradeoffs were made: The explicit executable override is limited to packaged Windows portable builds. Development, installed Windows, macOS, and Linux protocol registration keep their existing behavior.

The following alternatives were considered: Falling back to another provider-registry path was rejected because the diagnostic evidence showed the entire extracted resource tree had expired, not only `providers.json`. Changing the single-instance lock was also rejected because the incorrectly launched process had already lost its portable identity and selected a different `userData` directory.

Links to places where the discussion took place: #19990, #19562

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

The restricted diagnostic archive was used only for local root-cause analysis and is not included in this branch. It showed the original portable process using portable-local data while a later process from the same NSIS extraction directory used the default roaming data directory.

Verified locally:

- `pnpm exec vitest run --project main src/main/services/protocol/__tests__/ProtocolService.test.ts` (16 passed)
- `pnpm lint`
- `pnpm test:lint`

The electron-builder 26.15.6 portable template was audited to confirm that the outer launcher sets `PORTABLE_EXECUTABLE_FILE` and forwards all protocol arguments. A packaged Windows smoke test was not available from the macOS development host. This is a non-visual protocol-registration fix, so no UI screenshot is applicable.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note in the below code block. If this PR requires additional action from users switching to the new release, include the string "action required". -->

```release-note
Fix Windows portable deep links opening a second app instance that can lose packaged resources.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Windows portable protocol registration only; aligns with existing portable launcher handling and does not touch auth or data APIs.
> 
> **Overview**
> Fixes **`cherrystudio://` deep links on packaged Windows portable builds** by registering the stable outer launcher instead of the extracted inner executable.
> 
> `registerProtocolScheme()` gains a branch when **`isWin`**, **`isPortable`**, and **`PORTABLE_EXECUTABLE_FILE`** are set: it calls `setAsDefaultProtocolClient` with that path and an empty args list. Dev, installed Windows, macOS, and Linux registration are unchanged.
> 
> Tests mock **`@main/core/platform`**, reset portable flags in **`beforeEach`**, stub **`PORTABLE_EXECUTABLE_FILE`**, and assert the portable registration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ad7705dfdb58b35a5d7bab648940890af772c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->