### PR TITLE
fix(open-responses): ignore marked keep-alive deltas

### DIFF
--- a/patches/@ai-sdk__open-responses@1.0.34.patch
+++ b/patches/@ai-sdk__open-responses@1.0.34.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.js b/dist/index.js
-index 74fedcb995ae1955ba56b5bfd39e3f9785f90385..a96fff7fd467756e268ed400d8a7df12445e3602 100644
+index 74fedcb995ae1955ba56b5bfd39e3f9785f90385..83f10a1a770adb5049c62db0e8ba1dfeb980c939 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -89,9 +89,18 @@ async function convertToOpenResponsesInput({
@@ -47,15 +47,19 @@ index 74fedcb995ae1955ba56b5bfd39e3f9785f90385..a96fff7fd467756e268ed400d8a7df12
              } else if (chunk.type === "response.reasoning_text.delta") {
                const reasoningChunk = chunk;
                controller.enqueue({
-@@ -577,6 +591,7 @@ var OpenResponsesLanguageModel = class {
+@@ -577,8 +591,11 @@ var OpenResponsesLanguageModel = class {
              } else if (chunk.type === "response.output_item.done" && chunk.item.type === "reasoning") {
                controller.enqueue({ type: "reasoning-end", id: chunk.item.id });
                isActiveReasoning = false;
 +              activeReasoningId = null;
              } else if (chunk.type === "response.output_item.added" && chunk.item.type === "message") {
                controller.enqueue({ type: "text-start", id: chunk.item.id });
++            } else if (chunk.type === "response.output_text.delta" && chunk.item_id === "SSE-Keep-Alive" && chunk["SSE-Keep-Alive"] === true) {
++              return;
              } else if (chunk.type === "response.output_text.delta") {
-@@ -606,8 +621,8 @@ var OpenResponsesLanguageModel = class {
+               controller.enqueue({
+                 type: "text-delta",
+@@ -606,8 +623,8 @@ var OpenResponsesLanguageModel = class {
              }
            },
            flush(controller) {
@@ -67,7 +71,7 @@ index 74fedcb995ae1955ba56b5bfd39e3f9785f90385..a96fff7fd467756e268ed400d8a7df12
              controller.enqueue({
                type: "finish",
 diff --git a/dist/index.mjs b/dist/index.mjs
-index c3b70bc3a46afbe82f704939e4b1ccc6d47706ee..bf720e89213a9748411d256e1b1c76188a9e23c8 100644
+index c3b70bc3a46afbe82f704939e4b1ccc6d47706ee..9636569f9016ffd81929b82531a2b7900329c9fb 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
 @@ -75,9 +75,18 @@ async function convertToOpenResponsesInput({
@@ -115,15 +119,19 @@ index c3b70bc3a46afbe82f704939e4b1ccc6d47706ee..bf720e89213a9748411d256e1b1c7618
              } else if (chunk.type === "response.reasoning_text.delta") {
                const reasoningChunk = chunk;
                controller.enqueue({
-@@ -566,6 +580,7 @@ var OpenResponsesLanguageModel = class {
+@@ -566,8 +580,11 @@ var OpenResponsesLanguageModel = class {
              } else if (chunk.type === "response.output_item.done" && chunk.item.type === "reasoning") {
                controller.enqueue({ type: "reasoning-end", id: chunk.item.id });
                isActiveReasoning = false;
 +              activeReasoningId = null;
              } else if (chunk.type === "response.output_item.added" && chunk.item.type === "message") {
                controller.enqueue({ type: "text-start", id: chunk.item.id });
++            } else if (chunk.type === "response.output_text.delta" && chunk.item_id === "SSE-Keep-Alive" && chunk["SSE-Keep-Alive"] === true) {
++              return;
              } else if (chunk.type === "response.output_text.delta") {
-@@ -595,8 +610,8 @@ var OpenResponsesLanguageModel = class {
+               controller.enqueue({
+                 type: "text-delta",
+@@ -595,8 +612,8 @@ var OpenResponsesLanguageModel = class {
              }
            },
            flush(controller) {
@@ -179,7 +187,7 @@ index 2e06c35c5d13146dbb42ba9bbe61828bb4bd1a66..4e36fecc5c4a6afddf54a067db4ab5a9
          if (assistantContent.length > 0) {
            input.push({
 diff --git a/src/responses/open-responses-language-model.ts b/src/responses/open-responses-language-model.ts
-index 2650edaed75f2bb981f584f702b5da2894241b70..eac6ff3712948c9652b93310a2cbb79c3874e421 100644
+index 2650edaed75f2bb981f584f702b5da2894241b70..af2fed1ef181330385afa93a1adba20f4d87a135 100644
 --- a/src/responses/open-responses-language-model.ts
 +++ b/src/responses/open-responses-language-model.ts
 @@ -338,6 +338,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
@@ -206,7 +214,20 @@ index 2650edaed75f2bb981f584f702b5da2894241b70..eac6ff3712948c9652b93310a2cbb79c
              }
  
              // Text events
-@@ -501,8 +504,9 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
+@@ -467,6 +470,12 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
+               chunk.item.type === 'message'
+             ) {
+               controller.enqueue({ type: 'text-start', id: chunk.item.id });
++            } else if (
++              chunk.type === 'response.output_text.delta' &&
++              chunk.item_id === 'SSE-Keep-Alive' &&
++              (chunk as Record<string, unknown>)['SSE-Keep-Alive'] === true
++            ) {
++              return;
+             } else if (chunk.type === 'response.output_text.delta') {
+               controller.enqueue({
+                 type: 'text-delta',
+@@ -501,8 +510,9 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
            },
  
            flush(controller) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ overrides:
 patchedDependencies:
   '@ai-sdk/anthropic': a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34
   '@ai-sdk/google@3.0.113': 8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874
-  '@ai-sdk/open-responses@1.0.34': 7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648
+  '@ai-sdk/open-responses@1.0.34': 83f5f29fe22a32569d6255265c8ebd3420fabe87e392c751590c8f4c06dab366
   '@ai-sdk/openai-compatible@2.0.72': e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480
   '@ai-sdk/openai@3.0.53': 9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c
   '@ai-sdk/react@3.0.187': 8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230
@@ -259,7 +259,7 @@ importers:
         version: 3.0.30(zod@4.3.4)
       '@ai-sdk/open-responses':
         specifier: 1.0.34
-        version: 1.0.34(patch_hash=7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648)(zod@4.3.4)
+        version: 1.0.34(patch_hash=83f5f29fe22a32569d6255265c8ebd3420fabe87e392c751590c8f4c06dab366)(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
         version: 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)
@@ -16126,7 +16126,7 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/open-responses@1.0.34(patch_hash=7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648)(zod@4.3.4)':
+  '@ai-sdk/open-responses@1.0.34(patch_hash=83f5f29fe22a32569d6255265c8ebd3420fabe87e392c751590c8f4c06dab366)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)

--- a/src/main/ai/provider/__tests__/openResponsesPatch.test.ts
+++ b/src/main/ai/provider/__tests__/openResponsesPatch.test.ts
@@ -80,6 +80,27 @@ describe('patched @ai-sdk/open-responses', () => {
     ])
   })
 
+  it('exposes unknown events as bounded raw diagnostics without creating message parts', async () => {
+    const unknownEvent = { type: 'vendor.progress', sequence_number: 7, status: 'waiting' }
+    const chunks = await collect(
+      (
+        await sseModel([unknownEvent]).doStream({
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+          includeRawChunks: true
+        })
+      ).stream
+    )
+
+    expect(chunks.filter((chunk) => chunk.type === 'raw').map((chunk) => chunk.rawValue)).toEqual([unknownEvent])
+    expect(
+      chunks.some((chunk) =>
+        ['text-start', 'text-delta', 'text-end', 'reasoning-start', 'reasoning-delta', 'reasoning-end'].includes(
+          chunk.type
+        )
+      )
+    ).toBe(false)
+  })
+
   it('does not drop ordinary text solely because its item id resembles a keep-alive marker', async () => {
     const chunks = await collect(
       (

--- a/src/main/ai/provider/__tests__/openResponsesPatch.test.ts
+++ b/src/main/ai/provider/__tests__/openResponsesPatch.test.ts
@@ -2,12 +2,7 @@ import { createOpenResponses } from '@ai-sdk/open-responses'
 import type { LanguageModelV3StreamPart } from '@ai-sdk/provider'
 import { describe, expect, it } from 'vitest'
 
-/**
- * Guards patches/@ai-sdk__open-responses@1.0.34.patch — the two behaviors subset
- * Responses servers depend on: replaying the chain of thought itself (thinking
- * dialects reject a turn that dropped it, #18150) and closing an unterminated
- * reasoning item with its real id.
- */
+/** Guards the provider compatibility behaviors in patches/@ai-sdk__open-responses@1.0.34.patch. */
 
 function sseModel(events: unknown[]) {
   const body = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join('')}data: [DONE]\n\n`
@@ -31,6 +26,84 @@ async function collect(stream: ReadableStream<LanguageModelV3StreamPart>) {
 }
 
 describe('patched @ai-sdk/open-responses', () => {
+  it('drops gateway keep-alive deltas before they become text parts', async () => {
+    const chunks = await collect(
+      (
+        await sseModel([
+          {
+            type: 'response.output_text.delta',
+            item_id: 'SSE-Keep-Alive',
+            delta: '\u200b',
+            'SSE-Keep-Alive': true
+          }
+        ]).doStream({ prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] })
+      ).stream
+    )
+
+    expect(chunks.some((chunk) => chunk.type === 'text-delta')).toBe(false)
+  })
+
+  it('continues normal text streaming around gateway keep-alive deltas', async () => {
+    const heartbeat = {
+      type: 'response.output_text.delta',
+      item_id: 'SSE-Keep-Alive',
+      delta: '\u200b',
+      'SSE-Keep-Alive': true
+    }
+    const chunks = await collect(
+      (
+        await sseModel([
+          heartbeat,
+          { type: 'response.output_item.added', output_index: 0, item: { type: 'message', id: 'msg_1' } },
+          { type: 'response.output_text.delta', item_id: 'msg_1', output_index: 0, delta: 'color' },
+          heartbeat,
+          { type: 'response.output_text.delta', item_id: 'msg_1', output_index: 0, delta: ' answer' },
+          { type: 'response.output_item.done', output_index: 0, item: { type: 'message', id: 'msg_1' } },
+          { type: 'response.completed', response: { id: 'resp_1', usage: { input_tokens: 1, output_tokens: 2 } } }
+        ]).doStream({ prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] })
+      ).stream
+    )
+
+    expect(
+      chunks
+        .filter((chunk) => chunk.type === 'text-start' || chunk.type === 'text-delta' || chunk.type === 'text-end')
+        .map((chunk) => ({
+          id: chunk.id,
+          text: chunk.type === 'text-delta' ? chunk.delta : undefined,
+          type: chunk.type
+        }))
+    ).toEqual([
+      { id: 'msg_1', text: undefined, type: 'text-start' },
+      { id: 'msg_1', text: 'color', type: 'text-delta' },
+      { id: 'msg_1', text: ' answer', type: 'text-delta' },
+      { id: 'msg_1', text: undefined, type: 'text-end' }
+    ])
+  })
+
+  it('does not drop ordinary text solely because its item id resembles a keep-alive marker', async () => {
+    const chunks = await collect(
+      (
+        await sseModel([
+          {
+            type: 'response.output_item.added',
+            output_index: 0,
+            item: { type: 'message', id: 'SSE-Keep-Alive' }
+          },
+          { type: 'response.output_text.delta', item_id: 'SSE-Keep-Alive', output_index: 0, delta: 'legitimate' },
+          {
+            type: 'response.output_item.done',
+            output_index: 0,
+            item: { type: 'message', id: 'SSE-Keep-Alive' }
+          }
+        ]).doStream({ prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] })
+      ).stream
+    )
+
+    expect(chunks.filter((chunk) => chunk.type === 'text-delta')).toEqual([
+      { type: 'text-delta', id: 'SSE-Keep-Alive', delta: 'legitimate' }
+    ])
+  })
+
   it('replays assistant reasoning as reasoning_text content items', async () => {
     let body: any
     const model = createOpenResponses({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

An Open Responses-compatible gateway could encode its heartbeat as a marked `response.output_text.delta`. The provider forwarded that delta without a matching `text-start`, causing AI SDK assembly to abort with `text part SSE-Keep-Alive not found`.

After this PR:

The patched Open Responses provider ignores only gateway deltas carrying both the exact `SSE-Keep-Alive` item ID and the explicit `SSE-Keep-Alive: true` marker. Normal text streaming continues around heartbeats, while ordinary text that merely uses the same item ID remains intact.

Fixes #20026

### Why we need it and why it was done in this way

The malformed generated part originates in `@ai-sdk/open-responses`, before Cherry Studio or AI SDK core can safely assemble it. Filtering at the provider's event-to-part boundary prevents the orphan delta from entering message state while preserving all unrelated events.

The following tradeoffs were made:

- Keep the compatibility fix in the repository's existing pnpm dependency patch until the upstream provider handles this gateway marker.
- Require both gateway-specific markers instead of relying on the zero-width delta content.

The following alternatives were considered:

- Filtering SSE comments or the `event:` field does not address the JSON delta payload emitted by the affected gateway.
- Filtering only by item ID or zero-width content could discard legitimate model output.
- Catching the error in AI SDK's downstream part assembler is too late and would weaken its missing-part invariant.

Links to places where the discussion took place: #20026

### Breaking changes

None.

### Special notes for your reviewer

Observed gateway payload:

```json
{
  "type": "response.output_text.delta",
  "item_id": "SSE-Keep-Alive",
  "delta": "\u200b",
  "SSE-Keep-Alive": true
}
```

Verification:

- `pnpm exec vitest run --project main src/main/ai/provider/__tests__/openResponsesPatch.test.ts` (6 passed)
- `pnpm lint`
- `pnpm test:lint`
- Unknown JSON events remain bounded to one raw diagnostic when `includeRawChunks` is enabled and do not create message parts.
- Screenshots: N/A; this changes non-UI provider stream handling.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Open Responses conversations failing when compatible gateways emit marked SSE keep-alive deltas.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to a vendored provider patch and regression tests; behavior is narrowly gated on explicit keep-alive markers with no auth or data-model impact.
> 
> **Overview**
> Updates the **`@ai-sdk/open-responses@1.0.34`** pnpm patch so marked gateway heartbeats no longer break streaming assembly. **`response.output_text.delta`** events are skipped only when **`item_id`** is **`SSE-Keep-Alive`** and **`SSE-Keep-Alive: true`** are both present, so real message text with the same id still streams normally.
> 
> The same patch refresh keeps other compatibility fixes: assistant **`reasoning`** turns are sent back as **`reasoning`** / **`reasoning_text`** items, and stream **`flush`** emits **`reasoning-end`** with the tracked item id instead of a hardcoded **`reasoning-0`**.
> 
> **`openResponsesPatch.test.ts`** adds coverage for keep-alive filtering, interleaved heartbeats, non-dropping of legitimate **`SSE-Keep-Alive`** message ids, and raw unknown events; **`pnpm-lock.yaml`** records the new patch hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aca007c937a8e2aff7fce57d486f3100e6dec19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->