### PR TITLE
fix(agent-session): retry automatic title naming after failed turn

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -157,7 +157,7 @@ export interface BeginAgentSessionTurnInput {
   traceId?: string
   /** Author snapshot (agent + nested model) stamped onto every assistant row this turn produces. */
   messageSnapshot?: MessageSnapshot
-  /** Only an untouched session's initial turn may run the two-stage automatic naming flow. */
+  /** Whether this turn may complete the session's pending automatic naming flow. */
   shouldAutoName?: boolean
 }
 
@@ -198,7 +198,7 @@ type AgentSessionTurn = {
   modelId: UniqueModelId
   /** Immutable author snapshot captured when this exact turn was submitted. */
   messageSnapshot?: MessageSnapshot
-  /** Whether this initial turn owns the session's one automatic AI naming attempt. */
+  /** Whether this dispatch found the session eligible for automatic naming. */
   shouldAutoName?: boolean
   reasoningEffort: ReasoningEffortOption
   serviceTier: ServiceTierSelection
@@ -268,6 +268,8 @@ type AgentSessionRuntimeEntry = {
   modelId: UniqueModelId
   /** Author snapshot (agent + nested model) for assistant rows the runtime opens this session. */
   messageSnapshot?: MessageSnapshot
+  /** Retained across failed or paused turns until one successful persistence attempts naming. */
+  autoNamePending: boolean
   runtimeState: RuntimeState
   /** Capture owner/receipt of the installed connection; retained through terminal persistence. */
   usageCapture?: AgentSessionUsageCapture
@@ -512,6 +514,7 @@ export class AgentSessionRuntimeService extends BaseService {
       existing.agentType = input.agentType
       existing.modelId = input.modelId
       existing.messageSnapshot = messageSnapshot
+      existing.autoNamePending ||= turn.shouldAutoName === true
       this.applyRuntimeStateEvent(existing, { type: 'begin-turn', turn, clearQueue: true })
       this.applyRuntimeStateEvent(existing, { type: 'clear-steer-reservation' })
 
@@ -536,6 +539,7 @@ export class AgentSessionRuntimeService extends BaseService {
       agentType: input.agentType,
       modelId: input.modelId,
       messageSnapshot,
+      autoNamePending: turn.shouldAutoName === true,
       runtimeState: createAgentSessionRuntimeState(turn)
     }
     this.entries.set(input.sessionId, entry)
@@ -653,6 +657,7 @@ export class AgentSessionRuntimeService extends BaseService {
         agentId: session.agentId,
         agentType: agent.type,
         modelId: agent.model,
+        autoNamePending: false,
         runtimeState: createAgentSessionRuntimeState()
       }
       this.entries.set(sessionId, entry)
@@ -3082,8 +3087,9 @@ export class AgentSessionRuntimeService extends BaseService {
     }
     const { assistantMessageId, modelId } = currentTurn
     const userText = extractMessageText(userMessage)
-    const afterPersist = currentTurn.shouldAutoName
+    const afterPersist = entry.autoNamePending
       ? async (finalMessage: CherryUIMessage) => {
+          entry.autoNamePending = false
           await topicNamingService.maybeRenameAgentSession(entry.agentId, entry.sessionId, userText, finalMessage)
         }
       : undefined

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -213,6 +213,8 @@ type AgentSessionTurn = {
 
 type PendingAgentSessionTurn = {
   message: AgentSessionMessageEntity
+  /** Whether this queued turn may complete the session's pending automatic naming flow. */
+  shouldAutoName?: boolean
   reasoningEffort: ReasoningEffortOption
   serviceTier: ServiceTierSelection
   knowledgeBaseIds: readonly string[]
@@ -830,6 +832,7 @@ export class AgentSessionRuntimeService extends BaseService {
       reasoningEffort?: ReasoningEffortOption
       serviceTier?: ServiceTierSelection
       fastMode?: boolean
+      shouldAutoName?: boolean
     } = {}
   ): void {
     const entry = this.entries.get(sessionId)
@@ -892,6 +895,7 @@ export class AgentSessionRuntimeService extends BaseService {
         knowledgeBaseIds,
         fastMode,
         steer: true,
+        ...(opts.shouldAutoName ? { shouldAutoName: true } : {}),
         ...(headless ? { headless } : {}),
         ...(trustedNotifyChannels !== undefined ? { trustedNotifyChannels } : {}),
         ...(messageSnapshot ? { messageSnapshot } : {})
@@ -2667,6 +2671,7 @@ export class AgentSessionRuntimeService extends BaseService {
       headless,
       ...(trustedNotifyChannels !== undefined ? { trustedNotifyChannels } : {})
     }
+    entry.autoNamePending ||= pendingTurn.shouldAutoName === true
     this.applyRuntimeStateEvent(entry, { type: 'begin-turn', turn: nextTurn })
     const messages = createRuntimeSeedMessages(nextMessage, assistantMessageId)
     // Author the turn span's input/identity here (the runtime owns its continuation turns).

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -270,8 +270,6 @@ type AgentSessionRuntimeEntry = {
   modelId: UniqueModelId
   /** Author snapshot (agent + nested model) for assistant rows the runtime opens this session. */
   messageSnapshot?: MessageSnapshot
-  /** Retained across failed or paused turns until one successful persistence attempts naming. */
-  autoNamePending: boolean
   runtimeState: RuntimeState
   /** Capture owner/receipt of the installed connection; retained through terminal persistence. */
   usageCapture?: AgentSessionUsageCapture
@@ -516,7 +514,6 @@ export class AgentSessionRuntimeService extends BaseService {
       existing.agentType = input.agentType
       existing.modelId = input.modelId
       existing.messageSnapshot = messageSnapshot
-      existing.autoNamePending ||= turn.shouldAutoName === true
       this.applyRuntimeStateEvent(existing, { type: 'begin-turn', turn, clearQueue: true })
       this.applyRuntimeStateEvent(existing, { type: 'clear-steer-reservation' })
 
@@ -541,7 +538,6 @@ export class AgentSessionRuntimeService extends BaseService {
       agentType: input.agentType,
       modelId: input.modelId,
       messageSnapshot,
-      autoNamePending: turn.shouldAutoName === true,
       runtimeState: createAgentSessionRuntimeState(turn)
     }
     this.entries.set(input.sessionId, entry)
@@ -659,7 +655,6 @@ export class AgentSessionRuntimeService extends BaseService {
         agentId: session.agentId,
         agentType: agent.type,
         modelId: agent.model,
-        autoNamePending: false,
         runtimeState: createAgentSessionRuntimeState()
       }
       this.entries.set(sessionId, entry)
@@ -877,6 +872,7 @@ export class AgentSessionRuntimeService extends BaseService {
       this.currentConnection(entry)?.redirect?.({
         message,
         systemReminder: true,
+        ...(opts.shouldAutoName ? { shouldAutoName: true } : {}),
         ...(headless ? { headless } : {}),
         ...(messageSnapshot ? { messageSnapshot } : {})
       })
@@ -1736,6 +1732,7 @@ export class AgentSessionRuntimeService extends BaseService {
               knowledgeBaseIds: getKnowledgeBaseIdsFromParts(input.message.data.parts ?? []) ?? [],
               fastMode: this.currentTurn(entry)?.fastMode ?? false,
               steer: true,
+              ...(input.shouldAutoName ? { shouldAutoName: true } : {}),
               ...(input.headless ? { headless: true } : {}),
               ...(input.messageSnapshot ? { messageSnapshot: input.messageSnapshot } : {})
             }
@@ -2669,9 +2666,9 @@ export class AgentSessionRuntimeService extends BaseService {
       abortController: new AbortController(),
       activeToolIds: new Set(),
       headless,
+      shouldAutoName: pendingTurn.shouldAutoName === true,
       ...(trustedNotifyChannels !== undefined ? { trustedNotifyChannels } : {})
     }
-    entry.autoNamePending ||= pendingTurn.shouldAutoName === true
     this.applyRuntimeStateEvent(entry, { type: 'begin-turn', turn: nextTurn })
     const messages = createRuntimeSeedMessages(nextMessage, assistantMessageId)
     // Author the turn span's input/identity here (the runtime owns its continuation turns).
@@ -2953,6 +2950,7 @@ export class AgentSessionRuntimeService extends BaseService {
       abortController: new AbortController(),
       activeToolIds: new Set(),
       headless,
+      shouldAutoName: transition.inputs.some((input) => input.shouldAutoName === true),
       ...(trustedNotifyChannels !== undefined ? { trustedNotifyChannels } : {})
     }
     this.applyRuntimeStateEvent(entry, { type: 'continuation-turn-created', turn: continuationTurn })
@@ -3092,9 +3090,9 @@ export class AgentSessionRuntimeService extends BaseService {
     }
     const { assistantMessageId, modelId } = currentTurn
     const userText = extractMessageText(userMessage)
-    const afterPersist = entry.autoNamePending
+    const afterPersist = currentTurn.shouldAutoName
       ? async (finalMessage: CherryUIMessage) => {
-          entry.autoNamePending = false
+          currentTurn.shouldAutoName = false
           await topicNamingService.maybeRenameAgentSession(entry.agentId, entry.sessionId, userText, finalMessage)
         }
       : undefined

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -3307,6 +3307,29 @@ describe('AgentSessionRuntimeService', () => {
     expect(mocks.maybeRenameAgentSession).not.toHaveBeenCalled()
   })
 
+  it('carries automatic naming eligibility into queued turn persistence', async () => {
+    const service = new AgentSessionRuntimeService()
+    service.beginTurn(baseTurnInput)
+
+    service.enqueueUserMessage('session-1', userMessage('user-2', [], 'Try again'), { shouldAutoName: true })
+    service.markTurnTerminal('session-1', 'success')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const startedTurn = mocks.startRuntimeTurn.mock.calls.at(-1)?.[0]
+    expect(startedTurn).toBeDefined()
+    await persistenceListener(startedTurn).onDone({
+      status: 'success',
+      isTopicDone: true,
+      finalMessage: { id: 'assistant-2', role: 'assistant', parts: [{ type: 'text', text: 'recovered' }] }
+    })
+
+    expect(mocks.maybeRenameAgentSession).toHaveBeenCalledWith('agent-1', 'session-1', 'Try again', {
+      id: 'assistant-2',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'recovered' }]
+    })
+  })
+
   it.each(['paused', 'error'] as const)(
     'keeps automatic naming pending when the first assistant turn is %s',
     async (status) => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -99,7 +99,7 @@ const baseTurnInput = {
 }
 const switchedModelId = 'claude-code::claude-opus-4-5' as any
 
-function userMessage(id: string, knowledgeBaseIds: string[] = []) {
+function userMessage(id: string, knowledgeBaseIds: string[] = [], text = 'hello') {
   return {
     id,
     topicId: 'agent-session:session-1',
@@ -107,7 +107,7 @@ function userMessage(id: string, knowledgeBaseIds: string[] = []) {
     role: 'user',
     data: {
       parts: [
-        { type: 'text', text: 'hello' },
+        { type: 'text', text },
         ...(knowledgeBaseIds.length ? [{ type: 'data-knowledge-scope', data: { baseIds: knowledgeBaseIds } }] : [])
       ]
     },
@@ -3329,7 +3329,7 @@ describe('AgentSessionRuntimeService', () => {
       const second = service.beginTurn({
         ...baseTurnInput,
         assistantMessageId: 'assistant-2',
-        userMessage: userMessage('user-2')
+        userMessage: userMessage('user-2', [], 'Try again')
       })
       await persistenceListener(second).onDone({
         status: 'success',
@@ -3338,7 +3338,7 @@ describe('AgentSessionRuntimeService', () => {
       })
 
       expect(mocks.maybeRenameAgentSession).toHaveBeenCalledOnce()
-      expect(mocks.maybeRenameAgentSession).toHaveBeenCalledWith('agent-1', 'session-1', 'hello', {
+      expect(mocks.maybeRenameAgentSession).toHaveBeenCalledWith('agent-1', 'session-1', 'Try again', {
         id: 'assistant-2',
         role: 'assistant',
         parts: [{ type: 'text', text: 'recovered' }]

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -3307,6 +3307,45 @@ describe('AgentSessionRuntimeService', () => {
     expect(mocks.maybeRenameAgentSession).not.toHaveBeenCalled()
   })
 
+  it.each(['paused', 'error'] as const)(
+    'keeps automatic naming pending when the first assistant turn is %s',
+    async (status) => {
+      const service = new AgentSessionRuntimeService()
+      const first = service.beginTurn({
+        ...baseTurnInput,
+        userMessage: userMessage('user-1'),
+        shouldAutoName: true
+      })
+
+      if (status === 'paused') {
+        await persistenceListener(first).onPaused({ status, isTopicDone: true, finalMessage: undefined })
+        terminalListener(first).onPaused({ status, isTopicDone: true })
+      } else {
+        const error = { name: 'Error', message: 'first turn failed' }
+        await persistenceListener(first).onError({ status, isTopicDone: true, error, finalMessage: undefined })
+        terminalListener(first).onError({ status, isTopicDone: true, error })
+      }
+
+      const second = service.beginTurn({
+        ...baseTurnInput,
+        assistantMessageId: 'assistant-2',
+        userMessage: userMessage('user-2')
+      })
+      await persistenceListener(second).onDone({
+        status: 'success',
+        isTopicDone: true,
+        finalMessage: { id: 'assistant-2', role: 'assistant', parts: [{ type: 'text', text: 'recovered' }] }
+      })
+
+      expect(mocks.maybeRenameAgentSession).toHaveBeenCalledOnce()
+      expect(mocks.maybeRenameAgentSession).toHaveBeenCalledWith('agent-1', 'session-1', 'hello', {
+        id: 'assistant-2',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'recovered' }]
+      })
+    }
+  )
+
   it('persists empty paused terminals to the active assistant placeholder', async () => {
     const service = new AgentSessionRuntimeService()
     const handle = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -910,7 +910,10 @@ describe('AgentSessionRuntimeService', () => {
 
       // Native steer accepts the follow-up via redirect → its snapshot must still be stored, and the
       // steer-boundary continuation (A2) must freeze it, not the prior turn's entry snapshot.
-      service.enqueueUserMessage('session-1', userMessage('user-2'), { messageSnapshot: followUpSnapshot })
+      service.enqueueUserMessage('session-1', userMessage('user-2'), {
+        messageSnapshot: followUpSnapshot,
+        shouldAutoName: true
+      })
       expect(connection.redirect).toHaveBeenCalled()
       expect(entry.pendingTurns).toEqual([])
 
@@ -918,7 +921,7 @@ describe('AgentSessionRuntimeService', () => {
       // The driver echoes the redirected input verbatim, so its attributes ride the round-trip.
       ;(service as any).handleRuntimeEvent(entry, {
         type: 'steer-boundary',
-        inputs: [{ message: userMessage('user-2'), systemReminder: true, messageSnapshot: followUpSnapshot }]
+        inputs: [connection.redirect.mock.calls[0][0]]
       })
       service.markTurnTerminal('session-1', 'success', sourceTurnId)
       await vi.waitFor(() => expect(entry.currentTurn.userMessage.id).toBe('user-2'))
@@ -927,6 +930,18 @@ describe('AgentSessionRuntimeService', () => {
         .map((call) => call[0].message)
         .filter((m: any) => m.role === 'assistant')
       expect(assistantSaves.at(-1)?.messageSnapshot).toEqual(followUpSnapshot)
+
+      const continuation = mocks.startRuntimeTurn.mock.calls.at(-1)?.[0]
+      await persistenceListener(continuation).onDone({
+        status: 'success',
+        isTopicDone: true,
+        finalMessage: { id: 'assistant-2', role: 'assistant', parts: [{ type: 'text', text: 'recovered' }] }
+      })
+      expect(mocks.maybeRenameAgentSession).toHaveBeenCalledWith('agent-1', 'session-1', 'hello', {
+        id: 'assistant-2',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'recovered' }]
+      })
       void service.closeSession('session-1')
     })
 
@@ -989,14 +1004,17 @@ describe('AgentSessionRuntimeService', () => {
       entry.connectionModelId = baseTurnInput.modelId
       entry.runtimeState.execution = { ...entry.runtimeState.execution, stream: 'open', admission: 'admitted' }
 
-      service.enqueueUserMessage('session-1', userMessage('user-2'), { messageSnapshot: followUpSnapshot })
+      service.enqueueUserMessage('session-1', userMessage('user-2'), {
+        messageSnapshot: followUpSnapshot,
+        shouldAutoName: true
+      })
       expect(connection.redirect).toHaveBeenCalled()
 
       // Turn ended before the steer landed → requeued; the driver echoes the redirected input
       // (including its attributes), and the requeued turn must still freeze the follow-up snapshot.
       ;(service as any).handleRuntimeEvent(entry, {
         type: 'steer-undelivered',
-        inputs: [{ message: userMessage('user-2'), messageSnapshot: followUpSnapshot }]
+        inputs: [connection.redirect.mock.calls[0][0]]
       })
       service.markTurnTerminal('session-1', 'success')
       await new Promise((resolve) => setTimeout(resolve, 0))
@@ -1005,6 +1023,18 @@ describe('AgentSessionRuntimeService', () => {
         .map((call) => call[0].message)
         .filter((m: any) => m.role === 'assistant')
       expect(assistantSaves.at(-1)?.messageSnapshot).toEqual(followUpSnapshot)
+
+      const queuedTurn = mocks.startRuntimeTurn.mock.calls.at(-1)?.[0]
+      await persistenceListener(queuedTurn).onDone({
+        status: 'success',
+        isTopicDone: true,
+        finalMessage: { id: 'assistant-2', role: 'assistant', parts: [{ type: 'text', text: 'recovered' }] }
+      })
+      expect(mocks.maybeRenameAgentSession).toHaveBeenCalledWith('agent-1', 'session-1', 'hello', {
+        id: 'assistant-2',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'recovered' }]
+      })
     })
 
     it('opens an unmarked queued busy follow-up as interactive', async () => {
@@ -3331,7 +3361,7 @@ describe('AgentSessionRuntimeService', () => {
   })
 
   it.each(['paused', 'error'] as const)(
-    'keeps automatic naming pending when the first assistant turn is %s',
+    'auto-names an eligible retry after the first assistant turn is %s',
     async (status) => {
       const service = new AgentSessionRuntimeService()
       const first = service.beginTurn({
@@ -3352,7 +3382,8 @@ describe('AgentSessionRuntimeService', () => {
       const second = service.beginTurn({
         ...baseTurnInput,
         assistantMessageId: 'assistant-2',
-        userMessage: userMessage('user-2', [], 'Try again')
+        userMessage: userMessage('user-2', [], 'Try again'),
+        shouldAutoName: true
       })
       await persistenceListener(second).onDone({
         status: 'success',
@@ -3368,6 +3399,52 @@ describe('AgentSessionRuntimeService', () => {
       })
     }
   )
+
+  it('does not let receive-only persistence consume a later user turn naming retry', async () => {
+    const service = new AgentSessionRuntimeService()
+    const first = service.beginTurn({
+      ...baseTurnInput,
+      userMessage: userMessage('user-1', [], 'Initial request'),
+      shouldAutoName: true
+    })
+    const entry = getEntry(service)
+
+    const error = { name: 'Error', message: 'first turn failed' }
+    await persistenceListener(first).onError({ status: 'error', isTopicDone: true, error, finalMessage: undefined })
+    terminalListener(first).onError({ status: 'error', isTopicDone: true, error })
+
+    ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+    ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+    await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
+
+    const receiveOnly = mocks.startRuntimeTurn.mock.calls[0][0]
+    await persistenceListener(receiveOnly).onDone({
+      status: 'success',
+      isTopicDone: true,
+      finalMessage: { id: 'wake-1', role: 'assistant', parts: [{ type: 'text', text: 'background output' }] }
+    })
+    expect(mocks.maybeRenameAgentSession).not.toHaveBeenCalled()
+
+    terminalListener(receiveOnly).onDone({ status: 'success', isTopicDone: true })
+    const retry = service.beginTurn({
+      ...baseTurnInput,
+      assistantMessageId: 'assistant-2',
+      userMessage: userMessage('user-2', [], 'Try again'),
+      shouldAutoName: true
+    })
+    await persistenceListener(retry).onDone({
+      status: 'success',
+      isTopicDone: true,
+      finalMessage: { id: 'assistant-2', role: 'assistant', parts: [{ type: 'text', text: 'recovered' }] }
+    })
+
+    expect(mocks.maybeRenameAgentSession).toHaveBeenCalledOnce()
+    expect(mocks.maybeRenameAgentSession).toHaveBeenCalledWith('agent-1', 'session-1', 'Try again', {
+      id: 'assistant-2',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'recovered' }]
+    })
+  })
 
   it('persists empty paused terminals to the active assistant placeholder', async () => {
     const service = new AgentSessionRuntimeService()

--- a/src/main/ai/runtime/types.ts
+++ b/src/main/ai/runtime/types.ts
@@ -84,6 +84,7 @@ export interface AgentRuntimeUserInput {
    *  `steer-boundary`/`steer-undelivered`). Opaque to drivers. */
   headless?: boolean
   messageSnapshot?: MessageSnapshot
+  shouldAutoName?: boolean
 }
 
 /**

--- a/src/main/ai/streamManager/context/AgentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/AgentChatContextProvider.ts
@@ -329,7 +329,8 @@ export class AgentChatContextProvider implements ChatContextProvider {
         messageSnapshot: validated.messageSnapshot,
         reasoningEffort: validated.reasoningEffort,
         serviceTier: validated.serviceTier,
-        fastMode: validated.fastMode
+        fastMode: validated.fastMode,
+        shouldAutoName: validated.shouldAutoName
       })
 
       return {

--- a/src/main/ai/streamManager/context/AgentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/AgentChatContextProvider.ts
@@ -62,6 +62,7 @@ export type ValidatedAgentDispatch = {
   userMessageParts: CherryMessagePart[]
   deliveryMessage?: AgentSessionMessageEntity
   shouldAutoNameInitialTurn: boolean
+  shouldAutoName: boolean
 }
 
 export type PersistedAgentDispatch = {
@@ -138,6 +139,7 @@ export class AgentChatContextProvider implements ChatContextProvider {
     const shouldAutoNameInitialTurn = deliveryMessage
       ? !agentSessionMessageService.hasSessionMessages(sessionId, deliveryMessage.id)
       : !agentSessionMessageService.hasSessionMessages(sessionId)
+    const shouldAutoName = shouldAutoNameInitialTurn || topicNamingService.canAutoNameAgentSession(sessionId)
     return {
       sessionId,
       topicId: req.topicId,
@@ -163,7 +165,8 @@ export class AgentChatContextProvider implements ChatContextProvider {
       userMessageId: deliveryMessage?.id ?? uuidv7(),
       userMessageParts: deliveryMessage?.data.parts ?? req.userMessageParts ?? [],
       ...(deliveryMessage ? { deliveryMessage } : {}),
-      shouldAutoNameInitialTurn
+      shouldAutoNameInitialTurn,
+      shouldAutoName
     }
   }
 
@@ -252,7 +255,7 @@ export class AgentChatContextProvider implements ChatContextProvider {
         trustedNotifyChannels: validated.trustedNotifyChannels,
         traceId,
         messageSnapshot: validated.messageSnapshot,
-        shouldAutoName: validated.shouldAutoNameInitialTurn
+        shouldAutoName: validated.shouldAutoName
       })
     } catch (error) {
       turnTrace.end('error', error instanceof Error ? error : new Error(String(error)))

--- a/src/main/ai/streamManager/context/__tests__/AgentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/AgentChatContextProvider.test.ts
@@ -262,7 +262,8 @@ describe('AgentChatContextProvider', () => {
           model: { id: 'claude-sonnet', name: 'Claude Sonnet', provider: 'anthropic' }
         },
         reasoningEffort: 'default',
-        serviceTier: 'standard'
+        serviceTier: 'standard',
+        shouldAutoName: true
       }
     )
     expect(prepared.models).toEqual([])
@@ -312,7 +313,8 @@ describe('AgentChatContextProvider', () => {
           model: { id: 'claude-sonnet', name: 'Claude Sonnet', provider: 'anthropic' }
         },
         reasoningEffort: 'default',
-        serviceTier: 'standard'
+        serviceTier: 'standard',
+        shouldAutoName: true
       }
     )
   })
@@ -400,7 +402,7 @@ describe('AgentChatContextProvider', () => {
     expect(mocks.maybeRenameAgentSessionFromFirstUserMessage).toHaveBeenCalledWith('session-1', deliveryMessage.data)
   })
 
-  it('does not auto-name a busy follow-up turn', async () => {
+  it('queues a busy follow-up with its auto-naming eligibility', async () => {
     const subscriber = makeSubscriber()
     mocks.runtimeIsSessionBusy.mockReturnValue(true)
 
@@ -408,6 +410,11 @@ describe('AgentChatContextProvider', () => {
 
     expect(mocks.maybeRenameAgentSessionFromFirstUserMessage).not.toHaveBeenCalled()
     expect(mocks.hasSessionMessages).toHaveBeenCalledWith('session-1')
+    expect(mocks.runtimeEnqueueUserMessage).toHaveBeenCalledWith(
+      'session-1',
+      expect.anything(),
+      expect.objectContaining({ shouldAutoName: true })
+    )
   })
 
   it('retries auto-naming on a later idle turn while the temporary title remains', async () => {

--- a/src/main/ai/streamManager/context/__tests__/AgentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/AgentChatContextProvider.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   saveMessage: vi.fn(),
   saveMessagesTx: vi.fn(),
   hasSessionMessages: vi.fn(),
+  canAutoNameAgentSession: vi.fn(),
   maybeRenameAgentSessionFromFirstUserMessage: vi.fn(),
   maybeRenameAgentSession: vi.fn(),
   applicationGet: vi.fn(),
@@ -45,6 +46,7 @@ vi.mock('@data/services/AgentSessionMessageService', () => ({
 
 vi.mock('@main/services/TopicNamingService', () => ({
   topicNamingService: {
+    canAutoNameAgentSession: mocks.canAutoNameAgentSession,
     maybeRenameAgentSessionFromFirstUserMessage: mocks.maybeRenameAgentSessionFromFirstUserMessage,
     maybeRenameAgentSession: mocks.maybeRenameAgentSession
   }
@@ -132,6 +134,7 @@ describe('AgentChatContextProvider', () => {
       }))
     )
     mocks.hasSessionMessages.mockReturnValue(false)
+    mocks.canAutoNameAgentSession.mockReturnValue(true)
     mocks.applicationGet.mockImplementation((name: string) => {
       if (name === 'AgentSessionRuntimeService') {
         return {
@@ -407,8 +410,19 @@ describe('AgentChatContextProvider', () => {
     expect(mocks.hasSessionMessages).toHaveBeenCalledWith('session-1')
   })
 
-  it('does not auto-name a later idle turn in a session with messages', async () => {
+  it('retries auto-naming on a later idle turn while the temporary title remains', async () => {
     mocks.hasSessionMessages.mockReturnValue(true)
+
+    await provider.prepareDispatch(makeSubscriber(), openReq())
+
+    expect(mocks.maybeRenameAgentSessionFromFirstUserMessage).not.toHaveBeenCalled()
+    expect(mocks.canAutoNameAgentSession).toHaveBeenCalledWith('session-1')
+    expect(mocks.runtimeBeginTurn).toHaveBeenCalledWith(expect.objectContaining({ shouldAutoName: true }))
+  })
+
+  it('does not auto-name a later idle turn once the session has a stable title', async () => {
+    mocks.hasSessionMessages.mockReturnValue(true)
+    mocks.canAutoNameAgentSession.mockReturnValue(false)
 
     await provider.prepareDispatch(makeSubscriber(), openReq())
 

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -56,7 +56,7 @@ import {
 } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { isToolUIPart } from 'ai'
-import { and, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, type SQL, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, type SQL, sql } from 'drizzle-orm'
 import { v4 as uuidv4, v7 as uuidv7, validate as isUuid } from 'uuid'
 
 import { aiUsageRecordService, mergeMessageRuntimeStats } from './AiUsageRecordService'
@@ -458,6 +458,19 @@ export class AgentSessionMessageService {
         .limit(1)
         .all().length > 0
     )
+  }
+
+  getFirstUserMessage(sessionId: string): AgentSessionMessageEntity | null {
+    const [row] = application
+      .get('DbService')
+      .getDb()
+      .select()
+      .from(sessionMessagesTable)
+      .where(and(eq(sessionMessagesTable.sessionId, sessionId), eq(sessionMessagesTable.role, 'user')))
+      .orderBy(asc(sessionMessagesTable.createdAt), asc(sessionMessagesTable.id))
+      .limit(1)
+      .all()
+    return row ? this.rowToEntity(row) : null
   }
 
   hasSessionMessage(sessionId: string, messageId: string): boolean {

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -88,6 +88,44 @@ describe('AgentSessionMessageService', () => {
     expect(agentSessionMessageService.hasSessionMessages('session-2')).toBe(false)
   })
 
+  it('returns the oldest user message without loading assistant rows', async () => {
+    await dbh.db.insert(agentSessionMessageTable).values([
+      {
+        id: 'assistant-before-user',
+        sessionId: SESSION_ID,
+        role: 'assistant',
+        data: { parts: [{ type: 'text', text: 'assistant' }] },
+        status: 'error',
+        createdAt: 100,
+        updatedAt: 100
+      },
+      {
+        id: 'first-user',
+        sessionId: SESSION_ID,
+        role: 'user',
+        data: { parts: [{ type: 'text', text: 'first request' }] },
+        status: 'success',
+        createdAt: 200,
+        updatedAt: 200
+      },
+      {
+        id: 'later-user',
+        sessionId: SESSION_ID,
+        role: 'user',
+        data: { parts: [{ type: 'text', text: 'follow-up' }] },
+        status: 'success',
+        createdAt: 300,
+        updatedAt: 300
+      }
+    ])
+
+    expect(agentSessionMessageService.getFirstUserMessage(SESSION_ID)).toMatchObject({
+      id: 'first-user',
+      role: 'user',
+      data: { parts: [{ type: 'text', text: 'first request' }] }
+    })
+  })
+
   describe('cross-session delivery', () => {
     it('persists same-Agent and cross-Agent envelopes before scheduling', async () => {
       await seedAgent('agent-a', 'Agent A')

--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -1,4 +1,5 @@
 import { application } from '@application'
+import { agentSessionMessageService } from '@data/services/AgentSessionMessageService'
 import { agentSessionService } from '@data/services/AgentSessionService'
 import { modelService } from '@data/services/ModelService'
 import { providerService } from '@data/services/ProviderService'
@@ -144,6 +145,21 @@ function buildStructuredConversation(messages: StructuredMessage[]): string {
 }
 
 export class TopicNamingService {
+  canAutoNameAgentSession(sessionId: string): boolean {
+    const session = this.getAgentSession(sessionId, 'initial')
+    if (!session || session.isNameManuallyEdited) return false
+    if (isDefaultAgentSessionName(session.name)) return true
+
+    try {
+      const firstUserMessage = agentSessionMessageService.getFirstUserMessage(sessionId)
+      const firstUserText = firstUserMessage ? getMainTextContentFromMessageData(firstUserMessage.data) : undefined
+      return canAutoRenameAgentSessionName(session.name, firstUserText)
+    } catch (error) {
+      logger.debug('Failed to inspect agent session auto-naming eligibility', { sessionId, error: error as Error })
+      return false
+    }
+  }
+
   maybeRenameFromFirstUserMessage(topicId: string, userMessageId: string): void {
     try {
       const topic = this.getTopic(topicId)

--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -289,7 +289,7 @@ export class TopicNamingService {
    *
    * @param agentId    Agent id, used for failure logging context only.
    * @param sessionId  Cherry Studio session id.
-   * @param userText   Plain text of the persisted user turn, extracted by
+   * @param userText   Plain text of the successful user turn, extracted by
    *                   AgentSessionRuntimeService from the saved user message.
    * @param finalMessage Accumulated assistant UIMessage for this turn.
    */
@@ -319,7 +319,9 @@ export class TopicNamingService {
       const session = this.getAgentSession(sessionId, 'initial')
       if (!session || !session.agentId) return
       if (session.isNameManuallyEdited) return
-      if (!canAutoRenameAgentSessionName(session.name, userText)) return
+      const firstUserMessage = agentSessionMessageService.getFirstUserMessage(sessionId)
+      const firstUserText = firstUserMessage ? getMainTextContentFromMessageData(firstUserMessage.data) : undefined
+      if (!canAutoRenameAgentSessionName(session.name, firstUserText)) return
       const uniqueModelId = this.resolveNamingModelId()
 
       const structuredConversation: StructuredMessage[] = [
@@ -337,7 +339,7 @@ export class TopicNamingService {
       const nextName = sanitizeConversationTitle(title)
       const latestSession = this.getAgentSession(sessionId, 'latest')
       if (latestSession?.isNameManuallyEdited) return
-      if (!latestSession || !canAutoRenameAgentSessionName(latestSession.name, userText)) return
+      if (!latestSession || !canAutoRenameAgentSessionName(latestSession.name, firstUserText)) return
       if (!nextName || nextName === (latestSession.name ?? '').trim()) return
 
       agentSessionService.update(sessionId, { name: nextName, isNameManuallyEdited: false })

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   getProviderByProviderId: vi.fn(),
   getAgent: vi.fn(),
   getSession: vi.fn(),
+  getFirstUserMessage: vi.fn(),
   updateSession: vi.fn()
 }))
 
@@ -65,6 +66,12 @@ vi.mock('@data/services/AgentSessionService', () => ({
   agentSessionService: {
     getById: mocks.getSession,
     update: mocks.updateSession
+  }
+}))
+
+vi.mock('@data/services/AgentSessionMessageService', () => ({
+  agentSessionMessageService: {
+    getFirstUserMessage: mocks.getFirstUserMessage
   }
 }))
 
@@ -589,6 +596,21 @@ describe('TopicNamingService', () => {
       name: 'Generated Title',
       isNameManuallyEdited: false
     })
+  })
+
+  it.each([
+    ['truncated first-message title', 'x'.repeat(50), false, `${'x'.repeat(50)} later content`, true],
+    ['generated title', 'Generated Title', false, 'First user text', false],
+    ['manual title', 'Manual Title', true, 'First user text', false]
+  ])('reports a %s as auto-naming eligible: %s', (_case, name, isNameManuallyEdited, firstUserText, expected) => {
+    mocks.getSession.mockReturnValue({ id: 'session-1', agentId: 'agent-1', name, isNameManuallyEdited })
+    mocks.getFirstUserMessage.mockReturnValue({
+      id: 'user-1',
+      role: 'user',
+      data: { parts: [{ type: 'text', text: firstUserText }] }
+    })
+
+    expect(createService().canAutoNameAgentSession('session-1')).toBe(expected)
   })
 
   it('allows summary rename after first-message extraction and summary extraction see the same message data', async () => {

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -112,6 +112,11 @@ function mockRenameInputs() {
     role: 'user',
     data: { parts: [{ type: 'text', text: 'Hello there' }] }
   })
+  mocks.getFirstUserMessage.mockReturnValue({
+    id: 'user-1',
+    role: 'user',
+    data: { parts: [{ type: 'text', text: 'User request' }] }
+  })
   mocks.generateText.mockResolvedValue({ text: 'Generated Title' })
 }
 
@@ -598,6 +603,33 @@ describe('TopicNamingService', () => {
     })
   })
 
+  it('uses the first persisted user message to authorize naming after a different retry prompt', async () => {
+    mocks.getSession.mockReturnValue({
+      id: 'session-1',
+      agentId: 'agent-1',
+      name: 'Initial request',
+      isNameManuallyEdited: false
+    })
+    mocks.getFirstUserMessage.mockReturnValue({
+      id: 'user-1',
+      role: 'user',
+      data: { parts: [{ type: 'text', text: 'Initial request' }] }
+    })
+
+    await createService().maybeRenameAgentSession('agent-1', 'session-1', 'Try again', {
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Recovered response' }]
+    } as never)
+
+    expect(mocks.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: expect.stringContaining('"mainText":"Try again"') })
+    )
+    expect(mocks.updateSession).toHaveBeenCalledWith('session-1', {
+      name: 'Generated Title',
+      isNameManuallyEdited: false
+    })
+  })
+
   it.each([
     ['truncated first-message title', 'x'.repeat(50), false, `${'x'.repeat(50)} later content`, true],
     ['generated title', 'Generated Title', false, 'First user text', false],
@@ -640,6 +672,11 @@ describe('TopicNamingService', () => {
       agentId: 'agent-1',
       name: 'first line second line',
       isNameManuallyEdited: false
+    })
+    mocks.getFirstUserMessage.mockReturnValue({
+      id: 'user-1',
+      role: 'user',
+      data: userMessageData
     })
     mocks.generateText.mockResolvedValue({ text: 'Generated Title' })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

If an agent session's first assistant turn ended in an error or pause, only that failed turn retained the automatic naming flag. Later successful turns never retried summary naming, so the session could remain on its 50-character first-message title indefinitely.

After this PR:

Each eligible user dispatch carries the naming decision on its own turn. That decision survives queued follow-ups and steer driver round-trips, while receive-only autonomous persistence has no naming eligibility. Later dispatches reconstruct retry eligibility from the persisted session title and first user message, while generated and manually edited titles remain protected.

Fixes #19964

### Why we need it and why it was done in this way

The persisted temporary title is already the durable state that distinguishes an unfinished naming flow from a generated title. Reusing that invariant restores retries after process restarts without adding a schema field or migration. Keeping eligibility on the concrete user turn prevents background output from consuming it while preserving it across queue and steer transitions.

The following tradeoffs were made:

The runtime consumes the pending attempt when a successful assistant response starts summary naming. If the naming provider itself fails, the existing actionable naming-failure notification is shown; this change does not add automatic background retries for provider failures.

The following alternatives were considered:

Retrying every non-manually-edited session was rejected because generated titles also use `isNameManuallyEdited: false` and would be overwritten. Persisting a separate title-source column was unnecessary because equality with the normalized first-message title already provides the required durable distinction.

Links to places where the discussion took place: #19964

### Breaking changes

None.

### Special notes for your reviewer

- No screenshot is included because this is a main-process persistence/retry fix with no visual component or layout change; it restores the existing title update behavior.
- RED evidence: provider eligibility, busy-queue propagation, and runtime `paused`/`error` recovery cases failed before the implementation.
- Verification: four focused main suites pass (288/288), `pnpm lint`, `pnpm test:lint`, and `git diff --check`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
<!--LANG:en-->
[Agent sessions] Automatic title naming now retries after the first assistant response is paused or fails.
<!--LANG:zh-CN-->
[智能体会话] 首次助手回复暂停或失败后，自动标题命名会在后续成功回复时重试。
<!--LANG:END-->
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to agent-session title naming and runtime flag propagation; no auth or schema migrations, with broad test coverage for edge cases.
> 
> **Overview**
> **Agent session auto-titles can complete on a later successful turn** when the first assistant reply errors or pauses, instead of being tied only to the very first dispatch.
> 
> Dispatch now sets **`shouldAutoName`** from “brand-new session” **or** `TopicNamingService.canAutoNameAgentSession` (session still has a default/truncated-first-message title and was not manually renamed). That flag is carried through **queued follow-ups**, **steer redirect / boundary / undelivered** paths, and into the active turn; after a successful persist, **`maybeRenameAgentSession`** runs once and the turn clears its pending flag so background/receive-only turns do not steal the attempt.
> 
> **Naming authorization** no longer keys off the retry prompt alone: **`getFirstUserMessage`** loads the oldest user row, and rename eligibility compares the session title to that first message while the summary still uses the successful turn’s user/assistant text.
> 
> **`AgentChatContextProvider`** forwards `shouldAutoName` on both `beginTurn` and busy **`enqueueUserMessage`**; tests cover pause/error retry, queue propagation, steer continuations, and receive-only not consuming the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69df4b1eef0e83a041e3987ae0cba5fed5025b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->