### PR TITLE
fix(chat-errors): classify client certificate failures

### DIFF
--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -122,6 +123,28 @@ describe('ErrorBlock', () => {
 
     expect(screen.getByText('error.diagnosis.quota')).toBeInTheDocument()
     expect(screen.queryByText('error.diagnosis.rate_limit')).toBeNull()
+  })
+
+  it('offers network settings for a client-certificate authentication failure', async () => {
+    const user = userEvent.setup()
+    const navigateErrorTarget = vi.fn()
+    mocks.actions = { navigateErrorTarget }
+
+    render(
+      <ErrorBlock
+        partId="message-1-part-0"
+        error={{
+          name: 'StreamError',
+          message: 'net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED',
+          stack: 'Error: net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED'
+        }}
+        message={message}
+      />
+    )
+
+    expect(screen.getByText('error.diagnosis.proxy')).toBeInTheDocument()
+    await user.click(screen.getByText('error.diagnosis.go_to_settings'))
+    expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/general')
   })
 
   it('ignores non-serializable provider data when classifying an error', () => {

--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -125,28 +125,6 @@ describe('ErrorBlock', () => {
     expect(screen.queryByText('error.diagnosis.rate_limit')).toBeNull()
   })
 
-  it('offers network settings for a client-certificate authentication failure', async () => {
-    const user = userEvent.setup()
-    const navigateErrorTarget = vi.fn()
-    mocks.actions = { navigateErrorTarget }
-
-    render(
-      <ErrorBlock
-        partId="message-1-part-0"
-        error={{
-          name: 'StreamError',
-          message: 'net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED',
-          stack: 'Error: net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED'
-        }}
-        message={message}
-      />
-    )
-
-    expect(screen.getByText('error.diagnosis.proxy')).toBeInTheDocument()
-    await user.click(screen.getByText('error.diagnosis.go_to_settings'))
-    expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/general')
-  })
-
   it('ignores non-serializable provider data when classifying an error', () => {
     const circularData: Record<string, unknown> = {}
     circularData.self = circularData
@@ -254,5 +232,27 @@ describe('ErrorBlock', () => {
 
     expect(await screen.findByText('中文摘要')).toBeInTheDocument()
     expect(diagnoseMessageError).toHaveBeenLastCalledWith(expect.objectContaining({ language: 'zh-CN' }))
+  })
+
+  it('offers network settings for a client-certificate authentication failure', async () => {
+    const user = userEvent.setup()
+    const navigateErrorTarget = vi.fn()
+    mocks.actions = { navigateErrorTarget }
+
+    render(
+      <ErrorBlock
+        partId="message-1-part-0"
+        error={{
+          name: 'StreamError',
+          message: 'net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED',
+          stack: 'Error: net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED'
+        }}
+        message={message}
+      />
+    )
+
+    expect(screen.getByText('error.diagnosis.proxy')).toBeInTheDocument()
+    await user.click(screen.getByText('error.diagnosis.go_to_settings'))
+    expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/general')
   })
 })

--- a/src/renderer/utils/__tests__/errorClassifier.test.ts
+++ b/src/renderer/utils/__tests__/errorClassifier.test.ts
@@ -365,6 +365,11 @@ describe('classifyError', () => {
     expect(result.category).toBe('proxy')
   })
 
+  it('classifies Chromium ERR_SSL_CLIENT_AUTH_CERT_NEEDED as proxy', () => {
+    const result = classifyError(makeError({ message: 'net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED' }))
+    expect(result.category).toBe('proxy')
+  })
+
   it('does not match plain "proxy" without qualifier', () => {
     const result = classifyError(makeError({ message: 'something proxy related' }))
     expect(result.category).not.toBe('proxy')

--- a/src/renderer/utils/errorClassifier.ts
+++ b/src/renderer/utils/errorClassifier.ts
@@ -248,6 +248,7 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
 
   // Proxy / SSL certificate errors
   if (
+    msg.includes('err_ssl_client_auth_cert_needed') ||
     isProxyErrorMessage(msg) ||
     msg.includes('socks') ||
     msg.includes('certificate') ||


### PR DESCRIPTION
### What this PR does

Before this PR:

Agent requests that failed with Chromium's `net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED` were classified as unknown, so the error card offered no supported recovery action.

After this PR:

The existing proxy and SSL-certificate diagnosis recognizes this exact client-certificate authentication failure and links the error card to General Settings for network and proxy recovery.

Fixes #19577

### Why we need it and why it was done in this way

Restricted diagnostic evidence contains four ordinary `Error` instances whose message and stack carry `net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED`, followed by the existing Agent execution-loop terminal path. The serialized message reaches the shared error classifier, but the Chromium code abbreviates certificate as `CERT`, so the existing `certificate` check did not match it.

The following tradeoffs were made:

- Match the exact Chromium error code and reuse the existing proxy/SSL category, copy, and `/settings/general` action.
- Keep certificate selection and storage outside this focused presentation fix.

The following alternatives were considered:

- Adding a new error category and translations was unnecessary because the existing proxy/SSL diagnosis already describes the failure and provides the relevant recovery destination.
- Implementing client-certificate selection would require endpoint scoping, lifecycle, and secure storage decisions that are separate from making the current terminal error actionable.

Links to places where the discussion took place: #19577

### Breaking changes

None.

### Special notes for your reviewer

The regression test uses the serialized `StreamError` shape and safe Chromium error code confirmed by the restricted diagnostic package. It verifies both the rendered proxy/SSL diagnosis and navigation to `/settings/general`.

No screenshot is attached because this workspace did not have a credible isolated Cherry Studio UI instance. The existing Electron process belonged to another workspace and was intentionally not controlled or reused.

Validation:

- `pnpm exec vitest run --project renderer src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx src/renderer/utils/__tests__/errorClassifier.test.ts`
- `pnpm exec biome check src/renderer/utils/errorClassifier.ts src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx`
- `pnpm lint`
- `pnpm test:lint`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Agent client-certificate authentication failures now show proxy and SSL recovery guidance with a link to General Settings.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow heuristic addition to error classification and tests only; no changes to auth, networking, or certificate handling logic.
> 
> **Overview**
> Chromium **`net::ERR_SSL_CLIENT_AUTH_CERT_NEEDED`** agent/stream failures were treated as unknown errors, so chat error cards showed no recovery path.
> 
> **`classifyError`** now maps that code (via `err_ssl_client_auth_cert_needed`) into the existing **proxy/SSL** category, reusing **`error.diagnosis.proxy`** and navigation to **`/settings/general`**. The mismatch was that the generic `certificate` substring does not appear in Chromium’s abbreviated `CLIENT_AUTH_CERT` wording.
> 
> Regression coverage adds a classifier unit test and an **`ErrorBlock`** test that asserts the proxy diagnosis and “go to settings” action for a serialized **`StreamError`** with this message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5afdb681fca5ea2adab351025fe63c8d36017e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->