### PR TITLE
fix(mcp): reject unresolved launch paths

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -217,7 +217,12 @@ export class McpRuntimeService extends BaseService {
     return mcpServerService.getById(serverId)
   }
 
-  public setServerStatus(serverId: string, state: McpRuntimeState, error?: unknown): void {
+  public setServerStatus(
+    serverId: string,
+    state: McpRuntimeState,
+    error?: unknown,
+    details?: Record<string, number | string>
+  ): void {
     // A late writer racing removal (e.g. a connectivity check's error path) must not
     // resurrect the status entry doRemoveServer deleted for a removed server.
     if (this.removedServerIds.has(serverId)) {
@@ -226,6 +231,13 @@ export class McpRuntimeService extends BaseService {
 
     const lastError =
       state === 'error' ? (error instanceof Error ? error.message : String(error ?? 'Unknown error')) : undefined
+    const errorProperties = error && typeof error === 'object' ? (error as { code?: unknown; path?: unknown }) : {}
+    const code = details?.code ?? errorProperties.code
+    const errorCode =
+      state === 'error' && (typeof code === 'string' || typeof code === 'number') ? String(code) : undefined
+    const path = details?.path ?? errorProperties.path
+    const errorPath =
+      state === 'error' && (typeof path === 'string' || typeof path === 'number') ? String(path) : undefined
 
     const cacheService = application.get('CacheService')
     const key = mcpStatusCacheKey(serverId)
@@ -234,14 +246,22 @@ export class McpRuntimeService extends BaseService {
     // guard every status touch (ping/list/prewarm hot paths) would broadcast IPC to all
     // windows. lastCheckedAt has no UI consumer, so leaving it stale on no-op writes is safe.
     const current = cacheService.getShared(key) as McpRuntimeStatus | undefined
-    if (current && current.state === state && current.lastError === lastError) {
+    if (
+      current &&
+      current.state === state &&
+      current.lastError === lastError &&
+      current.errorCode === errorCode &&
+      current.errorPath === errorPath
+    ) {
       return
     }
 
     const status: McpRuntimeStatus = {
       state,
       lastCheckedAt: Date.now(),
-      ...(lastError !== undefined ? { lastError } : {})
+      ...(lastError !== undefined ? { lastError } : {}),
+      ...(errorCode !== undefined ? { errorCode } : {}),
+      ...(errorPath !== undefined ? { errorPath } : {})
     }
     cacheService.setShared(key, status)
   }
@@ -458,6 +478,7 @@ export class McpRuntimeService extends BaseService {
     })
 
     const args = [...(server.args || [])]
+    let transportErrorDetails: Record<string, number | string> | undefined
     const createServerTransport = (typeOverride?: McpServerType) =>
       createTransport({
         sdk,
@@ -466,7 +487,10 @@ export class McpRuntimeService extends BaseService {
         typeOverride,
         authProvider,
         logger: getServerLogger(server),
-        onServerLog: (entry) => this.emitServerLog(server, entry)
+        onServerLog: (entry) => this.emitServerLog(server, entry),
+        onTransportError: (details) => {
+          transportErrorDetails = details
+        }
       })
 
     try {
@@ -508,7 +532,7 @@ export class McpRuntimeService extends BaseService {
       })
       return client
     } catch (error) {
-      this.setServerStatus(server.id, 'error', error)
+      this.setServerStatus(server.id, 'error', error, transportErrorDetails)
       getServerLogger(server).error(`Error activating server ${server.name}`, error as Error)
       this.emitServerLog(server, {
         timestamp: Date.now(),

--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -229,17 +229,27 @@ export class McpRuntimeService extends BaseService {
       return
     }
 
-    const lastError =
+    const reportedLastError =
       state === 'error' ? (error instanceof Error ? error.message : String(error ?? 'Unknown error')) : undefined
     const cacheService = application.get('CacheService')
     const key = mcpStatusCacheKey(serverId)
     const current = cacheService.getShared(key) as McpRuntimeStatus | undefined
-    const repeatsCurrentError = current?.state === 'error' && state === 'error' && current.lastError === lastError
     const errorProperties = error && typeof error === 'object' ? (error as { code?: unknown; path?: unknown }) : {}
-    const code = details?.code ?? errorProperties.code ?? (repeatsCurrentError ? current.errorCode : undefined)
+    const incomingCode = details?.code ?? errorProperties.code
+    const incomingPath = details?.path ?? errorProperties.path
+    // A generic SDK/connectivity error must not erase a richer stdio failure; non-error transitions still clear it.
+    const preservesCurrentDiagnostic =
+      state === 'error' &&
+      current?.state === 'error' &&
+      (current.errorCode !== undefined || current.errorPath !== undefined) &&
+      incomingCode === undefined &&
+      incomingPath === undefined
+    const lastError = preservesCurrentDiagnostic ? current.lastError : reportedLastError
+    const repeatsCurrentError = current?.state === 'error' && state === 'error' && current.lastError === lastError
+    const code = incomingCode ?? (repeatsCurrentError ? current.errorCode : undefined)
     const errorCode =
       state === 'error' && (typeof code === 'string' || typeof code === 'number') ? String(code) : undefined
-    const path = details?.path ?? errorProperties.path ?? (repeatsCurrentError ? current.errorPath : undefined)
+    const path = incomingPath ?? (repeatsCurrentError ? current.errorPath : undefined)
     const errorPath =
       state === 'error' && (typeof path === 'string' || typeof path === 'number') ? String(path) : undefined
 

--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -231,21 +231,21 @@ export class McpRuntimeService extends BaseService {
 
     const lastError =
       state === 'error' ? (error instanceof Error ? error.message : String(error ?? 'Unknown error')) : undefined
-    const errorProperties = error && typeof error === 'object' ? (error as { code?: unknown; path?: unknown }) : {}
-    const code = details?.code ?? errorProperties.code
-    const errorCode =
-      state === 'error' && (typeof code === 'string' || typeof code === 'number') ? String(code) : undefined
-    const path = details?.path ?? errorProperties.path
-    const errorPath =
-      state === 'error' && (typeof path === 'string' || typeof path === 'number') ? String(path) : undefined
-
     const cacheService = application.get('CacheService')
     const key = mcpStatusCacheKey(serverId)
+    const current = cacheService.getShared(key) as McpRuntimeStatus | undefined
+    const repeatsCurrentError = current?.state === 'error' && state === 'error' && current.lastError === lastError
+    const errorProperties = error && typeof error === 'object' ? (error as { code?: unknown; path?: unknown }) : {}
+    const code = details?.code ?? errorProperties.code ?? (repeatsCurrentError ? current.errorCode : undefined)
+    const errorCode =
+      state === 'error' && (typeof code === 'string' || typeof code === 'number') ? String(code) : undefined
+    const path = details?.path ?? errorProperties.path ?? (repeatsCurrentError ? current.errorPath : undefined)
+    const errorPath =
+      state === 'error' && (typeof path === 'string' || typeof path === 'number') ? String(path) : undefined
 
     // setShared dedups via isEqual, but lastCheckedAt changes every call, so without this
     // guard every status touch (ping/list/prewarm hot paths) would broadcast IPC to all
     // windows. lastCheckedAt has no UI consumer, so leaving it stale on no-op writes is safe.
-    const current = cacheService.getShared(key) as McpRuntimeStatus | undefined
     if (
       current &&
       current.state === state &&

--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -488,8 +488,11 @@ export class McpRuntimeService extends BaseService {
         authProvider,
         logger: getServerLogger(server),
         onServerLog: (entry) => this.emitServerLog(server, entry),
-        onTransportError: (details) => {
+        onTransportError: (error, details) => {
           transportErrorDetails = details
+          if (this.clients.get(serverKey) === client) {
+            this.setServerStatus(server.id, 'error', error, details)
+          }
         }
       })
 

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -296,6 +296,34 @@ describe('McpRuntimeService stdio environment', () => {
     expect(MockMainCacheServiceUtils.getSharedCacheValue('mcp.status.other-server')).toBeUndefined()
   })
 
+  it('reports a stdio transport error that occurs after the client connected', async () => {
+    const command = 'C:\\Program Files\\MCP\\server.exe'
+    const service = new McpRuntimeService()
+    const server = {
+      id: 'stdio-server',
+      name: 'stdio-server',
+      command: 'npx',
+      isActive: true
+    } as McpServer
+    getByIdMock.mockReturnValue(server)
+
+    await service.withClient(server.id, async () => undefined)
+    const error = Object.assign(new Error(`spawn ${command} EPERM`), {
+      code: 'EPERM',
+      errno: -4048,
+      syscall: `spawn ${command}`,
+      path: command
+    })
+    mcpSdkMock.stdioTransports.at(-1)?.onerror?.(error)
+
+    expect(MockMainCacheServiceUtils.getSharedCacheValue('mcp.status.stdio-server')).toMatchObject({
+      state: 'error',
+      lastError: error.message,
+      errorCode: 'EPERM',
+      errorPath: command
+    })
+  })
+
   it('rejects an unresolved placeholder before creating an SDK transport and identifies the configured path', async () => {
     const command = '${MCP_COMMAND}'
     const service = new McpRuntimeService()

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -479,6 +479,31 @@ describe('McpRuntimeService.setServerStatus', () => {
     })
     expect(MockMainCacheServiceUtils.getMockCallCounts().setShared).toBe(1)
   })
+
+  it('does not replace a structured transport diagnostic with a later generic error', () => {
+    const service = new McpRuntimeService()
+    const command = 'C:\\MCP\\server.exe'
+    const transportError = new Error(`spawn ${command} EPERM`)
+
+    service.setServerStatus('server-1', 'error', transportError, { code: 'EPERM', path: command })
+    service.setServerStatus('server-1', 'error', new Error('Connection closed'))
+
+    expect(MockMainCacheServiceUtils.getSharedCacheValue('mcp.status.server-1')).toMatchObject({
+      state: 'error',
+      lastError: transportError.message,
+      errorCode: 'EPERM',
+      errorPath: command
+    })
+    expect(MockMainCacheServiceUtils.getMockCallCounts().setShared).toBe(1)
+
+    service.setServerStatus('server-1', 'connected')
+
+    const connected = MockMainCacheServiceUtils.getSharedCacheValue('mcp.status.server-1')
+    expect(connected).toMatchObject({ state: 'connected' })
+    expect(connected).not.toHaveProperty('lastError')
+    expect(connected).not.toHaveProperty('errorCode')
+    expect(connected).not.toHaveProperty('errorPath')
+  })
 })
 
 describe('McpRuntimeService connect single-flight', () => {

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -435,6 +435,22 @@ describe('McpRuntimeService.setServerStatus', () => {
 
     expect(MockMainCacheServiceUtils.getMockCallCounts().setShared).toBe(2)
   })
+
+  it('preserves structured diagnostics when the same error is reported again without details', () => {
+    const service = new McpRuntimeService()
+    const error = new Error('Connection closed')
+
+    service.setServerStatus('server-1', 'error', error, { code: 'EPERM', path: 'C:\\MCP\\server.exe' })
+    service.setServerStatus('server-1', 'error', error)
+
+    expect(MockMainCacheServiceUtils.getSharedCacheValue('mcp.status.server-1')).toMatchObject({
+      state: 'error',
+      lastError: 'Connection closed',
+      errorCode: 'EPERM',
+      errorPath: 'C:\\MCP\\server.exe'
+    })
+    expect(MockMainCacheServiceUtils.getMockCallCounts().setShared).toBe(1)
+  })
 })
 
 describe('McpRuntimeService connect single-flight', () => {

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -5,7 +5,7 @@ import type { McpServer } from '@shared/data/types/mcpServer'
 import { BuiltinMcpServerNames } from '@shared/utils/mcp'
 import { MockMainCacheServiceUtils } from '@test-mocks/main/CacheService'
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mcpCatalogMock = vi.hoisted(() => ({
   clearSharedToolsCache: vi.fn(),
@@ -90,7 +90,7 @@ const mcpSdkMock = vi.hoisted(() => {
     constructor() {
       clients.push(this)
     }
-    async connect(transport: { kind: string }) {
+    async connect(transport: { kind: string; onerror?: (error: Error) => void }) {
       // Mirror MCP SDK Protocol.connect: _transport is set before start() runs, and a failed
       // start() leaves it set. This is what makes the fallback retry fail unless client.close()
       // resets it — the test would not catch that regression otherwise.
@@ -101,6 +101,10 @@ const mcpSdkMock = vi.hoisted(() => {
       this.connectCalls.push({ kind: transport.kind })
       if (transport.kind === 'sse') {
         throw new SseError(405, 'Non-200 status code (405)')
+      }
+      if (transport.kind === 'stdio' && mcpSdkMock.state.stdioError) {
+        transport.onerror?.(mcpSdkMock.state.stdioError)
+        throw new Error('Connection closed')
       }
       if (mcpSdkMock.state.failStreamable) {
         if (mcpSdkMock.state.failStreamableUnauthorized) {
@@ -119,13 +123,16 @@ const mcpSdkMock = vi.hoisted(() => {
       this.code = code
     }
   }
-  const stdioTransports: Array<{ env?: Record<string, string> }> = []
+  const stdioTransports: StdioClientTransport[] = []
   const streamableHttpTransports: Array<{ url: unknown; opts?: any }> = []
   class StdioClientTransport {
     kind = 'stdio' as const
     stderr = null
+    onerror?: (error: Error) => void
+    env?: Record<string, string>
     constructor(params: { env?: Record<string, string> }) {
-      stdioTransports.push(params)
+      this.env = params.env
+      stdioTransports.push(this)
     }
   }
   return {
@@ -142,6 +149,7 @@ const mcpSdkMock = vi.hoisted(() => {
       failStreamable: false,
       failStreamableUnauthorized: false,
       failStreamableCode: 503,
+      stdioError: undefined as NodeJS.ErrnoException | undefined,
       capabilities: undefined as Record<string, unknown> | undefined
     }
   }
@@ -210,7 +218,12 @@ describe('McpRuntimeService stdio environment', () => {
     BaseService.resetInstances()
     MockMainCacheServiceUtils.resetMocks()
     mcpSdkMock.stdioTransports.length = 0
+    mcpSdkMock.state.stdioError = undefined
     shellEnvMock.getShellEnv.mockResolvedValue({ Path: 'C:\\Users\\me\\.cherrystudio\\bin;C:\\Windows' })
+  })
+
+  afterEach(() => {
+    mcpSdkMock.state.stdioError = undefined
   })
 
   it('canonicalizes a mixed-case Windows Path key to PATH before crossing the MCP SDK boundary', async () => {
@@ -253,6 +266,55 @@ describe('McpRuntimeService stdio environment', () => {
     expect(transportEnv?.PATH).toBe('/shell/bin')
     expect(transportEnv?.Path).toBe('server-metadata')
     platformSpy.mockRestore()
+  })
+
+  it('preserves EPERM details when the SDK reduces the connection failure to Connection closed', async () => {
+    const command = 'C:\\Program Files\\MCP\\server.exe'
+    mcpSdkMock.state.stdioError = Object.assign(new Error(`spawn ${command} EPERM`), {
+      code: 'EPERM',
+      errno: -4048,
+      syscall: `spawn ${command}`,
+      path: command
+    })
+    const service = new McpRuntimeService()
+    const server = {
+      id: 'stdio-server',
+      name: 'stdio-server',
+      command: 'npx',
+      isActive: true
+    } as McpServer
+    getByIdMock.mockReturnValue(server)
+
+    await expect(service.withClient(server.id, async () => undefined)).rejects.toThrow('Connection closed')
+
+    expect(MockMainCacheServiceUtils.getSharedCacheValue('mcp.status.stdio-server')).toMatchObject({
+      state: 'error',
+      lastError: 'Connection closed',
+      errorCode: 'EPERM',
+      errorPath: command
+    })
+    expect(MockMainCacheServiceUtils.getSharedCacheValue('mcp.status.other-server')).toBeUndefined()
+  })
+
+  it('rejects an unresolved placeholder before creating an SDK transport and identifies the configured path', async () => {
+    const command = '${MCP_COMMAND}'
+    const service = new McpRuntimeService()
+    const server = {
+      id: 'stdio-server',
+      name: 'stdio-server',
+      command,
+      isActive: true
+    } as McpServer
+    getByIdMock.mockReturnValue(server)
+
+    await expect(service.withClient(server.id, async () => undefined)).rejects.toThrow(/unresolved placeholder/i)
+
+    expect(mcpSdkMock.stdioTransports).toHaveLength(0)
+    expect(MockMainCacheServiceUtils.getSharedCacheValue('mcp.status.stdio-server')).toMatchObject({
+      state: 'error',
+      errorCode: 'MCP_UNRESOLVED_PLACEHOLDER',
+      errorPath: command
+    })
   })
 })
 

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -181,6 +181,7 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
 const { McpRuntimeService, McpCallToolPayloadSchema, McpGetResourcePayloadSchema } = await import(
   '../McpRuntimeService'
 )
+const { getTransportCandidates } = await import('../mcpClientSdk')
 
 /** Build the JSON server key shape the service uses internally (only `id` is read by close logic). */
 function serverKeyFor(id: string): string {
@@ -1154,6 +1155,10 @@ describe('McpRuntimeService transport fallback (issue #16891)', () => {
   }
 
   type MockClient = InstanceType<typeof mcpSdkMock.Client>
+
+  it('does not create HTTP fallback candidates for a whitespace-only URL', () => {
+    expect(getTransportCandidates({ ...urlServer('sse'), baseUrl: '   ', command: 'npx' })).toBeNull()
+  })
 
   it('falls back to Streamable HTTP when an sse-typed server rejects the SSE GET with 405', async () => {
     const service = new McpRuntimeService()

--- a/src/main/ai/mcp/__tests__/mcpLaunch.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpLaunch.test.ts
@@ -110,4 +110,16 @@ describe('resolveLaunchCommand', () => {
     await expect(resolve('   ')).rejects.toThrow(/MCP stdio command cannot be empty/)
     expect(commandMock.findCommandInShellEnv).not.toHaveBeenCalled()
   })
+
+  it.each(['${MCP_COMMAND}', 'C:\\%MCP_HOME%\\server.exe', 'YOUR_MCP_COMMAND'])(
+    'rejects unresolved command placeholder %s before launch',
+    async (command) => {
+      await expect(resolve(command)).rejects.toMatchObject({
+        message: expect.stringMatching(/unresolved placeholder/i),
+        code: 'MCP_UNRESOLVED_PLACEHOLDER',
+        path: command
+      })
+      expect(commandMock.findCommandInShellEnv).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/src/main/ai/mcp/__tests__/mcpTransport.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpTransport.test.ts
@@ -7,6 +7,7 @@ const createInMemoryMcpServer = vi.hoisted(() => vi.fn().mockResolvedValue(inMem
 const getBuiltinHttpHeaders = vi.hoisted(() => vi.fn<() => Record<string, string>>(() => ({})))
 const hasInMemoryImplementation = vi.hoisted(() => vi.fn<(name: string) => boolean>(() => true))
 const getShellEnv = vi.hoisted(() => vi.fn(async () => ({ PATH: '/shell/bin' })))
+const mcpPackageService = vi.hoisted(() => ({ getResolvedMcpConfig: vi.fn() }))
 vi.mock('@main/ai/mcp/servers/factory', () => ({
   createInMemoryMcpServer,
   getBuiltinRegistryEnv: () => ({}),
@@ -16,7 +17,7 @@ vi.mock('@main/ai/mcp/servers/factory', () => ({
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
-  return mockApplicationFactory({} as Record<string, unknown>)
+  return mockApplicationFactory({ McpPackageService: mcpPackageService } as never)
 })
 vi.mock('electron', () => ({ net: { fetch: vi.fn() } }))
 vi.mock('@main/utils/shellEnv', () => ({ getShellEnv }))
@@ -176,6 +177,21 @@ describe('createTransport', () => {
     expect(getShellEnv).not.toHaveBeenCalled()
   })
 
+  it('rejects an unresolved DXT command placeholder before requesting the login shell environment', async () => {
+    mcpPackageService.getResolvedMcpConfig.mockReturnValueOnce({
+      command: '${user_config.MCP_COMMAND}',
+      args: [],
+      env: {}
+    })
+
+    await expect(create({ type: 'stdio', command: 'fallback', dxtPath: '/tmp/example.dxt' })).rejects.toMatchObject({
+      code: 'MCP_UNRESOLVED_PLACEHOLDER',
+      path: '${user_config.MCP_COMMAND}'
+    })
+
+    expect(getShellEnv).not.toHaveBeenCalled()
+  })
+
   it('forwards stdio stderr to the server log, skipping empty chunks', async () => {
     const entries: McpServerLogEntry[] = []
     const transport = (await create(
@@ -254,6 +270,7 @@ describe('createTransport', () => {
     const transport = (await create({
       type: 'inMemory',
       name: '@cherry/mcp-auto-install',
+      baseUrl: '   ',
       command: 'npx'
     })) as unknown as FakeStdioTransport
 

--- a/src/main/ai/mcp/__tests__/mcpTransport.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpTransport.test.ts
@@ -238,7 +238,7 @@ describe('createTransport', () => {
 
     transport.onerror?.(error)
 
-    expect(onTransportError).toHaveBeenCalledWith({
+    expect(onTransportError).toHaveBeenCalledWith(error, {
       code: 'EPERM',
       errno: -4048,
       syscall: `spawn ${command}`,

--- a/src/main/ai/mcp/__tests__/mcpTransport.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpTransport.test.ts
@@ -6,6 +6,7 @@ const inMemoryServerMock = vi.hoisted(() => ({ connect: vi.fn().mockResolvedValu
 const createInMemoryMcpServer = vi.hoisted(() => vi.fn().mockResolvedValue(inMemoryServerMock))
 const getBuiltinHttpHeaders = vi.hoisted(() => vi.fn<() => Record<string, string>>(() => ({})))
 const hasInMemoryImplementation = vi.hoisted(() => vi.fn<(name: string) => boolean>(() => true))
+const getShellEnv = vi.hoisted(() => vi.fn(async () => ({ PATH: '/shell/bin' })))
 vi.mock('@main/ai/mcp/servers/factory', () => ({
   createInMemoryMcpServer,
   getBuiltinRegistryEnv: () => ({}),
@@ -18,7 +19,7 @@ vi.mock('@application', async () => {
   return mockApplicationFactory({} as Record<string, unknown>)
 })
 vi.mock('electron', () => ({ net: { fetch: vi.fn() } }))
-vi.mock('@main/utils/shellEnv', () => ({ getShellEnv: async () => ({ PATH: '/shell/bin' }) }))
+vi.mock('@main/utils/shellEnv', () => ({ getShellEnv }))
 vi.mock('@main/utils/commandResolver', () => ({
   findExecutableInEnv: async () => '/usr/local/bin/npx',
   findCommandInShellEnv: async () => null
@@ -149,6 +150,15 @@ describe('createTransport', () => {
     expect(transport.params.env.NPM_CONFIG_REGISTRY).toBe('https://registry.example')
     expect(transport.params.env.PATH).toBe('/shell/bin')
     expect(transport.params.stderr).toBe('pipe')
+  })
+
+  it('rejects an unresolved stdio placeholder before requesting the login shell environment', async () => {
+    await expect(create({ type: 'stdio', command: '${MCP_COMMAND}' })).rejects.toMatchObject({
+      code: 'MCP_UNRESOLVED_PLACEHOLDER',
+      path: '${MCP_COMMAND}'
+    })
+
+    expect(getShellEnv).not.toHaveBeenCalled()
   })
 
   it('forwards stdio stderr to the server log, skipping empty chunks', async () => {

--- a/src/main/ai/mcp/__tests__/mcpTransport.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpTransport.test.ts
@@ -196,6 +196,32 @@ describe('createTransport', () => {
     })
   })
 
+  it('reports structured details for a Windows spawn permission error', async () => {
+    const entries: McpServerLogEntry[] = []
+    const onTransportError = vi.fn()
+    const command = 'C:\\Program Files\\MCP\\server.exe'
+    const transport = (await create(
+      { type: 'stdio', command },
+      { onServerLog: (entry) => entries.push(entry), onTransportError }
+    )) as unknown as FakeStdioTransport
+    const error = Object.assign(new Error(`spawn ${command} EPERM`), {
+      code: 'EPERM',
+      errno: -4048,
+      syscall: `spawn ${command}`,
+      path: command
+    })
+
+    transport.onerror?.(error)
+
+    expect(onTransportError).toHaveBeenCalledWith({
+      code: 'EPERM',
+      errno: -4048,
+      syscall: `spawn ${command}`,
+      path: command
+    })
+    expect(entries[0]?.data).toMatchObject({ code: 'EPERM', path: command })
+  })
+
   it('runs an in-memory row we cannot start in-process through the connection it declares', async () => {
     // Legacy rows kept `inMemory` alongside a command; before, they connected via that command.
     hasInMemoryImplementation.mockReturnValueOnce(false)

--- a/src/main/ai/mcp/__tests__/mcpTransport.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpTransport.test.ts
@@ -82,6 +82,21 @@ describe('createTransport', () => {
     )
   })
 
+  it('preserves structured details from a failed in-process start', async () => {
+    inMemoryServerMock.connect.mockRejectedValueOnce(
+      Object.assign(new Error('Unresolved placeholder'), {
+        code: 'MCP_UNRESOLVED_PLACEHOLDER',
+        path: '${MEMORY_FILE_PATH}'
+      })
+    )
+
+    await expect(create({ type: 'inMemory', name: '@cherry/memory' })).rejects.toMatchObject({
+      message: 'Failed to start in-memory server: Unresolved placeholder',
+      code: 'MCP_UNRESOLVED_PLACEHOLDER',
+      path: '${MEMORY_FILE_PATH}'
+    })
+  })
+
   it('sends the app headers plus the server’s own on both URL transports', async () => {
     const config = { type: 'streamableHttp' as const, baseUrl: 'https://mcp.example/mcp', headers: { APP: 'x' } }
 

--- a/src/main/ai/mcp/__tests__/mcpTransport.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpTransport.test.ts
@@ -30,7 +30,7 @@ vi.mock('@main/utils/binaryResolver', () => ({
   getBinaryPath: async (name?: string) => `/bundled/${name}`
 }))
 
-const { createTransport } = await import('../mcpTransport')
+const { createTransport, isMcpOAuthEnabled } = await import('../mcpTransport')
 
 class FakeTransport {
   constructor(
@@ -288,5 +288,20 @@ describe('createTransport', () => {
 
   it('refuses a config that says neither where to connect nor what to run', async () => {
     await expect(create({ type: 'stdio' })).rejects.toThrow(/Either baseUrl or command must be provided/)
+  })
+})
+
+describe('isMcpOAuthEnabled', () => {
+  it('does not enable HTTP OAuth for a command-backed server with a whitespace-only URL', () => {
+    expect(
+      isMcpOAuthEnabled({
+        id: 'legacy-command-server',
+        name: 'Legacy command server',
+        type: 'sse',
+        baseUrl: '   ',
+        command: 'npx',
+        isActive: true
+      } as McpServer)
+    ).toBe(false)
   })
 })

--- a/src/main/ai/mcp/mcpClientSdk.ts
+++ b/src/main/ai/mcp/mcpClientSdk.ts
@@ -15,6 +15,7 @@ import type {
   ToolListChangedNotificationSchema
 } from '@modelcontextprotocol/sdk/types.js'
 import type { McpServer, McpServerType } from '@shared/data/types/mcpServer'
+import { normalizeMcpBaseUrl } from '@shared/utils/mcp'
 
 export type McpClientSdk = {
   Client: typeof Client
@@ -68,7 +69,7 @@ export function loadMcpClientSdk(): Promise<McpClientSdk> {
 // This bridges legacy SSE servers and modern Streamable HTTP servers (which reject the
 // SSE GET handshake with 405) without the user having to know the difference.
 export function getTransportCandidates(server: McpServer): McpServerType[] | null {
-  if (!server.baseUrl) return null
+  if (!normalizeMcpBaseUrl(server.baseUrl)) return null
   if (server.type === 'sse') return ['sse', 'streamableHttp']
   if (server.type === 'streamableHttp') return ['streamableHttp', 'sse']
   return null

--- a/src/main/ai/mcp/mcpLaunch.ts
+++ b/src/main/ai/mcp/mcpLaunch.ts
@@ -38,6 +38,8 @@ const RUNNERS: Record<string, Runner> = {
   uv: uvRunner
 }
 
+const UNRESOLVED_COMMAND_PLACEHOLDER = /\$\{[A-Za-z_][A-Za-z0-9_]*\}|%[A-Za-z_][A-Za-z0-9_]*%|^YOUR_[A-Z0-9_]+$/
+
 export type LaunchCommand = {
   command: string
   args: string[]
@@ -66,6 +68,12 @@ export async function resolveLaunchCommand({
   const normalizedCommand = command.trim()
   if (!normalizedCommand) {
     throw new Error('MCP stdio command cannot be empty')
+  }
+  if (UNRESOLVED_COMMAND_PLACEHOLDER.test(normalizedCommand)) {
+    throw Object.assign(new Error(`MCP stdio command contains an unresolved placeholder: '${normalizedCommand}'`), {
+      code: 'MCP_UNRESOLVED_PLACEHOLDER',
+      path: normalizedCommand
+    })
   }
 
   const runner = RUNNERS[normalizedCommand]

--- a/src/main/ai/mcp/mcpLaunch.ts
+++ b/src/main/ai/mcp/mcpLaunch.ts
@@ -2,6 +2,8 @@ import type { LoggerService } from '@logger'
 import { getBinaryPath, isBinaryExists } from '@main/utils/binaryResolver'
 import { findCommandInShellEnv, findExecutableInEnv } from '@main/utils/commandResolver'
 
+import { containsUnresolvedConfigPlaceholder } from './mcpPlaceholder'
+
 type Runner = {
   /** Bundled binary to fall back on when the command is missing from PATH; defaults to the command. */
   bundled?: string
@@ -38,8 +40,6 @@ const RUNNERS: Record<string, Runner> = {
   uv: uvRunner
 }
 
-const UNRESOLVED_COMMAND_PLACEHOLDER = /\$\{[A-Za-z_][A-Za-z0-9_]*\}|%[A-Za-z_][A-Za-z0-9_]*%|^YOUR_[A-Z0-9_]+$/
-
 export type LaunchCommand = {
   command: string
   args: string[]
@@ -69,7 +69,7 @@ export async function resolveLaunchCommand({
   if (!normalizedCommand) {
     throw new Error('MCP stdio command cannot be empty')
   }
-  if (UNRESOLVED_COMMAND_PLACEHOLDER.test(normalizedCommand)) {
+  if (containsUnresolvedConfigPlaceholder(normalizedCommand)) {
     throw Object.assign(new Error(`MCP stdio command contains an unresolved placeholder: '${normalizedCommand}'`), {
       code: 'MCP_UNRESOLVED_PLACEHOLDER',
       path: normalizedCommand

--- a/src/main/ai/mcp/mcpLaunch.ts
+++ b/src/main/ai/mcp/mcpLaunch.ts
@@ -47,6 +47,20 @@ export type LaunchCommand = {
   env: Record<string, string>
 }
 
+export function validateLaunchCommand(command: string): string {
+  const normalizedCommand = command.trim()
+  if (!normalizedCommand) {
+    throw new Error('MCP stdio command cannot be empty')
+  }
+  if (containsUnresolvedConfigPlaceholder(normalizedCommand)) {
+    throw Object.assign(new Error(`MCP stdio command contains an unresolved placeholder: '${normalizedCommand}'`), {
+      code: 'MCP_UNRESOLVED_PLACEHOLDER',
+      path: normalizedCommand
+    })
+  }
+  return normalizedCommand
+}
+
 /**
  * Resolves what a stdio server is actually started with: the user's own `npx` / `uvx` / `uv`
  * when it is in PATH, otherwise the bundled binary. Any other command is best-effort resolved
@@ -65,16 +79,7 @@ export async function resolveLaunchCommand({
   loginShellEnv: Record<string, string>
   logger: LoggerService
 }): Promise<LaunchCommand> {
-  const normalizedCommand = command.trim()
-  if (!normalizedCommand) {
-    throw new Error('MCP stdio command cannot be empty')
-  }
-  if (containsUnresolvedConfigPlaceholder(normalizedCommand)) {
-    throw Object.assign(new Error(`MCP stdio command contains an unresolved placeholder: '${normalizedCommand}'`), {
-      code: 'MCP_UNRESOLVED_PLACEHOLDER',
-      path: normalizedCommand
-    })
-  }
+  const normalizedCommand = validateLaunchCommand(command)
 
   const runner = RUNNERS[normalizedCommand]
   const env = runner?.registryEnv && registryUrl ? runner.registryEnv(registryUrl) : {}

--- a/src/main/ai/mcp/mcpPlaceholder.ts
+++ b/src/main/ai/mcp/mcpPlaceholder.ts
@@ -1,0 +1,5 @@
+const UNRESOLVED_CONFIG_PLACEHOLDER = /\$\{[A-Za-z_][A-Za-z0-9_]*\}|%[A-Za-z_][A-Za-z0-9_]*%|^YOUR_[A-Z0-9_]+$/
+
+export function containsUnresolvedConfigPlaceholder(value: string): boolean {
+  return UNRESOLVED_CONFIG_PLACEHOLDER.test(value.trim())
+}

--- a/src/main/ai/mcp/mcpPlaceholder.ts
+++ b/src/main/ai/mcp/mcpPlaceholder.ts
@@ -1,4 +1,4 @@
-const UNRESOLVED_CONFIG_PLACEHOLDER = /\$\{[A-Za-z_][A-Za-z0-9_]*\}|%[A-Za-z_][A-Za-z0-9_]*%|^YOUR_[A-Z0-9_]+$/
+const UNRESOLVED_CONFIG_PLACEHOLDER = /\$\{[A-Za-z_][A-Za-z0-9_.]*\}|%[A-Za-z_][A-Za-z0-9_]*%|^YOUR_[A-Z0-9_]+$/
 
 export function containsUnresolvedConfigPlaceholder(value: string): boolean {
   return UNRESOLVED_CONFIG_PLACEHOLDER.test(value.trim())

--- a/src/main/ai/mcp/mcpTransport.ts
+++ b/src/main/ai/mcp/mcpTransport.ts
@@ -14,6 +14,7 @@ import type { StdioServerParameters } from '@modelcontextprotocol/sdk/client/std
 import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp'
 import type { McpServer, McpServerType } from '@shared/data/types/mcpServer'
 import type { McpServerLogEntry } from '@shared/types/mcp'
+import { normalizeMcpBaseUrl } from '@shared/utils/mcp'
 import { redactDeep } from '@shared/utils/redaction'
 import { net } from 'electron'
 
@@ -68,7 +69,7 @@ function hasAuthorization(headers: Record<string, string>): boolean {
 export function isMcpOAuthEnabled(server: McpServer): boolean {
   const type = server.type ?? 'sse'
   return (
-    Boolean(server.baseUrl) &&
+    Boolean(normalizeMcpBaseUrl(server.baseUrl)) &&
     (type === 'sse' || type === 'streamableHttp') &&
     !hasAuthorization(buildHttpHeaders(server))
   )
@@ -246,7 +247,7 @@ export async function createTransport(input: CreateTransportInput): Promise<McpT
   if (server.type === 'inMemory' && hasInMemoryImplementation(server.name)) {
     return createInMemory(input)
   }
-  const baseUrl = server.baseUrl?.trim()
+  const baseUrl = normalizeMcpBaseUrl(server.baseUrl)
   if (baseUrl) {
     return createUrlTransport(input, baseUrl)
   }

--- a/src/main/ai/mcp/mcpTransport.ts
+++ b/src/main/ai/mcp/mcpTransport.ts
@@ -246,8 +246,9 @@ export async function createTransport(input: CreateTransportInput): Promise<McpT
   if (server.type === 'inMemory' && hasInMemoryImplementation(server.name)) {
     return createInMemory(input)
   }
-  if (server.baseUrl) {
-    return createUrlTransport(input, server.baseUrl)
+  const baseUrl = server.baseUrl?.trim()
+  if (baseUrl) {
+    return createUrlTransport(input, baseUrl)
   }
   if (server.command) {
     return createStdio(input, server.command)

--- a/src/main/ai/mcp/mcpTransport.ts
+++ b/src/main/ai/mcp/mcpTransport.ts
@@ -30,6 +30,7 @@ type CreateTransportInput = {
   authProvider: McpOAuthClientProvider
   logger: LoggerService
   onServerLog: (entry: McpServerLogEntry) => void
+  onTransportError?: (details: Record<string, number | string>) => void
 }
 
 function fetchViaNet(url: string | URL | Request, init?: RequestInit): Promise<Response> {
@@ -146,7 +147,7 @@ function createUrlTransport(
 }
 
 async function createStdio(
-  { sdk, server, args, logger, onServerLog }: CreateTransportInput,
+  { sdk, server, args, logger, onServerLog, onTransportError }: CreateTransportInput,
   configuredCommand: string
 ): Promise<McpTransport> {
   let command = configuredCommand
@@ -209,6 +210,7 @@ async function createStdio(
   transport.onerror = (error) => {
     const details = getStdioTransportErrorDetails(error)
     logger.error(`Stdio transport error`, error, details)
+    onTransportError?.(details)
     onServerLog({
       timestamp: Date.now(),
       level: 'error',

--- a/src/main/ai/mcp/mcpTransport.ts
+++ b/src/main/ai/mcp/mcpTransport.ts
@@ -30,7 +30,7 @@ type CreateTransportInput = {
   authProvider: McpOAuthClientProvider
   logger: LoggerService
   onServerLog: (entry: McpServerLogEntry) => void
-  onTransportError?: (details: Record<string, number | string>) => void
+  onTransportError?: (error: Error, details: Record<string, number | string>) => void
 }
 
 function fetchViaNet(url: string | URL | Request, init?: RequestInit): Promise<Response> {
@@ -215,7 +215,7 @@ async function createStdio(
   transport.onerror = (error) => {
     const details = getStdioTransportErrorDetails(error)
     logger.error(`Stdio transport error`, error, details)
-    onTransportError?.(details)
+    onTransportError?.(error, details)
     onServerLog({
       timestamp: Date.now(),
       level: 'error',

--- a/src/main/ai/mcp/mcpTransport.ts
+++ b/src/main/ai/mcp/mcpTransport.ts
@@ -18,7 +18,7 @@ import { redactDeep } from '@shared/utils/redaction'
 import { net } from 'electron'
 
 import type { McpClientSdk, McpTransport } from './mcpClientSdk'
-import { buildStdioEnvironment, resolveLaunchCommand } from './mcpLaunch'
+import { buildStdioEnvironment, resolveLaunchCommand, validateLaunchCommand } from './mcpLaunch'
 import type { McpOAuthClientProvider } from './oauth/provider'
 
 type CreateTransportInput = {
@@ -160,9 +160,6 @@ async function createStdio(
   // untouched so the key stays stable everywhere; see the "deep-copy don't mutate" pattern.
   const connectEnv: Record<string, string> = { ...server.env }
 
-  // Note: getShellEnv() is memoized, so subsequent calls are fast
-  const loginShellEnv = await getShellEnv()
-
   // For package servers, use resolved configuration with platform overrides and variable substitution
   if (server.dxtPath) {
     const resolvedConfig = application.get('McpPackageService').getResolvedMcpConfig(server.dxtPath)
@@ -175,6 +172,11 @@ async function createStdio(
       logger.warn(`Failed to resolve package config, falling back to manifest values`)
     }
   }
+
+  command = validateLaunchCommand(command)
+
+  // Note: getShellEnv() is memoized, so subsequent calls are fast
+  const loginShellEnv = await getShellEnv()
 
   const launch = await resolveLaunchCommand({
     command,

--- a/src/main/ai/mcp/mcpTransport.ts
+++ b/src/main/ai/mcp/mcpTransport.ts
@@ -114,7 +114,10 @@ async function createInMemory({ sdk, server, args, logger }: CreateTransportInpu
     logger.debug(`In-memory server started`)
   } catch (error: any) {
     logger.error(`Error starting in-memory server`, error as Error)
-    throw new Error(`Failed to start in-memory server: ${error.message}`)
+    throw Object.assign(new Error(`Failed to start in-memory server: ${error.message}`), {
+      code: error.code,
+      path: error.path
+    })
   }
   return clientTransport
 }

--- a/src/main/ai/mcp/servers/__tests__/memory.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/memory.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({} as Record<string, unknown>)
+})
+
+const { application } = await import('@application')
+const { default: MemoryServer } = await import('../memory')
+
+async function listTools(server: InstanceType<typeof MemoryServer>) {
+  const handlers = (server.server as any)._requestHandlers
+  const listHandler = handlers?.get('tools/list')
+  if (!listHandler) throw new Error('No tools/list handler registered')
+  return listHandler({ method: 'tools/list', params: {} }, {})
+}
+
+describe('MemoryServer', () => {
+  let tempDir: string
+  let originalCwd: string
+
+  beforeEach(async () => {
+    originalCwd = process.cwd()
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'memory-mcp-'))
+    process.chdir(tempDir)
+    vi.mocked(application.getPath).mockReturnValue(path.join(tempDir, 'default-memory.json'))
+  })
+
+  afterEach(async () => {
+    process.chdir(originalCwd)
+    await rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it('uses the application memory path when no custom path is configured', async () => {
+    const result = await listTools(new MemoryServer())
+
+    expect(result.tools.length).toBeGreaterThan(0)
+    await expect(readFile(path.join(tempDir, 'default-memory.json'), 'utf8')).resolves.toContain('"entities": []')
+  })
+
+  it.each(['YOUR_MEMORY_FILE_PATH', '  YOUR_MEMORY_FILE_PATH  '])(
+    'rejects the unresolved built-in placeholder before accessing the file system as %j',
+    (configuredPath) => {
+      expect(() => new MemoryServer(configuredPath)).toThrow(
+        expect.objectContaining({
+          code: 'MCP_UNRESOLVED_PLACEHOLDER',
+          path: 'YOUR_MEMORY_FILE_PATH'
+        })
+      )
+    }
+  )
+})

--- a/src/main/ai/mcp/servers/__tests__/memory.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/memory.test.ts
@@ -43,15 +43,28 @@ describe('MemoryServer', () => {
     await expect(readFile(path.join(tempDir, 'default-memory.json'), 'utf8')).resolves.toContain('"entities": []')
   })
 
-  it.each(['YOUR_MEMORY_FILE_PATH', '  YOUR_MEMORY_FILE_PATH  '])(
-    'rejects the unresolved built-in placeholder before accessing the file system as %j',
-    (configuredPath) => {
-      expect(() => new MemoryServer(configuredPath)).toThrow(
-        expect.objectContaining({
-          code: 'MCP_UNRESOLVED_PLACEHOLDER',
-          path: 'YOUR_MEMORY_FILE_PATH'
-        })
-      )
+  it.each([
+    ['YOUR_MEMORY_FILE_PATH', 'YOUR_MEMORY_FILE_PATH'],
+    ['  YOUR_MEMORY_FILE_PATH  ', 'YOUR_MEMORY_FILE_PATH'],
+    ['${MEMORY_FILE_PATH}', '${MEMORY_FILE_PATH}'],
+    ['  YOUR_CUSTOM_MEMORY_PATH  ', 'YOUR_CUSTOM_MEMORY_PATH'],
+    ['C:\\%USERPROFILE%\\memory.json', 'C:\\%USERPROFILE%\\memory.json']
+  ])('rejects unresolved placeholders before accessing the file system as %j', (configuredPath, expectedPath) => {
+    expect(() => new MemoryServer(configuredPath)).toThrow(
+      expect.objectContaining({
+        code: 'MCP_UNRESOLVED_PLACEHOLDER',
+        path: expectedPath
+      })
+    )
+  })
+
+  it.each(['memory-${not-placeholder}.json', 'YOUR_MEMORY_FILE_PATH/graph.json', 'memory-%20.json'])(
+    'accepts a literal path that does not contain a supported placeholder as %j',
+    async (configuredPath) => {
+      const result = await listTools(new MemoryServer(configuredPath))
+
+      expect(result.tools.length).toBeGreaterThan(0)
+      await expect(readFile(path.resolve(configuredPath), 'utf8')).resolves.toContain('"entities": []')
     }
   )
 })

--- a/src/main/ai/mcp/servers/memory.ts
+++ b/src/main/ai/mcp/servers/memory.ts
@@ -343,10 +343,17 @@ class MemoryServer {
   private initializationPromise: Promise<void> // To track initialization
 
   constructor(envPath: string = '') {
-    const memoryPath = envPath
-      ? path.isAbsolute(envPath)
-        ? envPath
-        : path.resolve(envPath) // Use path.resolve for relative paths based on CWD
+    const configuredPath = envPath.trim()
+    if (configuredPath === 'YOUR_MEMORY_FILE_PATH') {
+      throw Object.assign(new Error('Memory MCP path contains an unresolved placeholder'), {
+        code: 'MCP_UNRESOLVED_PLACEHOLDER',
+        path: configuredPath
+      })
+    }
+    const memoryPath = configuredPath
+      ? path.isAbsolute(configuredPath)
+        ? configuredPath
+        : path.resolve(configuredPath) // Use path.resolve for relative paths based on CWD
       : getDefaultMemoryPath()
 
     this.server = new Server(

--- a/src/main/ai/mcp/servers/memory.ts
+++ b/src/main/ai/mcp/servers/memory.ts
@@ -7,6 +7,8 @@ import { Mutex } from 'async-mutex' // 引入 Mutex
 import { promises as fs } from 'fs'
 import path from 'path'
 
+import { containsUnresolvedConfigPlaceholder } from '../mcpPlaceholder'
+
 const logger = loggerService.withContext('McpServer:Memory')
 
 // Define memory file path
@@ -344,7 +346,7 @@ class MemoryServer {
 
   constructor(envPath: string = '') {
     const configuredPath = envPath.trim()
-    if (configuredPath === 'YOUR_MEMORY_FILE_PATH') {
+    if (containsUnresolvedConfigPlaceholder(configuredPath)) {
       throw Object.assign(new Error('Memory MCP path contains an unresolved placeholder'), {
         code: 'MCP_UNRESOLVED_PLACEHOLDER',
         path: configuredPath

--- a/src/renderer/pages/settings/McpSettings/McpServerFields.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServerFields.tsx
@@ -59,8 +59,12 @@ export const buildMcpSchema = (t: (key: string) => string) =>
 export type McpFormValues = z.infer<ReturnType<typeof buildMcpSchema>>
 export type McpForm = UseFormReturn<McpFormValues>
 
-export function resolveMcpConfigTransportType(type: McpServer['type'], name: string): McpServer['type'] {
-  return type === 'inMemory' && name === BuiltinMcpServerNames.mcpAutoInstall ? 'stdio' : type
+export function resolveMcpConfigTransportType(
+  type: McpServer['type'],
+  name: string,
+  command?: string
+): McpServer['type'] {
+  return type === 'inMemory' && (name === BuiltinMcpServerNames.mcpAutoInstall || Boolean(command)) ? 'stdio' : type
 }
 
 /**
@@ -216,7 +220,7 @@ export function toMcpFormDefaultValues(server: McpServer): DefaultValues<McpForm
   return {
     name: server.name,
     description: server.description ?? '',
-    serverType: resolveMcpConfigTransportType(server.type, server.name),
+    serverType: resolveMcpConfigTransportType(server.type, server.name, server.command),
     baseUrl: server.baseUrl || '',
     command: server.command || '',
     registryUrl: server.registryUrl || '',

--- a/src/renderer/pages/settings/McpSettings/McpServerFields.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServerFields.tsx
@@ -19,6 +19,7 @@ import {
 } from '@cherrystudio/ui'
 import { parseKeyValueString } from '@renderer/utils/env'
 import { cn } from '@renderer/utils/style'
+import { PRESET_MCP_SERVERS } from '@shared/data/presets/mcpServers'
 import { type McpServer, type McpServerType, McpServerTypeSchema } from '@shared/data/types/mcpServer'
 import { BuiltinMcpServerNames } from '@shared/utils/mcp'
 import type React from 'react'
@@ -62,9 +63,16 @@ export type McpForm = UseFormReturn<McpFormValues>
 export function resolveMcpConfigTransportType(
   type: McpServer['type'],
   name: string,
-  command?: string
+  command?: string,
+  baseUrl?: string
 ): McpServer['type'] {
-  return type === 'inMemory' && (name === BuiltinMcpServerNames.mcpAutoInstall || Boolean(command)) ? 'stdio' : type
+  if (type !== 'inMemory') return type
+  if (name === BuiltinMcpServerNames.mcpAutoInstall) return 'stdio'
+
+  const hasInMemoryImplementation = PRESET_MCP_SERVERS.some(
+    (server) => server.name === name && server.type === 'inMemory'
+  )
+  return !hasInMemoryImplementation && !baseUrl && command ? 'stdio' : type
 }
 
 /**
@@ -220,7 +228,7 @@ export function toMcpFormDefaultValues(server: McpServer): DefaultValues<McpForm
   return {
     name: server.name,
     description: server.description ?? '',
-    serverType: resolveMcpConfigTransportType(server.type, server.name, server.command),
+    serverType: resolveMcpConfigTransportType(server.type, server.name, server.command, server.baseUrl),
     baseUrl: server.baseUrl || '',
     command: server.command || '',
     registryUrl: server.registryUrl || '',

--- a/src/renderer/pages/settings/McpSettings/McpServerFields.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServerFields.tsx
@@ -72,7 +72,7 @@ export function resolveMcpConfigTransportType(
   const hasInMemoryImplementation = PRESET_MCP_SERVERS.some(
     (server) => server.name === name && server.type === 'inMemory'
   )
-  return !hasInMemoryImplementation && !baseUrl && command ? 'stdio' : type
+  return !hasInMemoryImplementation && !baseUrl?.trim() && command ? 'stdio' : type
 }
 
 /**

--- a/src/renderer/pages/settings/McpSettings/McpServerFields.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServerFields.tsx
@@ -21,7 +21,7 @@ import { parseKeyValueString } from '@renderer/utils/env'
 import { cn } from '@renderer/utils/style'
 import { PRESET_MCP_SERVERS } from '@shared/data/presets/mcpServers'
 import { type McpServer, type McpServerType, McpServerTypeSchema } from '@shared/data/types/mcpServer'
-import { BuiltinMcpServerNames } from '@shared/utils/mcp'
+import { BuiltinMcpServerNames, normalizeMcpBaseUrl } from '@shared/utils/mcp'
 import type React from 'react'
 import { useCallback, useState } from 'react'
 import type { DefaultValues, UseFormReturn } from 'react-hook-form'
@@ -66,13 +66,14 @@ export function resolveMcpConfigTransportType(
   command?: string,
   baseUrl?: string
 ): McpServer['type'] {
-  if (type !== 'inMemory') return type
-  if (name === BuiltinMcpServerNames.mcpAutoInstall) return 'stdio'
-
-  const hasInMemoryImplementation = PRESET_MCP_SERVERS.some(
-    (server) => server.name === name && server.type === 'inMemory'
-  )
-  return !hasInMemoryImplementation && !baseUrl?.trim() && command ? 'stdio' : type
+  if (type === 'inMemory') {
+    if (name === BuiltinMcpServerNames.mcpAutoInstall) return 'stdio'
+    const hasInMemoryImplementation = PRESET_MCP_SERVERS.some(
+      (server) => server.name === name && server.type === 'inMemory'
+    )
+    if (hasInMemoryImplementation) return type
+  }
+  return !normalizeMcpBaseUrl(baseUrl) && command ? 'stdio' : type
 }
 
 /**

--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -432,7 +432,15 @@ const McpSettingsContent: React.FC<McpSettingsContentProps> = ({ server, updateM
     error: t('settings.mcp.runtimeStatus.error', 'Error')
   }[server.isActive ? runtimeStatus.state : 'disabled']
   const focusRuntimeErrorField = () =>
-    form.setFocus(serverType === 'stdio' ? 'command' : serverType === 'inMemory' ? 'env' : 'baseUrl')
+    form.setFocus(
+      isQVerisApiKeyMissing(server)
+        ? 'env'
+        : serverType === 'stdio'
+          ? 'command'
+          : serverType === 'inMemory'
+            ? 'env'
+            : 'baseUrl'
+    )
 
   const fieldsProps = {
     form,

--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -431,6 +431,7 @@ const McpSettingsContent: React.FC<McpSettingsContentProps> = ({ server, updateM
     connected: t('settings.mcp.runtimeStatus.connected', 'Connected'),
     error: t('settings.mcp.runtimeStatus.error', 'Error')
   }[server.isActive ? runtimeStatus.state : 'disabled']
+  const focusRuntimeErrorField = () => form.setFocus(serverType === 'stdio' ? 'command' : 'env')
 
   const fieldsProps = {
     form,
@@ -452,6 +453,27 @@ const McpSettingsContent: React.FC<McpSettingsContentProps> = ({ server, updateM
             onChange={() => setIsFormChanged(true)}
             className="flex w-full min-w-0 flex-col gap-4 pb-6 [&_[data-slot=select-trigger]]:bg-background [&_input[data-slot=form-control]]:bg-background [&_textarea[data-slot=form-control]]:bg-background"
             id="mcp-settings-form">
+            {runtimeError && (
+              <Alert
+                type="error"
+                showIcon
+                message={t('settings.mcp.runtimeStatus.unavailable', 'Server unavailable')}
+                description={
+                  <div className="space-y-1">
+                    <div>{runtimeStatus.errorCode ? `${runtimeStatus.errorCode}: ${runtimeError}` : runtimeError}</div>
+                    {runtimeStatus.errorPath && (
+                      <code className="block break-all text-xs">{runtimeStatus.errorPath}</code>
+                    )}
+                  </div>
+                }
+                action={
+                  <Button type="button" variant="outline" size="sm" onClick={focusRuntimeErrorField}>
+                    {t('common.edit')}
+                  </Button>
+                }
+                className="shadow-none"
+              />
+            )}
             <McpFormSection>
               <McpIdentityFields {...fieldsProps} />
             </McpFormSection>

--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -431,7 +431,8 @@ const McpSettingsContent: React.FC<McpSettingsContentProps> = ({ server, updateM
     connected: t('settings.mcp.runtimeStatus.connected', 'Connected'),
     error: t('settings.mcp.runtimeStatus.error', 'Error')
   }[server.isActive ? runtimeStatus.state : 'disabled']
-  const focusRuntimeErrorField = () => form.setFocus(serverType === 'stdio' ? 'command' : 'env')
+  const focusRuntimeErrorField = () =>
+    form.setFocus(serverType === 'stdio' ? 'command' : serverType === 'inMemory' ? 'env' : 'baseUrl')
 
   const fieldsProps = {
     form,

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpServerFields.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpServerFields.test.tsx
@@ -118,8 +118,14 @@ describe('resolveMcpConfigTransportType', () => {
     expect(resolveMcpConfigTransportType('inMemory', '@cherry/mcp-auto-install')).toBe('stdio')
   })
 
-  it('keeps other built-in servers on the in-memory configuration', () => {
-    expect(resolveMcpConfigTransportType('inMemory', '@cherry/memory')).toBe('inMemory')
+  it('keeps implemented built-in servers in memory when a legacy command remains', () => {
+    expect(resolveMcpConfigTransportType('inMemory', '@cherry/memory', 'npx')).toBe('inMemory')
+  })
+
+  it('does not let a legacy command override a higher-priority endpoint', () => {
+    expect(resolveMcpConfigTransportType('inMemory', 'Legacy server', 'npx', 'https://example.com/mcp')).toBe(
+      'inMemory'
+    )
   })
 
   it('exposes stdio configuration for legacy command-backed servers', () => {

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpServerFields.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpServerFields.test.tsx
@@ -131,6 +131,13 @@ describe('resolveMcpConfigTransportType', () => {
   it('exposes stdio configuration for legacy command-backed servers', () => {
     expect(resolveMcpConfigTransportType('inMemory', 'Legacy server', 'npx')).toBe('stdio')
   })
+
+  it.each(['sse', 'streamableHttp'] as const)(
+    'exposes stdio configuration for a command-backed %s row with a whitespace-only URL',
+    (type) => {
+      expect(resolveMcpConfigTransportType(type, 'Legacy server', 'npx', '   ')).toBe('stdio')
+    }
+  )
 })
 
 describe('resolveMcpConfigInstallSource', () => {

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpServerFields.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpServerFields.test.tsx
@@ -99,6 +99,18 @@ describe('toMcpFormDefaultValues', () => {
 
     expect(toMcpFormDefaultValues(server).serverType).toBe('stdio')
   })
+
+  it('exposes stdio fields for a legacy command-backed in-memory server', () => {
+    const server = {
+      id: 'legacy-command-server',
+      name: 'Legacy command server',
+      type: 'inMemory',
+      command: 'missing-mcp-command',
+      isActive: false
+    } satisfies McpServer
+
+    expect(toMcpFormDefaultValues(server).serverType).toBe('stdio')
+  })
 })
 
 describe('resolveMcpConfigTransportType', () => {
@@ -108,6 +120,10 @@ describe('resolveMcpConfigTransportType', () => {
 
   it('keeps other built-in servers on the in-memory configuration', () => {
     expect(resolveMcpConfigTransportType('inMemory', '@cherry/memory')).toBe('inMemory')
+  })
+
+  it('exposes stdio configuration for legacy command-backed servers', () => {
+    expect(resolveMcpConfigTransportType('inMemory', 'Legacy server', 'npx')).toBe('stdio')
   })
 })
 

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -93,12 +93,24 @@ vi.mock('../McpServerFields', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
-    McpEndpointField: ({ form }: { form: { register: (name: 'command') => Record<string, unknown> } }) => (
-      <label>
-        Command
-        <input {...form.register('command')} />
-      </label>
-    ),
+    McpEndpointField: ({
+      form,
+      serverType
+    }: {
+      form: { register: (name: 'baseUrl' | 'command') => Record<string, unknown> }
+      serverType: McpServer['type']
+    }) =>
+      serverType === 'stdio' ? (
+        <label>
+          Command
+          <input {...form.register('command')} />
+        </label>
+      ) : serverType === 'inMemory' ? null : (
+        <label>
+          URL
+          <input {...form.register('baseUrl')} />
+        </label>
+      ),
     McpIdentityFields: ({ form }: { form: { register: (name: 'name') => Record<string, unknown> } }) => (
       <label>
         Server name
@@ -106,12 +118,19 @@ vi.mock('../McpServerFields', async (importOriginal) => {
       </label>
     ),
     McpRuntimeFields: () => null,
-    McpTransportFields: ({ form }: { form: { register: (name: 'env') => Record<string, unknown> } }) => (
-      <label>
-        Environment
-        <textarea {...form.register('env')} />
-      </label>
-    )
+    McpTransportFields: ({
+      form,
+      serverType
+    }: {
+      form: { register: (name: 'env') => Record<string, unknown> }
+      serverType: McpServer['type']
+    }) =>
+      serverType === 'stdio' || serverType === 'inMemory' ? (
+        <label>
+          Environment
+          <textarea {...form.register('env')} />
+        </label>
+      ) : null
   }
 })
 
@@ -247,6 +266,27 @@ describe('McpSettings', () => {
     await user.click(screen.getByRole('button', { name: 'common.edit' }))
 
     expect(screen.getByRole('textbox', { name: 'Environment' })).toHaveFocus()
+  })
+
+  it('focuses the endpoint URL when a remote server is unavailable', async () => {
+    currentSearch = {}
+    currentServer = {
+      id: 'remote-server',
+      name: 'Remote Server',
+      type: 'streamableHttp',
+      baseUrl: 'https://mcp.example.com/mcp',
+      isActive: true
+    }
+    currentRuntimeStatus = {
+      state: 'error',
+      lastError: 'Connection failed'
+    }
+    const user = userEvent.setup()
+
+    render(<McpSettings />)
+    await user.click(screen.getByRole('button', { name: 'common.edit' }))
+
+    expect(screen.getByRole('textbox', { name: 'URL' })).toHaveFocus()
   })
 
   it('renders selectable MCP logs and copies them to the clipboard', async () => {

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -270,12 +270,12 @@ describe('McpSettings', () => {
     expect(screen.getByRole('textbox', { name: 'Environment' })).toHaveFocus()
   })
 
-  it('focuses the command for a legacy command-backed in-memory server', async () => {
+  it('focuses the command for a legacy remote-typed server with a whitespace-only URL', async () => {
     currentSearch = {}
     currentServer = {
       id: 'legacy-command-server',
       name: 'Legacy command server',
-      type: 'inMemory',
+      type: 'sse',
       baseUrl: '   ',
       command: 'missing-mcp-command',
       isActive: true

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -120,12 +120,14 @@ vi.mock('../McpServerFields', async (importOriginal) => {
     McpRuntimeFields: () => null,
     McpTransportFields: ({
       form,
-      serverType
+      serverType,
+      builtinRequiresEnv
     }: {
       form: { register: (name: 'env') => Record<string, unknown> }
       serverType: McpServer['type']
+      builtinRequiresEnv?: boolean
     }) =>
-      serverType === 'stdio' || serverType === 'inMemory' ? (
+      serverType === 'stdio' || serverType === 'inMemory' || builtinRequiresEnv ? (
         <label>
           Environment
           <textarea {...form.register('env')} />
@@ -310,6 +312,30 @@ describe('McpSettings', () => {
     await user.click(screen.getByRole('button', { name: 'common.edit' }))
 
     expect(screen.getByRole('textbox', { name: 'URL' })).toHaveFocus()
+  })
+
+  it('focuses the missing QVeris API key instead of its hosted endpoint', async () => {
+    currentSearch = {}
+    currentServer = {
+      id: 'qveris-server',
+      name: '@cherry/qveris',
+      type: 'streamableHttp',
+      baseUrl: 'https://mcp.qveris.ai/mcp',
+      installSource: 'builtin',
+      shouldConfig: true,
+      env: { QVERIS_API_KEY: '' },
+      isActive: true
+    }
+    currentRuntimeStatus = {
+      state: 'error',
+      lastError: 'QVeris MCP requires the QVERIS_API_KEY environment variable'
+    }
+    const user = userEvent.setup()
+
+    render(<McpSettings />)
+    await user.click(screen.getByRole('button', { name: 'common.edit' }))
+
+    expect(screen.getByRole('textbox', { name: 'Environment' })).toHaveFocus()
   })
 
   it('renders selectable MCP logs and copies them to the clipboard', async () => {

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -276,6 +276,7 @@ describe('McpSettings', () => {
       id: 'legacy-command-server',
       name: 'Legacy command server',
       type: 'inMemory',
+      baseUrl: '   ',
       command: 'missing-mcp-command',
       isActive: true
     }

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -268,6 +268,29 @@ describe('McpSettings', () => {
     expect(screen.getByRole('textbox', { name: 'Environment' })).toHaveFocus()
   })
 
+  it('focuses the command for a legacy command-backed in-memory server', async () => {
+    currentSearch = {}
+    currentServer = {
+      id: 'legacy-command-server',
+      name: 'Legacy command server',
+      type: 'inMemory',
+      command: 'missing-mcp-command',
+      isActive: true
+    }
+    currentRuntimeStatus = {
+      state: 'error',
+      lastError: 'spawn ENOENT',
+      errorCode: 'ENOENT',
+      errorPath: currentServer.command
+    }
+    const user = userEvent.setup()
+
+    render(<McpSettings />)
+    await user.click(screen.getByRole('button', { name: 'common.edit' }))
+
+    expect(screen.getByRole('textbox', { name: 'Command' })).toHaveFocus()
+  })
+
   it('focuses the endpoint URL when a remote server is unavailable', async () => {
     currentSearch = {}
     currentServer = {

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -27,6 +27,12 @@ const mocks = vi.hoisted(() => ({
 
 let currentServer: McpServer
 let currentSearch: { autoEnable?: 'true' }
+let currentRuntimeStatus: {
+  state: 'disabled' | 'connecting' | 'connected' | 'error'
+  lastError?: string
+  errorCode?: string
+  errorPath?: string
+}
 
 // Keep the real useMcpServerMutations so the delete tests exercise the actual
 // remove flow (IPC channel + cache invalidation), not a stand-in.
@@ -67,7 +73,7 @@ vi.mock('@renderer/services/toast', () => ({
   }
 }))
 vi.mock('@renderer/hooks/useMcpRuntimeStatus', () => ({
-  useMcpRuntimeStatus: () => ({ state: 'disabled', lastError: undefined })
+  useMcpRuntimeStatus: () => currentRuntimeStatus
 }))
 vi.mock('@renderer/hooks/useTheme', () => ({ useTheme: () => ({ theme: 'light' }) }))
 
@@ -87,7 +93,12 @@ vi.mock('../McpServerFields', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
-    McpEndpointField: () => null,
+    McpEndpointField: ({ form }: { form: { register: (name: 'command') => Record<string, unknown> } }) => (
+      <label>
+        Command
+        <input {...form.register('command')} />
+      </label>
+    ),
     McpIdentityFields: ({ form }: { form: { register: (name: 'name') => Record<string, unknown> } }) => (
       <label>
         Server name
@@ -95,7 +106,12 @@ vi.mock('../McpServerFields', async (importOriginal) => {
       </label>
     ),
     McpRuntimeFields: () => null,
-    McpTransportFields: () => null
+    McpTransportFields: ({ form }: { form: { register: (name: 'env') => Record<string, unknown> } }) => (
+      <label>
+        Environment
+        <textarea {...form.register('env')} />
+      </label>
+    )
   }
 })
 
@@ -121,6 +137,7 @@ describe('McpSettings', () => {
       isTrusted: false
     }
     currentSearch = { autoEnable: 'true' }
+    currentRuntimeStatus = { state: 'disabled' }
     mocks.confirm.mockResolvedValue(false)
     mocks.invalidate.mockResolvedValue(undefined)
     mocks.updateMcpServer.mockResolvedValue(undefined)
@@ -180,6 +197,56 @@ describe('McpSettings', () => {
     rerender(<McpSettings />)
 
     expect(screen.getByRole('textbox', { name: 'Server name' })).toHaveValue('Server B')
+  })
+
+  it('shows the failed executable path and focuses its configuration for recovery', async () => {
+    currentSearch = {}
+    currentServer = {
+      id: 'server-a',
+      name: 'Server A',
+      type: 'stdio',
+      command: 'C:\\Program Files\\MCP\\server.exe',
+      isActive: true
+    }
+    currentRuntimeStatus = {
+      state: 'error',
+      lastError: 'Connection closed',
+      errorCode: 'EPERM',
+      errorPath: currentServer.command
+    }
+    const user = userEvent.setup()
+
+    render(<McpSettings />)
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('EPERM')
+    expect(alert).toHaveTextContent(currentServer.command!)
+
+    await user.click(screen.getByRole('button', { name: 'common.edit' }))
+    expect(screen.getByRole('textbox', { name: 'Command' })).toHaveFocus()
+  })
+
+  it('focuses the environment configuration for an in-memory path placeholder', async () => {
+    currentSearch = {}
+    currentServer = {
+      id: 'memory-server',
+      name: '@cherry/memory',
+      type: 'inMemory',
+      env: { MEMORY_FILE_PATH: 'YOUR_MEMORY_FILE_PATH' },
+      isActive: true
+    }
+    currentRuntimeStatus = {
+      state: 'error',
+      lastError: 'Memory MCP path contains an unresolved placeholder',
+      errorCode: 'MCP_UNRESOLVED_PLACEHOLDER',
+      errorPath: 'YOUR_MEMORY_FILE_PATH'
+    }
+    const user = userEvent.setup()
+
+    render(<McpSettings />)
+    await user.click(screen.getByRole('button', { name: 'common.edit' }))
+
+    expect(screen.getByRole('textbox', { name: 'Environment' })).toHaveFocus()
   })
 
   it('renders selectable MCP logs and copies them to the clipboard', async () => {

--- a/src/shared/data/cache/cacheValueTypes.ts
+++ b/src/shared/data/cache/cacheValueTypes.ts
@@ -37,6 +37,8 @@ export type McpRuntimeStatus = {
   state: 'disabled' | 'connecting' | 'connected' | 'error'
   lastCheckedAt: number
   lastError?: string
+  errorCode?: string
+  errorPath?: string
 }
 
 /**

--- a/src/shared/utils/mcp.ts
+++ b/src/shared/utils/mcp.ts
@@ -36,6 +36,11 @@ export const isInMemoryBuiltinMcpServer = (server: McpServer): server is Builtin
   return server.type === 'inMemory' && isBuiltinMcpServerName(server.name)
 }
 
+export const normalizeMcpBaseUrl = (baseUrl: string | undefined): string | undefined => {
+  const normalized = baseUrl?.trim()
+  return normalized || undefined
+}
+
 /**
  * Spec-aligned guard for a single MCP `CallToolResult` content block
  * (text / image / audio / resource_link / embedded resource).


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- The built-in Memory MCP accepted `YOUR_MEMORY_FILE_PATH` as a relative path, so it could resolve inside the working directory instead of failing at configuration validation.
- Unresolved stdio command placeholders could reach command lookup or transport creation.
- The MCP SDK could reduce a Windows spawn error such as `EPERM` to `Connection closed`, hiding the executable path needed to recover.

After this PR:

- Memory and stdio launch validation reject unresolved placeholders before filesystem or process access.
- Structured spawn diagnostics (`code` and `path`) survive SDK error reduction and remain scoped to the affected server.
- The General settings tab shows the failure details and an Edit action that focuses the relevant command or environment field.
- Legacy `inMemory` rows that retain a command are exposed as stdio in the editor, so recovery can focus the Command field.
- Whitespace-only legacy base URLs are treated as unset consistently at runtime and in Settings.

Fixes #20018

### Why we need it and why it was done in this way

Validation happens at the launch boundary so an invalid configured value cannot be mistaken for a real relative path or executable. Transport diagnostics are captured before the SDK replaces the original spawn error, then exposed through the existing shared runtime-status cache for recovery in settings.

The following tradeoffs were made:

- Runtime status gains two optional fields rather than changing the existing `lastError` contract.
- The existing Tools-tab error remains because it serves a different tab; the new General-tab alert is where the configuration can be edited.

The following alternatives were considered:

- Inferring a replacement path for placeholders was rejected because Cherry Studio cannot know the user's intended file or executable.
- Parsing `Connection closed` after the fact was rejected because the SDK has already discarded the original spawn metadata at that point.

Links to places where the discussion took place: #20018

### Breaking changes

None.

### Special notes for your reviewer

Verification:

- Current focused main suites: 80 passed.
- Current MCP Settings renderer suites: 32 passed.
- `pnpm lint`: passed (45 pre-existing ESLint warnings in unchanged files; 0 errors).
- `pnpm test:lint`: passed (Oxlint deny-warnings: 0; ESLint: 0 errors).

The existing screenshot captures the resolved stdio recovery state: the editor exposes the Command field and Edit focuses it.

The current follow-up extends that same result to legacy rows stored as SSE or Streamable HTTP when their URL contains only whitespace. This persisted-type distinction is not visible once normalized, so it is verified by the focused component test; no additional Electron instance was started for a visually identical result.

<img width="1502" height="1153" alt="Legacy command-backed in-memory MCP recovery focuses the Command field" src="https://github.com/user-attachments/assets/b590a586-6394-4144-8d00-5f130b83fd24" />

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Memory MCP initialization failures caused by unresolved paths and preserve actionable Windows spawn diagnostics in settings.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP connect/status caching and transport selection for legacy server configs; changes are guarded by tests but affect a core integration path.
> 
> **Overview**
> Improves MCP failure recovery by validating configuration before launch and surfacing structured runtime errors in Settings.
> 
> **Launch validation** rejects unresolved placeholders (`${…}`, `%…%`, `YOUR_*`) for stdio commands (including DXT-resolved commands), Memory MCP file paths, and in-memory start failures—before shell lookup, transport creation, or filesystem access. Whitespace-only `baseUrl` values are treated as unset so command-backed legacy rows use stdio instead of bogus HTTP/OAuth fallback.
> 
> **Runtime status** adds optional `errorCode` and `errorPath` on shared `McpRuntimeStatus`. Stdio transport errors are captured via `onTransportError` and merged in `setServerStatus` so generic SDK messages like `Connection closed` do not wipe richer spawn metadata (e.g. `EPERM` + executable path).
> 
> **Settings UI** shows a General-tab error alert with code, message, and path, plus **Edit** to focus command, URL, or env (including QVeris API key). Form transport resolution exposes stdio for legacy `inMemory`/remote rows that only have a real command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b8625efc1b2862ae0c36ee3456d498805c55e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->