### PR TITLE
fix(subagent-resume): route continued subagent content in main process

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -286,6 +286,8 @@ type AgentSessionRuntimeEntry = {
   pendingBackgroundFlowChunks?: Map<string, UIMessageChunk[]>
   /** One continuation accumulator per persisted assistant row receiving detached flow chunks. */
   backgroundFlowAccumulators?: Map<string, BackgroundFlowAccumulator>
+  /** Flow roots whose host row was already looked up and not found — do not re-query the DB. */
+  checkedFlowHostMisses?: Set<string>
   /** Single-flight finalization of the current detached flow batch. */
   backgroundFlowFlush?: Promise<void>
 }
@@ -2045,7 +2047,27 @@ export class AgentSessionRuntimeService extends BaseService {
   ): void {
     if (!this.isCurrentEntry(entry) || (connection && this.currentConnection(entry) !== connection)) return
 
-    const messageId = entry.flowMessageIdsByToolCallId?.get(rootToolCallId)
+    let messageId = entry.flowMessageIdsByToolCallId?.get(rootToolCallId)
+    // A fresh entry (restart or session reopen) has no in-memory anchor. Recover it from the
+    // persisted host row once per root so resumed chunks land on the launch message; the looked-up
+    // rows are already committed, so seeding their accumulator from the DB needs no pending buffer.
+    if (!messageId && !entry.checkedFlowHostMisses?.has(rootToolCallId)) {
+      ;(entry.checkedFlowHostMisses ??= new Set()).add(rootToolCallId)
+      try {
+        const hostMessageId = agentSessionMessageService.findFlowHostMessageId(entry.sessionId, rootToolCallId)
+        if (hostMessageId) {
+          ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(rootToolCallId, hostMessageId)
+          ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
+          messageId = hostMessageId
+        }
+      } catch (error) {
+        logger.warn('Failed to recover flow host row for detached subagent chunk', {
+          sessionId: entry.sessionId,
+          rootToolCallId,
+          error
+        })
+      }
+    }
     if (!messageId) {
       logger.debug('Ignoring detached subagent flow chunk without a persisted message anchor', {
         sessionId: entry.sessionId,

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2083,6 +2083,7 @@ export class AgentSessionRuntimeService extends BaseService {
 
   private enqueueBackgroundFlowChunk(entry: AgentSessionRuntimeEntry, messageId: string, chunk: UIMessageChunk): void {
     const accumulator = this.getOrCreateBackgroundFlowAccumulator(entry, messageId)
+    if (!accumulator) return
     try {
       accumulator.controller.enqueue(chunk)
     } catch (error) {
@@ -2098,17 +2099,37 @@ export class AgentSessionRuntimeService extends BaseService {
   private getOrCreateBackgroundFlowAccumulator(
     entry: AgentSessionRuntimeEntry,
     messageId: string
-  ): BackgroundFlowAccumulator {
+  ): BackgroundFlowAccumulator | null {
     const accumulators = entry.backgroundFlowAccumulators ?? new Map<string, BackgroundFlowAccumulator>()
     entry.backgroundFlowAccumulators = accumulators
     const existing = accumulators.get(messageId)
-    if (existing) return existing
+    // A closed accumulator is mid-drain: reusing it would enqueue into a closed controller and
+    // drop the chunk. Its replacement must be seeded from the predecessor's in-memory overlay —
+    // the persisted row still lags behind it until the pending flush writes, so seeding from the
+    // DB here would drop everything the predecessor drained.
+    if (existing && !existing.closed) return existing
+    const inheritedParts = existing?.latest?.parts as CherryMessagePart[] | undefined
 
-    const persisted = agentSessionMessageService.getSessionMessage(entry.sessionId, messageId)
+    let persistedParts: CherryMessagePart[] | undefined
+    if (!inheritedParts) {
+      let persisted: { id: string; data: { parts?: CherryMessagePart[] } } | undefined
+      try {
+        persisted = agentSessionMessageService.getSessionMessage(entry.sessionId, messageId)
+      } catch (error) {
+        // The row was deleted while its anchors survived a reconnect — the chunk has nowhere to go.
+        logger.warn('Detached subagent flow chunk lost its host message', {
+          sessionId: entry.sessionId,
+          messageId,
+          error
+        })
+        return null
+      }
+      persistedParts = persisted.data.parts ?? []
+    }
     const seed: CherryUIMessage = {
-      id: persisted.id,
+      id: messageId,
       role: 'assistant',
-      parts: structuredClone(persisted.data.parts ?? [])
+      parts: structuredClone(inheritedParts ?? persistedParts ?? [])
     }
     let controller!: ReadableStreamDefaultController<UIMessageChunk>
     const stream = new ReadableStream<UIMessageChunk>({
@@ -2209,23 +2230,40 @@ export class AgentSessionRuntimeService extends BaseService {
 
     const flush = Promise.all(accumulators.map((accumulator) => accumulator.done))
       .then(() => {
-        const completedMessageIds = new Set<string>()
         const completedFlows: Array<{ messageId: string; parts: CherryMessagePart[] }> = []
         for (const accumulator of accumulators) {
           const parts = accumulator.latest?.parts as CherryMessagePart[] | undefined
           if (!parts) continue
-          completedMessageIds.add(accumulator.messageId)
-          agentSessionMessageService.replaceMessageParts(entry.sessionId, accumulator.messageId, parts)
+          try {
+            agentSessionMessageService.replaceMessageParts(entry.sessionId, accumulator.messageId, parts)
+          } catch (error) {
+            // One removed row must not abort the rest of the batch.
+            logger.warn('Failed to persist detached subagent flow parts', {
+              sessionId: entry.sessionId,
+              messageId: accumulator.messageId,
+              error
+            })
+            continue
+          }
           completedFlows.push({ messageId: accumulator.messageId, parts })
         }
 
-        entry.backgroundFlowAccumulators?.clear()
-        for (const [toolCallId, messageId] of entry.flowMessageIdsByToolCallId ?? []) {
-          if (completedMessageIds.has(messageId)) entry.flowMessageIdsByToolCallId?.delete(toolCallId)
+        // Only drop the accumulators this flush closed — one created mid-drain belongs to newer
+        // chunks and must survive, or its content leaks silently.
+        for (const accumulator of accumulators) {
+          if (entry.backgroundFlowAccumulators?.get(accumulator.messageId) === accumulator) {
+            entry.backgroundFlowAccumulators.delete(accumulator.messageId)
+          }
         }
+        // Flow anchors are retained on purpose: a SendMessage resume re-streams under the original
+        // tool-call id after these flows have drained, and must still find its host message.
         if (this.isCurrentEntry(entry)) {
           const cacheService = application.get('CacheService')
           for (const { messageId, parts } of completedFlows) {
+            // A successor created mid-drain publishes fresher overlays for the same row; the stale
+            // handoff must not overwrite them.
+            const successor = entry.backgroundFlowAccumulators?.get(messageId)
+            if (successor && successor.latest) continue
             cacheService.setShared(
               AGENT_SESSION_FLOW_PARTS_CACHE_KEY(entry.sessionId, messageId),
               parts,
@@ -2239,6 +2277,17 @@ export class AgentSessionRuntimeService extends BaseService {
       })
       .finally(() => {
         if (entry.backgroundFlowFlush === flush) entry.backgroundFlowFlush = undefined
+        // A replacement created mid-drain is not in this batch — drain it too, or its chunks stay
+        // unpersisted until some unrelated turn boundary happens to fire. Runs after the
+        // single-flight field clears so the recursive call is not short-circuited by it.
+        const survivors = [...(entry.backgroundFlowAccumulators?.values() ?? [])].filter((a) => !a.closed)
+        if (
+          this.isCurrentEntry(entry) &&
+          survivors.length > 0 &&
+          !hasAgentSessionRuntimeBackgroundWork(entry.runtimeState)
+        ) {
+          void this.finishBackgroundFlows(entry)
+        }
       })
     entry.backgroundFlowFlush = flush
     this.inFlightBackgroundFlowFlushes.set(flush, entry.sessionId)
@@ -2389,8 +2438,10 @@ export class AgentSessionRuntimeService extends BaseService {
   private resetConnectionRuntimeState(entry: AgentSessionRuntimeEntry, connection: AgentRuntimeConnection): void {
     if (!this.isCurrentEntry(entry) || this.currentConnection(entry) !== connection) return
     void this.finishBackgroundFlows(entry)
-    entry.flowMessageIdsByToolCallId?.clear()
-    entry.persistedFlowMessageIds?.clear()
+    // flowMessageIdsByToolCallId and persistedFlowMessageIds are deliberately kept: both record
+    // session facts (which tool call owns which row, and that the row already exists) that do not
+    // change at a connection boundary. Clearing only the persisted gate would buffer resumed
+    // chunks for an existing row into pendingBackgroundFlowChunks forever.
     entry.pendingBackgroundFlowChunks?.clear()
     this.applyRuntimeStateEvent(entry, { type: 'connection-occupancy', occupancy: 'background', active: false })
     if (entry.runtimeState.execution.kind === 'autonomous-turn') {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   saveMessage: vi.fn(),
   replaceMessageParts: vi.fn(),
   getSessionMessage: vi.fn(),
+  findFlowHostMessageId: vi.fn(),
   hasSessionMessage: vi.fn(() => true),
   applyToolApprovalDecision: vi.fn(),
   getLastRuntimeResumeToken: vi.fn(),
@@ -56,6 +57,7 @@ vi.mock('@data/services/AgentSessionMessageService', () => ({
     saveMessage: mocks.saveMessage,
     replaceMessageParts: mocks.replaceMessageParts,
     getSessionMessage: mocks.getSessionMessage,
+    findFlowHostMessageId: mocks.findFlowHostMessageId,
     hasSessionMessage: mocks.hasSessionMessage,
     applyToolApprovalDecision: mocks.applyToolApprovalDecision,
     getLastRuntimeResumeToken: mocks.getLastRuntimeResumeToken,
@@ -256,6 +258,7 @@ describe('AgentSessionRuntimeService', () => {
         ]
       }
     })
+    mocks.findFlowHostMessageId.mockReturnValue(null)
     mocks.applyToolApprovalDecision.mockReturnValue(true)
     mocks.getLastRuntimeResumeToken.mockReturnValue(null)
     mocks.findCrashOrphanedAssistantMessages.mockReturnValue([])
@@ -2265,6 +2268,61 @@ describe('AgentSessionRuntimeService', () => {
           expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
         )
       })
+    })
+
+    it('recovers the flow host row from the database after the entry was rebuilt', async () => {
+      // A fresh entry (restart / session reopen) has no in-memory anchor; the resumed chunks
+      // stream under the original launch tool-call id and must re-anchor to the persisted row.
+      mocks.findFlowHostMessageId.mockReturnValue('assistant-1')
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      for (const chunk of [
+        { type: 'text-start', id: 'resumed-text' },
+        { type: 'text-delta', id: 'resumed-text', delta: 'Resumed findings' },
+        { type: 'text-end', id: 'resumed-text' }
+      ]) {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk
+        })
+      }
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        expect(mocks.findFlowHostMessageId).toHaveBeenCalledWith('session-1', 'task-root')
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
+        )
+      })
+    })
+
+    it('does not re-query the database for flow roots that have no host row', async () => {
+      mocks.findFlowHostMessageId.mockReturnValue(null)
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      const sendChunk = () => {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk: { type: 'text-start', id: 'orphan-text' }
+        })
+      }
+      sendChunk()
+      sendChunk()
+
+      expect(mocks.findFlowHostMessageId).toHaveBeenCalledTimes(1)
+      expect(mocks.replaceMessageParts).not.toHaveBeenCalled()
     })
 
     it('publishes detached flow overlays under independent message keys', () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2208,6 +2208,65 @@ describe('AgentSessionRuntimeService', () => {
       )
     })
 
+    // A SendMessage resume re-streams under the original tool-call id after the first background
+    // flow has drained — the retained anchor is what lets that second generation still land.
+    it('patches resumed subagent chunks onto the spawning message after the first flow drained', async () => {
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit the codebase' }
+        }
+      })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+
+      const sendFlow = (text: string, textId: string) => {
+        for (const chunk of [
+          { type: 'text-start', id: textId },
+          { type: 'text-delta', id: textId, delta: text },
+          { type: 'text-end', id: textId }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+      }
+
+      service.markTurnTerminal('session-1', 'success')
+      sendFlow('First round findings', 'first-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      await vi.waitFor(() => {
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'First round findings' })])
+        )
+      })
+      mocks.replaceMessageParts.mockClear()
+
+      // The resume arrives after the drain that used to delete the anchor.
+      sendFlow('Resumed findings', 'resumed-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
+        )
+      })
+    })
+
     it('publishes detached flow overlays under independent message keys', () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn(baseTurnInput)

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -16,11 +16,22 @@ vi.mock('@logger', () => ({
   }
 }))
 
+const messageServiceMocks = vi.hoisted(() => ({
+  findLaunchToolCallId: vi.fn()
+}))
+
+vi.mock('@data/services/AgentSessionMessageService', () => ({
+  agentSessionMessageService: {
+    findLaunchToolCallId: messageServiceMocks.findLaunchToolCallId
+  }
+}))
+
 const { ClaudeCodeResultError, ClaudeCodeStreamAdapter } = await import('../streamAdapter')
 const { PersistenceListener } = await import('../../../streamManager/listeners/PersistenceListener')
 
 beforeEach(() => {
   vi.clearAllMocks()
+  messageServiceMocks.findLaunchToolCallId.mockReturnValue(null)
 })
 
 /**
@@ -1807,6 +1818,38 @@ describe('ClaudeCodeStreamAdapter', () => {
         description: 'Resumed review'
       })
 
+      const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(last).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_launch' }]
+      })
+    })
+
+    it('recovers the launch root from the database when the adapter starts fresh', () => {
+      // A restarted app builds a new adapter with no in-memory mapping; the first resume edge
+      // must land on the persisted launch tool-use id, not the resuming call.
+      messageServiceMocks.findLaunchToolCallId.mockReturnValue('call_launch')
+      const { adapter, statusEvents } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        tasks: [{ task_id: 'subagent-1', task_type: 'subagent', description: 'Review the patch' }]
+      } as any)
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        task_id: 'subagent-1',
+        tool_use_id: 'call_resume',
+        description: 'Resumed review',
+        task_type: 'subagent'
+      } as any)
+
+      expect(messageServiceMocks.findLaunchToolCallId).toHaveBeenCalledWith('session-1', 'subagent-1')
       const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
       expect(last).toEqual({
         type: 'background-tasks',

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -1586,6 +1586,86 @@ describe('ClaudeCodeStreamAdapter', () => {
       ])
     })
 
+    // A SendMessage to a still-running agent returns the queued form (no resumedAgentId, only
+    // pin.id). Its send call id must still tag that agent's subsequent content for round splitting.
+    it('re-tags content of a running agent from a queued-pin SendMessage receipt', () => {
+      const { adapter, parts } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [{ type: 'tool_use', id: 'launch-use', name: 'Agent', input: { prompt: 'review' } }]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'user',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'launch-use',
+              content: JSON.stringify({ status: 'async_launched', agentId: 'agent-a1b2c3d4e5f6' }),
+              is_error: false
+            }
+          ]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [{ type: 'tool_use', id: 'send-use', name: 'SendMessage', input: { to: 'agent-a1b2c3d4e5f6' } }]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'user',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'send-use',
+              content: JSON.stringify({
+                success: true,
+                message: 'Message queued for delivery to agent-a1b2c3d4e5f6 at its next tool round.',
+                pin: { id: 'agent-a1b2c3d4e5f6', name: 'worker', ref: 'abc' }
+              }),
+              is_error: false
+            }
+          ]
+        }
+      } as any)
+
+      const receiptChunk = parts.find(
+        (chunk) => chunk.type === 'tool-output-available' && chunk.toolCallId === 'send-use'
+      ) as { providerMetadata?: Record<string, Record<string, unknown>> }
+      expect(receiptChunk.providerMetadata?.cherry?.launchToolCallId).toBe('launch-use')
+
+      adapter.handleMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        parent_tool_use_id: 'launch-use',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID()
+      } as any)
+
+      const textStart = parts.filter((chunk) => chunk.type === 'text-start').at(-1) as {
+        providerMetadata?: Record<string, Record<string, unknown>>
+      }
+      expect(textStart.providerMetadata?.['claude-code']?.parentToolCallId).toBe('launch-use')
+      expect(textStart.providerMetadata?.cherry?.resumedViaCallId).toBe('send-use')
+    })
+
     it('enriches a local workflow task from its launch receipt without handling remote agents', () => {
       const { adapter, statusEvents } = createAdapter()
 
@@ -1695,6 +1775,43 @@ describe('ClaudeCodeStreamAdapter', () => {
           ]
         }
       ])
+    })
+
+    // A SendMessage resume re-points lifecycle edges at the resuming call's id; the navigation
+    // anchor must stay on the launch root the content actually streams under.
+    it('keeps the first navigation id for a task when resume edges report a new one', () => {
+      const { adapter, statusEvents } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        tasks: [{ task_id: 'subagent-1', task_type: 'subagent', description: 'Review the patch' }]
+      } as any)
+
+      const started = {
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        task_id: 'subagent-1',
+        tool_use_id: 'call_launch',
+        description: 'Review the patch',
+        task_type: 'subagent'
+      } as any
+      adapter.handleMessage({ ...started, uuid: crypto.randomUUID() })
+      adapter.handleMessage({
+        ...started,
+        uuid: crypto.randomUUID(),
+        tool_use_id: 'call_resume',
+        description: 'Resumed review'
+      })
+
+      const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(last).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_launch' }]
+      })
     })
 
     it('uses local workflow task starts to enrich navigation without changing authoritative membership', () => {

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -34,6 +34,7 @@ import type {
   BetaServerToolUseBlock,
   BetaToolUseBlock
 } from '@anthropic-ai/sdk/resources/beta/messages'
+import { agentSessionMessageService } from '@data/services/AgentSessionMessageService'
 import { loggerService } from '@logger'
 import { extractSystemReminderBodies, SystemReminderTextFilter } from '@main/ai/steerReminder'
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
@@ -1434,7 +1435,10 @@ export class ClaudeCodeStreamAdapter {
   private registerBackgroundTaskToolCallId(taskId: string, toolCallId: string): void {
     // First registration wins: resume edges carry the resuming call's id, not the launch root.
     if (this.backgroundTaskToolCallIds.has(taskId)) return
-    this.backgroundTaskToolCallIds.set(taskId, toolCallId)
+    // A fresh adapter (app restart) has no in-memory mapping: the persisted launch task event is
+    // authoritative and must win over a resume edge that arrives before the launch receipt context.
+    const launchToolCallId = agentSessionMessageService.findLaunchToolCallId(this.sessionId, taskId)
+    this.backgroundTaskToolCallIds.set(taskId, launchToolCallId ?? toolCallId)
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()
   }
 

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -501,6 +501,10 @@ export class ClaudeCodeStreamAdapter {
   /** The latest authoritative level, enriched only by explicit async-launch receipts from this driver. */
   private backgroundTasks: AgentSessionBackgroundTask[] = []
   private readonly backgroundTaskToolCallIds = new Map<string, string>()
+  /** launch root tool-call id → the SendMessage call id that last resumed it. Instance-scoped
+   *  (survives idle flow-context clears) and only-overwrite: resumed content arrives after the
+   *  turn's result, so clearing would strip markers from the bulk of a continued round. */
+  private readonly resumeMarkers = new Map<string, string>()
   /** Parented SDK streams get independent state so subagent text/tool deltas cannot pollute the
    *  main agent's counters. Their sink is detached from the turn when that turn completes. */
   private readonly flowContexts: FlowContext[] = []
@@ -1212,6 +1216,26 @@ export class ClaudeCodeStreamAdapter {
       const taskId = getLaunchedBackgroundTaskId(normalizedResult)
       if (taskId) this.registerBackgroundTaskToolCallId(taskId, result.tool_use_id)
     }
+    // A SendMessage receipt that resumed a background agent carries the launch root id in its
+    // own metadata (so the renderer can navigate without scanning) AND re-tags subsequent
+    // content of that agent for round splitting. Only-overwrite, never clear. A receipt for a
+    // still-running target has no resumedAgentId — its queued form only carries `pin.id`.
+    if (!isError && isRecord(normalizedResult)) {
+      const resumedAgentId =
+        typeof normalizedResult.resumedAgentId === 'string'
+          ? normalizedResult.resumedAgentId
+          : isRecord(normalizedResult.pin) && typeof normalizedResult.pin.id === 'string'
+            ? normalizedResult.pin.id
+            : undefined
+      if (resumedAgentId) {
+        const launchToolCallId = this.backgroundTaskToolCallIds.get(resumedAgentId)
+        if (launchToolCallId) {
+          this.resumeMarkers.set(launchToolCallId, result.tool_use_id)
+          const cherry = providerMetadata.cherry as Record<string, unknown>
+          cherry.launchToolCallId = launchToolCallId
+        }
+      }
+    }
     if (ctx.deniedToolUseIds.has(result.tool_use_id)) {
       // The chunk schema is strict — `toolCallId` is the only accepted field, so the rejection
       // text stays in the log written by `handlePermissionDeniedSystemMessage`.
@@ -1408,7 +1432,8 @@ export class ClaudeCodeStreamAdapter {
   }
 
   private registerBackgroundTaskToolCallId(taskId: string, toolCallId: string): void {
-    if (this.backgroundTaskToolCallIds.get(taskId) === toolCallId) return
+    // First registration wins: resume edges carry the resuming call's id, not the launch root.
+    if (this.backgroundTaskToolCallIds.has(taskId)) return
     this.backgroundTaskToolCallIds.set(taskId, toolCallId)
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()
   }
@@ -1790,17 +1815,20 @@ export class ClaudeCodeStreamAdapter {
 
   private buildParentProviderMetadata(sdkParentToolUseId: SdkParentToolUseId): Record<string, JSONObject> | undefined {
     if (!sdkParentToolUseId) return undefined
+    const resumedViaCallId = this.resumeMarkers.get(sdkParentToolUseId)
     return {
       'claude-code': {
         parentToolCallId: sdkParentToolUseId
       },
       cherry: {
-        transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport
+        transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport,
+        ...(resumedViaCallId ? { resumedViaCallId } : {})
       }
     }
   }
 
   private buildToolProviderMetadata(state: ToolStreamState): Record<string, JSONObject> {
+    const resumedViaCallId = state.parentToolCallId ? this.resumeMarkers.get(state.parentToolCallId) : undefined
     const claudeCode: JSONObject = {
       parentToolCallId: state.parentToolCallId ?? null,
       ...(state.sdkBlockType ? { sdkBlockType: state.sdkBlockType } : {}),
@@ -1812,6 +1840,7 @@ export class ClaudeCodeStreamAdapter {
       'claude-code': claudeCode,
       cherry: {
         transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport,
+        ...(resumedViaCallId ? { resumedViaCallId } : {}),
         tool: {
           type: state.toolType ?? 'provider',
           ...(state.displayName ? { name: state.displayName } : {}),

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -712,6 +712,42 @@ export class AgentSessionMessageService {
   }
 
   /**
+   * The launch tool-use id for a background task, recovered from the persisted task event part of
+   * its earliest assistant row. A fresh adapter (app restart) has no in-memory task→tool-call
+   * mapping; resume edges then carry the resuming call's id, which must not displace the launch
+   * root every entry resolves to.
+   */
+  findLaunchToolCallId(sessionId: string, taskId: string): string | null {
+    const database = application.get('DbService').getDb()
+    const row = database
+      .select({
+        toolUseId: sql<string>`(
+          select json_extract(part.value, '$.data.toolUseId')
+          from json_each(${sessionMessagesTable.data}, '$.parts') as part
+          where json_extract(part.value, '$.type') = 'data-agent-task-event'
+            and json_extract(part.value, '$.data.taskId') = ${taskId}
+          limit 1
+        )`
+      })
+      .from(sessionMessagesTable)
+      .where(
+        and(
+          eq(sessionMessagesTable.sessionId, sessionId),
+          eq(sessionMessagesTable.role, 'assistant'),
+          sql`EXISTS (
+            select 1 from json_each(${sessionMessagesTable.data}, '$.parts') as part
+            where json_extract(part.value, '$.type') = 'data-agent-task-event'
+              and json_extract(part.value, '$.data.taskId') = ${taskId}
+          )`
+        )
+      )
+      .orderBy(asc(sessionMessagesTable.createdAt), asc(sessionMessagesTable.id))
+      .limit(1)
+      .all()
+    return row[0]?.toolUseId ?? null
+  }
+
+  /**
    * Boot reconcile of crash-orphaned `pending` rows: resolve each row to `error` (with the
    * caller's terminalized `data`) and discard the affected sessions' resume tokens, atomically.
    * A crashed turn leaves the external CLI session in an untrusted state — resuming it can replay

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -56,7 +56,7 @@ import {
 } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { isToolUIPart } from 'ai'
-import { and, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, type SQL, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, type SQL, sql } from 'drizzle-orm'
 import { v4 as uuidv4, v7 as uuidv7, validate as isUuid } from 'uuid'
 
 import { aiUsageRecordService, mergeMessageRuntimeStats } from './AiUsageRecordService'
@@ -682,6 +682,33 @@ export class AgentSessionMessageService {
         )
       )
       .all()
+  }
+
+  /**
+   * The assistant host row whose parts contain `rootToolCallId`, for a fresh runtime entry (after
+   * a process restart or session reopen) to re-anchor detached subagent flow chunks to the launch
+   * message. The launch part is the earliest row carrying the id, so ascending creation order and
+   * LIMIT 1 pick it.
+   */
+  findFlowHostMessageId(sessionId: string, rootToolCallId: string): string | null {
+    const database = application.get('DbService').getDb()
+    const row = database
+      .select({ id: sessionMessagesTable.id })
+      .from(sessionMessagesTable)
+      .where(
+        and(
+          eq(sessionMessagesTable.sessionId, sessionId),
+          eq(sessionMessagesTable.role, 'assistant'),
+          sql<boolean>`exists (
+            select 1 from json_each(${sessionMessagesTable.data}, '$.parts') as part
+            where json_extract(part.value, '$.toolCallId') = ${rootToolCallId}
+          )`
+        )
+      )
+      .orderBy(asc(sessionMessagesTable.createdAt))
+      .limit(1)
+      .all()
+    return row[0]?.id ?? null
   }
 
   /**

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -552,6 +552,51 @@ describe('AgentSessionMessageService', () => {
     })
   })
 
+  describe('findFlowHostMessageId (restart anchor recovery)', () => {
+    const HOST = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d030'
+    const lateHostPart = () => ({
+      type: 'tool-Agent' as const,
+      toolCallId: 'root-1',
+      state: 'input-available' as const,
+      input: { prompt: 'Audit' }
+    })
+
+    it('finds the assistant row whose parts carry the launch tool call id', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: HOST, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBe(HOST)
+    })
+
+    it('returns null when no assistant row carries the id (user rows are not hosts)', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: HOST, role: 'user', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBeNull()
+    })
+
+    it('returns the earliest row when several carry the same id', async () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+      const EARLY = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d031'
+      const LATE = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d032'
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: EARLY, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+      now.mockReturnValue(2_000)
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: LATE, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBe(EARLY)
+    })
+  })
+
   it('atomically settles a persisted background tool approval with the user-updated input', () => {
     const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
     agentSessionMessageService.saveMessage({

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -552,6 +552,70 @@ describe('AgentSessionMessageService', () => {
     })
   })
 
+  describe('findLaunchToolCallId (fresh-adapter task root recovery)', () => {
+    const ROOT = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d033'
+    const taskEventPart = (taskId: string, toolUseId: string) => ({
+      type: 'data-agent-task-event' as const,
+      data: { taskId, toolUseId, event: 'started' as const, status: 'in_progress' as const }
+    })
+
+    it('returns the launch tool-use id from the earliest task event row', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: ROOT,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBe('launch-use')
+    })
+
+    it('returns null when no assistant row carries the task id (user rows are ignored)', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: ROOT,
+          role: 'user',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBeNull()
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-other')).toBeNull()
+    })
+
+    it('prefers the earliest row when several carry the same task id', async () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+      const EARLY = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d034'
+      const LATE = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d035'
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: EARLY,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+      now.mockReturnValue(2_000)
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: LATE,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'resume-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBe('launch-use')
+    })
+  })
+
   describe('findFlowHostMessageId (restart anchor recovery)', () => {
     const HOST = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d030'
     const lateHostPart = () => ({


### PR DESCRIPTION
### What this PR does

**Stacked chain — layer 1 of 3.** This PR fixes the main-process data routing for resumed (continued) subagents. The Claude Code CLI re-streams a continued agent under its **original launch tool-use id** while its lifecycle edges carry the **resuming call id**; when that mapping is lost or overwritten, resumed content is dropped, buffered forever, or persisted under the wrong row.

Before this PR (in the main process):

- The flow anchor map (`flowMessageIdsByToolCallId`) was **deleted after each drain** and **cleared on connection reset**, so a `SendMessage` resume that re-streams under the launch id could no longer find its host message — its chunks were dropped with only a debug log.
- A background-flow accumulator whose drain was settling was **reused** (`enqueue` into a closed controller), silently losing chunks; a replacement created mid-drain was never drained itself.
- The task→tool-call registration **overwrote on different value**, so a resume edge (carrying the resuming call id) displaced the launch root.
- After an **app restart**, no in-memory mapping existed at all: resumed chunks under the launch id had nowhere to go, and the task chip / resume receipt stamp resolved to the resuming call instead of the launch root.

After this PR:

- Flow anchors survive drain and connection resets — resumed content keeps landing on its spawning message.
- Closed accumulators are never reused; mid-drain replacements inherit the predecessor's overlay and are drained too.
- Task→tool-call registration is **first-registration-wins**; the adapter stamps `cherry.launchToolCallId` / `cherry.resumedViaCallId` onto resume receipts and resumed content.
- Fresh adapters (restart / reopen) **recover both anchors from the database**: the flow host row for the launch tool-call id (`findFlowHostMessageId`) and the launch tool-use id for a task (`findLaunchToolCallId`, read from the persisted `data-agent-task-event` part), so the launch root wins regardless of edge order.

### Why we need it and why it was done in this way

The resumed CLI keeps streaming under the original launch tool-use id; we cannot change the protocol, so the app converges on the launch id as the single identity and persists enough state to recover it after any process boundary.

The following tradeoffs were made:

- Recovery reads (`findFlowHostMessageId`, `findLaunchToolCallId`) are synchronous SQLite `json_each` scans constrained by the session index, executed at most once per (entry, root) / (adapter, task) — constant cost on the hot path.
- Launch-task recovery prefers the persisted task event (`data-agent-task-event.toolUseId`) over parsing launch receipt text — the SDK's launch output is a plain string trailer in this CLI version, with no structured fields (verified against real database data).

The following alternatives were considered:

- Persisting a `taskId → launch toolCallId` map in a new DB table — not justified for presentation state; the existing message rows already carry the truth.
- Blocking mid-run `SendMessage` via `canUseTool` — rejected: needs a name→running-state map that does not exist and risks mis-blocking reliable resumes.

Fixes #

### Breaking changes

NONE — all changes are additive to retained in-memory state and to `providerMetadata.cherry` fields; no schema, IPC or API surface changes.

### Special notes for your reviewer

This is **layer 1 of a stacked chain**: layer 2 (resume receipt presentation in the chat stream, `pr-b`) and layer 3 (flow view timeline, `pr-c`) build on this one. The two DB recovery methods are exercised with real-DB tests (`setupTestDatabase`); the adapter recovery is covered by a fresh-instance test asserting the launch root wins over a resume edge.

Acceptance: after a subagent round completes, a `SendMessage` resume's content is persisted under the launch host row (grows in `agent_session_message.parts`), including across an app restart.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Continued sub-agent content is now reliably saved: resuming a finished sub-agent (even after quitting and reopening the app) no longer loses its new rounds inside the sub-agent's own session record.
```
