### PR TITLE
fix(chat-errors): recover from wrapped authentication errors

### DIFF
--- a/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
@@ -87,6 +87,7 @@ const MessageErrorInfo: React.FC<{
   const [aiSummary, setAiSummary] = useState<string>('')
 
   const errorMessage = error?.message ?? undefined
+  const errorName = error?.name ?? null
   const errorStatus =
     (error as Record<string, unknown> | undefined)?.status ?? (error as Record<string, unknown> | undefined)?.statusCode
   const errorProviderId = (error as Record<string, unknown> | undefined)?.providerId as string | undefined
@@ -95,6 +96,8 @@ const MessageErrorInfo: React.FC<{
   const errorData = (error as Record<string, unknown> | undefined)?.data
   const errorFinishReason = (error as Record<string, unknown> | undefined)?.finishReason
   const errorI18nKey = (error as Record<string, unknown> | undefined)?.i18nKey
+  const retryLastError = errorName === 'AI_RetryError' ? error?.lastError : undefined
+  const retryErrors = errorName === 'AI_RetryError' ? error?.errors : undefined
   const hasAppOwnedI18nKey = typeof errorI18nKey === 'string' && i18n.exists(`error.${errorI18nKey}`)
   const classificationStatus =
     typeof errorStatus === 'number' || typeof errorStatus === 'string' ? errorStatus : undefined
@@ -114,7 +117,7 @@ const MessageErrorInfo: React.FC<{
   const providerId = getMessageListItemModel(message)?.provider ?? errorProviderId
   const classification = useMemo(() => {
     const classificationError: SerializedError = {
-      name: null,
+      name: errorName,
       message: errorMessage ?? null,
       stack: null,
       ...(classificationStatus !== undefined
@@ -125,7 +128,9 @@ const MessageErrorInfo: React.FC<{
         : {}),
       ...(classificationResponseBody !== undefined ? { responseBody: classificationResponseBody } : {}),
       ...(classificationData !== undefined ? { data: classificationData } : {}),
-      ...(classificationFinishReason !== undefined ? { finishReason: classificationFinishReason } : {})
+      ...(classificationFinishReason !== undefined ? { finishReason: classificationFinishReason } : {}),
+      ...(retryLastError !== undefined ? { lastError: retryLastError } : {}),
+      ...(retryErrors !== undefined ? { errors: retryErrors } : {})
     }
 
     return classifyError(classificationError, providerId)
@@ -135,7 +140,10 @@ const MessageErrorInfo: React.FC<{
     classificationResponseBody,
     classificationStatus,
     errorMessage,
-    providerId
+    errorName,
+    providerId,
+    retryErrors,
+    retryLastError
   ])
 
   useEffect(() => {

--- a/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
@@ -87,64 +87,13 @@ const MessageErrorInfo: React.FC<{
   const [aiSummary, setAiSummary] = useState<string>('')
 
   const errorMessage = error?.message ?? undefined
-  const errorName = error?.name ?? null
-  const errorStatus =
-    (error as Record<string, unknown> | undefined)?.status ?? (error as Record<string, unknown> | undefined)?.statusCode
   const errorProviderId = (error as Record<string, unknown> | undefined)?.providerId as string | undefined
   const errorModelId = (error as Record<string, unknown> | undefined)?.modelId as string | undefined
-  const errorResponseBody = (error as Record<string, unknown> | undefined)?.responseBody
-  const errorData = (error as Record<string, unknown> | undefined)?.data
-  const errorFinishReason = (error as Record<string, unknown> | undefined)?.finishReason
   const errorI18nKey = (error as Record<string, unknown> | undefined)?.i18nKey
-  const retryLastError = errorName === 'AI_RetryError' ? error?.lastError : undefined
-  const retryErrors = errorName === 'AI_RetryError' ? error?.errors : undefined
   const hasAppOwnedI18nKey = typeof errorI18nKey === 'string' && i18n.exists(`error.${errorI18nKey}`)
-  const classificationStatus =
-    typeof errorStatus === 'number' || typeof errorStatus === 'string' ? errorStatus : undefined
-  const classificationResponseBody = typeof errorResponseBody === 'string' ? errorResponseBody : undefined
-  let classificationData: string | undefined
-  if (typeof errorData === 'string') {
-    classificationData = errorData
-  } else if (errorData !== undefined && errorData !== null) {
-    try {
-      classificationData = JSON.stringify(errorData)
-    } catch {
-      // Ignore non-serializable provider data.
-    }
-  }
-  const classificationFinishReason = typeof errorFinishReason === 'string' ? errorFinishReason : undefined
 
   const providerId = getMessageListItemModel(message)?.provider ?? errorProviderId
-  const classification = useMemo(() => {
-    const classificationError: SerializedError = {
-      name: errorName,
-      message: errorMessage ?? null,
-      stack: null,
-      ...(classificationStatus !== undefined
-        ? {
-            status: classificationStatus,
-            statusCode: classificationStatus
-          }
-        : {}),
-      ...(classificationResponseBody !== undefined ? { responseBody: classificationResponseBody } : {}),
-      ...(classificationData !== undefined ? { data: classificationData } : {}),
-      ...(classificationFinishReason !== undefined ? { finishReason: classificationFinishReason } : {}),
-      ...(retryLastError !== undefined ? { lastError: retryLastError } : {}),
-      ...(retryErrors !== undefined ? { errors: retryErrors } : {})
-    }
-
-    return classifyError(classificationError, providerId)
-  }, [
-    classificationData,
-    classificationFinishReason,
-    classificationResponseBody,
-    classificationStatus,
-    errorMessage,
-    errorName,
-    providerId,
-    retryErrors,
-    retryLastError
-  ])
+  const classification = useMemo(() => classifyError(error, providerId), [error, providerId])
 
   useEffect(() => {
     if (hasAppOwnedI18nKey || classification.category !== 'unknown' || !errorMessage || !error || !diagnoseMessageError)

--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -185,8 +184,7 @@ describe('ErrorBlock', () => {
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 
-  it('offers provider settings recovery when a normal-chat retry wraps a 401 error', async () => {
-    const user = userEvent.setup()
+  it('offers provider settings recovery when a retry error wraps a 401', () => {
     const navigateErrorTarget = vi.fn()
     mocks.actions = { navigateErrorTarget }
 
@@ -197,26 +195,27 @@ describe('ErrorBlock', () => {
           name: 'AI_RetryError',
           message: 'Failed after 2 attempts. Last error:',
           stack: null,
+          cause: null,
           reason: 'maxRetriesExceeded',
+          lastError: {
+            name: 'AI_APICallError',
+            statusCode: 401,
+            responseBody: '{"error":{"message":"Invalid Authentication"}}'
+          },
           errors: [
             {
               name: 'AI_APICallError',
               statusCode: 401,
               responseBody: '{"error":{"message":"Invalid Authentication"}}'
             }
-          ],
-          lastError: {
-            name: 'AI_APICallError',
-            statusCode: 401,
-            responseBody: '{"error":{"message":"Invalid Authentication"}}'
-          }
+          ]
         }}
         message={message}
       />
     )
 
     expect(screen.getByText('error.diagnosis.auth')).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'error.diagnosis.go_to_settings' }))
+    fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 

--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -181,6 +182,41 @@ describe('ErrorBlock', () => {
     )
 
     fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
+    expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
+  })
+
+  it('offers provider settings recovery when a normal-chat retry wraps a 401 error', async () => {
+    const user = userEvent.setup()
+    const navigateErrorTarget = vi.fn()
+    mocks.actions = { navigateErrorTarget }
+
+    render(
+      <ErrorBlock
+        partId="message-1-part-0"
+        error={{
+          name: 'AI_RetryError',
+          message: 'Failed after 2 attempts. Last error:',
+          stack: null,
+          reason: 'maxRetriesExceeded',
+          errors: [
+            {
+              name: 'AI_APICallError',
+              statusCode: 401,
+              responseBody: '{"error":{"message":"Invalid Authentication"}}'
+            }
+          ],
+          lastError: {
+            name: 'AI_APICallError',
+            statusCode: 401,
+            responseBody: '{"error":{"message":"Invalid Authentication"}}'
+          }
+        }}
+        message={message}
+      />
+    )
+
+    expect(screen.getByText('error.diagnosis.auth')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'error.diagnosis.go_to_settings' }))
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 

--- a/src/renderer/utils/__tests__/errorClassifier.test.ts
+++ b/src/renderer/utils/__tests__/errorClassifier.test.ts
@@ -7,6 +7,17 @@ function makeError(overrides: Partial<SerializedError> = {}): SerializedError {
   return { name: 'Error', message: 'test error', stack: null, ...overrides }
 }
 
+/** Shaped like `serializeError(RetryError)`: nested attempts keep no `message`/`stack`. */
+function makeRetryError(overrides: Partial<SerializedError> = {}): SerializedError {
+  return makeError({
+    name: 'AI_RetryError',
+    message: 'Failed after 2 attempts. Last error:',
+    cause: null,
+    reason: 'maxRetriesExceeded',
+    ...overrides
+  })
+}
+
 describe('classifyError', () => {
   it('returns unknown for undefined error', () => {
     const result = classifyError(undefined)
@@ -17,6 +28,42 @@ describe('classifyError', () => {
   it('returns unknown for empty error', () => {
     const result = classifyError(makeError({ message: '' }))
     expect(result.category).toBe('unknown')
+  })
+
+  // Wrapped errors — RetryError itself carries no status, the cause does.
+  it.each([
+    [401, 'auth'],
+    [429, 'rate_limit'],
+    [503, 'server']
+  ])('classifies a retry error wrapping %i as %s', (statusCode, category) => {
+    const wrapped = classifyError(
+      makeRetryError({
+        lastError: { name: 'AI_APICallError', statusCode },
+        errors: [{ name: 'AI_APICallError', statusCode }]
+      })
+    )
+    expect(wrapped.category).toBe(category)
+  })
+
+  it('diagnoses an earlier attempt when the last one says nothing', () => {
+    const result = classifyError(
+      makeRetryError({
+        lastError: { name: 'AI_APICallError' },
+        errors: [{ name: 'AI_APICallError', statusCode: 401 }, { name: 'AI_APICallError' }]
+      })
+    )
+    expect(result.category).toBe('auth')
+  })
+
+  it('keeps the outer classification when the wrapper itself is diagnosable', () => {
+    const result = classifyError(
+      makeRetryError({
+        message: 'rate limit exceeded',
+        lastError: { name: 'AI_APICallError', statusCode: 401 },
+        errors: [{ name: 'AI_APICallError', statusCode: 401 }]
+      })
+    )
+    expect(result.category).toBe('rate_limit')
   })
 
   // Auth

--- a/src/renderer/utils/errorClassifier.ts
+++ b/src/renderer/utils/errorClassifier.ts
@@ -93,6 +93,19 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
 
   const status = errorBag.statusCode ?? errorBag.status
   const numStatus = typeof status === 'number' ? status : typeof status === 'string' ? parseInt(status, 10) : undefined
+  const retryErrors =
+    error.name === 'AI_RetryError'
+      ? [errorBag.lastError, ...(Array.isArray(errorBag.errors) ? errorBag.errors : [])]
+      : []
+  const hasNestedUnauthorizedStatus = retryErrors.some((nestedError) => {
+    if (typeof nestedError !== 'object' || nestedError === null || Array.isArray(nestedError)) {
+      return false
+    }
+
+    const nestedErrorBag = nestedError as Record<string, unknown>
+    const nestedStatus = nestedErrorBag.statusCode ?? nestedErrorBag.status
+    return nestedStatus === 401 || nestedStatus === '401'
+  })
   const providerSuffix = providerId ? `?id=${providerId}` : ''
 
   const messageText = ((error.message as string) || '').toLowerCase()
@@ -127,6 +140,7 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
   // validity, so claiming the key is invalid sends users off regenerating working keys.
   if (
     numStatus === 401 ||
+    hasNestedUnauthorizedStatus ||
     msg.includes('invalid_api_key') ||
     msg.includes('invalid api key') ||
     msg.includes('api key is invalid') ||

--- a/src/renderer/utils/errorClassifier.ts
+++ b/src/renderer/utils/errorClassifier.ts
@@ -1,4 +1,5 @@
 import type { SerializedError } from '@renderer/types/error'
+import { isSerializedAiSdkRetryError, isSerializedAiSdkToolCallRepairError } from '@renderer/types/error'
 
 export interface ErrorClassification {
   category:
@@ -75,6 +76,23 @@ export function isProxyErrorMessage(message: string): boolean {
   )
 }
 
+/**
+ * Errors nested inside a serialized AI SDK wrapper. `serializeError` drops non-enumerable
+ * `message`/`stack` from them, so they are partial — only shape-tolerant readers may use them.
+ */
+function unwrapNestedErrors(error: SerializedError): SerializedError[] {
+  const nested = isSerializedAiSdkRetryError(error)
+    ? [error.lastError, ...error.errors]
+    : isSerializedAiSdkToolCallRepairError(error)
+      ? [error.originalError]
+      : []
+
+  return nested.filter(
+    (candidate): candidate is SerializedError =>
+      typeof candidate === 'object' && candidate !== null && !Array.isArray(candidate)
+  )
+}
+
 export function classifyError(error?: SerializedError, providerId?: string): ErrorClassification {
   if (!error) {
     return { category: 'unknown', i18nKey: 'error.diagnosis.unknown', navTarget: null }
@@ -93,19 +111,6 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
 
   const status = errorBag.statusCode ?? errorBag.status
   const numStatus = typeof status === 'number' ? status : typeof status === 'string' ? parseInt(status, 10) : undefined
-  const retryErrors =
-    error.name === 'AI_RetryError'
-      ? [errorBag.lastError, ...(Array.isArray(errorBag.errors) ? errorBag.errors : [])]
-      : []
-  const hasNestedUnauthorizedStatus = retryErrors.some((nestedError) => {
-    if (typeof nestedError !== 'object' || nestedError === null || Array.isArray(nestedError)) {
-      return false
-    }
-
-    const nestedErrorBag = nestedError as Record<string, unknown>
-    const nestedStatus = nestedErrorBag.statusCode ?? nestedErrorBag.status
-    return nestedStatus === 401 || nestedStatus === '401'
-  })
   const providerSuffix = providerId ? `?id=${providerId}` : ''
 
   const messageText = ((error.message as string) || '').toLowerCase()
@@ -140,7 +145,6 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
   // validity, so claiming the key is invalid sends users off regenerating working keys.
   if (
     numStatus === 401 ||
-    hasNestedUnauthorizedStatus ||
     msg.includes('invalid_api_key') ||
     msg.includes('invalid api key') ||
     msg.includes('api key is invalid') ||
@@ -307,6 +311,14 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
     msg.includes('malformed json')
   ) {
     return { category: 'parse', i18nKey: 'error.diagnosis.parse', navTarget: null }
+  }
+
+  // A wrapper carries no status of its own — diagnose the first attempt that says something.
+  for (const nested of unwrapNestedErrors(error)) {
+    const nestedClassification = classifyError(nested, providerId)
+    if (nestedClassification.category !== 'unknown') {
+      return nestedClassification
+    }
   }
 
   return { category: 'unknown', i18nKey: 'error.diagnosis.unknown', navTarget: null }


### PR DESCRIPTION
### What this PR does

Before this PR:

When the AI SDK exhausted retries after an HTTP 401 response, normal chat classified the top-level `AI_RetryError` as unknown. The error card did not offer a settings action even though the nested API error retained the authentication status.

After this PR:

Normal chat preserves retry error metadata for classification. A nested HTTP 401 is classified as an authentication error and the error card links to the active provider's settings.

Fixes #19943

### Why we need it and why it was done in this way

`ai-retry` wraps the provider's `APICallError`, so the actionable status lives in `lastError`/`errors` rather than on the top-level error. The existing chat error boundary rebuilt a reduced classification object and discarded those fields.

The following tradeoffs were made:

- Only serialized `AI_RetryError` entries with a nested `status`/`statusCode` of 401 are unwrapped. Existing top-level classification precedence and provider error display remain unchanged.
- Nested provider payloads are not displayed or used for navigation; the provider target still comes from the message model.

The following alternatives were considered:

- A recursive normalization of all nested provider errors was avoided because it would broaden this focused authentication recovery fix and overlap the wider provider-error presentation work tracked in #19824.

Links to places where the discussion took place: #19943

### Breaking changes

None.

### Special notes for your reviewer

Focused regression coverage verifies the normal-chat error card renders authentication guidance and navigates to the active provider settings after a wrapped 401.

No screenshot is attached because this workspace did not have a credible isolated Cherry Studio UI instance. The only running Electron process belonged to another workspace and was intentionally not controlled or reused.

Validation:

- `pnpm exec vitest run --project renderer src/renderer/utils/__tests__/errorClassifier.test.ts src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx`
- `pnpm exec biome check src/renderer/utils/errorClassifier.ts src/renderer/components/chat/messages/blocks/ErrorBlock.tsx src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx`

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix normal chat authentication errors failing to link to provider settings after automatic retries.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only error classification and navigation; no auth or API behavior changes beyond surfacing existing nested status codes.
> 
> **Overview**
> When chat fails after automatic retries, the UI often shows an **`AI_RetryError`** whose HTTP **401** lives in **`lastError`/`errors`**, not on the top-level object. The error card was rebuilding a slim object for **`classifyError`** (dropping the error name and retry payload), so those failures stayed **unknown** and never showed **Go to settings**.
> 
> **`ErrorBlock`** now passes through **`errorName`**, **`lastError`**, and **`errors`** into classification. **`errorClassifier`** treats **`AI_RetryError`** by scanning nested attempts for **401** and classifying as **auth** with the provider settings link. A regression test covers the wrapped-401 retry scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0bea6eb2a4f5bc46018a7d48385f471056fa96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->