### PR TITLE
fix(code-mate): enforce Cherry Cloud model boundary

### DIFF
--- a/src/main/features/apiGateway/__tests__/proxyStream.parse.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.parse.test.ts
@@ -14,6 +14,7 @@ const {
   mockGetProvider,
   mockListModels,
   mockIsInternalAgentRequest,
+  mockIsModelAvailableForFeature,
   mockExtractStreamOptions,
   mockExtractProviderOptions,
   captured
@@ -22,6 +23,7 @@ const {
   mockGetProvider: vi.fn(),
   mockListModels: vi.fn(),
   mockIsInternalAgentRequest: vi.fn(),
+  mockIsModelAvailableForFeature: vi.fn(),
   mockExtractStreamOptions: vi.fn(),
   mockExtractProviderOptions: vi.fn(),
   captured: {
@@ -42,12 +44,13 @@ vi.mock('@application', () => ({
           isInternalAgentRequest: mockIsInternalAgentRequest
         }
       }
+      if (name === 'CherryCloudService') {
+        return { isModelAvailableForFeature: mockIsModelAvailableForFeature }
+      }
       return undefined
     })
   }
 }))
-// cn keeps Cherry Cloud agent-only, which the external-request rejection below relies on.
-vi.mock('@main/utils/appEdition', () => ({ getAppEdition: () => 'cn' }))
 vi.mock('@data/services/ProviderService', () => ({
   providerService: { getByProviderId: mockGetProvider }
 }))
@@ -87,6 +90,7 @@ beforeEach(() => {
   })
   mockListModels.mockReturnValue([])
   mockIsInternalAgentRequest.mockReturnValue(false)
