### PR TITLE
fix(provider-registry): prevent unsupported Kimi K3 reasoning effort

### DIFF
--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -17966,7 +17966,7 @@
           "wire": {
             "auto": {
               "effortMap": {
-                "auto": "medium"
+                "auto": "high"
               },
               "operations": [
                 {

--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -17264,12 +17264,14 @@
           },
           "wire": {
             "auto": {
+              "effortMap": {
+                "auto": "medium"
+              },
               "operations": [
                 {
                   "target": "reasoningEffort",
                   "value": {
-                    "source": "literal",
-                    "value": "medium"
+                    "source": "effort"
                   }
                 }
               ]
@@ -17361,12 +17363,14 @@
           },
           "wire": {
             "auto": {
+              "effortMap": {
+                "auto": "medium"
+              },
               "operations": [
                 {
                   "target": "reasoningEffort",
                   "value": {
-                    "source": "literal",
-                    "value": "medium"
+                    "source": "effort"
                   }
                 }
               ]
@@ -17966,7 +17970,7 @@
           "wire": {
             "auto": {
               "effortMap": {
-                "auto": "high"
+                "auto": "medium"
               },
               "operations": [
                 {
@@ -18018,7 +18022,7 @@
           "wire": {
             "auto": {
               "effortMap": {
-                "auto": "high"
+                "auto": "medium"
               },
               "operations": [
                 {
@@ -38745,5 +38749,5 @@
       "providerId": "zhipu"
     }
   ],
-  "version": "198c8902bf305786"
+  "version": "f48da95f7a82ba57"
 }

--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -18003,6 +18003,58 @@
       }
     },
     {
+      "modelId": "kimi-k3-fast",
+      "parameterSupport": {
+        "temperature": {
+          "supported": false
+        },
+        "topP": {
+          "supported": false
+        }
+      },
+      "providerId": "moonshot",
+      "reasoningContracts": {
+        "openai-chat-completions": {
+          "wire": {
+            "auto": {
+              "effortMap": {
+                "auto": "high"
+              },
+              "operations": [
+                {
+                  "target": "reasoningEffort",
+                  "value": {
+                    "source": "effort"
+                  }
+                }
+              ]
+            },
+            "effort": {
+              "operations": [
+                {
+                  "target": "reasoningEffort",
+                  "value": {
+                    "source": "effort"
+                  }
+                }
+              ]
+            },
+            "off": {
+              "operations": [
+                {
+                  "target": "reasoningEffort",
+                  "value": {
+                    "source": "literal",
+                    "value": "none"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "apiModelId": "nvidia/active-speaker-detection",
       "modelId": "active-speaker-detection",
       "pricing": {
@@ -38693,5 +38745,5 @@
       "providerId": "zhipu"
     }
   ],
-  "version": "ea68f0c96ce12011"
+  "version": "198c8902bf305786"
 }

--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -576,12 +576,14 @@
             "type": "openai-chat",
             "wire": {
               "auto": {
+                "effortMap": {
+                  "auto": "medium"
+                },
                 "operations": [
                   {
                     "target": "reasoning.effort",
                     "value": {
-                      "source": "literal",
-                      "value": "medium"
+                      "source": "effort"
                     }
                   }
                 ]
@@ -2483,5 +2485,5 @@
       "presetProviderId": "minimax"
     }
   ],
-  "version": "767516d2e8178b83"
+  "version": "c81369dcccb6c728"
 }

--- a/packages/provider-registry/src/__tests__/provider-reasoning-contracts.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-reasoning-contracts.test.ts
@@ -34,15 +34,43 @@ describe('provider reasoning contracts', () => {
     })
   })
 
-  it.each(['kimi-k3', 'kimi-k3-fast'])(
-    'keeps Moonshot %s reasoning within its supported effort vocabulary',
-    (modelId) => {
-      const moonshotWire = override('moonshot', modelId).reasoningContracts?.['openai-chat-completions']?.wire
+  it.each(['kimi-k3', 'kimi-k3-fast'])('gives Moonshot %s an effort wire of its own', (modelId) => {
+    // The provider wire only carries `thinking.type`; without this contract every tier collapses to it.
+    const moonshotWire = override('moonshot', modelId).reasoningContracts?.['openai-chat-completions']?.wire
 
-      expect(moonshotWire?.auto?.effortMap).toEqual({ auto: 'high' })
-      expect(moonshotWire?.effort?.operations).toEqual([{ target: 'reasoningEffort', value: { source: 'effort' } }])
+    expect(moonshotWire?.effort?.operations).toEqual([{ target: 'reasoningEffort', value: { source: 'effort' } }])
+  })
+
+  // `auto` is the one selection no model validates, so the serializer projects a profile's automatic
+  // tier onto the model's declared efforts. A tier buried in a literal operation is invisible to it
+  // and reaches the wire unchecked — which is how Kimi K3 received `medium` and returned 400 (#20029).
+  it('declares every automatic effort tier through effortMap, never as a literal', () => {
+    const tiers = new Set(['minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
+    const offenders: string[] = []
+
+    for (const entry of PROVIDERS) {
+      const wires = [
+        ...Object.entries(entry.endpointConfigs ?? {}).map(
+          ([endpoint, config]) => [`${entry.id}/${endpoint}`, config.reasoningFormat?.wire] as const
+        ),
+        ...(entry.overrides ?? []).flatMap((model) =>
+          Object.entries(model.reasoningContracts ?? {}).map(
+            ([endpoint, contract]) => [`${entry.id}/${model.modelId}/${endpoint}`, contract.wire] as const
+          )
+        )
+      ]
+
+      for (const [label, wire] of wires) {
+        for (const operation of wire?.auto?.operations ?? []) {
+          if (operation.value.source === 'literal' && tiers.has(String(operation.value.value))) {
+            offenders.push(`${label} → ${operation.target}=${operation.value.value}`)
+          }
+        }
+      }
     }
-  )
+
+    expect(offenders).toEqual([])
+  })
 
   it('keeps DashScope Kimi K3 reasoning within the provider-supported effort vocabulary', () => {
     const dashscopeSupport = override('dashscope', 'kimi-k3').reasoningContracts?.['openai-chat-completions']?.support

--- a/packages/provider-registry/src/__tests__/provider-reasoning-contracts.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-reasoning-contracts.test.ts
@@ -34,11 +34,19 @@ describe('provider reasoning contracts', () => {
     })
   })
 
-  it('keeps Kimi K3 reasoning within the provider-supported effort vocabulary', () => {
-    const moonshotWire = override('moonshot', 'kimi-k3').reasoningContracts?.['openai-chat-completions']?.wire
+  it.each(['kimi-k3', 'kimi-k3-fast'])(
+    'keeps Moonshot %s reasoning within its supported effort vocabulary',
+    (modelId) => {
+      const moonshotWire = override('moonshot', modelId).reasoningContracts?.['openai-chat-completions']?.wire
+
+      expect(moonshotWire?.auto?.effortMap).toEqual({ auto: 'high' })
+      expect(moonshotWire?.effort?.operations).toEqual([{ target: 'reasoningEffort', value: { source: 'effort' } }])
+    }
+  )
+
+  it('keeps DashScope Kimi K3 reasoning within the provider-supported effort vocabulary', () => {
     const dashscopeSupport = override('dashscope', 'kimi-k3').reasoningContracts?.['openai-chat-completions']?.support
 
-    expect(moonshotWire?.auto?.effortMap).toEqual({ auto: 'high' })
     expect(dashscopeSupport?.controls).toEqual([{ default: 'max', kind: 'effort', values: ['none', 'max'] }])
   })
 

--- a/packages/provider-registry/src/__tests__/provider-reasoning-contracts.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-reasoning-contracts.test.ts
@@ -34,6 +34,14 @@ describe('provider reasoning contracts', () => {
     })
   })
 
+  it('keeps Kimi K3 reasoning within the provider-supported effort vocabulary', () => {
+    const moonshotWire = override('moonshot', 'kimi-k3').reasoningContracts?.['openai-chat-completions']?.wire
+    const dashscopeSupport = override('dashscope', 'kimi-k3').reasoningContracts?.['openai-chat-completions']?.support
+
+    expect(moonshotWire?.auto?.effortMap).toEqual({ auto: 'high' })
+    expect(dashscopeSupport?.controls).toEqual([{ default: 'max', kind: 'effort', values: ['none', 'max'] }])
+  })
+
   // DeepSeek publishes one effort table for every V4 SKU (thinking_mode guide), so the Flash, Vision
   // and Pro contracts must not drift apart — and none may send `xhigh` verbatim, which DeepSeek
   // degrades to `high`.

--- a/packages/provider-registry/src/__tests__/reasoningControls.test.ts
+++ b/packages/provider-registry/src/__tests__/reasoningControls.test.ts
@@ -90,6 +90,7 @@ describe('inferReasoningControls (ingest-time heuristics)', () => {
     ['deepseek-v4', [{ kind: 'effort', values: ['none', 'low', 'high', 'max'] }]],
     ['deepseek-v3.1', [{ kind: 'toggle' }]],
     ['kimi-k3', [{ kind: 'effort', values: ['low', 'high', 'max'] }, { kind: 'toggle' }]],
+    ['kimi-k3-fast', [{ kind: 'effort', values: ['low', 'high', 'max'] }]],
     ['qwen3-32b', [{ kind: 'budget', min: 1024, max: 38_912 }, { kind: 'toggle' }]],
     // always-think SKU: budget only, no toggle
     ['qwen3-235b-a22b-thinking-2507', [{ kind: 'budget', min: 0, max: 81_920 }]],
@@ -145,6 +146,8 @@ describe('inferReasoningControls (ingest-time heuristics)', () => {
     'grok-4-fast', // the on/off knob is OpenRouter-only, not a model property
     'ling-3.0-flash', // the on/off wire is serving-provider specific
     'minimax-m2.1', // no documented knob
+    'kimi-k3.1', // no audited provider wire for future K3 variants
+    'kimi-k4', // no audited provider wire for future Kimi generations
     'xopdeepseekv2pro', // Xunfei MaaS pre-v3 deepseek — no knob
     'xopglmv42' // Xunfei MaaS glm-4.2 — below the 4.5+ toggle line
   ])('returns undefined for %s', (id) => {

--- a/packages/provider-registry/src/__tests__/reasoningControls.test.ts
+++ b/packages/provider-registry/src/__tests__/reasoningControls.test.ts
@@ -89,6 +89,7 @@ describe('inferReasoningControls (ingest-time heuristics)', () => {
     ['grok-4.3', [{ kind: 'effort', values: ['none', 'low', 'medium', 'high'] }]],
     ['deepseek-v4', [{ kind: 'effort', values: ['none', 'low', 'high', 'max'] }]],
     ['deepseek-v3.1', [{ kind: 'toggle' }]],
+    ['kimi-k3', [{ kind: 'effort', values: ['low', 'high', 'max'] }, { kind: 'toggle' }]],
     ['qwen3-32b', [{ kind: 'budget', min: 1024, max: 38_912 }, { kind: 'toggle' }]],
     // always-think SKU: budget only, no toggle
     ['qwen3-235b-a22b-thinking-2507', [{ kind: 'budget', min: 0, max: 81_920 }]],

--- a/packages/provider-registry/src/creators/moonshot.ts
+++ b/packages/provider-registry/src/creators/moonshot.ts
@@ -13,8 +13,10 @@ export default defineCreator({
     // claude-code guide: requests without it are rejected) — always-on, the
     // explicit `toggle: false` stops the generic toggle below.
     { pattern: '^kimi-k2[.-]7-code', toggle: false },
-    // Kimi K2.5+/K3+ expose the thinking toggle; kimi-k2-thinking is always-on.
-    { pattern: '^kimi-k(?:2[.-][5-9]\\d*|[3-9]\\d*(?:[.-]\\d+)?)', toggle: true },
+    // K3+ supports low/high/max thinking effort and can disable thinking.
+    { pattern: '^kimi-k[3-9]\\d*(?:[.-]\\d+)?', effort: ['low', 'high', 'max'], toggle: true },
+    // Kimi K2.5+ exposes the thinking toggle; kimi-k2-thinking is always-on.
+    { pattern: '^kimi-k2[.-][5-9]\\d*', toggle: true },
     // The thinking budget is a K2.x-era knob — K3 controls depth via
     // `reasoning_effort` only (platform.kimi.com thinking-effort guide).
     { pattern: 'kimi-k2[.-][5-9]\\d*', budget: { min: 0, max: 30720 }, template: true },

--- a/packages/provider-registry/src/creators/moonshot.ts
+++ b/packages/provider-registry/src/creators/moonshot.ts
@@ -13,8 +13,10 @@ export default defineCreator({
     // claude-code guide: requests without it are rejected) — always-on, the
     // explicit `toggle: false` stops the generic toggle below.
     { pattern: '^kimi-k2[.-]7-code', toggle: false },
-    // K3+ supports low/high/max thinking effort and can disable thinking.
-    { pattern: '^kimi-k[3-9]\\d*(?:[.-]\\d+)?', effort: ['low', 'high', 'max'], toggle: true },
+    // K3 supports low/high/max thinking effort and can disable thinking; K3 Fast
+    // exposes the same effort vocabulary but is always-on.
+    { pattern: '^kimi-k3$', effort: ['low', 'high', 'max'], toggle: true },
+    { pattern: '^kimi-k3-fast$', effort: ['low', 'high', 'max'] },
     // Kimi K2.5+ exposes the thinking toggle; kimi-k2-thinking is always-on.
     { pattern: '^kimi-k2[.-][5-9]\\d*', toggle: true },
     // The thinking budget is a K2.x-era knob — K3 controls depth via

--- a/packages/provider-registry/src/patterns/reasoning-families.gen.ts
+++ b/packages/provider-registry/src/patterns/reasoning-families.gen.ts
@@ -192,7 +192,8 @@ export const REASONING_FAMILY_RULES: readonly ReasoningFamilyRule[] = [
   { pattern: '^mistral-(?:small|medium)(?!.*instruct)' },
   // moonshot
   { pattern: '^kimi-k2[.-]7-code', toggle: false },
-  { pattern: '^kimi-k(?:2[.-][5-9]\\d*|[3-9]\\d*(?:[.-]\\d+)?)', toggle: true },
+  { pattern: '^kimi-k[3-9]\\d*(?:[.-]\\d+)?', effort: ['low', 'high', 'max'], toggle: true },
+  { pattern: '^kimi-k2[.-][5-9]\\d*', toggle: true },
   { pattern: 'kimi-k2[.-][5-9]\\d*', budget: { min: 0, max: 30720 }, template: true },
   { pattern: '^kimi-k2-thinking(?:-turbo)?$|^kimi-k(?:2[.-][5-9]\\d*|[3-9]\\d*(?:[.-]\\d+)?)(?:-[\\w-]+)?$' },
   // nvidia

--- a/packages/provider-registry/src/patterns/reasoning-families.gen.ts
+++ b/packages/provider-registry/src/patterns/reasoning-families.gen.ts
@@ -192,7 +192,8 @@ export const REASONING_FAMILY_RULES: readonly ReasoningFamilyRule[] = [
   { pattern: '^mistral-(?:small|medium)(?!.*instruct)' },
   // moonshot
   { pattern: '^kimi-k2[.-]7-code', toggle: false },
-  { pattern: '^kimi-k[3-9]\\d*(?:[.-]\\d+)?', effort: ['low', 'high', 'max'], toggle: true },
+  { pattern: '^kimi-k3$', effort: ['low', 'high', 'max'], toggle: true },
+  { pattern: '^kimi-k3-fast$', effort: ['low', 'high', 'max'] },
   { pattern: '^kimi-k2[.-][5-9]\\d*', toggle: true },
   { pattern: 'kimi-k2[.-][5-9]\\d*', budget: { min: 0, max: 30720 }, template: true },
   { pattern: '^kimi-k2-thinking(?:-turbo)?$|^kimi-k(?:2[.-][5-9]\\d*|[3-9]\\d*(?:[.-]\\d+)?)(?:-[\\w-]+)?$' },

--- a/packages/provider-registry/src/providers/mimo.ts
+++ b/packages/provider-registry/src/providers/mimo.ts
@@ -1,7 +1,7 @@
 import type { ReasoningSupport } from '../schemas/model'
 import type { ReasoningWireProfile } from '../schemas/reasoningWire'
 import { defineProvider } from './types'
-import { modeWire } from './wires'
+import { EFFORT, modeWire } from './wires'
 
 const toggleSupport: ReasoningSupport = {
   controls: [{ kind: 'toggle', default: true }]
@@ -9,7 +9,11 @@ const toggleSupport: ReasoningSupport = {
 
 const chatWire: ReasoningWireProfile = modeWire('thinking.type', { off: 'disabled', auto: 'enabled' })
 
-const responsesWire: ReasoningWireProfile = modeWire('reasoningEffort', { off: 'none', auto: 'medium' })
+const responsesWire: ReasoningWireProfile = modeWire(
+  'reasoningEffort',
+  { off: 'none', auto: EFFORT },
+  { autoEffort: 'medium' }
+)
 
 // MiMo's Anthropic-compatible API enables thinking by default. Omitting the
 // auto mode preserves that default without making the Anthropic SDK inject a

--- a/packages/provider-registry/src/providers/moonshot.ts
+++ b/packages/provider-registry/src/providers/moonshot.ts
@@ -43,11 +43,11 @@ export default openaiCompatible({
     // Moonshot fixes temperature and top_p (0.95) for these models and rejects other
     // values with HTTP 400; omitting the non-configurable parameters uses the server defaults.
     { modelId: 'kimi-k2.5', parameterSupport: fixedSamplingParameterSupport },
-    ...['kimi-k2.6', 'kimi-k3'].map((modelId) => ({
+    ...['kimi-k2.6', 'kimi-k3', 'kimi-k3-fast'].map((modelId) => ({
       modelId,
       parameterSupport: fixedSamplingParameterSupport,
       reasoningContracts: {
-        'openai-chat-completions': { wire: modelId === 'kimi-k3' ? k3EffortWire : effortWire }
+        'openai-chat-completions': { wire: modelId === 'kimi-k2.6' ? effortWire : k3EffortWire }
       }
     }))
   ]

--- a/packages/provider-registry/src/providers/moonshot.ts
+++ b/packages/provider-registry/src/providers/moonshot.ts
@@ -2,7 +2,6 @@ import { openaiCompatible } from './types'
 import { EFFORT, modeWire } from './wires'
 
 const effortWire = modeWire('reasoningEffort', { off: 'none', auto: EFFORT, effort: EFFORT }, { autoEffort: 'medium' })
-const k3EffortWire = modeWire('reasoningEffort', { off: 'none', auto: EFFORT, effort: EFFORT }, { autoEffort: 'high' })
 
 const fixedSamplingParameterSupport = {
   temperature: { supported: false },
@@ -43,11 +42,13 @@ export default openaiCompatible({
     // Moonshot fixes temperature and top_p (0.95) for these models and rejects other
     // values with HTTP 400; omitting the non-configurable parameters uses the server defaults.
     { modelId: 'kimi-k2.5', parameterSupport: fixedSamplingParameterSupport },
+    // Moonshot's provider wire only carries `thinking.type`, so these SKUs need their own contract
+    // for a chosen tier to reach the request at all.
     ...['kimi-k2.6', 'kimi-k3', 'kimi-k3-fast'].map((modelId) => ({
       modelId,
       parameterSupport: fixedSamplingParameterSupport,
       reasoningContracts: {
-        'openai-chat-completions': { wire: modelId === 'kimi-k2.6' ? effortWire : k3EffortWire }
+        'openai-chat-completions': { wire: effortWire }
       }
     }))
   ]

--- a/packages/provider-registry/src/providers/moonshot.ts
+++ b/packages/provider-registry/src/providers/moonshot.ts
@@ -2,6 +2,7 @@ import { openaiCompatible } from './types'
 import { EFFORT, modeWire } from './wires'
 
 const effortWire = modeWire('reasoningEffort', { off: 'none', auto: EFFORT, effort: EFFORT }, { autoEffort: 'medium' })
+const k3EffortWire = modeWire('reasoningEffort', { off: 'none', auto: EFFORT, effort: EFFORT }, { autoEffort: 'high' })
 
 const fixedSamplingParameterSupport = {
   temperature: { supported: false },
@@ -46,7 +47,7 @@ export default openaiCompatible({
       modelId,
       parameterSupport: fixedSamplingParameterSupport,
       reasoningContracts: {
-        'openai-chat-completions': { wire: effortWire }
+        'openai-chat-completions': { wire: modelId === 'kimi-k3' ? k3EffortWire : effortWire }
       }
     }))
   ]

--- a/packages/provider-registry/src/providers/openrouter.ts
+++ b/packages/provider-registry/src/providers/openrouter.ts
@@ -1,5 +1,6 @@
 import { CURRENCY } from '../schemas/enums'
 import { defineProvider } from './types'
+import { EFFORT, modeWire } from './wires'
 
 export default defineProvider({
   id: 'openrouter',
@@ -30,11 +31,7 @@ export default defineProvider({
       baseUrl: 'https://openrouter.ai/api/v1/',
       reasoningFormat: {
         type: 'openai-chat',
-        wire: {
-          off: { operations: [{ target: 'reasoning.effort', value: { source: 'literal', value: 'none' } }] },
-          auto: { operations: [{ target: 'reasoning.effort', value: { source: 'literal', value: 'medium' } }] },
-          effort: { operations: [{ target: 'reasoning.effort', value: { source: 'effort' } }] }
-        }
+        wire: modeWire('reasoning.effort', { off: 'none', auto: EFFORT, effort: EFFORT }, { autoEffort: 'medium' })
       },
       requestControls: {
         serviceTier: {

--- a/resources/builtin-agents/cherry-assistant/product-manifest.json
+++ b/resources/builtin-agents/cherry-assistant/product-manifest.json
@@ -449,7 +449,7 @@
     }
   ],
   "providers": {
-    "version": "767516d2e8178b83",
+    "version": "c81369dcccb6c728",
     "count": 61,
     "entries": [
       {

--- a/src/main/ai/runtime/pi/modelInjection.test.ts
+++ b/src/main/ai/runtime/pi/modelInjection.test.ts
@@ -729,3 +729,67 @@ describe('modelInjection service resolution', () => {
     ).toThrow('Pi provider credentials changed during materialization: p')
   })
 })
+
+// pi defaults its thinking level to `medium` and clamps it against the model's ladder. Cherry used to
+// send no ladder, so pi assumed medium was available and emitted it verbatim — rejected by endpoints
+// serving Kimi K3, whose vocabulary is low/high/max (#20029).
+describe('pi thinking level ladder', () => {
+  const relay = () =>
+    makeProvider({
+      id: 'new-api',
+      defaultChatEndpoint: 'openai-chat-completions',
+      endpointConfigs: {
+        'openai-chat-completions': { adapterFamily: 'openai-compatible', baseUrl: 'https://relay.example.com' }
+      }
+    })
+
+  const piModelFrom = (model: Model) =>
+    buildPiProviderInjection(relay(), model, REAL_KEY).providerConfig.models?.[0] as never
+
+  it("clamps pi's medium default onto a tier Kimi K3 actually offers", async () => {
+    const { clampThinkingLevel, getSupportedThinkingLevels } = await import('@earendil-works/pi-ai/compat')
+    const piModel = piModelFrom(
+      makeModel({
+        id: 'new-api::moonshotai/kimi-k3',
+        apiModelId: 'moonshotai/kimi-k3',
+        capabilities: ['reasoning'],
+        reasoning: {
+          controls: [{ kind: 'effort', values: ['low', 'high', 'max'] }, { kind: 'toggle' }],
+          selectableEfforts: ['low', 'high', 'max', 'none']
+        }
+      } as Partial<Model>)
+    )
+
+    expect(getSupportedThinkingLevels(piModel)).toEqual(['off', 'low', 'high', 'max'])
+    expect(clampThinkingLevel(piModel, 'medium')).toBe('high')
+  })
+
+  it('withholds the off level from an always-on model', async () => {
+    const { getSupportedThinkingLevels } = await import('@earendil-works/pi-ai/compat')
+    const piModel = piModelFrom(
+      makeModel({
+        apiModelId: 'kimi-k3-fast',
+        capabilities: ['reasoning'],
+        reasoning: {
+          controls: [{ kind: 'effort', values: ['low', 'high', 'max'] }],
+          selectableEfforts: ['low', 'high', 'max']
+        }
+      } as Partial<Model>)
+    )
+
+    expect(getSupportedThinkingLevels(piModel)).not.toContain('off')
+  })
+
+  // A toggle model expresses on/off through the wire, not a ladder; an all-null map would read as
+  // "no level supported" and silently disable its thinking.
+  it('sends no ladder for a model that declares no concrete tier', () => {
+    const piModel = piModelFrom(
+      makeModel({
+        capabilities: ['reasoning'],
+        reasoning: { controls: [{ kind: 'toggle' }], selectableEfforts: ['none', 'auto'] }
+      } as Partial<Model>)
+    )
+
+    expect(piModel).not.toHaveProperty('thinkingLevelMap')
+  })
+})

--- a/src/main/ai/runtime/pi/modelInjection.ts
+++ b/src/main/ai/runtime/pi/modelInjection.ts
@@ -379,6 +379,29 @@ export async function assertPiProviderUsable(uniqueModelId: UniqueModelId): Prom
   if (!apiKeys.some((entry) => entry.key.trim())) throw new PiMissingApiKeyError(providerId)
 }
 
+/** pi's thinking ladder. `off` is its name for Cherry's `none`; the rest share Cherry's spelling. */
+const PI_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const
+
+/**
+ * Project the model's declared efforts onto pi's ladder, marking the rest `null`.
+ *
+ * pi clamps its own default level (`medium`) against this map. Without one it assumes every level
+ * below `xhigh` is available and sends `medium` verbatim — which strict endpoints reject for models
+ * like Kimi K3, whose vocabulary is low/high/max (#20029). A model declaring no concrete tier gets
+ * no map: its toggle is expressed by the wire, and an all-`null` ladder would disable thinking.
+ */
+function buildThinkingLevelMap(model: Model): ProviderModelConfig['thinkingLevelMap'] | undefined {
+  const declared = model.reasoning?.selectableEfforts ?? []
+  if (!declared.some((effort) => effort !== 'none' && effort !== 'auto')) return undefined
+
+  const map: NonNullable<ProviderModelConfig['thinkingLevelMap']> = {}
+  for (const level of PI_THINKING_LEVELS) {
+    const effort = level === 'off' ? 'none' : level
+    map[level] = declared.includes(effort) ? effort : null
+  }
+  return map
+}
+
 function buildPiModelConfig(
   provider: Provider,
   model: Model,
@@ -393,12 +416,14 @@ function buildPiModelConfig(
   if (supportsImage) {
     input.push('image')
   }
+  const thinkingLevelMap = buildThinkingLevelMap(model)
 
   return {
     id,
     name: model.name,
     api,
     reasoning: model.capabilities.includes(MODEL_CAPABILITY.REASONING) || model.reasoning !== undefined,
+    ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
     input,
     // pi tracks per-token cost for its own UI; Cherry owns cost accounting, so
     // leave zeros — pi's tracking is unused here.

--- a/src/main/ai/utils/__tests__/reasoningSerializers.test.ts
+++ b/src/main/ai/utils/__tests__/reasoningSerializers.test.ts
@@ -117,6 +117,37 @@ describe('automatic effort against a model that does not declare it', () => {
     expect(encodeReasoningInvocation(invocation)).toEqual({ reasoningEffort: 'high' })
   })
 
+  // A profile with no auto mode resolves to its effort one, which carries no tier for `auto`.
+  // DashScope's Kimi K3 is shaped this way and would otherwise receive the literal string `auto`.
+  describe('a profile whose effort mode has to stand in for auto', () => {
+    const effortOnly = {
+      effort: { operations: [{ target: 'reasoning_effort', value: { source: 'effort' } }] }
+    } satisfies ReasoningWireProfile
+
+    it("falls back to the model's own default tier", () => {
+      const model = makeModel({
+        reasoning: {
+          controls: [{ kind: 'effort', values: ['none', 'max'] }],
+          selectableEfforts: ['none', 'max'],
+          defaultEffort: 'max'
+        }
+      })
+      const invocation = resolveReasoningInvocation({ selection: 'auto', model, profile: effortOnly })
+
+      expect(encodeReasoningInvocation(invocation)).toEqual({ reasoning_effort: 'max' })
+    })
+
+    it('omits the mode when the model declares no default, letting the provider decide', () => {
+      const invocation = resolveReasoningInvocation({
+        selection: 'auto',
+        model: withEfforts('low', 'high'),
+        profile: effortOnly
+      })
+
+      expect(invocation).toMatchObject({ kind: 'omit', emissions: [] })
+    })
+  })
+
   // The projection lands on a canonical tier; the map's vendor translation must still apply to it.
   it('translates the projected tier through the same effortMap', () => {
     const invocation = resolveReasoningInvocation({

--- a/src/main/ai/utils/__tests__/reasoningSerializers.test.ts
+++ b/src/main/ai/utils/__tests__/reasoningSerializers.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import {
   inferReasoningControls,
   REASONING_FORMAT_PROFILES,
+  type ReasoningEffort,
   type ReasoningWireProfile
 } from '@cherrystudio/provider-registry'
 import { readProviderRegistry } from '@cherrystudio/provider-registry/node'
@@ -85,6 +86,72 @@ describe('resolveReasoningInvocation budget constraints', () => {
 
     expect(encodeReasoningInvocation(enabled)).toEqual({ think: true })
     expect(encodeReasoningInvocation(disabled)).toEqual({ think: false })
+  })
+})
+
+// A gateway request carries canonical `auto` (Claude Code's adaptive thinking, Gemini's -1 budget),
+// which no model vocabulary contains. The tier the profile substitutes for it is therefore the one
+// value that can reach the wire without ever being checked against the model — #20029.
+describe('automatic effort against a model that does not declare it', () => {
+  const autoWire = (
+    autoEffort: ReasoningEffort,
+    translations: Partial<Record<ReasoningEffort, ReasoningEffort>> = {}
+  ) =>
+    ({
+      auto: {
+        operations: [{ target: 'reasoningEffort', value: { source: 'effort' } }],
+        effortMap: { auto: autoEffort, ...translations }
+      }
+    }) satisfies ReasoningWireProfile
+
+  const withEfforts = (...selectableEfforts: ReasoningEffort[]) =>
+    makeModel({ reasoning: { controls: [{ kind: 'effort', values: selectableEfforts }], selectableEfforts } })
+
+  it('sends the nearest declared tier instead of the provider default Kimi K3 rejects', () => {
+    const invocation = resolveReasoningInvocation({
+      selection: 'auto',
+      model: withEfforts('low', 'high', 'max'),
+      profile: autoWire('medium')
+    })
+
+    expect(encodeReasoningInvocation(invocation)).toEqual({ reasoningEffort: 'high' })
+  })
+
+  // The projection lands on a canonical tier; the map's vendor translation must still apply to it.
+  it('translates the projected tier through the same effortMap', () => {
+    const invocation = resolveReasoningInvocation({
+      selection: 'auto',
+      model: withEfforts('xhigh'),
+      profile: autoWire('medium', { xhigh: 'max' })
+    })
+
+    expect(encodeReasoningInvocation(invocation)).toEqual({ reasoningEffort: 'max' })
+  })
+
+  // A toggle-only model offers no tier to project onto, so the profile's value is all there is.
+  it('keeps the profile tier when the model declares no efforts', () => {
+    const toggleOnly = makeModel({
+      reasoning: { controls: [{ kind: 'toggle' }], selectableEfforts: ['none', 'auto'] }
+    })
+    const invocation = resolveReasoningInvocation({ selection: 'auto', model: toggleOnly, profile: autoWire('medium') })
+
+    expect(encodeReasoningInvocation(invocation)).toEqual({ reasoningEffort: 'medium' })
+  })
+
+  // An explicit selection was already clamped to the model; its map entry is a vendor rename.
+  it('leaves an explicitly selected effort untouched by the projection', () => {
+    const invocation = resolveReasoningInvocation({
+      selection: 'xhigh',
+      model: withEfforts('low', 'xhigh'),
+      profile: {
+        effort: {
+          operations: [{ target: 'reasoningEffort', value: { source: 'effort' } }],
+          effortMap: { xhigh: 'max' }
+        }
+      }
+    })
+
+    expect(encodeReasoningInvocation(invocation)).toEqual({ reasoningEffort: 'max' })
   })
 })
 

--- a/src/main/ai/utils/reasoningSerializers.ts
+++ b/src/main/ai/utils/reasoningSerializers.ts
@@ -75,6 +75,13 @@ export function normalizeRequestedSelection(
   return (model.reasoning?.selectableEfforts ?? []).includes(selection) ? selection : 'default'
 }
 
+/** The concrete tiers a model declares — its vocabulary minus the two non-tier selections. */
+function declaredEfforts(model: Model): Exclude<ReasoningEffort, 'none' | 'auto'>[] {
+  return (model.reasoning?.selectableEfforts ?? []).filter(
+    (effort): effort is Exclude<ReasoningEffort, 'none' | 'auto'> => effort !== 'none' && effort !== 'auto'
+  )
+}
+
 /**
  * Project a selection onto what this model declares: the value itself, the
  * nearest effort it does declare, or `undefined` when it declares none.
@@ -93,11 +100,9 @@ export function resolveSelection(
     return selectable.includes(selection) ? selection : undefined
   }
 
-  const declared = selectable.filter(
-    (effort): effort is Exclude<ReasoningEffort, 'none' | 'auto'> => effort !== 'none' && effort !== 'auto'
-  )
-  // `selectableEfforts` is the model's UI vocabulary. A cross-dialect request can still carry
-  // canonical `auto`; let the wire profile map it when the target has adjustable effort tiers.
+  const declared = declaredEfforts(model)
+  // A cross-dialect request can still carry canonical `auto`; let the wire profile map it when the
+  // target has adjustable effort tiers. {@link resolveModeEffort} holds that mapping to this set.
   if (selection === 'auto') {
     return selectable.includes(selection) || declared.length > 0 ? selection : undefined
   }
@@ -117,12 +122,26 @@ function resolveMode(
   return profile.effort
 }
 
+/**
+ * An `effortMap` entry keyed by a real tier translates a selection the model already declared into
+ * the vendor's token, so it is deliberately outside the model's vocabulary and must stand. The
+ * `auto` entry is different: `auto` is synthesized per provider and never checked against a model,
+ * so it is the one value that reaches the wire unvalidated. Project it onto a declared tier first,
+ * then translate that tier exactly as an explicit selection would be.
+ */
 function resolveModeEffort(
   selection: CanonicalReasoningSelection,
-  mode: ReasoningWireMode
+  mode: ReasoningWireMode,
+  model: Model
 ): ReasoningEffort | undefined {
   if (selection === 'default' || selection === 'none') return undefined
-  return mode.effortMap?.[selection] ?? selection
+  const mapped = mode.effortMap?.[selection] ?? selection
+  if (selection !== 'auto' || mapped === 'auto') return mapped
+
+  const declared = declaredEfforts(model)
+  const projected = nearestThinkingOption(mapped, declared)
+  const nearest = declared.find((effort) => effort === projected)
+  return nearest ? (mode.effortMap?.[nearest] ?? nearest) : mapped
 }
 
 function resolveModeBudget(
@@ -166,7 +185,7 @@ export function resolveReasoningInvocation(input: ResolveReasoningInvocationInpu
   const mode = resolveMode(selection, input.profile)
   if (!mode) return omit('the profile has no wire mode for this effort', input.model, selection)
 
-  const effort = resolveModeEffort(selection, mode)
+  const effort = resolveModeEffort(selection, mode, input.model)
   const budgetTokens =
     'budget' in mode ? resolveModeBudget(selection, input.model, mode.budget, input.maxTokens) : undefined
 

--- a/src/main/ai/utils/reasoningSerializers.ts
+++ b/src/main/ai/utils/reasoningSerializers.ts
@@ -136,12 +136,18 @@ function resolveModeEffort(
 ): ReasoningEffort | undefined {
   if (selection === 'default' || selection === 'none') return undefined
   const mapped = mode.effortMap?.[selection] ?? selection
-  if (selection !== 'auto' || mapped === 'auto') return mapped
+  if (selection !== 'auto') return mapped
+
+  // A profile with no auto mode resolves to its effort one, which has no tier to stand for `auto`.
+  // The model's own default is the only one; without it `auto` keeps its plain meaning — omit the
+  // value and let the provider decide, rather than send the literal `auto` no vendor accepts.
+  const tier = mapped === 'auto' ? model.reasoning?.defaultEffort : mapped
+  if (tier === undefined || tier === 'auto') return undefined
 
   const declared = declaredEfforts(model)
-  const projected = nearestThinkingOption(mapped, declared)
+  const projected = nearestThinkingOption(tier, declared)
   const nearest = declared.find((effort) => effort === projected)
-  return nearest ? (mode.effortMap?.[nearest] ?? nearest) : mapped
+  return nearest ? (mode.effortMap?.[nearest] ?? nearest) : tier
 }
 
 function resolveModeBudget(

--- a/src/main/data/services/__tests__/AgentService.test.ts
+++ b/src/main/data/services/__tests__/AgentService.test.ts
@@ -415,6 +415,37 @@ describe('AgentService', () => {
   })
 
   describe('model updates', () => {
+    it('normalizes a stored medium effort when switching the agent to Kimi K3', async () => {
+      const kimiK3ModelId = createUniqueModelId('moonshot', 'kimi-k3')
+      await dbh.db
+        .insert(userProviderTable)
+        .values({
+          providerId: 'moonshot',
+          presetProviderId: 'moonshot',
+          name: 'Moonshot',
+          orderKey: generateOrderKeyBetween(null, null)
+        })
+        .onConflictDoNothing()
+      await dbh.db
+        .insert(userModelTable)
+        .values({
+          id: kimiK3ModelId,
+          providerId: 'moonshot',
+          modelId: 'kimi-k3',
+          presetModelId: 'kimi-k3',
+          orderKey: generateOrderKeyBetween(null, null)
+        })
+        .onConflictDoNothing()
+      const created = await insertAgent({ configuration: { reasoning_effort: 'medium' } })
+
+      const updated = agentService.updateAgent(created.id, { model: kimiK3ModelId })
+
+      expect(updated).toMatchObject({
+        model: kimiK3ModelId,
+        configuration: { reasoning_effort: 'high' }
+      })
+    })
+
     it('atomically normalizes the agent reasoning effort and preserves configuration', async () => {
       const created = await insertAgent({
         configuration: { avatar: '🤖', reasoning_effort: 'high' }

--- a/src/renderer/hooks/__tests__/useAssistant.test.tsx
+++ b/src/renderer/hooks/__tests__/useAssistant.test.tsx
@@ -1,6 +1,7 @@
-import { mockUseQuery } from '@test-mocks/renderer/useDataApi'
+import type { Model } from '@shared/data/types/model'
+import { mockUseMutation, mockUseQuery } from '@test-mocks/renderer/useDataApi'
 import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAssistant, useAssistants } from '../useAssistant'
@@ -202,5 +203,53 @@ describe('useAssistant', () => {
     expect(result.current.setModel).toBe(firstSetModel)
     expect(result.current.updateAssistant).toBe(firstUpdateAssistant)
     expect(result.current.updateAssistantSettings).toBe(firstUpdateAssistantSettings)
+  })
+
+  it('normalizes a stored medium effort when switching the assistant to Kimi K3', async () => {
+    const updateTrigger = vi.fn().mockResolvedValue({ id: 'assistant-1' })
+    mockUseMutation.mockImplementation((_method, path) => ({
+      trigger: path === '/assistants/:id' ? updateTrigger : vi.fn(),
+      isLoading: false,
+      error: undefined
+    }))
+    mockUseQuery.mockImplementation((path, options) => {
+      if (options?.enabled === false) return queryResult()
+      if (path === '/assistants/:id') {
+        return queryResult({
+          id: 'assistant-1',
+          name: 'Assistant 1',
+          modelId: 'moonshot::kimi-k2-6',
+          settings: { reasoning_effort: 'medium' },
+          mcpServerIds: [],
+          knowledgeBaseIds: []
+        })
+      }
+      return queryResult()
+    })
+    const kimiK3 = {
+      id: 'moonshot::kimi-k3',
+      providerId: 'moonshot',
+      apiModelId: 'kimi-k3',
+      name: 'Kimi K3',
+      capabilities: ['reasoning'],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false,
+      reasoning: {
+        controls: [{ kind: 'effort', values: ['low', 'high', 'max'] }, { kind: 'toggle' }],
+        selectableEfforts: ['low', 'high', 'max', 'none']
+      }
+    } as Model
+    const { result } = renderHook(() => useAssistant('assistant-1'))
+
+    await act(() => result.current.setModel(kimiK3))
+
+    expect(updateTrigger).toHaveBeenCalledWith({
+      params: { id: 'assistant-1' },
+      body: {
+        modelId: 'moonshot::kimi-k3',
+        settings: { reasoning_effort: 'high' }
+      }
+    })
   })
 })

--- a/src/renderer/hooks/__tests__/useAssistant.test.tsx
+++ b/src/renderer/hooks/__tests__/useAssistant.test.tsx
@@ -1,7 +1,6 @@
-import type { Model } from '@shared/data/types/model'
-import { mockUseMutation, mockUseQuery } from '@test-mocks/renderer/useDataApi'
+import { mockUseQuery } from '@test-mocks/renderer/useDataApi'
 import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
-import { act, renderHook } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAssistant, useAssistants } from '../useAssistant'
@@ -203,53 +202,5 @@ describe('useAssistant', () => {
     expect(result.current.setModel).toBe(firstSetModel)
     expect(result.current.updateAssistant).toBe(firstUpdateAssistant)
     expect(result.current.updateAssistantSettings).toBe(firstUpdateAssistantSettings)
-  })
-
-  it('normalizes a stored medium effort when switching the assistant to Kimi K3', async () => {
-    const updateTrigger = vi.fn().mockResolvedValue({ id: 'assistant-1' })
-    mockUseMutation.mockImplementation((_method, path) => ({
-      trigger: path === '/assistants/:id' ? updateTrigger : vi.fn(),
-      isLoading: false,
-      error: undefined
-    }))
-    mockUseQuery.mockImplementation((path, options) => {
-      if (options?.enabled === false) return queryResult()
-      if (path === '/assistants/:id') {
-        return queryResult({
-          id: 'assistant-1',
-          name: 'Assistant 1',
-          modelId: 'moonshot::kimi-k2-6',
-          settings: { reasoning_effort: 'medium' },
-          mcpServerIds: [],
-          knowledgeBaseIds: []
-        })
-      }
-      return queryResult()
-    })
-    const kimiK3 = {
-      id: 'moonshot::kimi-k3',
-      providerId: 'moonshot',
-      apiModelId: 'kimi-k3',
-      name: 'Kimi K3',
-      capabilities: ['reasoning'],
-      supportsStreaming: true,
-      isEnabled: true,
-      isHidden: false,
-      reasoning: {
-        controls: [{ kind: 'effort', values: ['low', 'high', 'max'] }, { kind: 'toggle' }],
-        selectableEfforts: ['low', 'high', 'max', 'none']
-      }
-    } as Model
-    const { result } = renderHook(() => useAssistant('assistant-1'))
-
-    await act(() => result.current.setModel(kimiK3))
-
-    expect(updateTrigger).toHaveBeenCalledWith({
-      params: { id: 'assistant-1' },
-      body: {
-        modelId: 'moonshot::kimi-k3',
-        settings: { reasoning_effort: 'high' }
-      }
-    })
   })
 })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Kimi K3 models inferred from their family name exposed only a reasoning toggle. A persisted `medium` selection could therefore normalize to `auto`, which the Moonshot provider mapped back to the unsupported `medium` effort and the request failed with HTTP 400.

After this PR:

The audited Kimi K3 SKU exposes only `low`, `high`, and `max` effort levels plus the off toggle. Kimi K3 Fast keeps its canonical effort-only controls. Uncontracted future K3/K4 identifiers no longer advertise effort controls before a matching provider wire exists. The Moonshot K3 provider maps automatic reasoning to `high`, while provider-specific overrides such as DashScope can still narrow the vocabulary. Existing Assistant and Agent settings normalize `medium` to `high` when switching to K3.

Fixes #20029

### Why we need it and why it was done in this way

The model capability registry is the upstream source of truth for reasoning controls, so the fix adds the documented K3 vocabulary there instead of adding model-ID conditionals to request builders. A K3-specific provider wire also prevents any automatic mode from reintroducing `medium`.

The following tradeoffs were made:

Effort controls are inferred only for the audited `kimi-k3` and `kimi-k3-fast` SKUs. Future Kimi generations retain reasoning-family membership but do not expose controls until their provider wire contract is known.

The following alternatives were considered:

Clamping `medium` only in the Moonshot request path was rejected because custom K3 models and Assistant/Agent model switches would still expose stale capability data. Broadly inferring controls for future K3/K4 identifiers was rejected because the Moonshot provider has no matching wire override for those identifiers.

Links to places where the discussion took place: #20029

### Breaking changes

None.

### Special notes for your reviewer

- Screenshots are not applicable because this changes capability metadata, request mapping, and persistence normalization without a visual UI change.
- Generated output is limited to the Moonshot K3 provider override, reasoning-family artifact, and required built-in product manifest provider-version sync; unrelated live upstream catalog drift is excluded.
- Verification: `pnpm lint`; `pnpm test:lint`; `pnpm build:builtin-knowledge:check`; `pnpm format:check`; 91 focused registry tests including catalog source sync; existing Assistant and Agent persistence tests from the original change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Kimi K3 requests failing when an unsupported medium reasoning effort was selected.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared reasoning serialization for all `auto` selections and provider wire metadata; regressions could affect non-Kimi models using automatic effort mapping.
> 
> **Overview**
> Fixes **HTTP 400 on Kimi K3** when stored or gateway **`auto`/`medium` reasoning** was serialized as unsupported `medium` (#20029).
> 
> **Registry & Moonshot:** `kimi-k3` and **`kimi-k3-fast`** now advertise **`low` / `high` / `max`** (plus off toggle on K3 only); future **`kimi-k3.1` / `kimi-k4`** no longer infer effort until wired. Moonshot adds a **`reasoningEffort` contract** for K3 SKUs (provider wire only had `thinking.type`). Catalog picks up **`kimi-k3-fast`** and bumps provider JSON versions.
> 
> **Wire profiles:** Several **`auto` modes** stop hard-coding effort as literals and use **`effortMap` + `source: effort`** (OpenRouter, MiMo responses, affected catalog entries) so the serializer can validate/project tiers. A registry test forbids effort-tier literals in `auto` operations.
> 
> **Serialization:** `resolveModeEffort` **projects profile `auto` onto the nearest declared model effort** before `effortMap` translation, so e.g. default `medium` becomes **`high`** for K3. Agent model updates **normalize persisted `medium` → `high`** when switching to Kimi K3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b6451ac5e51d740e8b3043e13285ff5ac9d51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
