### PR TITLE
feat(claude-code): advance the context-usage ring on each message_start

### DIFF
--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -488,6 +488,10 @@ The driver converts Claude SDK messages into runtime events:
   `assistant` messages are a whole-snapshot usage candidate when the terminal
   delta omits usage. Gateway-owned connections do not emit this record input;
 - `system/init` -> `resume-token`;
+- a top-level `message_start` -> a live `context-usage` projected from the
+  request's input usage (the occupancy at that provider call), so the usage
+  indicator advances mid-turn; the host's post-turn `getContextUsage()` pull
+  stays the authoritative reading;
 - a successful `result` -> flush pending per-request usage, then `resume-token`, a
   cumulative usage metadata `chunk` for live UI, `context-usage`, and `turn-complete`;
 - a failed `result` -> preserve its final usage and resume token, then emit `error` and

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -65,6 +65,7 @@ import {
   toolPolicyFactsEqual
 } from './agentSessionWarmup'
 import { spawnClaudeCodeProcess } from './ClaudeCodeProcessManager'
+import { effectiveContextWindowTokens } from './contextWindowSuffix'
 import {
   AgentSessionWorkspaceError,
   disposeToolPolicySnapshot,
@@ -609,6 +610,29 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
     }
   }
 
+  /**
+   * Project a top-level `message_start`'s input usage into a live reading: the request the CLI just
+   * sent carries exactly the tokens now occupying the window. `categories` stays empty (only the
+   * CLI's probe produces the breakdown); the host's post-turn pull remains the authoritative reading.
+   */
+  private emitLiveContextUsage(usage: InvocationUsageInput | undefined): void {
+    const totalTokens =
+      (usage?.input_tokens ?? 0) + (usage?.cache_read_input_tokens ?? 0) + (usage?.cache_creation_input_tokens ?? 0)
+    if (totalTokens <= 0) return
+    const model = this.adapterModelId ?? this.input.modelId
+    const maxTokens = effectiveContextWindowTokens(model)
+    this.eventQueue.push({
+      type: 'context-usage',
+      usage: {
+        categories: [],
+        totalTokens,
+        maxTokens,
+        percentage: Math.min(100, (totalTokens / maxTokens) * 100),
+        model
+      }
+    })
+  }
+
   async getSupportedCommands(): Promise<AgentSessionSlashCommand[] | null> {
     if (!this.query) return null
     try {
@@ -672,6 +696,16 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
           this.commitPendingInvocations()
           this.eventQueue.push({ type: 'steer-boundary', inputs: this.steerBoundaryPending })
           this.steerBoundaryPending = undefined
+        }
+
+        // A top-level message_start's input usage IS the current context occupancy — forward it so
+        // the ring advances per provider call, not only on the host's post-turn pull.
+        if (
+          message.type === 'stream_event' &&
+          message.event.type === 'message_start' &&
+          message.parent_tool_use_id == null
+        ) {
+          this.emitLiveContextUsage(message.event.message?.usage)
         }
 
         const messageAssociation = this.adapter!.isTurnActive ? 'current-turn' : 'stateless'

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -1942,6 +1942,114 @@ describe('ClaudeCodeRuntimeDriver', () => {
     void connection.close()
   })
 
+  it('emits a live context-usage reading on each top-level message_start', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'anthropic::sonnet' as any
+    })
+    const events = connection.events[Symbol.asyncIterator]()
+
+    await connection.send({ message: userMessage() })
+    queryQueue.push({
+      type: 'stream_event',
+      parent_tool_use_id: null,
+      event: {
+        type: 'message_start',
+        message: {
+          id: 'req-1',
+          model: 'sonnet-sdk',
+          usage: { input_tokens: 100, output_tokens: 1, cache_read_input_tokens: 800, cache_creation_input_tokens: 100 }
+        }
+      }
+    })
+    // Subagent lanes run in their own context and must not move the session ring.
+    queryQueue.push({
+      type: 'stream_event',
+      parent_tool_use_id: 'tool-1',
+      event: {
+        type: 'message_start',
+        message: { id: 'req-sub', model: 'sonnet-sdk', usage: { input_tokens: 50_000, output_tokens: 1 } }
+      }
+    })
+    // A usage-less start (sparse gateway reporting) must not zero the ring mid-turn.
+    queryQueue.push({
+      type: 'stream_event',
+      parent_tool_use_id: null,
+      event: { type: 'message_start', message: { id: 'req-2', model: 'sonnet-sdk', usage: {} } }
+    })
+    queryQueue.push({
+      type: 'result',
+      subtype: 'success',
+      session_id: 'live-usage-result',
+      usage: { input_tokens: 100, output_tokens: 5, cache_read_input_tokens: 800, cache_creation_input_tokens: 100 }
+    })
+
+    const seen: any[] = []
+    while (!seen.some((event) => event?.type === 'turn-complete')) {
+      seen.push((await events.next()).value)
+    }
+    expect(seen.filter((event) => event?.type === 'context-usage')).toEqual([
+      {
+        type: 'context-usage',
+        usage: { categories: [], totalTokens: 1000, maxTokens: 200_000, percentage: 0.5, model: 'sonnet-sdk' }
+      }
+    ])
+    await connection.close()
+  })
+
+  it('sizes the live context-usage window from the connection model id suffix', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    mocks.createClaudeQuery.mockReturnValue({ ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() })
+    mocks.buildRequest.mockResolvedValue({
+      connectionConfig: {
+        rebuildSignature: 'sig-1',
+        live: { toolPolicy: { permissionMode: null, disabledTools: [], mcps: [] } }
+      },
+      key: 'warm-key',
+      options: { model: 'deepseek-chat[1m]' },
+      settings: {},
+      sdkModelId: 'deepseek-chat[1m]',
+      initializeTimeoutMs: 100
+    })
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'deepseek::deepseek-chat' as any
+    })
+    const events = connection.events[Symbol.asyncIterator]()
+
+    await connection.send({ message: userMessage() })
+    queryQueue.push({
+      type: 'stream_event',
+      parent_tool_use_id: null,
+      event: {
+        type: 'message_start',
+        message: { id: 'req-1m', model: 'deepseek-chat', usage: { input_tokens: 300_000, output_tokens: 1 } }
+      }
+    })
+
+    for (;;) {
+      const event = (await events.next()).value
+      if (event?.type === 'context-usage') {
+        // The API-reported id never carries the suffix, so the reading is stamped with the
+        // configured id — the one the renderer's staleness filter matches against.
+        expect(event.usage).toEqual({
+          categories: [],
+          totalTokens: 300_000,
+          maxTokens: 1_000_000,
+          percentage: 30,
+          model: 'deepseek-chat[1m]'
+        })
+        break
+      }
+    }
+    await connection.close()
+  })
+
   it('preserves message-start input buckets when terminal usage only reports output', async () => {
     const queryQueue = createAsyncQueue<any>()
     const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }

--- a/src/main/ai/runtime/claudeCode/contextWindowSuffix.ts
+++ b/src/main/ai/runtime/claudeCode/contextWindowSuffix.ts
@@ -21,7 +21,13 @@
  */
 
 const ONE_MILLION = 1_000_000
+const DEFAULT_CONTEXT_WINDOW = 200_000
 const ANTHROPIC_OFFICIAL_HOST = 'api.anthropic.com'
+
+/** Claude Code's local context budget (see the header): 200K by default, 1M under the `[1m]` suffix. */
+export function effectiveContextWindowTokens(modelId: string | undefined): number {
+  return modelId && /\[1m\]$/i.test(modelId) ? ONE_MILLION : DEFAULT_CONTEXT_WINDOW
+}
 
 /**
  * True for the first-party Anthropic endpoint: an explicit `api.anthropic.com`


### PR DESCRIPTION
### What this PR does

Before this PR: the agent-session context-usage indicator (composer ring / right-pane summary) only refreshed at turn completion, compaction, and throttled on-demand pulls, so it stayed flat for the whole duration of a long-running turn.

After this PR: the Claude Code driver projects each top-level `message_start`'s input usage into a live `context-usage` event, so the indicator advances at every provider call (e.g. between tool calls) while the turn is still running. The host's post-turn `getContextUsage()` pull remains the authoritative reading.

Fixes #

### Why we need it and why it was done in this way

A `message_start` already reports the request's input usage (`input_tokens` + `cache_read_input_tokens` + `cache_creation_input_tokens`), which is exactly the occupancy of the context window at that provider call — no token-count probe needed. The driver was already parsing this data for per-request usage accounting; it just never fed the usage indicator.

The following tradeoffs were made:

- `maxTokens` mirrors the CLI's local budgeting rule (200K, or 1M under the `[1m]` suffix) instead of the probed value, which is unavailable mid-turn. The renderer already prefers the model's declared context window when it knows one, and the post-turn pull corrects any drift.
- `categories` stays empty in live readings (only the CLI's probe produces the breakdown) — same as the pi driver, which the renderer already handles.
- The reading is stamped with the configured SDK model id rather than the API-reported one: the API id drops the `[1m]` suffix, and the renderer's stale-model filter matches against the configured id.
- Subagent lanes (`parent_tool_use_id` set) and usage-less starts are skipped — subagents run in their own context, and a zero reading must not zero the ring mid-turn.

The following alternatives were considered:

- Polling `getContextUsage()` during a live turn — rejected: each call makes the SDK issue multiple token-count probes, which is why the host deliberately defers it to turn boundaries today.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Host (`AgentSessionRuntimeService`) and renderer (`useAgentSessionContextUsage`) needed no changes — the `context-usage` event type and cache subscription already existed (used by the pi driver); this PR only makes the Claude Code driver emit it.
- Tests: two new cases in `ClaudeCodeRuntimeDriver.test.ts` cover the per-call emission (including the subagent-lane and empty-usage skips) and the `[1m]` window sizing.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
The agent session context-usage indicator now advances live during a task (at every model call) instead of only when the task completes.
```
