### PR TITLE
fix: keep multi-model selection during streaming

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -1189,6 +1189,53 @@ describe('MessageGroup', () => {
     expect(updateMessageUiState).toHaveBeenCalledWith('model-b', { foldSelected: true })
   })
 
+  it('keeps another model selected while the active reply continues streaming', async () => {
+    mocks.settings.mockReturnValue({
+      multiModelMessageStyle: 'fold',
+      gridColumns: 2,
+      gridPopoverTrigger: 'click',
+      messageFont: 'system',
+      fontSize: 14,
+      messageStyle: 'plain',
+      showMessageOutline: false
+    })
+    const setActiveBranch = vi.fn().mockResolvedValue(undefined)
+    mocks.messageListActions.mockReturnValue({
+      setActiveBranch,
+      updateMessageUiState: vi.fn()
+    })
+    const streamingMessage = {
+      ...createMessage('model-a', 0, 'fold'),
+      isActiveBranch: true,
+      status: 'pending'
+    } as MessageListItem & { index: number; multiModelMessageStyle: MultiModelMessageStyle }
+    const otherMessage = {
+      ...createMessage('model-b', 1, 'fold'),
+      isActiveBranch: false
+    }
+
+    const { container, rerender } = render(<MessageGroup messages={[streamingMessage, otherMessage]} />)
+    const lastMenuCall = mocks.MessageGroupMenuBar.mock.calls.at(-1) as unknown as [
+      {
+        setSelectedMessage: (message: MessageListItem) => void
+      }
+    ]
+    const menuProps = lastMenuCall[0]
+
+    act(() => {
+      menuProps.setSelectedMessage(otherMessage)
+    })
+
+    await waitFor(() => expect(container.querySelector('#message-model-b')).toHaveClass('selected'))
+
+    rerender(<MessageGroup messages={[{ ...streamingMessage }, { ...otherMessage }]} />)
+
+    expect(container.querySelector('#message-model-b')).toHaveClass('selected')
+    expect(container.querySelector('#message-model-a')).not.toHaveClass('selected')
+    expect(setActiveBranch).toHaveBeenCalledOnce()
+    expect(setActiveBranch).toHaveBeenCalledWith('model-b')
+  })
+
   it('shows the context indicator on the active branch instead of stale useful UI state', () => {
     mocks.settings.mockReturnValue({
       multiModelMessageStyle: 'grid',

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -121,6 +121,7 @@ const MessageGroup = ({
     if (messages.length === 1) return messages[0]?.id
     return pickPreferredSelectedMessage(messages, getMessageUiState)?.id ?? messages.at(-1)?.id ?? messages[0]?.id
   })
+  const previousActiveBranchMessageIdRef = useRef(messages.find((message) => message.isActiveBranch)?.id)
 
   // Re-sync the selected ID when the active branch or group membership changes.
   // Without this, fold mode can keep showing an old model column even after
@@ -135,9 +136,11 @@ const MessageGroup = ({
 
     const hasSelected = messages.some((m) => m.id === selectedMessageId)
     const activeBranchMessage = messages.find((message) => message.isActiveBranch)
+    const activeBranchChanged = activeBranchMessage?.id !== previousActiveBranchMessageIdRef.current
+    previousActiveBranchMessageIdRef.current = activeBranchMessage?.id
     let nextSelectedMessage: MessageListItem | undefined
 
-    if (activeBranchMessage && activeBranchMessage.id !== selectedMessageId) {
+    if (activeBranchChanged && activeBranchMessage && activeBranchMessage.id !== selectedMessageId) {
       nextSelectedMessage = activeBranchMessage
     } else if (!hasSelected) {
       nextSelectedMessage = pickPreferredSelectedMessage(messages, getMessageUiState) ?? messages.at(-1) ?? messages[0]


### PR DESCRIPTION
### What this PR does

Before this PR:

In fold mode, selecting another model while the active model was still streaming could immediately switch the visible answer back to the persisted active branch.

After this PR:

The locally selected model remains visible across streaming rerenders. The fold view still follows the active branch when that branch genuinely changes.

Fixes #19659

### Why we need it and why it was done in this way

The selection synchronization effect previously treated every rerender as a reason to restore the persisted active branch. The effect now tracks the previous active-branch message ID and only follows it when that ID changes.

The following tradeoffs were made:

The fix adds one ref to distinguish a real active-branch transition from ordinary streaming updates, while preserving the existing local selection and persistence flow.

The following alternatives were considered:

Removing active-branch synchronization entirely was rejected because external branch navigation must still update the fold view.

Links to places where the discussion took place: #19659

### Breaking changes

None.

### Special notes for your reviewer

- Regression test: `keeps another model selected while the active reply continues streaming`
- Focused renderer tests: 69 passed
- `pnpm lint`: passed
- `pnpm test:lint`: passed
- No screenshot was produced because the only running Electron instance is user-owned and must remain untouched; launching a second dev app would violate the one-dev-app memory constraint. This change preserves the existing visual design and only corrects selection behavior during streaming.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix switching between multi-model answers while a response is streaming.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer-only fold selection sync; no auth, data, or API changes.
> 
> **Overview**
> Fixes fold-mode multi-model UI snapping back to the streaming active branch whenever the group re-rendered during a pending reply.
> 
> **`MessageGroup`** now remembers the previous active-branch message id and only auto-selects that branch when that id **changes** (e.g. branch navigation), not on every update to the same streaming message. Manual model picks stay selected across streaming rerenders; external active-branch changes still drive the fold view.
> 
> Adds regression coverage: **`keeps another model selected while the active reply continues streaming`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51755ed71fdf32b753c13a373f9976129249753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->