### PR TITLE
fix(tool-repair): preserve canonical argument shape

### DIFF
--- a/src/main/ai/messages/__tests__/messageRules.legacyToolSteps.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.legacyToolSteps.test.ts
@@ -4,12 +4,12 @@ import { describe, expect, it } from 'vitest'
 
 import { toModelMessages } from '../messageRules'
 
-const completedTool = (toolCallId: string): DynamicToolUIPart => ({
+const completedTool = (toolCallId: string, input: unknown = { query: toolCallId }): DynamicToolUIPart => ({
   type: 'dynamic-tool',
   toolName: 'lookup',
   toolCallId,
   state: 'output-available',
-  input: { query: toolCallId },
+  input,
   output: { result: toolCallId }
 })
 
@@ -45,11 +45,15 @@ describe('legacy tool step replay', () => {
   })
 
   it('serializes Responses tool outputs before the next assistant item', async () => {
+    const parameterized = {
+      paths: ['a.ts', 'b.ts'],
+      options: { filters: [{ field: 'status', values: ['open', 'closed'] }], flags: { recursive: true } }
+    }
     const prompt = await toModelMessages([
       assistant([
         { type: 'text', text: 'Before tools' },
-        completedTool('call-1'),
-        completedTool('call-2'),
+        completedTool('call-1', parameterized),
+        completedTool('call-2', {}),
         { type: 'text', text: 'After tools' }
       ])
     ])
@@ -82,6 +86,10 @@ describe('legacy tool step replay', () => {
       'function_call_output',
       'function_call_output',
       'assistant'
+    ])
+    expect(requestBody.input?.filter((item) => item.type === 'function_call')).toMatchObject([
+      { call_id: 'call-1', arguments: JSON.stringify(parameterized) },
+      { call_id: 'call-2', arguments: '{}' }
     ])
   })
 

--- a/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
@@ -69,38 +69,23 @@ describe('createAiRepair', () => {
     expect(params.output).toBeDefined()
   })
 
-  it('unwraps a repair envelope only when the original tool schema validates its arguments', async () => {
-    const complexSchema = z.object({
-      paths: z.array(z.string()),
-      options: z.object({ filters: z.array(z.object({ field: z.string(), values: z.array(z.string()) })) })
-    })
-    const expected = {
-      paths: ['a.ts', 'b.ts'],
-      options: { filters: [{ field: 'status', values: ['open', 'closed'] }] }
-    }
-    generateText.mockResolvedValue({ output: { arguments: expected } })
-
-    const repaired = await repair({
-      system: undefined,
-      messages: [],
-      toolCall: makeToolCall(KB_SEARCH_TOOL_NAME, { paths: 'a.ts' }),
-      tools: { [KB_SEARCH_TOOL_NAME]: { inputSchema: complexSchema } } as never,
-      inputSchema: async () => z.toJSONSchema(complexSchema) as never,
-      error: inputErr
-    })
+  it('re-parses a double-encoded original call without asking the model', async () => {
+    const doubleEncoded = JSON.stringify(JSON.stringify({ query: 'hello world' }))
+    const repaired = await callRepair(makeToolCall(KB_SEARCH_TOOL_NAME, doubleEncoded))
 
     expect(repaired).not.toBeNull()
-    expect(JSON.parse(repaired!.input)).toEqual(expected)
+    expect(JSON.parse(repaired!.input)).toEqual({ query: 'hello world' })
+    expect(generateText).not.toHaveBeenCalled()
   })
 
-  it('validates and unwraps repair envelopes for tools backed by JSON Schema', async () => {
+  it('rejects a repair that violates a JSON-Schema-backed tool (the SDK carries no validator there)', async () => {
     const schemaJson: JSONSchema7 = {
       type: 'object',
       properties: { query: { type: 'string' } },
       required: ['query'],
       additionalProperties: false
     }
-    generateText.mockResolvedValue({ output: { arguments: { query: 'hello world' } } })
+    generateText.mockResolvedValue({ output: { query: 42 } })
 
     const repaired = await repair({
       system: undefined,
@@ -111,8 +96,7 @@ describe('createAiRepair', () => {
       error: inputErr
     })
 
-    expect(repaired).not.toBeNull()
-    expect(JSON.parse(repaired!.input)).toEqual({ query: 'hello world' })
+    expect(repaired).toBeNull()
   })
 
   it('fails closed when a JSON Schema cannot be converted for validation', async () => {
@@ -129,45 +113,6 @@ describe('createAiRepair', () => {
     })
 
     expect(repaired).toBeNull()
-  })
-
-  it('canonicalizes an empty-parameter repair to an empty object', async () => {
-    const emptySchema = z.object({})
-    generateText.mockResolvedValue({ output: { arguments: {} } })
-
-    const repaired = await repair({
-      system: undefined,
-      messages: [],
-      toolCall: makeToolCall('empty_tool', undefined),
-      tools: { empty_tool: { inputSchema: emptySchema } } as never,
-      inputSchema: async () => z.toJSONSchema(emptySchema) as never,
-      error: inputErr
-    })
-
-    expect(repaired).not.toBeNull()
-    expect(JSON.parse(repaired!.input)).toEqual({})
-  })
-
-  it('preserves a schema whose canonical input is an arguments field', async () => {
-    const argumentsSchema = z.object({ arguments: z.object({ query: z.string() }) })
-    const repairArgumentsTool = createAiRepair({
-      providerId: 'openai',
-      providerSettings: { apiKey: 'test' },
-      modelId: 'gpt-4o-mini'
-    })
-    generateText.mockResolvedValue({ output: { arguments: { query: 'hello world' } } })
-
-    const repaired = await repairArgumentsTool({
-      system: undefined,
-      messages: [],
-      toolCall: makeToolCall('arguments_tool', { query: 'hello world' }),
-      tools: { arguments_tool: { inputSchema: argumentsSchema } } as never,
-      inputSchema: async () => z.toJSONSchema(argumentsSchema) as never,
-      error: inputErr
-    })
-
-    expect(repaired).not.toBeNull()
-    expect(JSON.parse(repaired!.input)).toEqual({ arguments: { query: 'hello world' } })
   })
 
   it('reuses the request usage middleware so repair is an independent invocation', async () => {
@@ -199,7 +144,7 @@ describe('createAiRepair', () => {
   })
 
   it('returns null when the structured repair still violates the tool schema', async () => {
-    generateText.mockResolvedValue({ output: { arguments: { query: 42 } } })
+    generateText.mockResolvedValue({ output: { query: 42 } })
 
     expect(await callRepair(makeToolCall(KB_SEARCH_TOOL_NAME, { q: 42 }))).toBeNull()
   })

--- a/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
@@ -78,7 +78,7 @@ describe('createAiRepair', () => {
     expect(generateText).not.toHaveBeenCalled()
   })
 
-  it('rejects a repair that violates a JSON-Schema-backed tool (the SDK carries no validator there)', async () => {
+  it('leaves a JSON-Schema-backed tool to its server — no fabricated client validator', async () => {
     const schemaJson: JSONSchema7 = {
       type: 'object',
       properties: { query: { type: 'string' } },
@@ -90,29 +90,14 @@ describe('createAiRepair', () => {
     const repaired = await repair({
       system: undefined,
       messages: [],
-      toolCall: makeToolCall('mcp_search', { q: 'hello world' }),
+      toolCall: makeToolCall('mcp_search', 'not json at all'),
       tools: { mcp_search: { inputSchema: jsonSchema(schemaJson) } } as never,
       inputSchema: async () => schemaJson as never,
       error: inputErr
     })
 
-    expect(repaired).toBeNull()
-  })
-
-  it('fails closed when a JSON Schema cannot be converted for validation', async () => {
-    const schemaJson = { not: { type: 'string' } } as const
-    generateText.mockResolvedValue({ output: { query: 'hello world' } })
-
-    const repaired = await repair({
-      system: undefined,
-      messages: [],
-      toolCall: makeToolCall('unsupported_schema', { query: 42 }),
-      tools: { unsupported_schema: { inputSchema: jsonSchema(schemaJson) } } as never,
-      inputSchema: async () => schemaJson as never,
-      error: inputErr
-    })
-
-    expect(repaired).toBeNull()
+    expect(repaired).not.toBeNull()
+    expect(JSON.parse(repaired!.input)).toEqual({ query: 42 })
   })
 
   it('reuses the request usage middleware so repair is an independent invocation', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
@@ -1,7 +1,8 @@
-import type { LanguageModelV3ToolCall } from '@ai-sdk/provider'
+import type { JSONSchema7, LanguageModelV3ToolCall } from '@ai-sdk/provider'
 import { KB_SEARCH_TOOL_NAME } from '@shared/ai/builtinTools'
-import { InvalidToolInputError, NoSuchToolError } from 'ai'
+import { InvalidToolInputError, jsonSchema, NoSuchToolError } from 'ai'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as z from 'zod'
 
 const { generateText } = vi.hoisted(() => ({ generateText: vi.fn() }))
 
@@ -22,6 +23,7 @@ const inputErr = new InvalidToolInputError({
 })
 
 const noSuchToolErr = new NoSuchToolError({ toolName: 'mystery' })
+const querySchema = z.object({ query: z.string() })
 
 function makeToolCall(toolName: string, input: unknown): LanguageModelV3ToolCall {
   return {
@@ -41,7 +43,7 @@ async function callRepair(
     system: undefined,
     messages: [],
     toolCall,
-    tools: {} as never,
+    tools: { [KB_SEARCH_TOOL_NAME]: { inputSchema: querySchema } } as never,
     inputSchema: async () => ({ type: 'object', properties: { query: { type: 'string' } } }) as never,
     error
   })
@@ -67,6 +69,107 @@ describe('createAiRepair', () => {
     expect(params.output).toBeDefined()
   })
 
+  it('unwraps a repair envelope only when the original tool schema validates its arguments', async () => {
+    const complexSchema = z.object({
+      paths: z.array(z.string()),
+      options: z.object({ filters: z.array(z.object({ field: z.string(), values: z.array(z.string()) })) })
+    })
+    const expected = {
+      paths: ['a.ts', 'b.ts'],
+      options: { filters: [{ field: 'status', values: ['open', 'closed'] }] }
+    }
+    generateText.mockResolvedValue({ output: { arguments: expected } })
+
+    const repaired = await repair({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall(KB_SEARCH_TOOL_NAME, { paths: 'a.ts' }),
+      tools: { [KB_SEARCH_TOOL_NAME]: { inputSchema: complexSchema } } as never,
+      inputSchema: async () => z.toJSONSchema(complexSchema) as never,
+      error: inputErr
+    })
+
+    expect(repaired).not.toBeNull()
+    expect(JSON.parse(repaired!.input)).toEqual(expected)
+  })
+
+  it('validates and unwraps repair envelopes for tools backed by JSON Schema', async () => {
+    const schemaJson: JSONSchema7 = {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+      additionalProperties: false
+    }
+    generateText.mockResolvedValue({ output: { arguments: { query: 'hello world' } } })
+
+    const repaired = await repair({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall('mcp_search', { q: 'hello world' }),
+      tools: { mcp_search: { inputSchema: jsonSchema(schemaJson) } } as never,
+      inputSchema: async () => schemaJson as never,
+      error: inputErr
+    })
+
+    expect(repaired).not.toBeNull()
+    expect(JSON.parse(repaired!.input)).toEqual({ query: 'hello world' })
+  })
+
+  it('fails closed when a JSON Schema cannot be converted for validation', async () => {
+    const schemaJson = { not: { type: 'string' } } as const
+    generateText.mockResolvedValue({ output: { query: 'hello world' } })
+
+    const repaired = await repair({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall('unsupported_schema', { query: 42 }),
+      tools: { unsupported_schema: { inputSchema: jsonSchema(schemaJson) } } as never,
+      inputSchema: async () => schemaJson as never,
+      error: inputErr
+    })
+
+    expect(repaired).toBeNull()
+  })
+
+  it('canonicalizes an empty-parameter repair to an empty object', async () => {
+    const emptySchema = z.object({})
+    generateText.mockResolvedValue({ output: { arguments: {} } })
+
+    const repaired = await repair({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall('empty_tool', undefined),
+      tools: { empty_tool: { inputSchema: emptySchema } } as never,
+      inputSchema: async () => z.toJSONSchema(emptySchema) as never,
+      error: inputErr
+    })
+
+    expect(repaired).not.toBeNull()
+    expect(JSON.parse(repaired!.input)).toEqual({})
+  })
+
+  it('preserves a schema whose canonical input is an arguments field', async () => {
+    const argumentsSchema = z.object({ arguments: z.object({ query: z.string() }) })
+    const repairArgumentsTool = createAiRepair({
+      providerId: 'openai',
+      providerSettings: { apiKey: 'test' },
+      modelId: 'gpt-4o-mini'
+    })
+    generateText.mockResolvedValue({ output: { arguments: { query: 'hello world' } } })
+
+    const repaired = await repairArgumentsTool({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall('arguments_tool', { query: 'hello world' }),
+      tools: { arguments_tool: { inputSchema: argumentsSchema } } as never,
+      inputSchema: async () => z.toJSONSchema(argumentsSchema) as never,
+      error: inputErr
+    })
+
+    expect(repaired).not.toBeNull()
+    expect(JSON.parse(repaired!.input)).toEqual({ arguments: { query: 'hello world' } })
+  })
+
   it('reuses the request usage middleware so repair is an independent invocation', async () => {
     const plugins = [{ name: 'usage' }]
     const repairWithUsage = createAiRepair({
@@ -81,7 +184,7 @@ describe('createAiRepair', () => {
       system: undefined,
       messages: [],
       toolCall: makeToolCall(KB_SEARCH_TOOL_NAME, { q: 'hello world' }),
-      tools: {} as never,
+      tools: { [KB_SEARCH_TOOL_NAME]: { inputSchema: querySchema } } as never,
       inputSchema: async () => ({ type: 'object', properties: { query: { type: 'string' } } }) as never,
       error: inputErr
     })
@@ -93,6 +196,12 @@ describe('createAiRepair', () => {
   it('returns null when generateText returns no structured output', async () => {
     generateText.mockResolvedValue({ output: undefined, text: 'sorry, cannot fix' })
     expect(await callRepair(makeToolCall(KB_SEARCH_TOOL_NAME, {}))).toBeNull()
+  })
+
+  it('returns null when the structured repair still violates the tool schema', async () => {
+    generateText.mockResolvedValue({ output: { arguments: { query: 42 } } })
+
+    expect(await callRepair(makeToolCall(KB_SEARCH_TOOL_NAME, { q: 42 }))).toBeNull()
   })
 
   it('returns null on non-input errors (NoSuchTool is the model picking a wrong tool name)', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
@@ -78,14 +78,14 @@ describe('createAiRepair', () => {
     expect(generateText).not.toHaveBeenCalled()
   })
 
-  it('leaves a JSON-Schema-backed tool to its server — no fabricated client validator', async () => {
+  it('rejects a JSON Schema repair that violates uniqueItems', async () => {
     const schemaJson: JSONSchema7 = {
       type: 'object',
-      properties: { query: { type: 'string' } },
-      required: ['query'],
+      properties: { tags: { type: 'array', items: { type: 'string' }, uniqueItems: true } },
+      required: ['tags'],
       additionalProperties: false
     }
-    generateText.mockResolvedValue({ output: { query: 42 } })
+    generateText.mockResolvedValue({ output: { tags: ['duplicate', 'duplicate'] } })
 
     const repaired = await repair({
       system: undefined,
@@ -96,8 +96,69 @@ describe('createAiRepair', () => {
       error: inputErr
     })
 
+    expect(repaired).toBeNull()
+  })
+
+  it('rejects a JSON Schema repair that violates contains', async () => {
+    const schemaJson: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        values: { type: 'array', items: { type: 'number' }, contains: { const: 42 } }
+      },
+      required: ['values'],
+      additionalProperties: false
+    }
+    generateText.mockResolvedValue({ output: { values: [1, 2] } })
+
+    const repaired = await repair({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall('mcp_search', 'not json at all'),
+      tools: { mcp_search: { inputSchema: jsonSchema(schemaJson) } } as never,
+      inputSchema: async () => schemaJson as never,
+      error: inputErr
+    })
+
+    expect(repaired).toBeNull()
+  })
+
+  it('unwraps a single arguments envelope when only its contents match the JSON Schema', async () => {
+    const schemaJson: JSONSchema7 = {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+      additionalProperties: false
+    }
+    generateText.mockResolvedValue({ output: { arguments: { query: 'hello world' } } })
+
+    const repaired = await repair({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall('mcp_search', { q: 'hello world' }),
+      tools: { mcp_search: { inputSchema: jsonSchema(schemaJson) } } as never,
+      inputSchema: async () => schemaJson as never,
+      error: inputErr
+    })
+
     expect(repaired).not.toBeNull()
-    expect(JSON.parse(repaired!.input)).toEqual({ query: 42 })
+    expect(JSON.parse(repaired!.input)).toEqual({ query: 'hello world' })
+  })
+
+  it('preserves an arguments field accepted by the tool schema', async () => {
+    const schema = z.object({ arguments: z.object({ query: z.string() }) })
+    generateText.mockResolvedValue({ output: { arguments: { query: 'hello world' } } })
+
+    const repaired = await repair({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall('arguments_tool', { query: 'hello world' }),
+      tools: { arguments_tool: { inputSchema: schema } } as never,
+      inputSchema: async () => z.toJSONSchema(schema) as never,
+      error: inputErr
+    })
+
+    expect(repaired).not.toBeNull()
+    expect(JSON.parse(repaired!.input)).toEqual({ arguments: { query: 'hello world' } })
   })
 
   it('reuses the request usage middleware so repair is an independent invocation', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/__tests__/repair.test.ts
@@ -122,6 +122,27 @@ describe('createAiRepair', () => {
     expect(repaired).toBeNull()
   })
 
+  it('rejects a JSON Schema repair that violates Draft 2020-12 unevaluatedProperties', async () => {
+    const schemaJson = {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+      unevaluatedProperties: false
+    } as JSONSchema7
+    generateText.mockResolvedValue({ output: { query: 'hello world', unexpected: true } })
+
+    const repaired = await repair({
+      system: undefined,
+      messages: [],
+      toolCall: makeToolCall('mcp_search', 'not json at all'),
+      tools: { mcp_search: { inputSchema: jsonSchema(schemaJson) } } as never,
+      inputSchema: async () => schemaJson as never,
+      error: inputErr
+    })
+
+    expect(repaired).toBeNull()
+  })
+
   it('unwraps a single arguments envelope when only its contents match the JSON Schema', async () => {
     const schemaJson: JSONSchema7 = {
       type: 'object',

--- a/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/mcpTools.execute.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/mcpTools.execute.test.ts
@@ -1,4 +1,5 @@
 import type { McpCallToolResponse } from '@main/ai/mcp/types'
+import { createToolInvokeTool } from '@main/ai/tools/adapters/aiSdk/meta/toolInvoke'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ToolRegistry } from '../../registry'
@@ -123,6 +124,39 @@ describe('mcpTools execute wrapper', () => {
     })
     expect(out.content).toEqual([{ type: 'text', text: 'ok' }])
     expect(out.metadata).toEqual({ description: '', name: 't', serverName: 's1', serverId: 's1', type: 'mcp' })
+  })
+
+  it('rejects Draft 2020-12-invalid deferred arguments before calling the MCP runtime', async () => {
+    const reg = new ToolRegistry()
+    const tool = {
+      ...mcpTool('s1', 't'),
+      inputSchema: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+        unevaluatedProperties: false
+      }
+    }
+    list.mockReturnValue({ items: [activeServer('s1')] })
+    listTools.mockReturnValue([tool])
+    getById.mockReturnValue(activeServer('s1'))
+    callTool.mockResolvedValue({
+      isError: false,
+      content: [{ type: 'text', text: 'should not run' }]
+    } as McpCallToolResponse)
+    await syncMcpToolsToRegistry(reg)
+
+    const invoke = createToolInvokeTool(reg, new Set([tool.id]), new Set([tool.id]))
+    const execute = invoke.execute
+    if (!execute) throw new Error('expected tool_invoke to have an execute fn')
+
+    await expect(
+      execute({ name: tool.id, params: { query: 'hello', unexpected: true } }, {
+        toolCallId: 'outer-1',
+        messages: []
+      } as never)
+    ).rejects.toThrow(/Invalid params/)
+    expect(callTool).not.toHaveBeenCalled()
   })
 
   it('executes the explicitly selected server when display names normalize alike', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/sync.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/sync.test.ts
@@ -145,6 +145,22 @@ describe('syncMcpToolsToRegistry', () => {
     expect(reg.getAll().filter((e) => e.name === 'mcp__s1__t').length).toBe(1)
   })
 
+  it('keeps the previous server snapshot when a tool schema cannot be compiled', async () => {
+    const reg = new ToolRegistry()
+    list.mockReturnValue({ items: [activeServer('s1')] })
+    listTools.mockReturnValueOnce([mcpTool('s1', 'a', 'a v1'), mcpTool('s1', 'b', 'b v1')])
+    await syncMcpToolsToRegistry(reg)
+
+    listTools.mockReturnValueOnce([
+      mcpTool('s1', 'a', 'a v2'),
+      { ...mcpTool('s1', 'b', 'b v2'), inputSchema: { $id: 'http://[' } }
+    ])
+    await syncMcpToolsToRegistry(reg)
+
+    expect(reg.getByName('mcp__s1__a')?.description).toBe('a v1')
+    expect(reg.getByName('mcp__s1__b')?.description).toBe('b v1')
+  })
+
   it('does not touch non-MCP entries', async () => {
     const reg = new ToolRegistry()
     reg.register({

--- a/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
@@ -5,9 +5,10 @@ import { mcpServerService } from '@main/data/services/McpServerService'
 import { isMcpToolForcePromptBySource } from '@shared/ai/tools/mcpSourcePolicy'
 import type { McpServer } from '@shared/data/types/mcpServer'
 import type { McpTool } from '@shared/types/mcp'
-import { jsonSchema, type JSONSchema7, type Tool } from 'ai'
+import { type JSONSchema7, type Tool } from 'ai'
 
 import { getRequestContext } from '../context'
+import { createMcpInputSchema } from '../mcpSchema'
 import { registry, type ToolRegistry } from '../registry'
 import type { ToolEntry } from '../types'
 import { mcpResultToTextSummary } from './utils'
@@ -40,7 +41,7 @@ function createMcpTool(mcpTool: McpTool, forcePrompt: boolean): Tool {
     type: 'function',
     description: mcpTool.description || mcpTool.name,
     metadata: { cherry: { tool: metadata } },
-    inputSchema: jsonSchema(mcpTool.inputSchema as JSONSchema7),
+    inputSchema: createMcpInputSchema(mcpTool.inputSchema as JSONSchema7),
     needsApproval: async () => forcePrompt,
     execute: async (args: Record<string, unknown>, options) => {
       const { toolCallId, abortSignal } = options

--- a/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/mcpTools.ts
@@ -141,12 +141,18 @@ export async function syncMcpToolsToRegistry(
       const enabledTools = application.get('McpCatalogService').listTools(server.id, { includeDisabled: false })
       const scopedTools = selectedToolIds ? enabledTools.filter((tool) => selectedToolIds.has(tool.id)) : enabledTools
       if (!selectedToolIds || scopedTools.length > 0) targetNamespaces.add(namespace)
+      const freshEntries: ToolEntry[] = []
+      const freshServerNames = new Set<string>()
       for (const mcpTool of scopedTools) {
         // A wire id encodes serverId + protocol tool name, so a repeat can only be the
         // same identity listed twice by one server. First wins.
-        if (freshNames.has(mcpTool.id)) continue
-        reg.register(toEntry(mcpTool, server))
-        freshNames.add(mcpTool.id)
+        if (freshNames.has(mcpTool.id) || freshServerNames.has(mcpTool.id)) continue
+        freshEntries.push(toEntry(mcpTool, server))
+        freshServerNames.add(mcpTool.id)
+      }
+      for (const entry of freshEntries) {
+        reg.register(entry)
+        freshNames.add(entry.name)
       }
       refreshedNamespaces.add(namespace)
     } catch (error) {

--- a/src/main/ai/tools/adapters/aiSdk/mcpSchema.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcpSchema.ts
@@ -1,0 +1,21 @@
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker'
+import { jsonSchema, type JSONSchema7 } from 'ai'
+
+const jsonSchemaValidator = new CfWorkerJsonSchemaValidator({ draft: '2020-12', shortcircuit: false })
+
+export function createMcpJsonSchemaValidator<T = unknown>(schema: JSONSchema7) {
+  const validate = jsonSchemaValidator.getValidator(schema as never)
+
+  return (value: unknown) => {
+    const result = validate(value)
+    return result.valid
+      ? { success: true as const, value: result.data as T }
+      : { success: false as const, error: new Error(result.errorMessage) }
+  }
+}
+
+export function createMcpInputSchema(schema: JSONSchema7) {
+  return jsonSchema<Record<string, unknown>>(schema, {
+    validate: createMcpJsonSchemaValidator<Record<string, unknown>>(schema)
+  })
+}

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolInvoke.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolInvoke.ts
@@ -8,12 +8,9 @@
  * retry" without being told up front it must inspect:
  *   A. unseen-schema guard — the first invoke of a tool whose signature the
  *      model hasn't seen is rejected with that signature; the name is then
- *      recorded so the corrected retry passes (no inspect loop). This is the
- *      only protection for `jsonSchema()`-wrapped tools (e.g. MCP), where B is a no-op.
+ *      recorded so the corrected retry passes (no inspect loop).
  *   B. param validation — arguments are validated against the tool input
- *      schema; a mismatch is rejected with the signature. (Tools backed by a
- *      `jsonSchema()`-wrapped schema (e.g. MCP) carry no validator, so B is a
- *      no-op for them — same as the SDK's native dispatch path.)
+ *      schema when it provides a validator; a mismatch is rejected with the signature.
  *
  * Forwards the AI SDK execution options (messages, abortSignal,
  * experimental_context) onto the inner tool's `execute` so the per-request
@@ -154,8 +151,7 @@ export function createToolInvokeTool(
 /**
  * Validate `params` against the tool input schema, returning the parsed value
  * (Zod defaults/coercions applied) on success. Throws with the tool signature
- * on mismatch. Schemas without a validator (`jsonSchema()`-wrapped, e.g. MCP
- * tools) pass through unchanged — Guard A is their protection.
+ * on mismatch. Schemas without a validator pass through unchanged.
  */
 async function validateParams(entry: ToolEntry, params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const validate = asSchema(entry.tool.inputSchema as Parameters<typeof asSchema>[0]).validate

--- a/src/main/ai/tools/adapters/aiSdk/repair.ts
+++ b/src/main/ai/tools/adapters/aiSdk/repair.ts
@@ -10,7 +10,6 @@ import {
   type ToolCallRepairFunction,
   type ToolSet
 } from 'ai'
-import * as z from 'zod'
 
 import type { AppProviderSettingsMap } from '../../../types'
 
@@ -40,18 +39,10 @@ export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>)
       return null
     }
 
-    let schema = asSchema(tools[toolCall.toolName].inputSchema)
-    if (!schema.validate) {
-      try {
-        schema = asSchema(z.fromJSONSchema(schemaJson as Parameters<typeof z.fromJSONSchema>[0]))
-      } catch (err) {
-        logger.warn('AI repair cannot validate the tool JSON Schema', err as Error, {
-          toolName: toolCall.toolName,
-          toolCallId: toolCall.toolCallId
-        })
-        return null
-      }
-    }
+    // A `jsonSchema()`-wrapped schema (e.g. MCP) carries no validator, so this
+    // validates nothing and the server stays the authority — same stance as
+    // `meta/toolInvoke.ts` and the SDK's own dispatch path.
+    const schema = asSchema(tools[toolCall.toolName].inputSchema)
 
     /** Canonical input, or undefined when the value does not fit the tool schema. */
     const canonicalize = async (value: unknown): Promise<unknown> => {

--- a/src/main/ai/tools/adapters/aiSdk/repair.ts
+++ b/src/main/ai/tools/adapters/aiSdk/repair.ts
@@ -2,7 +2,6 @@ import { asSchema, safeParseJSON, safeValidateTypes } from '@ai-sdk/provider-uti
 import { type AiPlugin, generateText as aiCoreGenerateText } from '@cherrystudio/ai-core'
 import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import { loggerService } from '@logger'
-import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv'
 import {
   InvalidToolInputError,
   jsonSchema,
@@ -13,9 +12,9 @@ import {
 } from 'ai'
 
 import type { AppProviderSettingsMap } from '../../../types'
+import { createMcpJsonSchemaValidator } from './mcpSchema'
 
 const logger = loggerService.withContext('repairToolCall')
-const jsonSchemaValidator = new AjvJsonSchemaValidator()
 
 type AppProviderId = StringKeys<AppProviderSettingsMap>
 
@@ -50,10 +49,10 @@ export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>)
       }
     } else {
       try {
-        const validator = jsonSchemaValidator.getValidator(schemaJson as never)
+        const validator = createMcpJsonSchemaValidator(schemaJson)
         validate = async (value) => {
           const result = validator(value)
-          return result.valid ? result.data : undefined
+          return result.success ? result.value : undefined
         }
       } catch (err) {
         logger.warn('AI repair cannot validate the tool JSON Schema', err as Error, {

--- a/src/main/ai/tools/adapters/aiSdk/repair.ts
+++ b/src/main/ai/tools/adapters/aiSdk/repair.ts
@@ -29,6 +29,14 @@ export interface AiRepairContext<T extends AppProviderId = AppProviderId> {
   getUsagePlugins?: () => AiPlugin[]
 }
 
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return undefined
+  }
+}
+
 export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>): ToolCallRepairFunction<ToolSet> {
   return async ({ toolCall, tools, error, inputSchema }) => {
     if (!InvalidToolInputError.isInstance(error)) return null
@@ -40,7 +48,40 @@ export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>)
       return null
     }
 
+    let schema = asSchema(tools[toolCall.toolName].inputSchema)
+    if (!schema.validate) {
+      try {
+        schema = asSchema(z.fromJSONSchema(schemaJson as Parameters<typeof z.fromJSONSchema>[0]))
+      } catch (err) {
+        logger.warn('AI repair cannot validate the tool JSON Schema', err as Error, {
+          toolName: toolCall.toolName,
+          toolCallId: toolCall.toolCallId
+        })
+        return null
+      }
+    }
+
+    /** Canonical input, or undefined when the value does not fit the tool schema. */
+    const canonicalize = async (value: unknown): Promise<unknown> => {
+      const direct = await safeValidateTypes({ value, schema })
+      if (direct.success) return direct.value
+      // Double-encoded arguments — the one malformation a re-parse alone canonicalizes.
+      if (typeof value !== 'string') return undefined
+      const reparsed = await safeValidateTypes({ value: parseJson(value), schema })
+      return reparsed.success ? reparsed.value : undefined
+    }
+
     const inputStr = typeof toolCall.input === 'string' ? toolCall.input : JSON.stringify(toolCall.input)
+
+    const parsedInput = parseJson(inputStr)
+    const canonicalInput = parsedInput === undefined ? undefined : await canonicalize(parsedInput)
+    if (canonicalInput !== undefined) {
+      logger.info('Repaired tool call without AI', {
+        toolName: toolCall.toolName,
+        toolCallId: toolCall.toolCallId
+      })
+      return { ...toolCall, input: JSON.stringify(canonicalInput) }
+    }
 
     const prompt = [
       `The previous tool call had invalid arguments. Produce a corrected JSON object that matches the schema, preserving the original intent.`,
@@ -79,29 +120,8 @@ export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>)
       return null
     }
 
-    let schema = asSchema(tools[toolCall.toolName].inputSchema)
-    if (!schema.validate) {
-      try {
-        schema = asSchema(z.fromJSONSchema(schemaJson as Parameters<typeof z.fromJSONSchema>[0]))
-      } catch (err) {
-        logger.warn('AI repair cannot validate the tool JSON Schema', err as Error, {
-          toolName: toolCall.toolName,
-          toolCallId: toolCall.toolCallId
-        })
-        return null
-      }
-    }
-    let validated = await safeValidateTypes({ value: repaired, schema })
-    if (
-      !validated.success &&
-      typeof repaired === 'object' &&
-      !Array.isArray(repaired) &&
-      Object.keys(repaired).length === 1 &&
-      'arguments' in repaired
-    ) {
-      validated = await safeValidateTypes({ value: repaired.arguments, schema })
-    }
-    if (!validated.success) {
+    const validated = await canonicalize(repaired)
+    if (validated === undefined) {
       logger.warn('AI repair returned invalid structured output', {
         toolName: toolCall.toolName,
         toolCallId: toolCall.toolCallId
@@ -113,6 +133,6 @@ export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>)
       toolName: toolCall.toolName,
       toolCallId: toolCall.toolCallId
     })
-    return { ...toolCall, input: JSON.stringify(validated.value) }
+    return { ...toolCall, input: JSON.stringify(validated) }
   }
 }

--- a/src/main/ai/tools/adapters/aiSdk/repair.ts
+++ b/src/main/ai/tools/adapters/aiSdk/repair.ts
@@ -2,6 +2,7 @@ import { asSchema, safeParseJSON, safeValidateTypes } from '@ai-sdk/provider-uti
 import { type AiPlugin, generateText as aiCoreGenerateText } from '@cherrystudio/ai-core'
 import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import { loggerService } from '@logger'
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv'
 import {
   InvalidToolInputError,
   jsonSchema,
@@ -14,6 +15,7 @@ import {
 import type { AppProviderSettingsMap } from '../../../types'
 
 const logger = loggerService.withContext('repairToolCall')
+const jsonSchemaValidator = new AjvJsonSchemaValidator()
 
 type AppProviderId = StringKeys<AppProviderSettingsMap>
 
@@ -39,19 +41,52 @@ export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>)
       return null
     }
 
-    // A `jsonSchema()`-wrapped schema (e.g. MCP) carries no validator, so this
-    // validates nothing and the server stays the authority — same stance as
-    // `meta/toolInvoke.ts` and the SDK's own dispatch path.
     const schema = asSchema(tools[toolCall.toolName].inputSchema)
+    let validate: (value: unknown) => Promise<unknown | undefined>
+    if (schema.validate) {
+      validate = async (value) => {
+        const result = await safeValidateTypes({ value, schema })
+        return result.success ? result.value : undefined
+      }
+    } else {
+      try {
+        const validator = jsonSchemaValidator.getValidator(schemaJson as never)
+        validate = async (value) => {
+          const result = validator(value)
+          return result.valid ? result.data : undefined
+        }
+      } catch (err) {
+        logger.warn('AI repair cannot validate the tool JSON Schema', err as Error, {
+          toolName: toolCall.toolName,
+          toolCallId: toolCall.toolCallId
+        })
+        return null
+      }
+    }
 
     /** Canonical input, or undefined when the value does not fit the tool schema. */
     const canonicalize = async (value: unknown): Promise<unknown> => {
-      const direct = await safeValidateTypes({ value, schema })
-      if (direct.success) return direct.value
-      // Double-encoded arguments — the one malformation a re-parse alone canonicalizes.
-      if (typeof value !== 'string') return undefined
-      const reparsed = await safeParseJSON({ text: value, schema })
-      return reparsed.success ? reparsed.value : undefined
+      const candidates = [value]
+      if (typeof value === 'string') {
+        const reparsed = await safeParseJSON({ text: value })
+        if (reparsed.success) candidates.push(reparsed.value)
+      }
+
+      for (const candidate of candidates) {
+        const direct = await validate(candidate)
+        if (direct !== undefined) return direct
+        if (
+          typeof candidate === 'object' &&
+          candidate !== null &&
+          !Array.isArray(candidate) &&
+          Object.keys(candidate).length === 1 &&
+          'arguments' in candidate
+        ) {
+          const unwrapped = await validate(candidate.arguments)
+          if (unwrapped !== undefined) return unwrapped
+        }
+      }
+      return undefined
     }
 
     const inputStr = typeof toolCall.input === 'string' ? toolCall.input : JSON.stringify(toolCall.input)

--- a/src/main/ai/tools/adapters/aiSdk/repair.ts
+++ b/src/main/ai/tools/adapters/aiSdk/repair.ts
@@ -1,3 +1,4 @@
+import { asSchema, safeValidateTypes } from '@ai-sdk/provider-utils'
 import { type AiPlugin, generateText as aiCoreGenerateText } from '@cherrystudio/ai-core'
 import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import { loggerService } from '@logger'
@@ -9,6 +10,7 @@ import {
   type ToolCallRepairFunction,
   type ToolSet
 } from 'ai'
+import * as z from 'zod'
 
 import type { AppProviderSettingsMap } from '../../../types'
 
@@ -28,7 +30,7 @@ export interface AiRepairContext<T extends AppProviderId = AppProviderId> {
 }
 
 export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>): ToolCallRepairFunction<ToolSet> {
-  return async ({ toolCall, error, inputSchema }) => {
+  return async ({ toolCall, tools, error, inputSchema }) => {
     if (!InvalidToolInputError.isInstance(error)) return null
 
     let schemaJson: JSONSchema7
@@ -77,10 +79,40 @@ export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>)
       return null
     }
 
+    let schema = asSchema(tools[toolCall.toolName].inputSchema)
+    if (!schema.validate) {
+      try {
+        schema = asSchema(z.fromJSONSchema(schemaJson as Parameters<typeof z.fromJSONSchema>[0]))
+      } catch (err) {
+        logger.warn('AI repair cannot validate the tool JSON Schema', err as Error, {
+          toolName: toolCall.toolName,
+          toolCallId: toolCall.toolCallId
+        })
+        return null
+      }
+    }
+    let validated = await safeValidateTypes({ value: repaired, schema })
+    if (
+      !validated.success &&
+      typeof repaired === 'object' &&
+      !Array.isArray(repaired) &&
+      Object.keys(repaired).length === 1 &&
+      'arguments' in repaired
+    ) {
+      validated = await safeValidateTypes({ value: repaired.arguments, schema })
+    }
+    if (!validated.success) {
+      logger.warn('AI repair returned invalid structured output', {
+        toolName: toolCall.toolName,
+        toolCallId: toolCall.toolCallId
+      })
+      return null
+    }
+
     logger.info('Repaired tool call via AI', {
       toolName: toolCall.toolName,
       toolCallId: toolCall.toolCallId
     })
-    return { ...toolCall, input: JSON.stringify(repaired) }
+    return { ...toolCall, input: JSON.stringify(validated.value) }
   }
 }

--- a/src/main/ai/tools/adapters/aiSdk/repair.ts
+++ b/src/main/ai/tools/adapters/aiSdk/repair.ts
@@ -1,4 +1,4 @@
-import { asSchema, safeValidateTypes } from '@ai-sdk/provider-utils'
+import { asSchema, safeParseJSON, safeValidateTypes } from '@ai-sdk/provider-utils'
 import { type AiPlugin, generateText as aiCoreGenerateText } from '@cherrystudio/ai-core'
 import type { StringKeys } from '@cherrystudio/ai-core/provider'
 import { loggerService } from '@logger'
@@ -27,14 +27,6 @@ export interface AiRepairContext<T extends AppProviderId = AppProviderId> {
   modelId: string
   /** Reuse the request's usage middleware so repair is its own invocation. */
   getUsagePlugins?: () => AiPlugin[]
-}
-
-function parseJson(text: string): unknown {
-  try {
-    return JSON.parse(text)
-  } catch {
-    return undefined
-  }
 }
 
 export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>): ToolCallRepairFunction<ToolSet> {
@@ -67,14 +59,14 @@ export function createAiRepair<T extends AppProviderId>(ctx: AiRepairContext<T>)
       if (direct.success) return direct.value
       // Double-encoded arguments — the one malformation a re-parse alone canonicalizes.
       if (typeof value !== 'string') return undefined
-      const reparsed = await safeValidateTypes({ value: parseJson(value), schema })
+      const reparsed = await safeParseJSON({ text: value, schema })
       return reparsed.success ? reparsed.value : undefined
     }
 
     const inputStr = typeof toolCall.input === 'string' ? toolCall.input : JSON.stringify(toolCall.input)
 
-    const parsedInput = parseJson(inputStr)
-    const canonicalInput = parsedInput === undefined ? undefined : await canonicalize(parsedInput)
+    const parsedInput = await safeParseJSON({ text: inputStr })
+    const canonicalInput = parsedInput.success ? await canonicalize(parsedInput.value) : undefined
     if (canonicalInput !== undefined) {
       logger.info('Repaired tool call without AI', {
         toolName: toolCall.toolName,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Agent tool-call repair could preserve an AI-generated `{ "arguments": ... }` envelope as the tool input itself. Complex and empty inputs could then reach replay or the Responses API with the wrong JSON shape.

After this PR:

Repaired tool inputs are validated against the original tool schema and serialized in their canonical shape. A single `arguments` envelope is unwrapped only when the inner value validates, while tools whose real schema contains an `arguments` field remain unchanged. Unsupported JSON Schemas fail closed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20025

### Why we need it and why it was done in this way

The original tool schema is the authoritative contract, so both direct structured output and a possible repair envelope are validated against it before serialization. Responses API replay coverage also asserts the exact JSON string sent for complex and empty arguments.

The following tradeoffs were made:

- JSON Schemas that cannot be converted into a validating schema return no repair instead of sending unvalidated arguments.
- Envelope compatibility is limited to an object whose only key is `arguments`.

The following alternatives were considered:

- Always unwrapping `arguments` was rejected because `arguments` can be a legitimate top-level tool field.
- Trusting structured generation without revalidation was rejected because provider output can still have the wrong shape.

Links to places where the discussion took place: #20025

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Screenshots: N/A. This changes Agent tool argument validation and serialization only; there is no UI change.
- Verification: `pnpm lint`, `pnpm test:lint`, `pnpm typecheck:node`, and 17 focused tests passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Agent tool calls so repaired and replayed arguments keep their expected JSON shape.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent tool repair, MCP registration, and invoke validation on the main AI path; behavior changes when repairs or MCP args were previously accepted unvalidated.
> 
> **Overview**
> Fixes Agent tool-call repair and MCP dispatch so arguments stay in the shape the tool schema expects (including Responses API replay with complex or empty JSON).
> 
> **MCP tools** now wrap catalog JSON Schemas with a Draft 2020-12 validator (`mcpSchema.ts` via MCP’s CfWorker validator), so `tool_invoke` param checks and runtime validation apply to MCP tools—not only Zod-backed builtins. Registry sync batches per-server registration and, when a schema cannot be compiled, leaves the prior server snapshot in place instead of partially updating.
> 
> **`createAiRepair`** canonicalizes inputs before calling the model: re-parses double-encoded JSON, validates against the tool schema (SDK validator or the same MCP JSON Schema path), and unwraps a lone `{ arguments: … }` envelope only when the inner object validates. AI-generated repairs are re-validated the same way; invalid output or uncompilable schemas return `null` instead of forwarding bad JSON.
> 
> Tests cover Responses `function_call` argument strings, repair edge cases (`uniqueItems`, `contains`, `unevaluatedProperties`), MCP invoke rejection before `callTool`, and sync rollback on broken schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95073548a5963f61ca14f1da2994bb5487acdc96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->