### PR TITLE
fix(chat-errors): recognize Claude Code sign-in failures

### DIFF
--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -184,6 +184,29 @@ describe('ErrorBlock', () => {
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 
+  it('offers provider settings recovery when Claude Code reports that the session is not logged in', () => {
+    const navigateErrorTarget = vi.fn()
+    mocks.actions = { navigateErrorTarget }
+
+    render(
+      <ErrorBlock
+        partId="message-1-part-0"
+        error={{
+          name: 'ClaudeCodeResultError',
+          message: 'Not logged in \u00b7 Please run /login',
+          stack: null,
+          cause: null,
+          errors: ['Not logged in \u00b7 Please run /login']
+        }}
+        message={message}
+      />
+    )
+
+    expect(screen.getByText('error.diagnosis.auth')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
+    expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
+  })
+
   it('uses injected diagnosis capability for unknown errors', async () => {
     const diagnoseMessageError = vi.fn().mockResolvedValue('AI summary')
     mocks.actions = {

--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -105,6 +105,29 @@ describe('ErrorBlock', () => {
     expect(screen.queryByText('common.detail')).toBeNull()
   })
 
+  it('offers provider settings recovery when Claude Code reports that the session is not logged in', () => {
+    const navigateErrorTarget = vi.fn()
+    mocks.actions = { navigateErrorTarget }
+
+    render(
+      <ErrorBlock
+        partId="message-1-part-0"
+        error={{
+          name: 'ClaudeCodeResultError',
+          message: 'Not logged in \u00b7 Please run /login',
+          stack: null,
+          cause: null,
+          errors: ['Not logged in \u00b7 Please run /login']
+        }}
+        message={message}
+      />
+    )
+
+    expect(screen.getByText('error.diagnosis.auth')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
+    expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
+  })
+
   it('uses structured provider data when classifying an error', () => {
     render(
       <ErrorBlock
@@ -180,29 +203,6 @@ describe('ErrorBlock', () => {
       })
     )
 
-    fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
-    expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
-  })
-
-  it('offers provider settings recovery when Claude Code reports that the session is not logged in', () => {
-    const navigateErrorTarget = vi.fn()
-    mocks.actions = { navigateErrorTarget }
-
-    render(
-      <ErrorBlock
-        partId="message-1-part-0"
-        error={{
-          name: 'ClaudeCodeResultError',
-          message: 'Not logged in \u00b7 Please run /login',
-          stack: null,
-          cause: null,
-          errors: ['Not logged in \u00b7 Please run /login']
-        }}
-        message={message}
-      />
-    )
-
-    expect(screen.getByText('error.diagnosis.auth')).toBeInTheDocument()
     fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })

--- a/src/renderer/utils/errorClassifier.ts
+++ b/src/renderer/utils/errorClassifier.ts
@@ -132,6 +132,7 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
     msg.includes('api key is invalid') ||
     msg.includes('incorrect api key') ||
     msg.includes('authentication') ||
+    msg.includes('not logged in') ||
     msg.includes('unauthorized')
   ) {
     return { category: 'auth', i18nKey: 'error.diagnosis.auth', navTarget: `/settings/provider${providerSuffix}` }


### PR DESCRIPTION
### What this PR does

Before this PR:

When Claude Code returned a direct `ClaudeCodeResultError` saying the session was not logged in, the Agent error card classified it as unknown and offered no supported recovery action.

After this PR:

The existing authentication classifier recognizes the Claude Code sign-in prerequisite and links the Agent error card to the active provider's settings.

Fixes #19944

### Why we need it and why it was done in this way

The restricted diagnostic evidence contains direct Claude Code result errors with the safe user-facing phrase `Not logged in` and the SDK's `/login` guidance. This result path reaches the shared error classifier without an HTTP status or the word `authentication`, so it previously fell through to `unknown`.

The following tradeoffs were made:

- This adds one unambiguous sign-in phrase to the existing authentication category. It does not add a new sign-in UI, expose account details, or change the Agent runtime.
- The recovery target continues to come from the message model, preserving the existing provider-settings behavior.

The following alternatives were considered:

- PR #20042 handles generic Claude Code process exits by safely classifying captured terminal diagnostics. Its current head still fails this regression because a direct `ClaudeCodeResultError` is not a process-exit error and has no explicit exit category, so changing that broader runtime PR would not cover this path.
- A Claude Code-specific UI branch was avoided because the existing authentication category and navigation already provide the required recovery behavior.

Links to places where the discussion took place: #19944, #20042

### Breaking changes

None.

### Special notes for your reviewer

The regression test uses the serialized error shape and safe sign-in phrase confirmed by the restricted diagnostic package. It verifies both authentication guidance and navigation to the active provider settings.

No screenshot is attached because this workspace did not have a credible isolated Cherry Studio UI instance. The only running Electron process belonged to another workspace and was intentionally not controlled or reused.

Synthetic merge checks against the current heads of PRs #20042 and #20046 complete without conflicts.

Validation:

- `pnpm exec vitest run --project renderer src/renderer/utils/__tests__/errorClassifier.test.ts src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx`
- `pnpm exec biome check src/renderer/utils/errorClassifier.ts src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx`
- `pnpm lint`
- `pnpm test:lint`

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Claude Code Agent sign-in failures now link to the provider settings needed for recovery.
```
