### PR TITLE
fix(ai-sdk): preserve provider-native citation sources

### DIFF
--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -313,6 +313,7 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
       const capturedUiErrors: Array<{ error: unknown }> = []
       const uiStream = result.toUIMessageStream({
         originalMessages: messages,
+        sendSources: true,
         onError: (error) => {
           capturedUiErrors.push({ error })
           return error instanceof Error ? error.message : String(error)

--- a/src/main/ai/runtime/aiSdk/loop/__tests__/agentLoop.test.ts
+++ b/src/main/ai/runtime/aiSdk/loop/__tests__/agentLoop.test.ts
@@ -54,6 +54,33 @@ describe('Agent', () => {
     vi.clearAllMocks()
   })
 
+  it('forwards provider-native URL sources to the UI stream', async () => {
+    const source = {
+      type: 'source-url' as const,
+      sourceId: 'citation-0',
+      url: 'https://example.com/source',
+      title: 'Example source'
+    }
+    mockCreateAgent.mockResolvedValue({
+      stream: vi.fn().mockResolvedValue({
+        toUIMessageStream: ({ sendSources }: { sendSources?: boolean }) =>
+          new ReadableStream({
+            start(controller) {
+              if (sendSources) controller.enqueue(source)
+              controller.close()
+            }
+          }),
+        steps: Promise.resolve([])
+      })
+    })
+
+    const agent = await makeAgent()
+    const reader = agent.stream([], new AbortController().signal).getReader()
+
+    await expect(reader.read()).resolves.toEqual({ value: source, done: false })
+    await expect(reader.read()).resolves.toEqual({ value: undefined, done: true })
+  })
+
   describe('generate', () => {
     it('routes a trusted terminal tool failure through onError without calling onFinish', async () => {
       const output = markTrustedLocalToolTerminalFailure({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Provider-native URL citation events were dropped while converting AI SDK model output into the UI message stream, so model-native web search answers could not display citation badges.

After this PR:

URL citations returned by providers are preserved as `source-url` message parts and can be rendered by the existing citation UI.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19769

### Why we need it and why it was done in this way

AI SDK's `toUIMessageStream()` disables source forwarding by default. Enabling its built-in `sendSources` option preserves provider-native source annotations without introducing provider-specific parsing.

The following tradeoffs were made:

Source chunks are included in the UI stream only when the provider emits them. The app cannot display citations that a provider did not return.

The following alternatives were considered:

Parsing URLs or inventing citations from generated text was rejected because it would be incomplete and could attribute claims to unsupported sources.

Links to places where the discussion took place: #19769

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

The issue's diagnostic bundle contains the final answer and environment metadata but no raw provider response or citation annotations. This change therefore fixes the confirmed transport omission: when a provider returns URL citation annotations, Cherry now preserves them.

No trustworthy UI screenshot was captured. The only tracked Electron development instance is owned by another worktree, and starting or controlling a second instance was prohibited to avoid duplicate app processes and memory pressure.

Validation:

- `pnpm test:main src/main/ai/runtime/aiSdk/loop/__tests__/agentLoop.test.ts` (24 passed)
- `pnpm test:renderer src/renderer/utils/message/__tests__/citations.test.ts` (73 passed)
- `pnpm lint`
- `pnpm test:lint`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Native web search citations returned by providers are now displayed in chat responses.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single streaming option change with no auth or persistence impact; citations only appear when the provider sends them.
> 
> **Overview**
> **Enables native web search citations** in chat by turning on AI SDK `sendSources` when building the UI message stream in `Agent.stream()`, so provider-emitted `source-url` chunks are no longer stripped during conversion.
> 
> A unit test asserts that `toUIMessageStream` is called with `sendSources: true` and that `source-url` parts reach the agent’s readable stream—matching what the renderer already renders as citation badges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b99a3c090d83b1de586e90003f4fbd3991e6e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->