### PR TITLE
fix(provider): retire Yi service integration

### DIFF
--- a/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
@@ -167,12 +167,12 @@ describe('ProviderModelMigrator', () => {
       expect(result.warnings?.some((w) => w.includes('managed CherryAI'))).toBe(true)
     })
 
-    it('skips providers whose upstream services have retired', async () => {
+    it.each(['github', 'yi'])('skips retired %s providers and preset-derived copies', async (providerId) => {
       const migrationContext = createContext(dbh.db, {
         llm: {
           providers: [
-            makeProvider('github', [{ id: 'openai/gpt-4o' }]),
-            { ...makeProvider('github-copy'), presetProviderId: 'github' },
+            makeProvider(providerId, [{ id: 'legacy-model' }]),
+            { ...makeProvider(`${providerId}-copy`), presetProviderId: providerId },
             makeProvider('openai')
           ]
         }

--- a/src/main/data/retiredProviders.ts
+++ b/src/main/data/retiredProviders.ts
@@ -1,4 +1,4 @@
-const RETIRED_PROVIDER_IDS = new Set(['cephalon', 'github', 'tokenflux'])
+const RETIRED_PROVIDER_IDS = new Set(['cephalon', 'github', 'tokenflux', 'yi'])
 
 /** Providers whose upstream services are no longer available. */
 export function isRetiredProvider(providerId: string | null | undefined, presetProviderId?: string | null): boolean {

--- a/src/main/data/services/__tests__/ProviderService.create.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.create.test.ts
@@ -48,13 +48,15 @@ describe('ProviderService.create — endpoint config overrides', () => {
 
   it.each([
     { providerId: 'github', presetProviderId: undefined },
-    { providerId: 'github-copy', presetProviderId: 'github' }
+    { providerId: 'github-copy', presetProviderId: 'github' },
+    { providerId: 'yi', presetProviderId: undefined },
+    { providerId: 'yi-copy', presetProviderId: 'yi' }
   ])('rejects creation of a retired provider identity ($providerId)', ({ providerId, presetProviderId }) => {
     expect(() =>
       providerService.create({
         providerId,
         presetProviderId,
-        name: 'Retired GitHub Models'
+        name: 'Retired provider'
       })
     ).toThrowError(expect.objectContaining({ code: ErrorCode.INVALID_OPERATION }))
   })

--- a/src/main/data/services/__tests__/ProviderService.readMerge.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.readMerge.test.ts
@@ -70,62 +70,69 @@ vi.mock('@cherrystudio/provider-registry/node', () => {
 describe('ProviderService read-time registry merge (#17096)', () => {
   const dbh = setupTestDatabase()
 
-  it('makes retired providers and their preset-derived copies unavailable to runtime reads and mutations', async () => {
-    await dbh.db.insert(userProviderTable).values([
-      {
-        providerId: 'github',
-        presetProviderId: 'github',
-        name: 'GitHub Models',
-        apiKeys: [{ id: 'github-key', key: 'secret', isEnabled: true }],
-        orderKey: 'a0'
-      },
-      {
-        providerId: 'github-copy',
-        presetProviderId: 'github',
-        name: 'GitHub Models Copy',
-        apiKeys: [{ id: 'github-copy-key', key: 'copy-secret', isEnabled: true }],
-        orderKey: 'a1'
-      },
-      {
-        providerId: 'custom-relay',
-        presetProviderId: null,
-        name: 'Custom Relay',
-        orderKey: 'a2'
+  it.each(['github', 'yi'])(
+    'makes retired %s providers and copies unavailable without deleting data',
+    async (retiredId) => {
+      await dbh.db.insert(userProviderTable).values([
+        {
+          providerId: retiredId,
+          presetProviderId: null,
+          name: 'Retired Provider',
+          apiKeys: [{ id: `${retiredId}-key`, key: 'secret', isEnabled: true }],
+          orderKey: 'a0'
+        },
+        {
+          providerId: `${retiredId}-copy`,
+          presetProviderId: retiredId,
+          name: 'Retired Provider Copy',
+          apiKeys: [{ id: `${retiredId}-copy-key`, key: 'copy-secret', isEnabled: true }],
+          orderKey: 'a1'
+        },
+        {
+          providerId: 'custom-relay',
+          presetProviderId: null,
+          name: 'Custom Relay',
+          orderKey: 'a2'
+        }
+      ])
+
+      const originalRows = dbh.db.select().from(userProviderTable).all()
+
+      expect(providerService.list({}).map((provider) => provider.id)).toEqual(['custom-relay'])
+      expect(() => providerService.getByProviderId(retiredId)).toThrowError(
+        expect.objectContaining({ code: ErrorCode.NOT_FOUND })
+      )
+      expect(() => providerService.getByProviderId(`${retiredId}-copy`)).toThrowError(
+        expect.objectContaining({ code: ErrorCode.NOT_FOUND })
+      )
+
+      for (const { providerId, keyId } of [
+        { providerId: retiredId, keyId: `${retiredId}-key` },
+        { providerId: `${retiredId}-copy`, keyId: `${retiredId}-copy-key` }
+      ]) {
+        const operations = [
+          () => providerService.assertAvailable(providerId),
+          () => providerService.update(providerId, { name: 'Still retired' }),
+          () => providerService.resolveApiKey(providerId),
+          () => providerService.getApiKeys(providerId),
+          () => providerService.getAuthConfig(providerId),
+          () => providerService.addApiKey(providerId, 'new-secret'),
+          () =>
+            providerService.replaceApiKeys(providerId, [
+              { id: 'replacement-key', key: 'replacement-secret', isEnabled: true }
+            ]),
+          () => providerService.updateApiKey(providerId, keyId, { label: 'updated' }),
+          () => providerService.deleteApiKey(providerId, keyId),
+          () => providerService.delete(providerId)
+        ]
+
+        for (const operation of operations) {
+          expect(operation).toThrowError(expect.objectContaining({ code: ErrorCode.NOT_FOUND }))
+        }
       }
-    ])
-
-    expect(providerService.list({}).map((provider) => provider.id)).toEqual(['custom-relay'])
-    expect(() => providerService.getByProviderId('github')).toThrowError(
-      expect.objectContaining({ code: ErrorCode.NOT_FOUND })
-    )
-    expect(() => providerService.getByProviderId('github-copy')).toThrowError(
-      expect.objectContaining({ code: ErrorCode.NOT_FOUND })
-    )
-
-    for (const { providerId, keyId } of [
-      { providerId: 'github', keyId: 'github-key' },
-      { providerId: 'github-copy', keyId: 'github-copy-key' }
-    ]) {
-      const operations = [
-        () => providerService.update(providerId, { name: 'Still retired' }),
-        () => providerService.resolveApiKey(providerId),
-        () => providerService.getApiKeys(providerId),
-        () => providerService.getAuthConfig(providerId),
-        () => providerService.addApiKey(providerId, 'new-secret'),
-        () =>
-          providerService.replaceApiKeys(providerId, [
-            { id: 'replacement-key', key: 'replacement-secret', isEnabled: true }
-          ]),
-        () => providerService.updateApiKey(providerId, keyId, { label: 'updated' }),
-        () => providerService.deleteApiKey(providerId, keyId),
-        () => providerService.delete(providerId)
-      ]
-
-      for (const operation of operations) {
-        expect(operation).toThrowError(expect.objectContaining({ code: ErrorCode.NOT_FOUND }))
-      }
+      expect(dbh.db.select().from(userProviderTable).all()).toEqual(originalRows)
     }
-  })
+  )
 
   it('surfaces a registry-added endpoint type absent from the persisted row', async () => {
     // Stale seed: only openai-chat persisted; google-generate-content added to

--- a/v2-refactor-temp/docs/breaking-changes.md
+++ b/v2-refactor-temp/docs/breaking-changes.md
@@ -22,6 +22,7 @@
 
 | Date | Change | Document |
 | --- | --- | --- |
+| 2026-09-05 | Yi provider retired | [2026-09-05-retire-yi-provider.md](./breaking-changes/2026-09-05-retire-yi-provider.md) |
 | 2026-08-21 | GitHub Models provider removed | [2026-08-21-remove-github-models.md](./breaking-changes/2026-08-21-remove-github-models.md) |
 | 2026-06-12 | Default assistant and CherryAI defaults are seeded | [2026-06-12-default-assistant-name.md](./breaking-changes/2026-06-12-default-assistant-name.md) |
 | 2026-04-23 | Web Search 移除本地搜索引擎与 RAG 压缩配置 | [2026-04-23-web-search-remove-local-providers-and-rag.md](./breaking-changes/2026-04-23-web-search-remove-local-providers-and-rag.md) |

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-05-retire-yi-provider.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-05-retire-yi-provider.md
@@ -2,7 +2,7 @@
 title: Yi provider is no longer available
 category: removed
 severity: breaking
-introduced_in_pr: TBD
+introduced_in_pr: "#20016"
 date: 2026-09-05
 ---
 

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-05-retire-yi-provider.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-05-retire-yi-provider.md
@@ -18,6 +18,13 @@ The official platform service adjustment notice states that model experiences, A
 
 Select a model from another available provider. Existing local provider records, credentials, and conversation history are not deleted. The notice states that balance refund applications remain open until December 3, 2026, 24:00.
 
+## Verification points
+
+- Existing `yi` providers and preset-derived copies are hidden and rejected by runtime reads and mutations; creating either identity is rejected.
+- The v1-to-v2 migration skips both retired identities while continuing to migrate available providers.
+- Rejected operations leave persisted provider records and API keys unchanged; saved conversation history is retained.
+- Other providers remain available, including providers serving Yi models under their own identities.
+
 ## Notes for release manager
 
 Source: the official 01.AI platform service adjustment notice supplied with the change request. Retirement is based on provider identity, including preset-derived copies, rather than model names; Yi models served by other providers are unaffected.

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-05-retire-yi-provider.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-05-retire-yi-provider.md
@@ -1,0 +1,23 @@
+---
+title: Yi provider is no longer available
+category: removed
+severity: breaking
+introduced_in_pr: TBD
+date: 2026-09-05
+---
+
+## What changed
+
+Existing Yi (01.AI) provider configurations and preset-derived copies are now hidden and unavailable. The provider was already absent from the built-in catalog; this change also prevents creating retired identities and importing them through the v1-to-v2 migration.
+
+## Why this matters to the user
+
+The official platform service adjustment notice states that model experiences, API calls, and related services stopped at September 3, 2026, 24:00. Assistants and conversations referencing this provider require another provider for new generations.
+
+## What the user should do
+
+Select a model from another available provider. Existing local provider records, credentials, and conversation history are not deleted. The notice states that balance refund applications remain open until December 3, 2026, 24:00.
+
+## Notes for release manager
+
+Source: the official 01.AI platform service adjustment notice supplied with the change request. Retirement is based on provider identity, including preset-derived copies, rather than model names; Yi models served by other providers are unaffected.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Yi was already absent from the built-in catalog, but saved Yi configurations and preset-derived copies remained available and could still be imported from v1.

After this PR: Yi joins the existing retired-provider set. Runtime access and creation reject canonical and preset-derived Yi identities, and v1 migration skips them. Existing local records and credentials are preserved. Regression coverage includes both Yi and GitHub Models and verifies rejected operations leave persisted data unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: reuse the retirement boundary introduced in #19072 without changing its public contract or deleting user data. The attached official notice states that API and model experience services stopped on September 3, 2026, at 24:00; refund applications remain open until December 3, 2026, at 24:00.

![Official 01.AI platform service shutdown notice](https://github.com/user-attachments/assets/da16650d-40e5-408e-a564-3641a236eaf1)

The following alternatives were considered: catalog removal alone leaves existing configurations usable; deleting stored rows is unnecessarily destructive. Neither is appropriate. Yi models hosted by other providers remain unaffected.

Links to places where the discussion took place: #19072 (GitHub Models retirement). Source evidence: the attached official 01.AI platform notice.

### Breaking changes

<!-- optional -->

Existing Yi configurations are hidden and unavailable. Users must select another available provider for new generations; saved conversations, provider records, and credentials are not deleted. See v2-refactor-temp/docs/breaking-changes/2026-09-05-retire-yi-provider.md.

### Special notes for your reviewer

- Focused ProviderService and ProviderModelMigrator suites: 3 files, 65 tests passed. The final read/retention test update was rerun: 11 tests passed.
- Tests ran through Electron in Node mode because the installed better-sqlite3 module targets Electron ABI 145; the initial Node 24 run stopped before tests due to ABI mismatch.
- pnpm lint passed, including node/web/AI Core typechecks and i18n checks. ESLint reported 47 existing warnings outside this change; Biome reported local oversized-file and broken-symlink notices.
- pnpm docs:check passed. No GUI verification was performed.
- The final diff was reviewed without actionable findings. Commit is SSH-signed and DCO-signed off.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
action required: Retired the Yi (01.AI) provider following its service shutdown. Select another provider to continue generating; existing local data is retained.

```