+  mockIsModelAvailableForFeature.mockImplementation((_modelId: string, feature: string) => feature === 'agent')
   mockExtractStreamOptions.mockReturnValue({})
   mockExtractProviderOptions.mockReturnValue(undefined)
   mockStreamPrompt.mockImplementation((opts) => {
@@ -240,7 +244,8 @@ describe('processMessage model-id parsing', () => {
     expect(await resolveValid('sophnet:DeepSeek-v3')).toBe(createUniqueModelId('sophnet', 'deepseek-v3'))
   })
 
-  it('does not resolve Cherry Cloud models for external requests', async () => {
+  it('rejects a Cherry Cloud model from external requests regardless of downloaded features', async () => {
+    mockIsModelAvailableForFeature.mockReturnValue(true)
     mockAvailableModel(CHERRY_CLOUD_PROVIDER_ID, 'deepseek-free', 'deepseek-free', CHERRY_CLOUD_MODEL_GROUP)
 
     await expect(
@@ -250,7 +255,6 @@ describe('processMessage model-id parsing', () => {
         outputFormat: 'anthropic'
       })
     ).rejects.toMatchObject({ status: 400 })
-    expect(mockListModels).not.toHaveBeenCalled()
     expect(mockStreamPrompt).not.toHaveBeenCalled()
   })
 

--- a/src/main/features/apiGateway/__tests__/proxyStream.parse.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.parse.test.ts
@@ -14,7 +14,7 @@ const {
   mockGetProvider,
   mockListModels,
   mockIsInternalAgentRequest,
-  mockIsModelAvailableForFeature,
+  mockSyncEntitledModelsIfStale,
   mockExtractStreamOptions,
   mockExtractProviderOptions,
   captured
@@ -23,7 +23,7 @@ const {
   mockGetProvider: vi.fn(),
   mockListModels: vi.fn(),
   mockIsInternalAgentRequest: vi.fn(),
-  mockIsModelAvailableForFeature: vi.fn(),
+  mockSyncEntitledModelsIfStale: vi.fn(),
   mockExtractStreamOptions: vi.fn(),
   mockExtractProviderOptions: vi.fn(),
   captured: {
@@ -45,7 +45,7 @@ vi.mock('@application', () => ({
         }
       }
       if (name === 'CherryCloudService') {
-        return { isModelAvailableForFeature: mockIsModelAvailableForFeature }
+        return { syncEntitledModelsIfStale: mockSyncEntitledModelsIfStale }
       }
       return undefined
     })
@@ -90,7 +90,16 @@ beforeEach(() => {
   })
   mockListModels.mockReturnValue([])
   mockIsInternalAgentRequest.mockReturnValue(false)
-  mockIsModelAvailableForFeature.mockImplementation((_modelId: string, feature: string) => feature === 'agent')
+  mockSyncEntitledModelsIfStale.mockResolvedValue({
+    entitledModelIds: [`${CHERRY_CLOUD_PROVIDER_ID}::deepseek-free`],
+    freeModelIds: [],
+    availableModelIdsByFeature: {
+      agent: [`${CHERRY_CLOUD_PROVIDER_ID}::deepseek-free`],
+      chat: [],
+      translate: []
+    },
+    quotaExhaustedModelIds: []
+  })
   mockExtractStreamOptions.mockReturnValue({})
   mockExtractProviderOptions.mockReturnValue(undefined)
   mockStreamPrompt.mockImplementation((opts) => {
@@ -245,7 +254,6 @@ describe('processMessage model-id parsing', () => {
   })
 
   it('rejects a Cherry Cloud model from external requests regardless of downloaded features', async () => {
-    mockIsModelAvailableForFeature.mockReturnValue(true)
     mockAvailableModel(CHERRY_CLOUD_PROVIDER_ID, 'deepseek-free', 'deepseek-free', CHERRY_CLOUD_MODEL_GROUP)
 
     await expect(
@@ -276,6 +284,7 @@ describe('processMessage model-id parsing', () => {
     await vi.waitFor(() => expect(captured.opts).toBeDefined())
     expect(captured.opts?.uniqueModelId).toBe(createUniqueModelId(CHERRY_CLOUD_PROVIDER_ID, 'deepseek-free'))
     expect(mockListModels).toHaveBeenCalledWith({ providerId: CHERRY_CLOUD_PROVIDER_ID, enabled: true })
+    expect(mockSyncEntitledModelsIfStale).toHaveBeenCalledOnce()
     void captured.opts!.listener!.onDone({} as any)
 
     await expect(responsePromise.then((response) => response.json())).resolves.toEqual({ ok: true })

--- a/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
@@ -584,7 +584,9 @@ describe('processMessage (streaming)', () => {
     await vi.waitFor(() => expect(captured.listener).toBeDefined())
 
     expect(mockResolveAgentSessionUsage).toHaveBeenCalledWith(requestHeaders)
-    expect(mockStreamPrompt).toHaveBeenCalledWith(expect.objectContaining({ tokenUsageSource: 'agent', usageContext }))
+    expect(mockStreamPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ modelUsageFeature: 'agent', tokenUsageSource: 'agent', usageContext })
+    )
 
     commit(captured.listener!)
     await captured.listener!.onDone({} as any)
@@ -602,7 +604,9 @@ describe('processMessage (streaming)', () => {
     await vi.waitFor(() => expect(captured.listener).toBeDefined())
 
     const streamPromptInput = mockStreamPrompt.mock.calls[0][0]
-    expect(streamPromptInput).toEqual(expect.objectContaining({ tokenUsageSource: 'agent' }))
+    expect(streamPromptInput).toEqual(
+      expect.objectContaining({ modelUsageFeature: 'agent', tokenUsageSource: 'agent' })
+    )
     expect(streamPromptInput).not.toHaveProperty('usageContext')
 
     commit(captured.listener!)
@@ -724,7 +728,9 @@ describe('processMessage (streaming)', () => {
     })
 
     await vi.waitFor(() => expect(captured.listener).toBeDefined())
-    expect(mockStreamPrompt).toHaveBeenCalledWith(expect.objectContaining({ tokenUsageSource: 'agent' }))
+    expect(mockStreamPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ modelUsageFeature: 'agent', tokenUsageSource: 'agent' })
+    )
     await captured.listener!.onDone({} as any)
     await resPromise
   })

--- a/src/main/features/apiGateway/proxyStream.ts
+++ b/src/main/features/apiGateway/proxyStream.ts
@@ -384,7 +384,9 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
             callOverrides,
             contextOwner: 'caller',
             ...(usageContext ? { usageContext } : {}),
-            ...(isInternalAgentRequest ? { tokenUsageSource: 'agent' as const } : {}),
+            ...(isInternalAgentRequest
+              ? { modelUsageFeature: 'agent' as const, tokenUsageSource: 'agent' as const }
+              : {}),
             idleTimeoutMs: GATEWAY_STREAM_IDLE_TIMEOUT_MS
           })
         } catch (error) {
@@ -468,7 +470,7 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
       callOverrides,
       contextOwner: 'caller',
       ...(usageContext ? { usageContext } : {}),
-      ...(isInternalAgentRequest ? { tokenUsageSource: 'agent' as const } : {}),
+      ...(isInternalAgentRequest ? { modelUsageFeature: 'agent' as const, tokenUsageSource: 'agent' as const } : {}),
       idleTimeoutMs: GATEWAY_STREAM_IDLE_TIMEOUT_MS
     })
 

--- a/src/main/features/apiGateway/proxyStream.ts
+++ b/src/main/features/apiGateway/proxyStream.ts
@@ -143,9 +143,9 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
   const isInternalAgentRequest =
     config.requestHeaders !== undefined &&
     application.get('ApiGatewayService').isInternalAgentRequest(config.requestHeaders)
-  let resolvedAddress: ReturnType<typeof resolveGatewayModelAddress>
+  let resolvedAddress: Awaited<ReturnType<typeof resolveGatewayModelAddress>>
   try {
-    resolvedAddress = resolveGatewayModelAddress(modelString, isInternalAgentRequest)
+    resolvedAddress = await resolveGatewayModelAddress(modelString, isInternalAgentRequest)
   } catch (error) {
     throw asClientError(error)
   }

--- a/src/main/features/apiGateway/tokens/estimateAnthropicRequestTokens.ts
+++ b/src/main/features/apiGateway/tokens/estimateAnthropicRequestTokens.ts
@@ -55,7 +55,7 @@ async function estimateConvertedRequest(body: MessageCreateParams, signal?: Abor
   let caps = ALL_MEDIA
   let resolved: ResolvedGatewayModelAddress | undefined
   try {
-    resolved = resolveGatewayModelAddress(body.model)
+    resolved = await resolveGatewayModelAddress(body.model)
     dialect = resolveModelTokenDialect(resolved.provider, resolved.model)
     caps = resolveMediaCapabilities(resolved.model)
   } catch (error) {

--- a/src/main/features/apiGateway/tokens/estimateGeminiRequestTokens.ts
+++ b/src/main/features/apiGateway/tokens/estimateGeminiRequestTokens.ts
@@ -63,7 +63,7 @@ async function estimateConvertedRequest(
   let caps = ALL_MEDIA
   let resolved: ResolvedGatewayModelAddress | undefined
   try {
-    resolved = resolveGatewayModelAddress(modelString)
+    resolved = await resolveGatewayModelAddress(modelString)
     dialect = resolveModelTokenDialect(resolved.provider, resolved.model)
     caps = resolveMediaCapabilities(resolved.model)
   } catch (error) {

--- a/src/main/features/apiGateway/utils/__tests__/models.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/models.test.ts
@@ -4,18 +4,21 @@ import {
   CHERRYAI_PROVIDER_ID
 } from '@shared/data/presets/cherryai'
 import { MODEL_CAPABILITY } from '@shared/data/types/model'
-import type { AppEdition } from '@shared/types/appEdition'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  appEdition: 'cn' as AppEdition,
+  applicationGet: vi.fn(),
+  availableCloudModelIds: {
+    agent: new Set<string>(),
+    chat: new Set<string>()
+  },
   getProvider: vi.fn(),
   listProviders: vi.fn(),
   listModels: vi.fn()
 }))
 
-vi.mock('@main/utils/appEdition', () => ({
-  getAppEdition: () => mocks.appEdition
+vi.mock('@application', () => ({
+  application: { get: mocks.applicationGet }
 }))
 
 vi.mock('@data/services/ProviderService', () => ({
@@ -42,7 +45,15 @@ import { getModels, resolveGatewayModelAddress } from '../models'
 describe('api gateway model listing', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.appEdition = 'cn'
+    mocks.availableCloudModelIds.agent.clear()
+    mocks.availableCloudModelIds.chat.clear()
+    mocks.applicationGet.mockImplementation((service: string) => {
+      if (service !== 'CherryCloudService') throw new Error(`Unexpected service: ${service}`)
+      return {
+        isModelAvailableForFeature: (modelId: string, feature: 'agent' | 'chat') =>
+          mocks.availableCloudModelIds[feature].has(modelId)
+      }
+    })
     mocks.getProvider.mockReturnValue({ id: 'openai', name: 'OpenAI', isEnabled: true })
     mocks.listProviders.mockReturnValue([
       { id: CHERRYAI_PROVIDER_ID, name: 'CherryAI' },
@@ -204,7 +215,7 @@ describe('api gateway model listing', () => {
     expect(response.data.map((model) => model.id)).toEqual(['openai:gpt-4o'])
   })
 
-  describe('Cherry Cloud audience', () => {
+  describe('Cherry Cloud module availability', () => {
     const cloudModel = {
       id: `${CHERRY_CLOUD_PROVIDER_ID}::deepseek-free`,
       providerId: CHERRY_CLOUD_PROVIDER_ID,
@@ -226,7 +237,8 @@ describe('api gateway model listing', () => {
       mocks.getProvider.mockReturnValue({ id: CHERRY_CLOUD_PROVIDER_ID, name: 'CherryAI', isEnabled: true })
     })
 
-    it('hides Cherry Cloud models from external callers in the cn edition', async () => {
+    it('keeps Cherry Cloud out of the public gateway while allowing authenticated Work requests', async () => {
+      mocks.availableCloudModelIds.agent.add(cloudModel.id)
       const response = await getModels()
       expect(response.data.map((model) => model.id)).toEqual(['openai:gpt-4o'])
 
@@ -236,15 +248,14 @@ describe('api gateway model listing', () => {
       expect(resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`, true).model).toBe(cloudModel)
     })
 
-    it('exposes Cherry Cloud models to every caller in the global edition', async () => {
-      mocks.appEdition = 'global'
+    it('does not treat conversation availability as Code Mate availability', async () => {
+      mocks.availableCloudModelIds.chat.add(cloudModel.id)
 
       const response = await getModels()
-      expect(response.data.map((model) => model.id)).toEqual([
-        `${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`,
-        'openai:gpt-4o'
-      ])
-      expect(resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`).model).toBe(cloudModel)
+      expect(response.data.map((model) => model.id)).toEqual(['openai:gpt-4o'])
+      expect(() => resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`)).toThrow(
+        'not available through the API gateway'
+      )
     })
   })
 })

--- a/src/main/features/apiGateway/utils/__tests__/models.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/models.test.ts
@@ -14,7 +14,8 @@ const mocks = vi.hoisted(() => ({
   },
   getProvider: vi.fn(),
   listProviders: vi.fn(),
-  listModels: vi.fn()
+  listModels: vi.fn(),
+  syncEntitledModelsIfStale: vi.fn()
 }))
 
 vi.mock('@application', () => ({
@@ -50,10 +51,19 @@ describe('api gateway model listing', () => {
     mocks.applicationGet.mockImplementation((service: string) => {
       if (service !== 'CherryCloudService') throw new Error(`Unexpected service: ${service}`)
       return {
-        isModelAvailableForFeature: (modelId: string, feature: 'agent' | 'chat') =>
-          mocks.availableCloudModelIds[feature].has(modelId)
+        syncEntitledModelsIfStale: mocks.syncEntitledModelsIfStale
       }
     })
+    mocks.syncEntitledModelsIfStale.mockImplementation(async () => ({
+      entitledModelIds: [...mocks.availableCloudModelIds.agent, ...mocks.availableCloudModelIds.chat],
+      freeModelIds: [],
+      availableModelIdsByFeature: {
+        agent: [...mocks.availableCloudModelIds.agent],
+        chat: [...mocks.availableCloudModelIds.chat],
+        translate: []
+      },
+      quotaExhaustedModelIds: []
+    }))
     mocks.getProvider.mockReturnValue({ id: 'openai', name: 'OpenAI', isEnabled: true })
     mocks.listProviders.mockReturnValue([
       { id: CHERRYAI_PROVIDER_ID, name: 'CherryAI' },
@@ -90,7 +100,7 @@ describe('api gateway model listing', () => {
     expect(response.data.map((model) => model.id)).toEqual(['openai:gpt-4o'])
   })
 
-  it('surfaces the resolved model record for provider-option translation', () => {
+  it('surfaces the resolved model record for provider-option translation', async () => {
     const resolvedModel = {
       id: 'openai::gpt-4o',
       providerId: 'openai',
@@ -101,7 +111,7 @@ describe('api gateway model listing', () => {
     }
     mocks.listModels.mockReturnValue([resolvedModel])
 
-    expect(resolveGatewayModelAddress('openai:gpt-4o')).toMatchObject({
+    await expect(resolveGatewayModelAddress('openai:gpt-4o')).resolves.toMatchObject({
       providerId: 'openai',
       apiModelId: 'gpt-4o',
       uniqueModelId: 'openai::gpt-4o',
@@ -231,21 +241,28 @@ describe('api gateway model listing', () => {
       ])
       mocks.listModels.mockImplementation(({ providerId }: { providerId: string }) =>
         providerId === CHERRY_CLOUD_PROVIDER_ID
-          ? [cloudModel]
+          ? mocks.syncEntitledModelsIfStale.mock.calls.length > 0
+            ? [cloudModel]
+            : []
           : [{ id: 'openai::gpt-4o', providerId: 'openai', apiModelId: 'gpt-4o', ownedBy: 'OpenAI', capabilities: [] }]
       )
       mocks.getProvider.mockReturnValue({ id: CHERRY_CLOUD_PROVIDER_ID, name: 'CherryAI', isEnabled: true })
     })
 
-    it('keeps Cherry Cloud out of the public gateway while allowing authenticated Work requests', async () => {
+    it('keeps Cherry Cloud out of the public gateway and refreshes permissions for Work requests', async () => {
       mocks.availableCloudModelIds.agent.add(cloudModel.id)
       const response = await getModels()
       expect(response.data.map((model) => model.id)).toEqual(['openai:gpt-4o'])
 
-      expect(() => resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`)).toThrow(
+      await expect(resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`)).rejects.toThrow(
         'not available through the API gateway'
       )
-      expect(resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`, true).model).toBe(cloudModel)
+      await expect(
+        resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`, true)
+      ).resolves.toMatchObject({
+        model: cloudModel
+      })
+      expect(mocks.syncEntitledModelsIfStale).toHaveBeenCalledOnce()
     })
 
     it('does not treat conversation availability as Code Mate availability', async () => {
@@ -253,7 +270,7 @@ describe('api gateway model listing', () => {
 
       const response = await getModels()
       expect(response.data.map((model) => model.id)).toEqual(['openai:gpt-4o'])
-      expect(() => resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`)).toThrow(
+      await expect(resolveGatewayModelAddress(`${CHERRY_CLOUD_PROVIDER_ID}:deepseek-free`)).rejects.toThrow(
         'not available through the API gateway'
       )
     })

--- a/src/main/features/apiGateway/utils/models.ts
+++ b/src/main/features/apiGateway/utils/models.ts
@@ -1,8 +1,8 @@
+import { application } from '@application'
 import { modelService } from '@data/services/ModelService'
 import { providerService } from '@data/services/ProviderService'
 import { loggerService } from '@logger'
-import { getAppEdition } from '@main/utils/appEdition'
-import { isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
+import { isManagedCherryAiDefaultModel, isManagedCherryCloudModel } from '@shared/data/presets/cherryai'
 import { type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { formatGatewayModelId } from '@shared/utils/apiGateway'
@@ -85,6 +85,11 @@ function transformModelToOpenAi(model: Model, provider?: Provider): ApiModel {
   }
 }
 
+function isCherryCloudModelAvailable(model: Model, allowInternalAgent: boolean): boolean {
+  if (!isManagedCherryCloudModel(model.providerId)) return true
+  return allowInternalAgent && application.get('CherryCloudService').isModelAvailableForFeature(model.id, 'agent')
+}
+
 /** Resolve a `providerId:apiModelId`; Agent-only models require an authenticated internal request. */
 export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly = false): ResolvedGatewayModelAddress {
   const sepIdx = modelAddress.indexOf(':')
@@ -107,16 +112,12 @@ export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly 
   if (!provider.isEnabled || isExternalCliProvider(provider)) {
     throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
   }
-  if (!allowAgentOnly && isAgentOnlyProvider(provider, getAppEdition())) {
-    throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
-  }
-
   const model = modelService.list({ providerId, enabled: true }).find((candidate) => {
     if (!isGatewayRoutableModel(candidate)) return false
     const candidateApiModelId = candidate.apiModelId ?? parseUniqueModelId(candidate.id).modelId
     return candidateApiModelId === apiModelId
   })
-  if (!model) {
+  if (!model || !isCherryCloudModelAvailable(model, allowAgentOnly)) {
     throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
   }
 
@@ -137,15 +138,16 @@ export async function getModels(filter: ModelsFilter = {}): Promise<ApiModelsRes
     const uniqueModels = new Map<string, ApiModel>()
     for (const model of models) {
       const provider = providers.find((p) => p.id === model.providerId)
-      // Agent-only providers (external-CLI, edition-gated Cherry Cloud) are never advertised to
-      // external callers even though they pass the routable-model predicate (matches the renderer
-      // picker's exclusion).
-      if (provider && isAgentOnlyProvider(provider, getAppEdition())) {
+      // External-CLI providers carry no app-side credentials and cannot be proxied.
+      if (provider && isAgentOnlyProvider(provider)) {
         continue
       }
       // Same routable-model predicate as the renderer's gateway picker — the
       // listing must never advertise a model the proxy cannot route.
       if (!isGatewayRoutableModel(model)) {
+        continue
+      }
+      if (!isCherryCloudModelAvailable(model, false)) {
         continue
       }
 

--- a/src/main/features/apiGateway/utils/models.ts
+++ b/src/main/features/apiGateway/utils/models.ts
@@ -85,13 +85,11 @@ function transformModelToOpenAi(model: Model, provider?: Provider): ApiModel {
   }
 }
 
-function isCherryCloudModelAvailable(model: Model, allowInternalAgent: boolean): boolean {
-  if (!isManagedCherryCloudModel(model.providerId)) return true
-  return allowInternalAgent && application.get('CherryCloudService').isModelAvailableForFeature(model.id, 'agent')
-}
-
-/** Resolve a `providerId:apiModelId`; Agent-only models require an authenticated internal request. */
-export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly = false): ResolvedGatewayModelAddress {
+/** Resolve a `providerId:apiModelId`; Cherry Cloud models require an authenticated internal Work request. */
+export async function resolveGatewayModelAddress(
+  modelAddress: string,
+  allowInternalAgent = false
+): Promise<ResolvedGatewayModelAddress> {
   const sepIdx = modelAddress.indexOf(':')
   if (sepIdx <= 0 || sepIdx >= modelAddress.length - 1) {
     throw new Error(`Invalid model format: "${modelAddress}". Expected "providerId:apiModelId".`)
@@ -112,12 +110,22 @@ export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly 
   if (!provider.isEnabled || isExternalCliProvider(provider)) {
     throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
   }
+
+  let availableCloudAgentModelIds: Set<UniqueModelId> | undefined
+  if (isManagedCherryCloudModel(providerId)) {
+    if (!allowInternalAgent) {
+      throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
+    }
+    const availability = await application.get('CherryCloudService').syncEntitledModelsIfStale()
+    availableCloudAgentModelIds = new Set(availability.availableModelIdsByFeature.agent)
+  }
+
   const model = modelService.list({ providerId, enabled: true }).find((candidate) => {
     if (!isGatewayRoutableModel(candidate)) return false
     const candidateApiModelId = candidate.apiModelId ?? parseUniqueModelId(candidate.id).modelId
     return candidateApiModelId === apiModelId
   })
-  if (!model || !isCherryCloudModelAvailable(model, allowAgentOnly)) {
+  if (!model || (availableCloudAgentModelIds && !availableCloudAgentModelIds.has(model.id))) {
     throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
   }
 
@@ -147,7 +155,7 @@ export async function getModels(filter: ModelsFilter = {}): Promise<ApiModelsRes
       if (!isGatewayRoutableModel(model)) {
         continue
       }
-      if (!isCherryCloudModelAvailable(model, false)) {
+      if (isManagedCherryCloudModel(model.providerId)) {
         continue
       }
 

--- a/src/renderer/pages/code/hooks/__tests__/useConfigMetadata.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useConfigMetadata.test.ts
@@ -156,20 +156,14 @@ describe('useConfigMetadata.makeModelFilter (gateway)', () => {
     expect(filter(model(CHERRYAI_PROVIDER_ID, 'some-other-model'))).toBe(true)
   })
 
-  it('routes Cherry Cloud models only where the edition allows them outside Agents', () => {
+  it('excludes Cherry Cloud models because Code Mate has no cloud feature entitlement', () => {
     const cloudProvider = enabledProvider(CHERRY_CLOUD_PROVIDER_ID)
     const cloudModel = model(CHERRY_CLOUD_PROVIDER_ID, 'deepseek-free')
-
-    vi.stubGlobal('__APP_EDITION__', 'cn')
-    try {
-      const { result } = renderHook(() => useConfigMetadata(CodeCli.CLAUDE_CODE, [cloudProvider]))
-      expect(result.current.makeModelFilter(CLI_API_GATEWAY_PROVIDER_ID)(cloudModel)).toBe(false)
-    } finally {
-      vi.stubGlobal('__APP_EDITION__', 'global')
-    }
+    modelRecords.push(cloudModel)
 
     const { result } = renderHook(() => useConfigMetadata(CodeCli.CLAUDE_CODE, [cloudProvider]))
-    expect(result.current.makeModelFilter(CLI_API_GATEWAY_PROVIDER_ID)(cloudModel)).toBe(true)
+    expect(result.current.makeModelFilter(CLI_API_GATEWAY_PROVIDER_ID)(cloudModel)).toBe(false)
+    expect(result.current.gatewayModelsById.has(cloudModel.id)).toBe(false)
   })
 
   // The picker shares isGatewayRoutableModel with the gateway's /v1/models listing, so every

--- a/src/renderer/pages/code/hooks/useConfigMetadata.ts
+++ b/src/renderer/pages/code/hooks/useConfigMetadata.ts
@@ -2,8 +2,8 @@ import { usePreference } from '@data/hooks/usePreference'
 import { useModels } from '@renderer/hooks/useModel'
 import { getProviderDisplayName } from '@renderer/hooks/useProvider'
 import { getClaudeContextModelId, hasClaudeDetailedModels } from '@renderer/pages/code/cliConfig'
-import { getAppEdition } from '@renderer/utils/appEdition'
 import type { CliProviderConfig } from '@shared/data/preference/preferenceTypes'
+import { isManagedCherryCloudModel } from '@shared/data/presets/cherryai'
 import { isUniqueModelId, type Model, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { CodeCli, isApiGatewayProviderId } from '@shared/types/codeCli'
@@ -31,7 +31,7 @@ export function useConfigMetadata(selectedCliTool: CodeCli, providers: Provider[
     () =>
       new Set(
         providers
-          .filter((provider) => provider.isEnabled && !isAgentOnlyProvider(provider, getAppEdition()))
+          .filter((provider) => provider.isEnabled && !isAgentOnlyProvider(provider))
           .map((provider) => provider.id)
       ),
     [providers]
@@ -40,7 +40,12 @@ export function useConfigMetadata(selectedCliTool: CodeCli, providers: Provider[
     () =>
       new Map(
         allModels
-          .filter((model) => gatewayProviderIds.has(model.providerId) && isGatewayRoutableModel(model))
+          .filter(
+            (model) =>
+              gatewayProviderIds.has(model.providerId) &&
+              !isManagedCherryCloudModel(model.providerId) &&
+              isGatewayRoutableModel(model)
+          )
           .map((model) => [model.id, model])
       ),
     [allModels, gatewayProviderIds]
@@ -69,9 +74,14 @@ export function useConfigMetadata(selectedCliTool: CodeCli, providers: Provider[
         if (isEmbeddingModel(model) || isRerankModel(model) || isTextToImageModel(model)) return false
         // The gateway does dialect conversion, so any chat model of any enabled provider is usable
         // regardless of the CLI tool — drop the per-tool endpoint gate and the single-provider scope,
-        // keeping only what the gateway can route (same predicate as its /v1/models listing).
+        // keeping only what Code Mate may route through the gateway. Cherry Cloud does not expose
+        // a Code Mate feature entitlement, so its managed models are never offered here.
         if (isApiGatewayProviderId(providerId)) {
-          return gatewayProviderIds.has(model.providerId) && isGatewayRoutableModel(model)
+          return (
+            gatewayProviderIds.has(model.providerId) &&
+            !isManagedCherryCloudModel(model.providerId) &&
+            isGatewayRoutableModel(model)
+          )
         }
         if (!modelSupportsCliTool(selectedCliTool, model)) return false
         return model.providerId === providerId

--- a/src/shared/data/presets/cherryai.ts
+++ b/src/shared/data/presets/cherryai.ts
@@ -1,5 +1,4 @@
 import { createUniqueModelId } from '@shared/data/types/model'
-import type { AppEdition } from '@shared/types/appEdition'
 
 export const CHERRYAI_PROVIDER_ID = 'cherryai' as const
 export const CHERRYAI_PROVIDER_NAME = 'CherryAI' as const
@@ -10,13 +9,6 @@ export const CHERRYAI_DEFAULT_MODEL_GROUP = 'Qwen' as const
 export const CHERRY_CLOUD_MODEL_GROUP = 'Cherry Cloud' as const
 export const CHERRYAI_API_BASE_URL = 'https://api.cherry-ai.com' as const
 export const CHERRYAI_DEFAULT_UNIQUE_MODEL_ID = createUniqueModelId(CHERRYAI_PROVIDER_ID, CHERRYAI_DEFAULT_MODEL_ID)
-
-export type CherryCloudAudience = 'agent' | 'all'
-/** Where Cherry Cloud models may be used per edition: 'agent' = Agent pickers/runtimes only, 'all' = any module. */
-export const CHERRY_CLOUD_AUDIENCE = {
-  cn: 'agent',
-  global: 'all'
-} as const satisfies Record<AppEdition, CherryCloudAudience>
 
 export function isManagedCherryAiProviderId(providerId: string): boolean {
   return providerId === CHERRYAI_PROVIDER_ID

--- a/src/shared/utils/__tests__/provider.isAgentOnlyProvider.test.ts
+++ b/src/shared/utils/__tests__/provider.isAgentOnlyProvider.test.ts
@@ -10,19 +10,17 @@ const provider = (id: string, authMethods?: Provider['authMethods']): Pick<Provi
 })
 
 describe('isAgentOnlyProvider', () => {
-  it('is true for external-cli providers in every edition', () => {
-    expect(isAgentOnlyProvider(provider('claude-code', ['external-cli']), 'cn')).toBe(true)
-    expect(isAgentOnlyProvider(provider('claude-code', ['external-cli']), 'global')).toBe(true)
+  it('is true for external-cli providers', () => {
+    expect(isAgentOnlyProvider(provider('claude-code', ['external-cli']))).toBe(true)
   })
 
-  it('follows CHERRY_CLOUD_AUDIENCE for the Cherry Cloud provider', () => {
-    expect(isAgentOnlyProvider(provider(CHERRY_CLOUD_PROVIDER_ID), 'cn')).toBe(true)
-    expect(isAgentOnlyProvider(provider(CHERRY_CLOUD_PROVIDER_ID), 'global')).toBe(false)
+  it('does not infer Cherry Cloud module availability from the provider', () => {
+    expect(isAgentOnlyProvider(provider(CHERRY_CLOUD_PROVIDER_ID))).toBe(false)
   })
 
   it('is false for api-key and oauth providers', () => {
-    expect(isAgentOnlyProvider(provider('openai', ['api-key']), 'cn')).toBe(false)
-    expect(isAgentOnlyProvider(provider('codex', ['oauth']), 'cn')).toBe(false)
-    expect(isAgentOnlyProvider(provider('openai'), 'global')).toBe(false)
+    expect(isAgentOnlyProvider(provider('openai', ['api-key']))).toBe(false)
+    expect(isAgentOnlyProvider(provider('codex', ['oauth']))).toBe(false)
+    expect(isAgentOnlyProvider(provider('openai'))).toBe(false)
   })
 })

--- a/src/shared/utils/provider.ts
+++ b/src/shared/utils/provider.ts
@@ -8,15 +8,9 @@ import {
   type ServerToolConfig,
   supportsServerToolFunctionMixing
 } from '@cherrystudio/provider-registry'
-import {
-  CHERRY_CLOUD_AUDIENCE,
-  CHERRYAI_PROVIDER_ID,
-  isManagedCherryCloudModel,
-  isManagedCherryProviderId
-} from '@shared/data/presets/cherryai'
+import { CHERRYAI_PROVIDER_ID, isManagedCherryProviderId } from '@shared/data/presets/cherryai'
 import { ENDPOINT_TYPE, type EndpointType, type Model } from '@shared/data/types/model'
 import type { EndpointDialect, Provider } from '@shared/data/types/provider'
-import type { AppEdition } from '@shared/types/appEdition'
 
 import { getLowerBaseModelName, getRawModelId, isFunctionCallingModel, isGeminiModel, isNonChatModel } from './model'
 import { getProviderHostTopology } from './providerTopology'
@@ -182,13 +176,11 @@ export function isExternalCliProvider(provider: Pick<Provider, 'authMethods'>): 
 
 /**
  * Agent-only providers are surfaced only to Agent pickers / runtimes — never to
- * general chat selectors or the public gateway catalog. External-CLI providers are
- * always agent-only (no app-side credential); Cherry Cloud follows `CHERRY_CLOUD_AUDIENCE`.
+ * general chat selectors or the public gateway catalog. External-CLI providers have
+ * no app-side credential, so their models cannot be used outside their Agent runtime.
  */
-export function isAgentOnlyProvider(provider: Pick<Provider, 'id' | 'authMethods'>, edition: AppEdition): boolean {
-  if (isExternalCliProvider(provider)) return true
-  if (isManagedCherryCloudModel(provider.id)) return CHERRY_CLOUD_AUDIENCE[edition] === 'agent'
-  return false
+export function isAgentOnlyProvider(provider: Pick<Provider, 'authMethods'>): boolean {
+  return isExternalCliProvider(provider)
 }
 
 export function isAnthropicSupportedProvider(provider: Provider): boolean {

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-07-code-mate-cloud-models.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-07-code-mate-cloud-models.md
@@ -1,0 +1,19 @@
+---
+title: Cherry Cloud models are no longer available in Code Mate
+category: removed
+severity: breaking
+introduced_in_pr: "#20048"
+date: 2026-09-07
+---
+
+## What changed
+
+Managed Cherry Cloud models are no longer offered in Code Mate or through the public API gateway. Work can still use models that the Cherry Cloud service explicitly enables for the Agent feature.
+
+## Why this matters to the user
+
+An existing Code Mate configuration that selected a managed Cherry Cloud model must use a different provider before it can launch. Conversation, translation, and Work availability continue to follow the features declared by the service.
+
+## What the user should do
+
+Select a non-Cherry Cloud provider and model in Code Mate. No action is needed for Work configurations.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Code Mate could infer Cherry Cloud availability from `agent`, `chat`, or edition-level provider rules even though the server does not define a Code Mate feature entitlement. The external API Gateway could therefore expose a managed cloud model through an unrelated feature.

After this PR: Code Mate excludes managed Cherry Cloud models from direct providers and Unified Gateway models. The external API Gateway rejects them regardless of downloaded features, while authenticated internal Work requests refresh the server snapshot and require the declared `agent` feature before routing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: This PR uses an explicit deny boundary for Code Mate instead of introducing a new server feature. It is stacked on the Cherry Cloud feature synchronization PR because the internal Work gateway check depends on that lower-layer contract.

The following alternatives were considered: Reusing `chat` or `agent`, or inventing a `codemate` feature, was rejected because Code Mate is an independent module and the server will not publish that feature. Reading the cached feature set directly was rejected because authorization must honor the Cherry Cloud service's freshness contract.

Links to places where the discussion took place: #19988

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

Existing Code Mate configurations that selected a managed Cherry Cloud model must select a non-Cherry Cloud provider before launching. No provider, model, or conversation data is deleted. This is recorded in `v2-refactor-temp/docs/breaking-changes/2026-09-07-code-mate-cloud-models.md`.

### Special notes for your reviewer

<!-- optional -->

Stacked on #19988. Review this PR as the Code Mate and API Gateway boundary layer only.

Validation: `pnpm lint`, `pnpm test:lint`, `pnpm docs:check`, 39 focused main-process tests, 18 focused renderer tests, and 3 focused shared tests passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Prevent managed Cherry Cloud models from appearing or being routed through Code Mate. Action required: existing Code Mate configurations using one must select another provider.
```
