### PR TITLE
fix(image-generation): disable automatic retries

### DIFF
--- a/.changeset/aicore-image-retry-tests.md
+++ b/.changeset/aicore-image-retry-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only coverage for direct image request retries and large OpenAI image-edit responses; no package release is required.

--- a/packages/aiCore/src/core/providers/__tests__/openaiImageModel.test.ts
+++ b/packages/aiCore/src/core/providers/__tests__/openaiImageModel.test.ts
@@ -1,4 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai'
+import { generateImage } from 'ai'
 import { describe, expect, it, vi } from 'vitest'
 
 describe('OpenAI image response compatibility', () => {
@@ -49,6 +50,50 @@ describe('OpenAI image response compatibility', () => {
     })
 
     expect(result.images).toEqual(expected)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts a large base64 response for image edits', async () => {
+    const base64 = 'a'.repeat(2_950_000)
+    const fetch = vi.fn<typeof globalThis.fetch>(
+      async () =>
+        new Response(JSON.stringify({ data: [{ b64_json: base64 }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+    )
+    const openai = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://api.example.com/v1',
+      fetch
+    })
+
+    const result = await generateImage({
+      model: openai.imageModel('gpt-image-2'),
+      prompt: { text: 'edit this image', images: [new Uint8Array([137, 80, 78, 71])] },
+      maxRetries: 0
+    })
+
+    expect(result.image.base64).toHaveLength(base64.length)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry a failed image request when retries are disabled', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response('gateway timeout', { status: 504 }))
+    const openai = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://api.example.com/v1',
+      fetch
+    })
+
+    await expect(
+      generateImage({
+        model: openai.imageModel('gpt-image-2'),
+        prompt: { text: 'edit this image', images: [new Uint8Array([137, 80, 78, 71])] },
+        maxRetries: 0
+      })
+    ).rejects.toThrow()
+
     expect(fetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -822,6 +822,7 @@ export class AiService extends BaseService {
       model: sdkConfig.modelId,
       prompt: promptParam,
       n: structured.n ?? 1,
+      maxRetries: 0,
       ...(requestSize !== undefined && { size: requestSize as `${number}x${number}` }),
       ...(structured.seed !== undefined ? { seed: structured.seed } : {}),
       ...(structured.aspectRatio ? { aspectRatio: structured.aspectRatio as `${number}:${number}` } : {}),

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -822,7 +822,7 @@ export class AiService extends BaseService {
       model: sdkConfig.modelId,
       prompt: promptParam,
       n: structured.n ?? 1,
-      maxRetries: 0,
+      maxRetries: request.requestOptions?.maxRetries ?? 0,
       ...(requestSize !== undefined && { size: requestSize as `${number}x${number}` }),
       ...(structured.seed !== undefined ? { seed: structured.seed } : {}),
       ...(structured.aspectRatio ? { aspectRatio: structured.aspectRatio as `${number}:${number}` } : {}),

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -533,6 +533,31 @@ describe('AiService', () => {
     expect(result).toEqual({ files: [fileEntry] })
   })
 
+  it('honors an explicit retry override for direct image requests', async () => {
+    const service = createService()
+    vi.spyOn(service as never, 'buildAgentParamsFor').mockResolvedValue({
+      sdkConfig: {
+        providerId: 'test-provider',
+        providerSettings: {},
+        modelId: 'test-model'
+      }
+    } as never)
+    mockGenerateImage.mockResolvedValue({ images: [] })
+    mockApplicationGet.mockImplementation((name: string) =>
+      name === 'FileManager' ? { createInternalEntry: vi.fn() } : undefined
+    )
+
+    await service.generateImage({
+      uniqueModelId: 'test-provider::test-model',
+      cleanupPolicy: 'delete_when_unreferenced',
+      prompt: 'draw a cat',
+      paramValues: {},
+      requestOptions: { maxRetries: 3 }
+    })
+
+    expect(mockGenerateImage.mock.calls[0]?.[2]).toEqual(expect.objectContaining({ maxRetries: 3 }))
+  })
+
   it("omits the SDK size for the 'auto' sentinel AND when no size is given (no 1024x1024 default)", async () => {
     const service = createService()
     vi.spyOn(service as never, 'buildAgentParamsFor').mockResolvedValue({

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -493,6 +493,7 @@ describe('AiService', () => {
         size: '1024x1024',
         aspectRatio: '9:19.5',
         seed: 7,
+        maxRetries: 0,
         providerOptions: {
           'test-provider': {
             negative_prompt: 'blurry',


### PR DESCRIPTION
### What this PR does

Before this PR:

Direct image generation and editing relied on the AI SDK default of two automatic retries. A timeout or response-processing failure could therefore repeat a non-idempotent, potentially billable image operation up to three times.

After this PR:

Direct image generation and editing default to one provider request per user operation by setting `maxRetries: 0` when the caller does not provide an explicit per-request override. Provider failures are returned immediately for current user-facing callers, so the user remains in control of any retry.

Related to #19991

### Why we need it and why it was done in this way

Image generation is not guaranteed to be idempotent, and the affected provider does not expose an idempotency contract. Retrying automatically can duplicate completed upstream work even when Cherry Studio cannot use the response.

The following tradeoffs were made:

Transient failures no longer receive an invisible automatic retry on the direct image path. Users can still retry explicitly.

The following alternatives were considered:

- Relaxing the OpenAI image response schema was rejected because the failing HTTP 200 response body was not retained. A regression test confirms that a standard approximately 2.95 MB image-edit response already parses successfully.
- Retrying only selected errors was rejected because a timeout cannot prove that the provider did not finish a billable operation.

Links to places where the discussion took place: #19991

### Breaking changes

None.

### Special notes for your reviewer

This PR addresses the proven duplicate-request risk only. It does not claim to fix the unknown HTTP 200 response shape from #19991; that still requires a sanitized response sample or server-side evidence.

No UI files are changed, so screenshots are not applicable.

Validation:

- `pnpm test:main src/main/ai/__tests__/AiService.test.ts` (62 passed)
- `pnpm test:aicore packages/aiCore/src/core/providers/__tests__/openaiImageModel.test.ts` (5 passed)
- `pnpm lint`
- `pnpm test:lint`

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this targeted behavior fix
- [x] Self-review: I have reviewed my own code and the exact pushed diff before requesting review from others

### Release note

```release-note
Disable automatic retries for image generation and editing to avoid duplicate billable requests.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing-sensitive retry behavior on the direct image path; default is safer (no duplicate charges) but transient failures no longer get silent automatic retries unless callers opt in via requestOptions.
> 
> **Overview**
> Direct image generation and editing no longer inherit the AI SDK’s default automatic retries. **`AiService.generateImage`** now passes **`maxRetries: request.requestOptions?.maxRetries ?? 0`** into the ai-core call, so each user action makes a single provider request unless **`requestOptions.maxRetries`** is set explicitly.
> 
> This avoids repeating potentially billable, non-idempotent image work when a timeout or response-handling failure occurs after the provider may already have completed the job.
> 
> Tests lock in the behavior: default **`maxRetries: 0`** on the main image path, honoring an override (e.g. **`maxRetries: 3`**), OpenAI compatibility for ~2.95 MB base64 edit responses, and no SDK retry when **`maxRetries: 0`** and the provider returns 504. A changeset notes test-only coverage with no package release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b164fd44d6126faf4ae3df5420d119f9e8719e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->