### PR TITLE
fix(assistant-editor): clamp unsafe max token values

### DIFF
--- a/src/main/data/api/handlers/__tests__/assistants.test.ts
+++ b/src/main/data/api/handlers/__tests__/assistants.test.ts
@@ -212,6 +212,17 @@ describe('assistantHandlers', () => {
       expect(updateMock).toHaveBeenCalledWith(ASSISTANT_ID, { settings: { maxTokens: 8192 } })
     })
 
+    it('should reject unsafe max tokens before calling the service', async () => {
+      await expect(
+        assistantHandlers['/assistants/:id'].PATCH({
+          params: { id: ASSISTANT_ID },
+          body: { settings: { maxTokens: Number.MAX_SAFE_INTEGER + 1 } }
+        } as never)
+      ).rejects.toHaveProperty('name', 'ZodError')
+
+      expect(updateMock).not.toHaveBeenCalled()
+    })
+
     it('should reject an invalid group id before calling the service', async () => {
       await expect(
         assistantHandlers['/assistants/:id'].PATCH({

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -782,6 +782,7 @@ function AssistantAdvancedFields({
             render={({ field }) => (
               <InputNumber
                 min={1}
+                max={Number.MAX_SAFE_INTEGER}
                 step={1}
                 aria-label={t('library.config.basic.max_tokens')}
                 className="h-8 rounded-lg px-2.5"

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1487,6 +1487,33 @@ describe('edit dialogs', () => {
     )
   })
 
+  it('normalizes unsafe max tokens before auto-save persistence', async () => {
+    render(
+      <AssistantEditDialog
+        open
+        resource={{
+          ...ASSISTANT,
+          settings: { ...ASSISTANT.settings, enableMaxTokens: true }
+        }}
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    selectTab('Model')
+    const maxTokensInput = await screen.findByRole('spinbutton', { name: 'Max tokens' })
+
+    fireEvent.focus(maxTokensInput)
+    fireEvent.change(maxTokensInput, { target: { value: String(Number.MAX_SAFE_INTEGER + 1) } })
+    fireEvent.blur(maxTokensInput)
+
+    expect(maxTokensInput).toHaveValue(String(Number.MAX_SAFE_INTEGER))
+    await waitFor(() =>
+      expect(updateAssistantMock).toHaveBeenCalledWith({
+        body: { settings: { maxTokens: Number.MAX_SAFE_INTEGER } }
+      })
+    )
+  })
+
   it('shows the default tool-call cap and clamps custom rounds at 1000', async () => {
     render(
       <AssistantEditDialog

--- a/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
+++ b/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
@@ -152,6 +152,35 @@ describe('diffAssistantUpdate', () => {
     })
   })
 
+  it('repairs unsafe legacy max tokens without resending them during unrelated edits', () => {
+    const assistant = createAssistant({
+      settings: {
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        maxTokens: Number.MAX_SAFE_INTEGER + 1,
+        enableMaxTokens: false,
+        temperature: 0.7
+      } as AssistantSettings
+    })
+    const baseline = initialAssistantFormState(assistant)
+
+    expect(baseline.maxTokens).toBe(DEFAULT_ASSISTANT_SETTINGS.maxTokens)
+
+    const unrelatedUpdate = diffAssistantUpdate({ ...baseline, description: 'edited' }, baseline, assistant)
+    expect(unrelatedUpdate?.dto).toEqual({ description: 'edited' })
+    expect({ ...assistant.settings, ...unrelatedUpdate?.dto.settings }).toMatchObject({
+      temperature: 0.7
+    })
+
+    const repairUpdate = diffAssistantUpdate({ ...baseline, enableMaxTokens: true }, baseline, assistant)
+    expect(repairUpdate?.dto).toEqual({
+      settings: {
+        maxTokens: DEFAULT_ASSISTANT_SETTINGS.maxTokens,
+        enableMaxTokens: true
+      }
+    })
+    expect(UpdateAssistantSchema.safeParse(repairUpdate?.dto).success).toBe(true)
+  })
+
   it('emits only the changed settings key', () => {
     const assistant = createAssistant({
       settings: {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Typing a `maxTokens` value above JavaScript's safe integer range left the unsafe value in the assistant form. Auto-save then sent it to `PATCH /assistants/:id`, where schema validation rejected the whole update.

After this PR:

The Max tokens input clamps typed values to `Number.MAX_SAFE_INTEGER` on blur before auto-save. Existing unsafe stored values still open with the safe 4096 fallback, unrelated edits do not resend them, and enabling the limit persists the repaired value.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20020

### Why we need it and why it was done in this way

`AssistantSettingsSchema` already rejects unsafe integers and `InputNumber` already owns blur-time min/max normalization. Supplying the missing maximum at the input boundary prevents invalid values from entering auto-save while preserving the API's validation boundary.

The following tradeoffs were made:

- The field normalizes the value instead of showing an error that would immediately become stale. Genuine persistence failures continue to use the dialog's existing Save failed state.
- The limit is JavaScript's safe integer boundary rather than a provider-specific token cap because assistant model limits vary by provider.

The following alternatives were considered:

- Relaxing the API schema was rejected because unsafe integers cannot be represented reliably.
- Adding custom form validation was rejected because the shared `InputNumber` max contract already provides the required normalization and accessibility metadata.

Links to places where the discussion took place: #20020

### Breaking changes

None.

### Special notes for your reviewer

No UI screenshot is attached. A single isolated dev instance was attempted with `CS_DEV_USER_DATA_SUFFIX=issue20020`, but the v2 migration path resolver redirected that fresh profile to the user's legacy data directory and then exited because relaunch is unsupported in dev mode. The repository exposes no supported migration skip/override. The launch-created exact boot-config mapping was removed immediately, JSON validity and key absence were reverified, the user's packaged process remained untouched, and the unsafe launch was not retried. The visible normalization is covered by the dialog regression test.

Validation:

- `pnpm test:renderer src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx` (63 passed)
- `pnpm test:renderer src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts` (29 passed)
- `pnpm test:main src/main/data/api/handlers/__tests__/assistants.test.ts` (21 passed)
- `pnpm lint`
- `pnpm test:lint`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Assistant settings] Prevent unsafe Max tokens values from breaking assistant auto-save.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized assistant settings UI and test coverage; API validation behavior is unchanged aside from an explicit handler test.
> 
> **Overview**
> Fixes assistant auto-save failing when **Max tokens** exceeds JavaScript’s safe integer range (`Number.MAX_SAFE_INTEGER`).
> 
> The assistant editor’s Max tokens `InputNumber` now sets **`max={Number.MAX_SAFE_INTEGER}`**, so blur-time normalization clamps oversized typed values before debounced auto-save sends `PATCH /assistants/:id`. Regression tests cover the dialog (clamp + persist), API handler (reject with `ZodError` without calling the service), and form diff behavior for legacy unsafe stored values (default fallback in the UI, no resend on unrelated edits, repair when enabling the limit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f7ced172afcc1552f26470590f6eb86341f84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->