### PR TITLE
fix(subagent-resume): flow view shows the resumed agent's whole timeline

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -286,6 +286,8 @@ type AgentSessionRuntimeEntry = {
   pendingBackgroundFlowChunks?: Map<string, UIMessageChunk[]>
   /** One continuation accumulator per persisted assistant row receiving detached flow chunks. */
   backgroundFlowAccumulators?: Map<string, BackgroundFlowAccumulator>
+  /** Flow roots whose host row was already looked up and not found — do not re-query the DB. */
+  checkedFlowHostMisses?: Set<string>
   /** Single-flight finalization of the current detached flow batch. */
   backgroundFlowFlush?: Promise<void>
 }
@@ -2045,7 +2047,27 @@ export class AgentSessionRuntimeService extends BaseService {
   ): void {
     if (!this.isCurrentEntry(entry) || (connection && this.currentConnection(entry) !== connection)) return
 
-    const messageId = entry.flowMessageIdsByToolCallId?.get(rootToolCallId)
+    let messageId = entry.flowMessageIdsByToolCallId?.get(rootToolCallId)
+    // A fresh entry (restart or session reopen) has no in-memory anchor. Recover it from the
+    // persisted host row once per root so resumed chunks land on the launch message; the looked-up
+    // rows are already committed, so seeding their accumulator from the DB needs no pending buffer.
+    if (!messageId && !entry.checkedFlowHostMisses?.has(rootToolCallId)) {
+      ;(entry.checkedFlowHostMisses ??= new Set()).add(rootToolCallId)
+      try {
+        const hostMessageId = agentSessionMessageService.findFlowHostMessageId(entry.sessionId, rootToolCallId)
+        if (hostMessageId) {
+          ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(rootToolCallId, hostMessageId)
+          ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
+          messageId = hostMessageId
+        }
+      } catch (error) {
+        logger.warn('Failed to recover flow host row for detached subagent chunk', {
+          sessionId: entry.sessionId,
+          rootToolCallId,
+          error
+        })
+      }
+    }
     if (!messageId) {
       logger.debug('Ignoring detached subagent flow chunk without a persisted message anchor', {
         sessionId: entry.sessionId,

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2083,6 +2083,7 @@ export class AgentSessionRuntimeService extends BaseService {
 
   private enqueueBackgroundFlowChunk(entry: AgentSessionRuntimeEntry, messageId: string, chunk: UIMessageChunk): void {
     const accumulator = this.getOrCreateBackgroundFlowAccumulator(entry, messageId)
+    if (!accumulator) return
     try {
       accumulator.controller.enqueue(chunk)
     } catch (error) {
@@ -2098,17 +2099,37 @@ export class AgentSessionRuntimeService extends BaseService {
   private getOrCreateBackgroundFlowAccumulator(
     entry: AgentSessionRuntimeEntry,
     messageId: string
-  ): BackgroundFlowAccumulator {
+  ): BackgroundFlowAccumulator | null {
     const accumulators = entry.backgroundFlowAccumulators ?? new Map<string, BackgroundFlowAccumulator>()
     entry.backgroundFlowAccumulators = accumulators
     const existing = accumulators.get(messageId)
-    if (existing) return existing
+    // A closed accumulator is mid-drain: reusing it would enqueue into a closed controller and
+    // drop the chunk. Its replacement must be seeded from the predecessor's in-memory overlay —
+    // the persisted row still lags behind it until the pending flush writes, so seeding from the
+    // DB here would drop everything the predecessor drained.
+    if (existing && !existing.closed) return existing
+    const inheritedParts = existing?.latest?.parts as CherryMessagePart[] | undefined
 
-    const persisted = agentSessionMessageService.getSessionMessage(entry.sessionId, messageId)
+    let persistedParts: CherryMessagePart[] | undefined
+    if (!inheritedParts) {
+      let persisted: { id: string; data: { parts?: CherryMessagePart[] } } | undefined
+      try {
+        persisted = agentSessionMessageService.getSessionMessage(entry.sessionId, messageId)
+      } catch (error) {
+        // The row was deleted while its anchors survived a reconnect — the chunk has nowhere to go.
+        logger.warn('Detached subagent flow chunk lost its host message', {
+          sessionId: entry.sessionId,
+          messageId,
+          error
+        })
+        return null
+      }
+      persistedParts = persisted.data.parts ?? []
+    }
     const seed: CherryUIMessage = {
-      id: persisted.id,
+      id: messageId,
       role: 'assistant',
-      parts: structuredClone(persisted.data.parts ?? [])
+      parts: structuredClone(inheritedParts ?? persistedParts ?? [])
     }
     let controller!: ReadableStreamDefaultController<UIMessageChunk>
     const stream = new ReadableStream<UIMessageChunk>({
@@ -2209,23 +2230,40 @@ export class AgentSessionRuntimeService extends BaseService {
 
     const flush = Promise.all(accumulators.map((accumulator) => accumulator.done))
       .then(() => {
-        const completedMessageIds = new Set<string>()
         const completedFlows: Array<{ messageId: string; parts: CherryMessagePart[] }> = []
         for (const accumulator of accumulators) {
           const parts = accumulator.latest?.parts as CherryMessagePart[] | undefined
           if (!parts) continue
-          completedMessageIds.add(accumulator.messageId)
-          agentSessionMessageService.replaceMessageParts(entry.sessionId, accumulator.messageId, parts)
+          try {
+            agentSessionMessageService.replaceMessageParts(entry.sessionId, accumulator.messageId, parts)
+          } catch (error) {
+            // One removed row must not abort the rest of the batch.
+            logger.warn('Failed to persist detached subagent flow parts', {
+              sessionId: entry.sessionId,
+              messageId: accumulator.messageId,
+              error
+            })
+            continue
+          }
           completedFlows.push({ messageId: accumulator.messageId, parts })
         }
 
-        entry.backgroundFlowAccumulators?.clear()
-        for (const [toolCallId, messageId] of entry.flowMessageIdsByToolCallId ?? []) {
-          if (completedMessageIds.has(messageId)) entry.flowMessageIdsByToolCallId?.delete(toolCallId)
+        // Only drop the accumulators this flush closed — one created mid-drain belongs to newer
+        // chunks and must survive, or its content leaks silently.
+        for (const accumulator of accumulators) {
+          if (entry.backgroundFlowAccumulators?.get(accumulator.messageId) === accumulator) {
+            entry.backgroundFlowAccumulators.delete(accumulator.messageId)
+          }
         }
+        // Flow anchors are retained on purpose: a SendMessage resume re-streams under the original
+        // tool-call id after these flows have drained, and must still find its host message.
         if (this.isCurrentEntry(entry)) {
           const cacheService = application.get('CacheService')
           for (const { messageId, parts } of completedFlows) {
+            // A successor created mid-drain publishes fresher overlays for the same row; the stale
+            // handoff must not overwrite them.
+            const successor = entry.backgroundFlowAccumulators?.get(messageId)
+            if (successor && successor.latest) continue
             cacheService.setShared(
               AGENT_SESSION_FLOW_PARTS_CACHE_KEY(entry.sessionId, messageId),
               parts,
@@ -2239,6 +2277,17 @@ export class AgentSessionRuntimeService extends BaseService {
       })
       .finally(() => {
         if (entry.backgroundFlowFlush === flush) entry.backgroundFlowFlush = undefined
+        // A replacement created mid-drain is not in this batch — drain it too, or its chunks stay
+        // unpersisted until some unrelated turn boundary happens to fire. Runs after the
+        // single-flight field clears so the recursive call is not short-circuited by it.
+        const survivors = [...(entry.backgroundFlowAccumulators?.values() ?? [])].filter((a) => !a.closed)
+        if (
+          this.isCurrentEntry(entry) &&
+          survivors.length > 0 &&
+          !hasAgentSessionRuntimeBackgroundWork(entry.runtimeState)
+        ) {
+          void this.finishBackgroundFlows(entry)
+        }
       })
     entry.backgroundFlowFlush = flush
     this.inFlightBackgroundFlowFlushes.set(flush, entry.sessionId)
@@ -2389,8 +2438,10 @@ export class AgentSessionRuntimeService extends BaseService {
   private resetConnectionRuntimeState(entry: AgentSessionRuntimeEntry, connection: AgentRuntimeConnection): void {
     if (!this.isCurrentEntry(entry) || this.currentConnection(entry) !== connection) return
     void this.finishBackgroundFlows(entry)
-    entry.flowMessageIdsByToolCallId?.clear()
-    entry.persistedFlowMessageIds?.clear()
+    // flowMessageIdsByToolCallId and persistedFlowMessageIds are deliberately kept: both record
+    // session facts (which tool call owns which row, and that the row already exists) that do not
+    // change at a connection boundary. Clearing only the persisted gate would buffer resumed
+    // chunks for an existing row into pendingBackgroundFlowChunks forever.
     entry.pendingBackgroundFlowChunks?.clear()
     this.applyRuntimeStateEvent(entry, { type: 'connection-occupancy', occupancy: 'background', active: false })
     if (entry.runtimeState.execution.kind === 'autonomous-turn') {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   saveMessage: vi.fn(),
   replaceMessageParts: vi.fn(),
   getSessionMessage: vi.fn(),
+  findFlowHostMessageId: vi.fn(),
   hasSessionMessage: vi.fn(() => true),
   applyToolApprovalDecision: vi.fn(),
   getLastRuntimeResumeToken: vi.fn(),
@@ -56,6 +57,7 @@ vi.mock('@data/services/AgentSessionMessageService', () => ({
     saveMessage: mocks.saveMessage,
     replaceMessageParts: mocks.replaceMessageParts,
     getSessionMessage: mocks.getSessionMessage,
+    findFlowHostMessageId: mocks.findFlowHostMessageId,
     hasSessionMessage: mocks.hasSessionMessage,
     applyToolApprovalDecision: mocks.applyToolApprovalDecision,
     getLastRuntimeResumeToken: mocks.getLastRuntimeResumeToken,
@@ -256,6 +258,7 @@ describe('AgentSessionRuntimeService', () => {
         ]
       }
     })
+    mocks.findFlowHostMessageId.mockReturnValue(null)
     mocks.applyToolApprovalDecision.mockReturnValue(true)
     mocks.getLastRuntimeResumeToken.mockReturnValue(null)
     mocks.findCrashOrphanedAssistantMessages.mockReturnValue([])
@@ -2265,6 +2268,61 @@ describe('AgentSessionRuntimeService', () => {
           expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
         )
       })
+    })
+
+    it('recovers the flow host row from the database after the entry was rebuilt', async () => {
+      // A fresh entry (restart / session reopen) has no in-memory anchor; the resumed chunks
+      // stream under the original launch tool-call id and must re-anchor to the persisted row.
+      mocks.findFlowHostMessageId.mockReturnValue('assistant-1')
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      for (const chunk of [
+        { type: 'text-start', id: 'resumed-text' },
+        { type: 'text-delta', id: 'resumed-text', delta: 'Resumed findings' },
+        { type: 'text-end', id: 'resumed-text' }
+      ]) {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk
+        })
+      }
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        expect(mocks.findFlowHostMessageId).toHaveBeenCalledWith('session-1', 'task-root')
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
+        )
+      })
+    })
+
+    it('does not re-query the database for flow roots that have no host row', async () => {
+      mocks.findFlowHostMessageId.mockReturnValue(null)
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      const sendChunk = () => {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk: { type: 'text-start', id: 'orphan-text' }
+        })
+      }
+      sendChunk()
+      sendChunk()
+
+      expect(mocks.findFlowHostMessageId).toHaveBeenCalledTimes(1)
+      expect(mocks.replaceMessageParts).not.toHaveBeenCalled()
     })
 
     it('publishes detached flow overlays under independent message keys', () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2208,6 +2208,65 @@ describe('AgentSessionRuntimeService', () => {
       )
     })
 
+    // A SendMessage resume re-streams under the original tool-call id after the first background
+    // flow has drained — the retained anchor is what lets that second generation still land.
+    it('patches resumed subagent chunks onto the spawning message after the first flow drained', async () => {
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit the codebase' }
+        }
+      })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+
+      const sendFlow = (text: string, textId: string) => {
+        for (const chunk of [
+          { type: 'text-start', id: textId },
+          { type: 'text-delta', id: textId, delta: text },
+          { type: 'text-end', id: textId }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+      }
+
+      service.markTurnTerminal('session-1', 'success')
+      sendFlow('First round findings', 'first-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      await vi.waitFor(() => {
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'First round findings' })])
+        )
+      })
+      mocks.replaceMessageParts.mockClear()
+
+      // The resume arrives after the drain that used to delete the anchor.
+      sendFlow('Resumed findings', 'resumed-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
+        )
+      })
+    })
+
     it('publishes detached flow overlays under independent message keys', () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn(baseTurnInput)

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -16,11 +16,22 @@ vi.mock('@logger', () => ({
   }
 }))
 
+const messageServiceMocks = vi.hoisted(() => ({
+  findLaunchToolCallId: vi.fn()
+}))
+
+vi.mock('@data/services/AgentSessionMessageService', () => ({
+  agentSessionMessageService: {
+    findLaunchToolCallId: messageServiceMocks.findLaunchToolCallId
+  }
+}))
+
 const { ClaudeCodeResultError, ClaudeCodeStreamAdapter } = await import('../streamAdapter')
 const { PersistenceListener } = await import('../../../streamManager/listeners/PersistenceListener')
 
 beforeEach(() => {
   vi.clearAllMocks()
+  messageServiceMocks.findLaunchToolCallId.mockReturnValue(null)
 })
 
 /**
@@ -1807,6 +1818,38 @@ describe('ClaudeCodeStreamAdapter', () => {
         description: 'Resumed review'
       })
 
+      const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(last).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_launch' }]
+      })
+    })
+
+    it('recovers the launch root from the database when the adapter starts fresh', () => {
+      // A restarted app builds a new adapter with no in-memory mapping; the first resume edge
+      // must land on the persisted launch tool-use id, not the resuming call.
+      messageServiceMocks.findLaunchToolCallId.mockReturnValue('call_launch')
+      const { adapter, statusEvents } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        tasks: [{ task_id: 'subagent-1', task_type: 'subagent', description: 'Review the patch' }]
+      } as any)
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        task_id: 'subagent-1',
+        tool_use_id: 'call_resume',
+        description: 'Resumed review',
+        task_type: 'subagent'
+      } as any)
+
+      expect(messageServiceMocks.findLaunchToolCallId).toHaveBeenCalledWith('session-1', 'subagent-1')
       const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
       expect(last).toEqual({
         type: 'background-tasks',

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -1586,6 +1586,86 @@ describe('ClaudeCodeStreamAdapter', () => {
       ])
     })
 
+    // A SendMessage to a still-running agent returns the queued form (no resumedAgentId, only
+    // pin.id). Its send call id must still tag that agent's subsequent content for round splitting.
+    it('re-tags content of a running agent from a queued-pin SendMessage receipt', () => {
+      const { adapter, parts } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [{ type: 'tool_use', id: 'launch-use', name: 'Agent', input: { prompt: 'review' } }]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'user',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'launch-use',
+              content: JSON.stringify({ status: 'async_launched', agentId: 'agent-a1b2c3d4e5f6' }),
+              is_error: false
+            }
+          ]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [{ type: 'tool_use', id: 'send-use', name: 'SendMessage', input: { to: 'agent-a1b2c3d4e5f6' } }]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'user',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'send-use',
+              content: JSON.stringify({
+                success: true,
+                message: 'Message queued for delivery to agent-a1b2c3d4e5f6 at its next tool round.',
+                pin: { id: 'agent-a1b2c3d4e5f6', name: 'worker', ref: 'abc' }
+              }),
+              is_error: false
+            }
+          ]
+        }
+      } as any)
+
+      const receiptChunk = parts.find(
+        (chunk) => chunk.type === 'tool-output-available' && chunk.toolCallId === 'send-use'
+      ) as { providerMetadata?: Record<string, Record<string, unknown>> }
+      expect(receiptChunk.providerMetadata?.cherry?.launchToolCallId).toBe('launch-use')
+
+      adapter.handleMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        parent_tool_use_id: 'launch-use',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID()
+      } as any)
+
+      const textStart = parts.filter((chunk) => chunk.type === 'text-start').at(-1) as {
+        providerMetadata?: Record<string, Record<string, unknown>>
+      }
+      expect(textStart.providerMetadata?.['claude-code']?.parentToolCallId).toBe('launch-use')
+      expect(textStart.providerMetadata?.cherry?.resumedViaCallId).toBe('send-use')
+    })
+
     it('enriches a local workflow task from its launch receipt without handling remote agents', () => {
       const { adapter, statusEvents } = createAdapter()
 
@@ -1695,6 +1775,43 @@ describe('ClaudeCodeStreamAdapter', () => {
           ]
         }
       ])
+    })
+
+    // A SendMessage resume re-points lifecycle edges at the resuming call's id; the navigation
+    // anchor must stay on the launch root the content actually streams under.
+    it('keeps the first navigation id for a task when resume edges report a new one', () => {
+      const { adapter, statusEvents } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        tasks: [{ task_id: 'subagent-1', task_type: 'subagent', description: 'Review the patch' }]
+      } as any)
+
+      const started = {
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        task_id: 'subagent-1',
+        tool_use_id: 'call_launch',
+        description: 'Review the patch',
+        task_type: 'subagent'
+      } as any
+      adapter.handleMessage({ ...started, uuid: crypto.randomUUID() })
+      adapter.handleMessage({
+        ...started,
+        uuid: crypto.randomUUID(),
+        tool_use_id: 'call_resume',
+        description: 'Resumed review'
+      })
+
+      const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(last).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_launch' }]
+      })
     })
 
     it('uses local workflow task starts to enrich navigation without changing authoritative membership', () => {

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -34,6 +34,7 @@ import type {
   BetaServerToolUseBlock,
   BetaToolUseBlock
 } from '@anthropic-ai/sdk/resources/beta/messages'
+import { agentSessionMessageService } from '@data/services/AgentSessionMessageService'
 import { loggerService } from '@logger'
 import { extractSystemReminderBodies, SystemReminderTextFilter } from '@main/ai/steerReminder'
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
@@ -1434,7 +1435,10 @@ export class ClaudeCodeStreamAdapter {
   private registerBackgroundTaskToolCallId(taskId: string, toolCallId: string): void {
     // First registration wins: resume edges carry the resuming call's id, not the launch root.
     if (this.backgroundTaskToolCallIds.has(taskId)) return
-    this.backgroundTaskToolCallIds.set(taskId, toolCallId)
+    // A fresh adapter (app restart) has no in-memory mapping: the persisted launch task event is
+    // authoritative and must win over a resume edge that arrives before the launch receipt context.
+    const launchToolCallId = agentSessionMessageService.findLaunchToolCallId(this.sessionId, taskId)
+    this.backgroundTaskToolCallIds.set(taskId, launchToolCallId ?? toolCallId)
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()
   }
 

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -501,6 +501,10 @@ export class ClaudeCodeStreamAdapter {
   /** The latest authoritative level, enriched only by explicit async-launch receipts from this driver. */
   private backgroundTasks: AgentSessionBackgroundTask[] = []
   private readonly backgroundTaskToolCallIds = new Map<string, string>()
+  /** launch root tool-call id → the SendMessage call id that last resumed it. Instance-scoped
+   *  (survives idle flow-context clears) and only-overwrite: resumed content arrives after the
+   *  turn's result, so clearing would strip markers from the bulk of a continued round. */
+  private readonly resumeMarkers = new Map<string, string>()
   /** Parented SDK streams get independent state so subagent text/tool deltas cannot pollute the
    *  main agent's counters. Their sink is detached from the turn when that turn completes. */
   private readonly flowContexts: FlowContext[] = []
@@ -1212,6 +1216,26 @@ export class ClaudeCodeStreamAdapter {
       const taskId = getLaunchedBackgroundTaskId(normalizedResult)
       if (taskId) this.registerBackgroundTaskToolCallId(taskId, result.tool_use_id)
     }
+    // A SendMessage receipt that resumed a background agent carries the launch root id in its
+    // own metadata (so the renderer can navigate without scanning) AND re-tags subsequent
+    // content of that agent for round splitting. Only-overwrite, never clear. A receipt for a
+    // still-running target has no resumedAgentId — its queued form only carries `pin.id`.
+    if (!isError && isRecord(normalizedResult)) {
+      const resumedAgentId =
+        typeof normalizedResult.resumedAgentId === 'string'
+          ? normalizedResult.resumedAgentId
+          : isRecord(normalizedResult.pin) && typeof normalizedResult.pin.id === 'string'
+            ? normalizedResult.pin.id
+            : undefined
+      if (resumedAgentId) {
+        const launchToolCallId = this.backgroundTaskToolCallIds.get(resumedAgentId)
+        if (launchToolCallId) {
+          this.resumeMarkers.set(launchToolCallId, result.tool_use_id)
+          const cherry = providerMetadata.cherry as Record<string, unknown>
+          cherry.launchToolCallId = launchToolCallId
+        }
+      }
+    }
     if (ctx.deniedToolUseIds.has(result.tool_use_id)) {
       // The chunk schema is strict — `toolCallId` is the only accepted field, so the rejection
       // text stays in the log written by `handlePermissionDeniedSystemMessage`.
@@ -1408,7 +1432,8 @@ export class ClaudeCodeStreamAdapter {
   }
 
   private registerBackgroundTaskToolCallId(taskId: string, toolCallId: string): void {
-    if (this.backgroundTaskToolCallIds.get(taskId) === toolCallId) return
+    // First registration wins: resume edges carry the resuming call's id, not the launch root.
+    if (this.backgroundTaskToolCallIds.has(taskId)) return
     this.backgroundTaskToolCallIds.set(taskId, toolCallId)
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()
   }
@@ -1790,17 +1815,20 @@ export class ClaudeCodeStreamAdapter {
 
   private buildParentProviderMetadata(sdkParentToolUseId: SdkParentToolUseId): Record<string, JSONObject> | undefined {
     if (!sdkParentToolUseId) return undefined
+    const resumedViaCallId = this.resumeMarkers.get(sdkParentToolUseId)
     return {
       'claude-code': {
         parentToolCallId: sdkParentToolUseId
       },
       cherry: {
-        transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport
+        transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport,
+        ...(resumedViaCallId ? { resumedViaCallId } : {})
       }
     }
   }
 
   private buildToolProviderMetadata(state: ToolStreamState): Record<string, JSONObject> {
+    const resumedViaCallId = state.parentToolCallId ? this.resumeMarkers.get(state.parentToolCallId) : undefined
     const claudeCode: JSONObject = {
       parentToolCallId: state.parentToolCallId ?? null,
       ...(state.sdkBlockType ? { sdkBlockType: state.sdkBlockType } : {}),
@@ -1812,6 +1840,7 @@ export class ClaudeCodeStreamAdapter {
       'claude-code': claudeCode,
       cherry: {
         transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport,
+        ...(resumedViaCallId ? { resumedViaCallId } : {}),
         tool: {
           type: state.toolType ?? 'provider',
           ...(state.displayName ? { name: state.displayName } : {}),

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -712,6 +712,42 @@ export class AgentSessionMessageService {
   }
 
   /**
+   * The launch tool-use id for a background task, recovered from the persisted task event part of
+   * its earliest assistant row. A fresh adapter (app restart) has no in-memory task→tool-call
+   * mapping; resume edges then carry the resuming call's id, which must not displace the launch
+   * root every entry resolves to.
+   */
+  findLaunchToolCallId(sessionId: string, taskId: string): string | null {
+    const database = application.get('DbService').getDb()
+    const row = database
+      .select({
+        toolUseId: sql<string>`(
+          select json_extract(part.value, '$.data.toolUseId')
+          from json_each(${sessionMessagesTable.data}, '$.parts') as part
+          where json_extract(part.value, '$.type') = 'data-agent-task-event'
+            and json_extract(part.value, '$.data.taskId') = ${taskId}
+          limit 1
+        )`
+      })
+      .from(sessionMessagesTable)
+      .where(
+        and(
+          eq(sessionMessagesTable.sessionId, sessionId),
+          eq(sessionMessagesTable.role, 'assistant'),
+          sql`EXISTS (
+            select 1 from json_each(${sessionMessagesTable.data}, '$.parts') as part
+            where json_extract(part.value, '$.type') = 'data-agent-task-event'
+              and json_extract(part.value, '$.data.taskId') = ${taskId}
+          )`
+        )
+      )
+      .orderBy(asc(sessionMessagesTable.createdAt), asc(sessionMessagesTable.id))
+      .limit(1)
+      .all()
+    return row[0]?.toolUseId ?? null
+  }
+
+  /**
    * Boot reconcile of crash-orphaned `pending` rows: resolve each row to `error` (with the
    * caller's terminalized `data`) and discard the affected sessions' resume tokens, atomically.
    * A crashed turn leaves the external CLI session in an untrusted state — resuming it can replay

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -56,7 +56,7 @@ import {
 } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { isToolUIPart } from 'ai'
-import { and, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, type SQL, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, type SQL, sql } from 'drizzle-orm'
 import { v4 as uuidv4, v7 as uuidv7, validate as isUuid } from 'uuid'
 
 import { aiUsageRecordService, mergeMessageRuntimeStats } from './AiUsageRecordService'
@@ -682,6 +682,33 @@ export class AgentSessionMessageService {
         )
       )
       .all()
+  }
+
+  /**
+   * The assistant host row whose parts contain `rootToolCallId`, for a fresh runtime entry (after
+   * a process restart or session reopen) to re-anchor detached subagent flow chunks to the launch
+   * message. The launch part is the earliest row carrying the id, so ascending creation order and
+   * LIMIT 1 pick it.
+   */
+  findFlowHostMessageId(sessionId: string, rootToolCallId: string): string | null {
+    const database = application.get('DbService').getDb()
+    const row = database
+      .select({ id: sessionMessagesTable.id })
+      .from(sessionMessagesTable)
+      .where(
+        and(
+          eq(sessionMessagesTable.sessionId, sessionId),
+          eq(sessionMessagesTable.role, 'assistant'),
+          sql<boolean>`exists (
+            select 1 from json_each(${sessionMessagesTable.data}, '$.parts') as part
+            where json_extract(part.value, '$.toolCallId') = ${rootToolCallId}
+          )`
+        )
+      )
+      .orderBy(asc(sessionMessagesTable.createdAt))
+      .limit(1)
+      .all()
+    return row[0]?.id ?? null
   }
 
   /**

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -552,6 +552,51 @@ describe('AgentSessionMessageService', () => {
     })
   })
 
+  describe('findFlowHostMessageId (restart anchor recovery)', () => {
+    const HOST = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d030'
+    const lateHostPart = () => ({
+      type: 'tool-Agent' as const,
+      toolCallId: 'root-1',
+      state: 'input-available' as const,
+      input: { prompt: 'Audit' }
+    })
+
+    it('finds the assistant row whose parts carry the launch tool call id', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: HOST, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBe(HOST)
+    })
+
+    it('returns null when no assistant row carries the id (user rows are not hosts)', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: HOST, role: 'user', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBeNull()
+    })
+
+    it('returns the earliest row when several carry the same id', async () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+      const EARLY = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d031'
+      const LATE = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d032'
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: EARLY, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+      now.mockReturnValue(2_000)
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: LATE, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBe(EARLY)
+    })
+  })
+
   it('atomically settles a persisted background tool approval with the user-updated input', () => {
     const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
     agentSessionMessageService.saveMessage({

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -552,6 +552,70 @@ describe('AgentSessionMessageService', () => {
     })
   })
 
+  describe('findLaunchToolCallId (fresh-adapter task root recovery)', () => {
+    const ROOT = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d033'
+    const taskEventPart = (taskId: string, toolUseId: string) => ({
+      type: 'data-agent-task-event' as const,
+      data: { taskId, toolUseId, event: 'started' as const, status: 'in_progress' as const }
+    })
+
+    it('returns the launch tool-use id from the earliest task event row', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: ROOT,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBe('launch-use')
+    })
+
+    it('returns null when no assistant row carries the task id (user rows are ignored)', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: ROOT,
+          role: 'user',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBeNull()
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-other')).toBeNull()
+    })
+
+    it('prefers the earliest row when several carry the same task id', async () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+      const EARLY = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d034'
+      const LATE = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d035'
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: EARLY,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+      now.mockReturnValue(2_000)
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: LATE,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'resume-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBe('launch-use')
+    })
+  })
+
   describe('findFlowHostMessageId (restart anchor recovery)', () => {
     const HOST = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d030'
     const lateHostPart = () => ({

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -13,7 +13,7 @@ import type { CherryMessagePart } from '@shared/data/types/message'
 import { type ComponentProps, lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import NarrowLayout from '../layout/NarrowLayout'
-import { PartsProvider, usePartsMap } from './blocks/MessagePartsContext'
+import { FullPartsMapProvider, PartsProvider, usePartsMap } from './blocks/MessagePartsContext'
 import { MessageListInitialLoading } from './layout/MessageListLoading'
 import { MessagesContainer } from './layout/shared'
 import MessageAnchorLine from './list/MessageAnchorLine'
@@ -122,19 +122,21 @@ function MessageGroupLayer({
 }: MessageGroupLayerProps) {
   void isLive
   return (
-    <PartsProvider value={partsByMessageId ?? null}>
-      <NarrowLayout
-        narrowMode={narrowMode}
-        withSidePadding
-        // The gutter is mirrored on the left so the column stays
-        // centred and both margins match while the rail fades in.
-        style={{
-          paddingLeft: CHAT_SIDE_PADDING_PX + railGutterPx,
-          paddingRight: CHAT_SIDE_PADDING_PX + railGutterPx
-        }}>
-        <MessageGroup key={groupKey} {...messageGroupProps} messages={messages} partsByMessageId={partsByMessageId} />
-      </NarrowLayout>
-    </PartsProvider>
+    <FullPartsMapProvider value={partsByMessageId ?? null}>
+      <PartsProvider value={partsByMessageId ?? null}>
+        <NarrowLayout
+          narrowMode={narrowMode}
+          withSidePadding
+          // The gutter is mirrored on the left so the column stays
+          // centred and both margins match while the rail fades in.
+          style={{
+            paddingLeft: CHAT_SIDE_PADDING_PX + railGutterPx,
+            paddingRight: CHAT_SIDE_PADDING_PX + railGutterPx
+          }}>
+          <MessageGroup key={groupKey} {...messageGroupProps} messages={messages} partsByMessageId={partsByMessageId} />
+        </NarrowLayout>
+      </PartsProvider>
+    </FullPartsMapProvider>
   )
 }
 

--- a/src/renderer/components/chat/messages/MessageListProvider.tsx
+++ b/src/renderer/components/chat/messages/MessageListProvider.tsx
@@ -9,7 +9,7 @@ import type { CherryMessagePart } from '@shared/data/types/message'
 import type { Context, ReactNode } from 'react'
 import { createContext, use, useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
 
-import { PartsProvider } from './blocks/MessagePartsContext'
+import { FullPartsMapProvider, PartsProvider } from './blocks/MessagePartsContext'
 import type {
   MessageListActions,
   MessageListItem,
@@ -193,27 +193,29 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
   return (
     <MessageListDataContext value={data}>
       <MessageListMessagesContext value={state.messages}>
-        <PartsProvider value={state.partsByMessageId}>
-          <MessageListCitationRegistryContext value={citationRegistry}>
-            <MessageListActionsContext value={actions}>
-              <MessageListMetaContext value={meta}>
-                <MessageListRenderConfigContext value={state.renderConfig}>
-                  <MessageListSelectionContext value={state.selection}>
-                    <MessageListUiStaticContext value={uiStatic}>
-                      <MessageListUiSelectorsContext value={uiSelectors}>
-                        <MessageListActivityContext value={activity}>
-                          <MessageListEditingContext value={state.editingMessageId ?? null}>
-                            {children}
-                          </MessageListEditingContext>
-                        </MessageListActivityContext>
-                      </MessageListUiSelectorsContext>
-                    </MessageListUiStaticContext>
-                  </MessageListSelectionContext>
-                </MessageListRenderConfigContext>
-              </MessageListMetaContext>
-            </MessageListActionsContext>
-          </MessageListCitationRegistryContext>
-        </PartsProvider>
+        <FullPartsMapProvider value={state.partsByMessageId}>
+          <PartsProvider value={state.partsByMessageId}>
+            <MessageListCitationRegistryContext value={citationRegistry}>
+              <MessageListActionsContext value={actions}>
+                <MessageListMetaContext value={meta}>
+                  <MessageListRenderConfigContext value={state.renderConfig}>
+                    <MessageListSelectionContext value={state.selection}>
+                      <MessageListUiStaticContext value={uiStatic}>
+                        <MessageListUiSelectorsContext value={uiSelectors}>
+                          <MessageListActivityContext value={activity}>
+                            <MessageListEditingContext value={state.editingMessageId ?? null}>
+                              {children}
+                            </MessageListEditingContext>
+                          </MessageListActivityContext>
+                        </MessageListUiSelectorsContext>
+                      </MessageListUiStaticContext>
+                    </MessageListSelectionContext>
+                  </MessageListRenderConfigContext>
+                </MessageListMetaContext>
+              </MessageListActionsContext>
+            </MessageListCitationRegistryContext>
+          </PartsProvider>
+        </FullPartsMapProvider>
       </MessageListMessagesContext>
     </MessageListDataContext>
   )

--- a/src/renderer/components/chat/messages/blocks/MessagePartsContext.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsContext.tsx
@@ -78,6 +78,27 @@ export function usePartsMap() {
   return use(PartsContext)
 }
 
+// ============================================================================
+// Full Parts Map Context — survives tool-group boundaries
+// ============================================================================
+
+const FullPartsMapContext = createContext<Record<string, CherryMessagePart[]> | null>(null)
+
+/**
+ * Provide the list-level parts map for cross-message lookups. Unlike
+ * PartsContext, nested boundaries never null this out — completed tool groups
+ * reset PartsContext to skip approval checks, which would also hide any
+ * consumer that must see other messages' parts.
+ */
+export function FullPartsMapProvider({ value, children }: { value: PartsMap; children: ReactNode }) {
+  return <FullPartsMapContext value={value}>{children}</FullPartsMapContext>
+}
+
+/** Read the list-level parts map (null when no provider is mounted). */
+export function useFullPartsMap() {
+  return use(FullPartsMapContext)
+}
+
 /** Check if parts data is provided. */
 export function useHasMessageParts(): boolean {
   return use(PartsContext) !== null

--- a/src/renderer/components/chat/messages/blocks/ToolBlockGroup.tsx
+++ b/src/renderer/components/chat/messages/blocks/ToolBlockGroup.tsx
@@ -26,13 +26,14 @@ import { useTranslation } from 'react-i18next'
 import { BeatLoader } from 'react-spinners'
 
 import { useMessageDisclosureState } from '../hooks/useMessageDisclosureState'
+import { buildResumeToolHeader } from '../tools/agent'
 import MessageTools from '../tools/MessageTools'
-import { AgentToolsType } from '../tools/shared/agentToolTypes'
+import { AgentToolsType, getResumedAgentId } from '../tools/shared/agentToolTypes'
 import { getEffectiveStatus, type ToolStatus } from '../tools/shared/GenericTools'
 import ToolHeader, { getReadableToolActivity } from '../tools/ToolHeader'
 import { isToolPartAwaitingApproval, type ToolRenderItem, type ToolResponseLike } from '../tools/toolResponse'
 import BlockErrorFallback from './BlockErrorFallback'
-import { PartsContext, PartsProvider, usePartsMap } from './MessagePartsContext'
+import { PartsContext, PartsProvider, useFullPartsMap, usePartsMap } from './MessagePartsContext'
 import { PlaceholderShimmerText } from './PlaceholderShimmerText'
 import { useMinimumDisplayDuration } from './useMinimumDisplayDuration'
 import { useScrollAnchor } from './useScrollAnchor'
@@ -232,14 +233,28 @@ function getMcpToolGroupPresentation(
   return { action, icon, target: target ?? (action ? 'relatedContent' : undefined) }
 }
 
-export function getToolGroupIcon(tool: ToolGroupTool | undefined, toolArguments?: unknown): LucideIcon {
+export function getToolGroupIcon(
+  tool: ToolGroupTool | undefined,
+  toolArguments?: unknown,
+  toolOutput?: unknown
+): LucideIcon {
+  // A SendMessage receipt that resumed an agent presents exactly like that agent's launch.
+  if (tool?.name === AgentToolsType.SendMessage && getResumedAgentId(toolOutput)) return Sparkles
   return (
     (tool && TOOL_GROUP_ICON_BY_NAME[tool.name]) || getMcpToolGroupPresentation(tool, toolArguments)?.icon || Wrench
   )
 }
 
-function ToolGroupContentIcon({ tool, toolArguments }: { tool?: ToolGroupTool; toolArguments?: unknown }) {
-  const Icon = getToolGroupIcon(tool, toolArguments)
+function ToolGroupContentIcon({
+  tool,
+  toolArguments,
+  toolOutput
+}: {
+  tool?: ToolGroupTool
+  toolArguments?: unknown
+  toolOutput?: unknown
+}) {
+  const Icon = getToolGroupIcon(tool, toolArguments, toolOutput)
   return <Icon aria-hidden="true" className={TOOL_GROUP_ICON_CLASS_NAME} />
 }
 
@@ -338,6 +353,7 @@ const DynamicToolBlockGroupHeaderContent = React.memo(
   }: ToolBlockGroupHeaderContentProps) => {
     const { t } = useTranslation()
     const partsMap = usePartsMap()
+    const fullPartsMap = useFullPartsMap()
     const allCompleted = items.every((item) => isToolGroupItemCompleted(item.toolResponse.status))
     const fallbackLabel = summary ?? t('message.tools.groupHeader', { count: items.length })
     const nextCandidate = React.useMemo<ToolHeaderCandidate>(() => {
@@ -435,7 +451,11 @@ const DynamicToolBlockGroupHeaderContent = React.memo(
 
     const latestTool = items.at(-1)?.toolResponse
     const latestToolIcon = showContentIcon ? (
-      <ToolGroupContentIcon tool={latestTool?.tool} toolArguments={latestTool?.arguments} />
+      <ToolGroupContentIcon
+        tool={latestTool?.tool}
+        toolArguments={latestTool?.arguments}
+        toolOutput={latestTool?.response}
+      />
     ) : undefined
 
     if (displayCandidate.kind === 'summary') {
@@ -461,12 +481,26 @@ const DynamicToolBlockGroupHeaderContent = React.memo(
       )
     }
 
+    // A send-then-resume receipt heads its group exactly like the launch card: continue-handling
+    // verb + launch identity, in place of the generic SendMessage or semantic title.
+    const resumeHeader = buildResumeToolHeader(displayCandidate.item.toolResponse, fullPartsMap, t)
+
+    if (resumeHeader) {
+      return renderWithElapsed(
+        <div className="min-w-0 max-w-full overflow-hidden" key={displayCandidate.item.id}>
+          {resumeHeader.header}
+        </div>,
+        activityIcon ?? latestToolIcon
+      )
+    }
+
     if (semanticToolTitle) {
       const title = getSemanticToolTitle(displayCandidate, t)
       const icon = showContentIcon ? (
         <ToolGroupContentIcon
           tool={displayCandidate.item.toolResponse.tool}
           toolArguments={displayCandidate.item.toolResponse.arguments}
+          toolOutput={displayCandidate.item.toolResponse.response}
         />
       ) : undefined
       return renderSemanticTitle(title, icon, displayCandidate.item.id)
@@ -513,6 +547,7 @@ export const ToolBlockGroupHeaderContent = React.memo((props: ToolBlockGroupHead
               <ToolGroupContentIcon
                 tool={items.at(-1)?.toolResponse.tool}
                 toolArguments={items.at(-1)?.toolResponse.arguments}
+                toolOutput={items.at(-1)?.toolResponse.response}
               />
             )}
           </span>

--- a/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
@@ -37,7 +37,8 @@ vi.mock('@renderer/components/chat/messages/blocks/MessagePartsContext', async (
   const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
-    usePartsMap: () => mockPartsMap()
+    usePartsMap: () => mockPartsMap(),
+    useFullPartsMap: () => mockPartsMap()
   }
 })
 
@@ -154,6 +155,7 @@ describe('AgentToolRenderer', () => {
     'message.tools.activity.executingCommand': 'Running task',
     'message.tools.activity.file': 'file',
     'message.tools.activity.handle': 'Handle',
+    'message.tools.activity.continueHandle': 'Continue handling',
     'message.tools.activity.handling': 'Handling',
     'message.tools.activity.installing': 'Installing',
     'message.tools.activity.projectDependencies': 'project requirements',
@@ -688,6 +690,42 @@ describe('AgentToolRenderer', () => {
       expect(container).toBeEmptyDOMElement()
     })
 
+    // A status flip on the same mounted instance must not change the hook count: the resume
+    // lookup's useMemo used to sit after the `waiting` early return and crashed with React #310.
+    it('keeps hook order stable when an approval wait flips to executing', () => {
+      const toolResponse = createToolResponse({ status: 'pending', partialArguments: undefined })
+
+      // First render: approval-requested → effective 'waiting' → early return null.
+      mockPartsMap.mockReturnValue({
+        msg1: [
+          {
+            type: 'tool-Read',
+            toolCallId: toolResponse.toolCallId,
+            state: 'approval-requested',
+            approval: { id: 'approval-1' },
+            input: undefined
+          }
+        ]
+      })
+      const { container, rerender } = render(<AgentToolRenderer toolResponse={toolResponse} />)
+      expect(container).toBeEmptyDOMElement()
+
+      // Second render, same mount: approval resolved → execution passes the guard.
+      mockPartsMap.mockReturnValue({
+        msg1: [
+          {
+            type: 'tool-Read',
+            toolCallId: toolResponse.toolCallId,
+            state: 'input-available',
+            approval: { id: 'approval-1' },
+            input: undefined
+          }
+        ]
+      })
+      rerender(<AgentToolRenderer toolResponse={toolResponse} />)
+      expect(screen.getByText('Invoking')).toBeInTheDocument()
+    })
+
     it('should show pending indicator when no streaming and no permission', () => {
       const toolResponse = createToolResponse({
         status: 'pending',
@@ -1160,6 +1198,105 @@ describe('AgentToolRenderer', () => {
         title: 'Inspect renderer'
       })
       expect(screen.queryByRole('button', { name: 'code_block.expand' })).toBeNull()
+    })
+
+    // The resumed agent keeps streaming under its launch tool-call id, so the SendMessage receipt's
+    // entry must open that flow — not an empty SendMessage-rooted one.
+    it('opens the resumed subagent flow from a SendMessage receipt', () => {
+      const openAgentToolFlow = vi.fn()
+      mockMessageListActions.mockReturnValue({ openAgentToolFlow })
+      mockPartsMap.mockReturnValue({
+        m1: [
+          {
+            type: 'dynamic-tool',
+            toolCallId: 'call-launch',
+            toolName: 'Agent',
+            state: 'output-available',
+            input: { description: 'Inspect renderer', prompt: 'Check the message renderer' },
+            output: "done. agentId: agent-77 (internal metadata. Use SendMessage with to: 'agent-77')"
+          }
+        ]
+      })
+      const toolResponse = createToolResponse({
+        tool: { id: 'SendMessage', name: 'SendMessage', description: 'Message an agent', type: 'provider' },
+        status: 'done',
+        arguments: { to: 'agent-77', summary: 'Continue the review', message: 'please continue' },
+        response: { success: true, message: 'resumed from transcript in the background', resumedAgentId: 'agent-77' }
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      // The entry identifies itself by the resumed agent's own description, not "SendMessage",
+      // and echoes the launch card's verb.
+      expect(screen.queryByText('SendMessage')).toBeNull()
+      expect(screen.getByText('Continue handling')).toBeInTheDocument()
+      expect(screen.getByText('Inspect renderer')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByText('Continue handling').closest('[role="button"]')!)
+      // The flow's title is the agent's launch identity, not the resume request's summary — the
+      // same agent must read identically from every entry point.
+      expect(openAgentToolFlow).toHaveBeenCalledWith({
+        toolCallId: 'call-launch',
+        toolName: 'SendMessage',
+        title: 'Inspect renderer'
+      })
+    })
+
+    it('keeps a SendMessage without a resolvable launch root locally clickable only', () => {
+      const openAgentToolFlow = vi.fn()
+      mockMessageListActions.mockReturnValue({ openAgentToolFlow })
+      const toolResponse = createToolResponse({
+        tool: { id: 'SendMessage', name: 'SendMessage', description: 'Message an agent', type: 'provider' },
+        status: 'done',
+        arguments: { to: 'agent-77', message: 'please continue' },
+        response: { success: true, message: 'queued for delivery at its next tool round.' }
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      expect(screen.getByText('SendMessage').closest('[role="button"]')).toBeNull()
+      expect(openAgentToolFlow).not.toHaveBeenCalled()
+    })
+
+    // A send to a still-running agent queues instead of resuming — its receipt carries only
+    // pin.id, and the entry must still resolve back to the launch flow.
+    it('opens the launch flow from a queued-pin SendMessage receipt', () => {
+      const openAgentToolFlow = vi.fn()
+      mockMessageListActions.mockReturnValue({ openAgentToolFlow })
+      mockPartsMap.mockReturnValue({
+        m1: [
+          {
+            type: 'dynamic-tool',
+            toolCallId: 'call-launch',
+            toolName: 'Agent',
+            state: 'output-available',
+            input: { description: 'Inspect renderer', prompt: 'Check the message renderer' },
+            output: "done. agentId: agent-77 (internal metadata. Use SendMessage with to: 'agent-77')"
+          }
+        ]
+      })
+      const toolResponse = createToolResponse({
+        tool: { id: 'SendMessage', name: 'SendMessage', description: 'Message an agent', type: 'provider' },
+        status: 'done',
+        arguments: { to: 'flow-marker-reader', summary: 'Continue the review', message: 'please continue' },
+        response: {
+          success: true,
+          message: 'Message queued for delivery at its next tool round.',
+          pin: { id: 'agent-77', name: 'flow-marker-reader', ref: 'abc' }
+        }
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      expect(screen.queryByText('SendMessage')).toBeNull()
+      expect(screen.getByText('Continue handling')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByText('Continue handling').closest('[role="button"]')!)
+      expect(openAgentToolFlow).toHaveBeenCalledWith({
+        toolCallId: 'call-launch',
+        toolName: 'SendMessage',
+        title: 'Inspect renderer'
+      })
     })
 
     it('keeps ordinary tool row clicks local even when the flow action exists', () => {

--- a/src/renderer/components/chat/messages/tools/__tests__/ToolBlockGroupResumeParts.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/ToolBlockGroupResumeParts.test.tsx
@@ -1,0 +1,126 @@
+import type { NormalToolResponse } from '@renderer/types/mcpTool'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FullPartsMapProvider, PartsProvider } from '../../blocks/MessagePartsContext'
+import { ToolBlockGroup } from '../../blocks/ToolBlockGroup'
+
+const mockUseTranslation = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => mockUseTranslation()
+}))
+
+vi.mock('@renderer/components/chat/messages/MessageListProvider', () => ({
+  useOptionalMessageListActions: () => ({}),
+  useOptionalMessageListUi: () => ({}),
+  useOptionalMessageListTopicId: () => undefined
+}))
+
+vi.mock('@renderer/services/AssistantService', () => ({
+  getDefaultAssistant: vi.fn(() => ({ id: 'test-assistant', name: 'Test Assistant', settings: {} })),
+  getDefaultTopic: vi.fn(() => ({
+    id: 'test-topic',
+    assistantId: 'test-assistant',
+    createdAt: new Date().toISOString()
+  }))
+}))
+
+// Mirrors the CLI's real receipt (capitalized "Use SendMessage") so a casing-sensitive matcher
+// can never pass these tests again.
+const LAUNCH_OUTPUT = "done. agentId: agent-77 (internal metadata. Use SendMessage with to: 'agent-77')"
+
+function launchParts(): Record<string, CherryMessagePart[]> {
+  return {
+    m1: [
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-launch',
+        toolName: 'Agent',
+        state: 'output-available',
+        input: { description: 'Inspect renderer', prompt: 'Check the message renderer' },
+        output: LAUNCH_OUTPUT
+      }
+    ]
+  }
+}
+
+function resumeReceipt(): NormalToolResponse {
+  return {
+    id: 'send-1',
+    tool: { id: 'SendMessage', name: 'SendMessage', description: 'Send a message', type: 'provider' },
+    arguments: { to: 'agent-77', summary: 'Continue the review', message: 'please continue' },
+    status: 'done',
+    toolCallId: 'call_resume',
+    response: { success: true, message: 'resumed from transcript in the background', resumedAgentId: 'agent-77' }
+  }
+}
+
+describe('resume presentation inside a completed tool group', () => {
+  beforeEach(() => {
+    mockUseTranslation.mockReturnValue({
+      t: (key: string) => (key === 'message.tools.activity.continueHandle' ? 'Continue handling' : key)
+    })
+  })
+
+  // ToolGroupPartsBoundary nulls PartsContext once every item completes — the launch-resolution
+  // path must survive on the list-level FullPartsMapContext, or this label disappears.
+  it('renders the continue label for a resumed agent from the full-parts map', () => {
+    const parts = launchParts()
+    const receipt = resumeReceipt()
+
+    render(
+      <FullPartsMapProvider value={parts}>
+        <PartsProvider value={parts}>
+          <ToolBlockGroup items={[{ id: 'resume-group', toolResponse: receipt }]} />
+        </PartsProvider>
+      </FullPartsMapProvider>
+    )
+
+    expect(screen.getByText('Continue handling')).toBeInTheDocument()
+    expect(screen.getByText('Inspect renderer')).toBeInTheDocument()
+  })
+
+  // Even without full-parts map resolution, the continue-handling verb still renders (the
+  // receipt's own resumedAgentId is sufficient). Only the identity text is lost.
+  it('shows the bare continue-handling verb without launch identity when map is unavailable', () => {
+    const receipt = resumeReceipt()
+
+    render(
+      <FullPartsMapProvider value={null}>
+        <PartsProvider value={null}>
+          <ToolBlockGroup items={[{ id: 'resume-group', toolResponse: receipt }]} />
+        </PartsProvider>
+      </FullPartsMapProvider>
+    )
+
+    expect(screen.getByText('Continue handling')).toBeInTheDocument()
+    expect(screen.queryByText('Inspect renderer')).toBeNull()
+  })
+
+  // A queued send to a still-running agent carries only pin.id — the group header must treat it
+  // as the same continuation entry.
+  it('renders the continue label for a queued-pin receipt', () => {
+    const parts = launchParts()
+    const receipt: NormalToolResponse = {
+      ...resumeReceipt(),
+      response: {
+        success: true,
+        message: 'Message queued for delivery at its next tool round.',
+        pin: { id: 'agent-77', name: 'flow-marker-reader', ref: 'abc' }
+      }
+    }
+
+    render(
+      <FullPartsMapProvider value={parts}>
+        <PartsProvider value={parts}>
+          <ToolBlockGroup items={[{ id: 'resume-group', toolResponse: receipt }]} />
+        </PartsProvider>
+      </FullPartsMapProvider>
+    )
+
+    expect(screen.getByText('Continue handling')).toBeInTheDocument()
+    expect(screen.getByText('Inspect renderer')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/chat/messages/tools/agent/AgentExecutionTimeline.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/AgentExecutionTimeline.tsx
@@ -1,21 +1,70 @@
-import { usePartsMap } from '@renderer/components/chat/messages/blocks/MessagePartsContext'
+import { useFullPartsMap, usePartsMap } from '@renderer/components/chat/messages/blocks/MessagePartsContext'
 import type { NormalToolResponse } from '@renderer/types/mcpTool'
+import type { CherryMessagePart } from '@shared/data/types/message'
 import { parse as parsePartialJson } from 'partial-json'
-import { useDeferredValue, useMemo } from 'react'
+import { type ReactElement, useDeferredValue, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 
-import { AgentToolsType, isAskUserQuestionToolName } from '../shared/agentToolTypes'
-import { getEffectiveStatus, StreamingContext } from '../shared/GenericTools'
+import {
+  AgentToolsType,
+  getResumedAgentId,
+  isAskUserQuestionToolName,
+  resolveResumedAgent
+} from '../shared/agentToolTypes'
+import { getEffectiveStatus, StreamingContext, ToolHeader } from '../shared/GenericTools'
 import { ToolApprovalOutcome } from '../shared/ToolApprovalOutcome'
-import { isToolPartAwaitingApproval } from '../toolResponse'
-import { AgentToolCallCard } from './AgentToolCallCard'
+import { getPartLaunchToolCallId } from '../toolParentMetadata'
+import { isToolPartAwaitingApproval, type ToolResponseLike } from '../toolResponse'
+import { AgentToolCallCard, getAgentToolFlowTitle } from './AgentToolCallCard'
 import { AskUserQuestionCard } from './AskUserQuestionCard'
 import { NavigateToolInline } from './NavigateTool'
 import { isCherrySessionToolResponse } from './sessionToolResult'
 
+function getStringArg(args: unknown, key: string): string | undefined {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return undefined
+  const value = (args as Record<string, unknown>)[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+/**
+ * The presentation of a send-then-resume receipt — "continue handling" verb plus the launch
+ * identity — shared by the chat row and the tool-group header so a resume reads exactly like the
+ * launch card's continuation. Returns undefined when this receipt does not resolve to a launch.
+ */
+export function buildResumeToolHeader(
+  toolResponse: ToolResponseLike,
+  fullPartsMap: Record<string, CherryMessagePart[]> | null,
+  t: ReturnType<typeof useTranslation>['t'],
+  resumedLaunch?: { toolCallId: string; description?: string }
+): { resumedLaunch?: { toolCallId: string; description?: string }; header: ReactElement } | undefined {
+  // Resume detection only needs the receipt's own output; launch-identity resolution is an
+  // enhancement that must never gate the label. Gated to SendMessage — only its receipts carry
+  // agent ids, and this header drives labels for every tool row.
+  if (toolResponse.tool.name !== AgentToolsType.SendMessage) return undefined
+  if (!getResumedAgentId(toolResponse.response)) return undefined
+  const resolved = resumedLaunch ?? resolveResumedAgent(toolResponse.response, fullPartsMap)
+  const identity = resolved?.description ?? getStringArg(toolResponse.arguments, 'summary')
+  return {
+    resumedLaunch: resolved,
+    header: (
+      <ToolHeader
+        label={t('message.tools.activity.continueHandle')}
+        toolName={toolResponse.tool.name}
+        args={toolResponse.arguments}
+        params={identity}
+        variant="collapse-label"
+        showStatus={false}
+      />
+    )
+  }
+}
+
 export function AgentExecutionTimeline({ toolResponse }: { toolResponse: NormalToolResponse }) {
   const { arguments: args, response, tool, status, partialArguments } = toolResponse
+  const { t } = useTranslation()
 
   const partsMap = usePartsMap()
+  const fullPartsMap = useFullPartsMap()
   const awaitingApproval = isToolPartAwaitingApproval(partsMap, toolResponse.toolCallId)
 
   const deferredPartialArguments = useDeferredValue(partialArguments)
@@ -27,6 +76,19 @@ export function AgentExecutionTimeline({ toolResponse }: { toolResponse: NormalT
       return undefined
     }
   }, [deferredPartialArguments])
+
+  // Hooks stay above every early return below: a tool flipping out of its approval wait must not
+  // change this component's hook count (React #310).
+  const resumedAgentId = tool?.name === AgentToolsType.SendMessage ? getResumedAgentId(response) : undefined
+  // Primary source: adapter-stamped launch root (zero scanning). Fallback: cross-message scan.
+  const stampedLaunchId =
+    tool?.name === AgentToolsType.SendMessage
+      ? getPartLaunchToolCallId(toolResponse as unknown as CherryMessagePart)
+      : undefined
+  const resumedLaunch = useMemo(() => {
+    if (stampedLaunchId) return { toolCallId: stampedLaunchId }
+    return resumedAgentId ? resolveResumedAgent(response, fullPartsMap) : undefined
+  }, [response, fullPartsMap, resumedAgentId, stampedLaunchId])
 
   if (tool?.name === 'mcp__assistant__navigate') {
     return <NavigateToolInline input={args ?? parsedPartialArgs} output={response} />
@@ -52,6 +114,9 @@ export function AgentExecutionTimeline({ toolResponse }: { toolResponse: NormalT
 
   const isLoading = effectiveStatus === 'streaming' || effectiveStatus === 'invoking'
   const isSubagentTool = tool?.name === AgentToolsType.Agent || tool?.name === AgentToolsType.Task
+  // Reuse the memoized launch resolution instead of re-scanning — buildResumeToolHeader keeps
+  // its own scan for the group header, which has no memo here.
+  const resumeHeader = buildResumeToolHeader(toolResponse, fullPartsMap, t, resumedLaunch)
   return (
     <>
       <AgentToolCallCard
@@ -63,7 +128,12 @@ export function AgentExecutionTimeline({ toolResponse }: { toolResponse: NormalT
         status={effectiveStatus}
         hasError={status === 'error'}
         isCherrySessionTool={isCherrySessionToolResponse(toolResponse)}
-        openFlowOnClick={isSubagentTool}
+        openFlowOnClick={isSubagentTool || resumeHeader !== undefined}
+        flowTargetToolCallId={resumedLaunch?.toolCallId}
+        // The flow is the agent's whole timeline — keep its title the launch identity, not the
+        // resume request's summary.
+        flowTitle={resumedLaunch?.description ?? getAgentToolFlowTitle(tool?.name, args ?? parsedPartialArgs)}
+        labelOverride={resumeHeader?.header}
         showInlineDetails={!isSubagentTool}
       />
       <ToolApprovalOutcome approval={toolResponse.approval} />

--- a/src/renderer/components/chat/messages/tools/agent/AgentToolCallCard.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/AgentToolCallCard.tsx
@@ -1,4 +1,5 @@
 import { SESSION_CREATE_TOOL_NAME, SESSION_SEND_TOOL_NAME } from '@shared/ai/agentSessionDelivery'
+import type { ReactNode } from 'react'
 
 import { useOptionalMessageListActions } from '../../MessageListProvider'
 import {
@@ -21,12 +22,15 @@ function shouldShowHeaderErrorText(toolName: string | undefined, renderedItem: T
   return renderedItem.children === undefined || renderedItem.children === null || toolName === AgentToolsType.Write
 }
 
-function getAgentToolFlowTitle(toolName: string | undefined, input: ToolInput | Record<string, unknown> | undefined) {
+export function getAgentToolFlowTitle(
+  toolName: string | undefined,
+  input: ToolInput | Record<string, unknown> | undefined
+) {
   if (typeof input === 'string') return input.trim() || toolName
   if (!input || typeof input !== 'object' || Array.isArray(input)) return toolName
 
   const inputEntries = Object.entries(input)
-  for (const key of ['description', 'subject', 'title', 'name']) {
+  for (const key of ['description', 'subject', 'title', 'name', 'summary']) {
     const value = inputEntries.find(([field]) => field === key)?.[1]
     if (typeof value === 'string' && value.trim()) return value.trim()
   }
@@ -53,6 +57,9 @@ export function AgentToolCallCard({
   hasError = false,
   isCherrySessionTool = false,
   openFlowOnClick = false,
+  flowTargetToolCallId,
+  flowTitle,
+  labelOverride,
   showInlineDetails = true
 }: {
   toolCallId?: string
@@ -64,6 +71,12 @@ export function AgentToolCallCard({
   hasError?: boolean
   isCherrySessionTool?: boolean
   openFlowOnClick?: boolean
+  /** Opens a different flow than this card's own call — e.g. a resume entry pointing at the launch root. */
+  flowTargetToolCallId?: string
+  /** Title for the opened flow; by default derived from this card's input. */
+  flowTitle?: string
+  /** Replaces the renderer's label — used when a caller knows a more identifying one. */
+  labelOverride?: ReactNode
   showInlineDetails?: boolean
 }) {
   const actions = useOptionalMessageListActions()
@@ -83,9 +96,9 @@ export function AgentToolCallCard({
     openFlowOnClick && actions?.openAgentToolFlow && toolCallId
       ? () =>
           actions.openAgentToolFlow?.({
-            toolCallId,
+            toolCallId: flowTargetToolCallId ?? toolCallId,
             toolName,
-            title: getAgentToolFlowTitle(toolName, input)
+            title: flowTitle ?? getAgentToolFlowTitle(toolName, input)
           })
       : undefined
   const errorText = shouldShowHeaderErrorText(toolName, renderedItem) ? extractToolErrorText(output) : undefined
@@ -96,7 +109,7 @@ export function AgentToolCallCard({
       <AgentToolDisclosureLabel
         label={
           <div className="flex min-w-0 items-center gap-1.5">
-            <div className="min-w-0">{renderedItem.label}</div>
+            <div className="min-w-0">{labelOverride ?? renderedItem.label}</div>
             {status && (status !== 'done' || hasError) && (
               <ToolStatusIndicator status={status} hasError={hasError} errorText={errorText} />
             )}

--- a/src/renderer/components/chat/messages/tools/agent/__tests__/AgentExecutionTimeline.test.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/__tests__/AgentExecutionTimeline.test.tsx
@@ -7,14 +7,16 @@ const cardProps = vi.hoisted(() => ({
 }))
 
 vi.mock('@renderer/components/chat/messages/blocks/MessagePartsContext', () => ({
-  usePartsMap: () => new Map()
+  usePartsMap: () => new Map(),
+  useFullPartsMap: () => null
 }))
 
 vi.mock('../AgentToolCallCard', () => ({
   AgentToolCallCard: (props: Record<string, unknown>) => {
     cardProps.current = props
     return <div data-testid="agent-tool-card" />
-  }
+  },
+  getAgentToolFlowTitle: () => undefined
 }))
 
 import { AgentExecutionTimeline } from '../AgentExecutionTimeline'

--- a/src/renderer/components/chat/messages/tools/agent/index.ts
+++ b/src/renderer/components/chat/messages/tools/agent/index.ts
@@ -1,5 +1,5 @@
 export { colorizeShellOutput, shellColorPalettes, TERMINAL_SURFACE_CLASS } from '../shared/terminalOutputHelpers'
-export { AgentExecutionTimeline, AgentToolRenderer } from './AgentExecutionTimeline'
+export { AgentExecutionTimeline, AgentToolRenderer, buildResumeToolHeader } from './AgentExecutionTimeline'
 export { agentInlineResultPresentationRegistry } from './agentInlineResultPresentationRegistry'
 export { AskUserQuestionCard } from './AskUserQuestionCard'
 export { AskUserQuestionOptimisticInputProvider } from './AskUserQuestionOptimisticContext'

--- a/src/renderer/components/chat/messages/tools/shared/agentToolTypes.ts
+++ b/src/renderer/components/chat/messages/tools/shared/agentToolTypes.ts
@@ -48,6 +48,7 @@ import type {
   WorkflowOutput
 } from '@anthropic-ai/claude-agent-sdk/sdk-tools'
 import { TO_MARKDOWN_TOOL_NAME } from '@shared/ai/builtinTools'
+import type { CherryMessagePart } from '@shared/data/types/message'
 import * as z from 'zod'
 
 import type { ToolDisclosureItem } from './ToolDisclosure'
@@ -278,6 +279,85 @@ export type WorkflowToolOutput = WorkflowOutput | string
 // Agent-teams tools are runtime/experimental (not in the SDK typed union) — loosely typed.
 export type SendMessageToolInput = { to?: string; message?: string } & Record<string, unknown>
 export type SendMessageToolOutput = string
+
+/** The background agent a SendMessage receipt points at: `resumedAgentId` when it woke a stopped
+ *  agent, or `pin.id` when the target was still running and the message was queued for delivery. */
+export function getResumedAgentId(output: unknown): string | undefined {
+  if (typeof output === 'string') {
+    return (
+      /"resumedAgentId"\s*:\s*"([^"]+)"/.exec(output)?.[1] ??
+      /"pin"\s*:\s*\{[^}]*"id"\s*:\s*"([^"]+)"/.exec(output)?.[1]
+    )
+  }
+  if (output && typeof output === 'object') {
+    const record = output as { resumedAgentId?: unknown; pin?: unknown }
+    if (typeof record.resumedAgentId === 'string') return record.resumedAgentId
+    if (record.pin && typeof record.pin === 'object' && typeof (record.pin as { id?: unknown }).id === 'string') {
+      return (record.pin as { id: string }).id
+    }
+  }
+  return undefined
+}
+
+/**
+ * Resolve a SendMessage receipt back to the agent run it continues: the resumed agent keeps
+ * streaming under its launch tool-call id, so entries must point at that launch. Returns the
+ * launch's toolCallId and description (which doubles as the agent's identity).
+ */
+/** A candidate Agent/Task output is the launch receipt for `resumedAgentId` when its serialized
+ *  form mentions the id: the id is session-scoped and generated at launch time, so the earliest
+ *  matching part is always the launch itself, and any textual trailer check would break whenever
+ *  the CLI rewords its receipt between versions. */
+function isLaunchReceiptFor(output: unknown, resumedAgentId: string): boolean {
+  if (typeof output === 'string') return output.includes(resumedAgentId)
+  if (isRecord(output)) return JSON.stringify(output).includes(resumedAgentId)
+  return false
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function resolveResumedAgent(
+  output: unknown,
+  fullPartsMap: Record<string, CherryMessagePart[]> | null
+): { toolCallId: string; description?: string } | undefined {
+  const resumedAgentId = getResumedAgentId(output)
+  if (!resumedAgentId || !fullPartsMap) return undefined
+  // First registration wins, mirroring the task-row binding: the launch receipt is the earliest
+  // part that can reference this id, and later mentions (a quote inside another part's output)
+  // must not redirect the entry.
+  for (const parts of Object.values(fullPartsMap)) {
+    for (const part of parts) {
+      const record = part as { toolName?: unknown; toolCallId?: unknown; input?: unknown; output?: unknown }
+      if (
+        (record.toolName === AgentToolsType.Agent || record.toolName === AgentToolsType.Task) &&
+        typeof record.toolCallId === 'string' &&
+        isLaunchReceiptFor(record.output, resumedAgentId)
+      ) {
+        const input = record.input
+        // A blank description must fall through to the prompt, or the continuation identity and
+        // the flow title render empty.
+        const description =
+          input && typeof input === 'object' && typeof (input as { description?: unknown }).description === 'string'
+            ? (input as { description: string }).description.trim() || undefined
+            : undefined
+        return {
+          toolCallId: record.toolCallId,
+          description:
+            description ??
+            (input && typeof input === 'object' && typeof (input as { prompt?: unknown }).prompt === 'string'
+              ? (input as { prompt: string }).prompt
+                  .split(/\r?\n/)
+                  .find((line) => line.trim())
+                  ?.trim()
+              : undefined)
+        }
+      }
+    }
+  }
+  return undefined
+}
 export type TeamCreateToolInput = Record<string, unknown>
 export type TeamCreateToolOutput = string
 export type TeamDeleteToolInput = Record<string, unknown>

--- a/src/renderer/components/chat/messages/tools/toolParentMetadata.ts
+++ b/src/renderer/components/chat/messages/tools/toolParentMetadata.ts
@@ -26,6 +26,16 @@ function getParentMetadata(part: CherryMessagePart): Record<string, unknown> | u
   return undefined
 }
 
+/** The launch root tool-call id stamped onto a SendMessage receipt by the adapter. */
+export function getPartLaunchToolCallId(part: CherryMessagePart): string | undefined {
+  for (const field of ['providerMetadata', 'callProviderMetadata', 'resultProviderMetadata']) {
+    const metadata = getMetadataRecord(part, field)
+    const entry = metadata?.cherry
+    if (isRecord(entry) && typeof entry.launchToolCallId === 'string') return entry.launchToolCallId
+  }
+  return undefined
+}
+
 export function getPartParentToolCallId(part: CherryMessagePart): string | undefined {
   const direct = (part as unknown as { parentToolUseId?: unknown }).parentToolUseId
   if (typeof direct === 'string' && direct) return direct
@@ -33,6 +43,16 @@ export function getPartParentToolCallId(part: CherryMessagePart): string | undef
   const parent = getParentMetadata(part)
   const parentToolCallId = parent?.parentToolCallId ?? parent?.parentToolUseId
   return typeof parentToolCallId === 'string' && parentToolCallId ? parentToolCallId : undefined
+}
+
+/** The SendMessage call id that resumed this part's round, when the runtime tagged it. */
+export function getPartResumeMarker(part: CherryMessagePart): string | undefined {
+  for (const field of ['providerMetadata', 'callProviderMetadata', 'resultProviderMetadata']) {
+    const metadata = getMetadataRecord(part, field)
+    const entry = metadata?.cherry
+    if (isRecord(entry) && typeof entry.resumedViaCallId === 'string') return entry.resumedViaCallId
+  }
+  return undefined
 }
 
 export function hasPartParentToolCallId(part: CherryMessagePart): boolean {

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "Codedateien",
   "message.tools.activity.codeHostInfo": "Informationen zum Remote-Repository",
   "message.tools.activity.configFiles": "Projektdokumentation und Konfiguration",
+  "message.tools.activity.continueHandle": "Verarbeitung fortsetzen",
   "message.tools.activity.copy": "Kopieren",
   "message.tools.activity.copying": "Wird kopiert",
   "message.tools.activity.create": "Erstellen",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "αρχεία κώδικα",
   "message.tools.activity.codeHostInfo": "πληροφορίες απομακρυσμένου αποθετηρίου",
   "message.tools.activity.configFiles": "τεκμηρίωση και ρυθμίσεις έργου",
+  "message.tools.activity.continueHandle": "Συνέχεια επεξεργασίας",
   "message.tools.activity.copy": "Αντιγραφή",
   "message.tools.activity.copying": "Γίνεται αντιγραφή",
   "message.tools.activity.create": "Δημιουργία",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "code files",
   "message.tools.activity.codeHostInfo": "remote repo info",
   "message.tools.activity.configFiles": "project docs and config",
+  "message.tools.activity.continueHandle": "Continue handling",
   "message.tools.activity.copy": "Copy",
   "message.tools.activity.copying": "Copying",
   "message.tools.activity.create": "Create",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "archivos de código",
   "message.tools.activity.codeHostInfo": "información del repositorio remoto",
   "message.tools.activity.configFiles": "documentación y configuración del proyecto",
+  "message.tools.activity.continueHandle": "Continuar el procesamiento",
   "message.tools.activity.copy": "Copiar",
   "message.tools.activity.copying": "Copiando",
   "message.tools.activity.create": "Crear",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "fichiers de code",
   "message.tools.activity.codeHostInfo": "informations sur le dépôt distant",
   "message.tools.activity.configFiles": "documentation et configuration du projet",
+  "message.tools.activity.continueHandle": "Continuer le traitement",
   "message.tools.activity.copy": "Copier",
   "message.tools.activity.copying": "Copie en cours",
   "message.tools.activity.create": "Créer",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "コードファイル",
   "message.tools.activity.codeHostInfo": "リモートリポジトリ情報",
   "message.tools.activity.configFiles": "プロジェクトのドキュメントと設定",
+  "message.tools.activity.continueHandle": "処理を継続",
   "message.tools.activity.copy": "コピー",
   "message.tools.activity.copying": "コピー中",
   "message.tools.activity.create": "作成",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "ficheiros de código",
   "message.tools.activity.codeHostInfo": "informações do repositório remoto",
   "message.tools.activity.configFiles": "documentação e configuração do projeto",
+  "message.tools.activity.continueHandle": "Continuar o processamento",
   "message.tools.activity.copy": "Copiar",
   "message.tools.activity.copying": "A copiar",
   "message.tools.activity.create": "Criar",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "fișiere de cod",
   "message.tools.activity.codeHostInfo": "informații despre depozitul la distanță",
   "message.tools.activity.configFiles": "documentația și configurația proiectului",
+  "message.tools.activity.continueHandle": "Continuă procesarea",
   "message.tools.activity.copy": "Copiază",
   "message.tools.activity.copying": "Se copiază",
   "message.tools.activity.create": "Creează",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "файлы кода",
   "message.tools.activity.codeHostInfo": "сведения об удалённом репозитории",
   "message.tools.activity.configFiles": "документация и конфигурация проекта",
+  "message.tools.activity.continueHandle": "Продолжить обработку",
   "message.tools.activity.copy": "Копировать",
   "message.tools.activity.copying": "Выполняется копирование",
   "message.tools.activity.create": "Создать",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "kod dosyaları",
   "message.tools.activity.codeHostInfo": "uzak depo bilgileri",
   "message.tools.activity.configFiles": "proje belgeleri ve yapılandırma",
+  "message.tools.activity.continueHandle": "İşlemeye devam et",
   "message.tools.activity.copy": "Kopyala",
   "message.tools.activity.copying": "Kopyalanıyor",
   "message.tools.activity.create": "Oluştur",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "tệp mã",
   "message.tools.activity.codeHostInfo": "thông tin kho lưu trữ từ xa",
   "message.tools.activity.configFiles": "tài liệu dự án và các tệp cấu hình",
+  "message.tools.activity.continueHandle": "Tiếp tục xử lý",
   "message.tools.activity.copy": "Sao chép",
   "message.tools.activity.copying": "Đang sao chép",
   "message.tools.activity.create": "Tạo",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "代码文件",
   "message.tools.activity.codeHostInfo": "远程仓库信息",
   "message.tools.activity.configFiles": "项目说明和配置文件",
+  "message.tools.activity.continueHandle": "继续处理",
   "message.tools.activity.copy": "复制",
   "message.tools.activity.copying": "正在复制",
   "message.tools.activity.create": "新建",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -2178,6 +2178,7 @@
   "message.tools.activity.codeFiles": "程式檔案",
   "message.tools.activity.codeHostInfo": "遠端儲存庫資訊",
   "message.tools.activity.configFiles": "專案文件與設定",
+  "message.tools.activity.continueHandle": "繼續處理",
   "message.tools.activity.copy": "複製",
   "message.tools.activity.copying": "正在複製",
   "message.tools.activity.create": "建立",

--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -106,7 +106,8 @@ import {
   type AgentStatusTask,
   type AgentToolFlowOpenInput,
   buildAgentRightPaneStatus,
-  buildAgentToolFlowProjection
+  buildAgentToolFlowProjection,
+  resolveFlowToolCallId
 } from './agentRightPaneProjection'
 
 const logger = loggerService.withContext('AgentRightPane')
@@ -318,11 +319,22 @@ function AgentRightPaneActionsProvider({
   }, [artifactOpenRequestRef, sessionId, workspacePath])
   const canOpenAgentToolFlow = conversationState === 'ready' && Boolean(sessionId)
   const canOpenArtifactFile = workspaceCurrent && Boolean(workspacePath) && panelActions.canOpen('files')
+  // Read the parts map at call time through a ref so message streaming does not re-create the
+  // actions object (and re-render consumers that only open flows).
+  const runtime = use(AgentRightPaneRuntimeContext)
+  const runtimeRef = useRef(runtime)
+  runtimeRef.current = runtime
   const openAgentToolFlow = useCallback(
     (input: AgentToolFlowOpenInput) => {
       if (!canOpenAgentToolFlow) return
-      replaceFlowTab(input)
-      panelActions.requestOpen(getFlowTabValue(input.toolCallId), { userInitiated: true })
+      // A task bound to its send-message receipt (cold reconnect replay) must still open the flow
+      // its agent actually streams under — the launch root.
+      const resolved = resolveFlowToolCallId(input.toolCallId, runtimeRef.current?.partsByMessageId ?? null)
+      const flowInput = resolved
+        ? { ...input, toolCallId: resolved.toolCallId, title: resolved.description ?? input.title }
+        : input
+      replaceFlowTab(flowInput)
+      panelActions.requestOpen(getFlowTabValue(flowInput.toolCallId), { userInitiated: true })
     },
     [canOpenAgentToolFlow, panelActions, replaceFlowTab]
   )
@@ -811,6 +823,8 @@ function AgentFlowRightPanel({ active, panelId, scope }: RightPanelComponentProp
   const runtime = useAgentRightPaneRuntime()
   const { t } = useTranslation()
   const tab = scope.flowTab && getFlowTabValue(scope.flowTab.toolCallId) === panelId ? scope.flowTab : null
+  // The resolved output feeds resume-round splitting only (the launch receipt carries the agent id
+  // that ties SendMessage continuations to this flow) — it is not rendered.
   const deferredToolResult = useMemo(
     () => findDeferredToolResult(runtime.partsByMessageId, tab?.toolCallId),
     [runtime.partsByMessageId, tab?.toolCallId]

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -162,7 +162,8 @@ vi.mock('@cherrystudio/ui', () => ({
       {children}
     </button>
   ),
-  Tooltip: ({ children }: PropsWithChildren) => <>{children}</>
+  Tooltip: ({ children }: PropsWithChildren) => <>{children}</>,
+  Alert: ({ message }: { message?: string }) => <div>{message}</div>
 }))
 
 vi.mock('@renderer/components/chat/shell/RightPaneHost', () => ({
@@ -982,6 +983,8 @@ describe('AgentRightPane', () => {
     expect(screen.getByTestId('shell-tab-title')).toHaveTextContent(title)
   })
 
+  // The resolved output feeds resume-round splitting (the receipt carries the agent id), even
+  // though its text is no longer rendered in the flow.
   it('resolves a deferred selected flow output by its stored address', async () => {
     const deferredToolResult = { topicId: 'agent-session:session-a', messageId: 'm1', toolCallId: 'flow-1' }
     const flowPart = {

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts
@@ -2,7 +2,11 @@ import { getPartParentToolCallId } from '@renderer/components/chat/messages/tool
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
 import { describe, expect, it } from 'vitest'
 
-import { buildAgentRightPaneStatus, buildAgentToolFlowProjection } from '../agentRightPaneProjection'
+import {
+  buildAgentRightPaneStatus,
+  buildAgentToolFlowProjection,
+  resolveFlowToolCallId
+} from '../agentRightPaneProjection'
 
 const message = (id: string, parts: CherryMessagePart[]): CherryUIMessage =>
   ({
@@ -66,7 +70,14 @@ const textPart = (text: string, parentToolCallId?: string): CherryMessagePart =>
 describe('agent right pane projections', () => {
   it('builds a selected tool subtree with text and reasoning parts owned by that subtree', () => {
     const parts = [
-      toolPart('root', 'Agent', undefined, 'output-available', { prompt: 'Explore the repo' }, 'Done exploring'),
+      toolPart(
+        'root',
+        'Agent',
+        undefined,
+        'output-available',
+        { prompt: 'Explore the repo' },
+        'Async agent launched successfully.\nagentId: b1c2d3e4f5a6b7c8'
+      ),
       textPart('child agent text', 'root'),
       toolPart('child', 'Read', 'root'),
       {
@@ -86,16 +97,13 @@ describe('agent right pane projections', () => {
 
     expect(projection.selectedToolCallIds).toEqual(new Set(['root', 'child']))
     expect(projection.messages.map((item) => item.id)).toEqual(['root:agent-flow-prompt', 'root:agent-flow-assistant'])
-    expect(projection.partsByMessageId['root:agent-flow-assistant']).toHaveLength(4)
+    expect(projection.partsByMessageId['root:agent-flow-assistant']).toHaveLength(3)
     expect(projection.partsByMessageId['root:agent-flow-assistant'][1]).not.toBe(parts[2])
     expect(getPartParentToolCallId(projection.partsByMessageId['root:agent-flow-assistant'][1])).toBeUndefined()
     expect(Object.values(projection.partsByMessageId).flat()).not.toContain(parts[0])
     expect(Object.values(projection.partsByMessageId).flat()).not.toContain(parts[4])
     expect((projection.partsByMessageId['root:agent-flow-prompt'][0] as { text?: string }).text).toBe(
       'Explore the repo'
-    )
-    expect((projection.partsByMessageId['root:agent-flow-assistant'][3] as { text?: string }).text).toBe(
-      'Done exploring'
     )
 
     const nextProjection = buildAgentToolFlowProjection(messages, { m1: parts }, 'root')
@@ -105,6 +113,348 @@ describe('agent right pane projections', () => {
     expect(nextProjection.partsByMessageId['root:agent-flow-assistant'][1]).toBe(
       projection.partsByMessageId['root:agent-flow-assistant'][1]
     )
+  })
+
+  // A cold reconnect can bind a resumed task to its SendMessage receipt — the entry must redirect
+  // to the launch root, or the flow opens empty.
+  it('resolves a send-message bound entry back to the launch root', () => {
+    const parts = [
+      toolPart(
+        'call_launch',
+        'Agent',
+        undefined,
+        'output-available',
+        { prompt: 'Launch the review' },
+        'Async agent launched successfully.\nagentId: af5051807ed7aaa30 (internal metadata - do not mention to user.)'
+      ),
+      toolPart(
+        'call_resume',
+        'SendMessage',
+        undefined,
+        'output-available',
+        { to: 'af5051807ed7aaa30', summary: 'Finish the review', message: 'Please finalize' },
+        { success: true, resumedAgentId: 'af5051807ed7aaa30' }
+      )
+    ]
+    const partsByMessageId = { m1: parts }
+
+    expect(resolveFlowToolCallId('call_resume', partsByMessageId)).toEqual({
+      toolCallId: 'call_launch',
+      description: 'Launch the review'
+    })
+    expect(resolveFlowToolCallId('call_launch', partsByMessageId)).toBeUndefined()
+    expect(resolveFlowToolCallId('missing', partsByMessageId)).toBeUndefined()
+  })
+
+  // A SendMessage receipt resolving to the selected launch splits its timeline: the prompt of
+  // each continuation lands as a user message between the agent's rounds.
+  it('interleaves resume prompts between the rounds of a continued agent', () => {
+    const launchOutput =
+      'Async agent launched successfully.\nagentId: af5051807ed7aaa30 (internal metadata - do not mention to user.)'
+    const parts = [
+      toolPart('call_launch', 'Agent', undefined, 'output-available', { prompt: 'Launch the review' }, launchOutput),
+      textPart('First round findings', 'call_launch'),
+      toolPart(
+        'call_resume',
+        'SendMessage',
+        undefined,
+        'output-available',
+        { to: 'af5051807ed7aaa30', summary: 'Finish the review', message: 'Please finalize the four conclusions' },
+        { success: true, resumedAgentId: 'af5051807ed7aaa30' }
+      ),
+      textPart('Second round findings', 'call_launch')
+    ]
+    const messages = [message('m1', parts)]
+
+    // Resolved output deliberately unset — the production path derives it from the part.
+    const projection = buildAgentToolFlowProjection(messages, { m1: parts }, 'call_launch')
+
+    expect(projection.messages.map((item) => item.id)).toEqual([
+      'call_launch:agent-flow-prompt',
+      'call_launch:agent-flow-assistant',
+      'call_launch:agent-flow-resume-1',
+      'call_launch:agent-flow-assistant-1'
+    ])
+    const texts = (id: string) => projection.partsByMessageId[id].map((part) => (part as { text?: string }).text)
+    expect(texts('call_launch:agent-flow-prompt')).toEqual(['Launch the review'])
+    // The receipt's own result text is not appended anywhere — it duplicates the agent's final
+    // message above and would go stale across continuations.
+    expect(texts('call_launch:agent-flow-assistant')).toEqual(['First round findings'])
+    expect(texts('call_launch:agent-flow-resume-1')).toEqual(['Please finalize the four conclusions'])
+    expect(texts('call_launch:agent-flow-assistant-1')).toEqual(['Second round findings'])
+  })
+
+  // Production ordering: the host row (holding both rounds) predates the receipt row, so position
+  // alone puts the resume prompt AFTER all content. Runtime-tagged parts must win.
+  it('splits rounds by runtime markers even when the receipt row comes last', () => {
+    const marker = { 'claude-code': { parentToolCallId: 'call_launch' }, cherry: { resumedViaCallId: 'call_send' } }
+    const parts = [
+      toolPart(
+        'call_launch',
+        'Agent',
+        undefined,
+        'output-available',
+        { prompt: 'Launch the review' },
+        'Async agent launched successfully.\nagentId: af5051807ed7aaa30 (internal metadata - do not mention to user.)'
+      ),
+      textPart('First round findings', 'call_launch'),
+      {
+        type: 'text',
+        text: 'Second round findings',
+        providerMetadata: marker
+      } as unknown as CherryMessagePart,
+      toolPart(
+        'call_send',
+        'SendMessage',
+        undefined,
+        'output-available',
+        { to: 'af5051807ed7aaa30', message: 'Please finalize' },
+        { success: true, resumedAgentId: 'af5051807ed7aaa30' }
+      )
+    ]
+    const messages = [message('m1', parts), message('m2', [parts[3]])]
+
+    // Simulate real walk order: m1 first (all content), then m2 (receipt).
+    const projection = buildAgentToolFlowProjection(
+      messages,
+      { m1: [parts[0], parts[1], parts[2]], m2: [parts[3]] },
+      'call_launch'
+    )
+
+    expect(projection.messages.map((item) => item.id)).toEqual([
+      'call_launch:agent-flow-prompt',
+      'call_launch:agent-flow-assistant',
+      'call_launch:agent-flow-resume-1',
+      'call_launch:agent-flow-assistant-1'
+    ])
+    const texts = (id: string) => projection.partsByMessageId[id].map((part) => (part as { text?: string }).text)
+    expect(texts('call_launch:agent-flow-assistant')).toEqual(['First round findings'])
+    expect(texts('call_launch:agent-flow-resume-1')).toEqual(['Please finalize'])
+    expect(texts('call_launch:agent-flow-assistant-1')).toEqual(['Second round findings'])
+  })
+
+  // A send to a still-running agent returns the queued form — no resumedAgentId, only pin.id.
+  // It must split the rounds and backfill its prompt just like a resume receipt does.
+  it('interleaves the queued instruction for a send to a running agent', () => {
+    const launchOutput =
+      'Async agent launched successfully.\nagentId: af5051807ed7aaa30 (internal metadata - do not mention to user.)'
+    const queuedOutput = {
+      success: true,
+      message: 'Message queued for delivery at its next tool round.',
+      pin: { id: 'af5051807ed7aaa30', name: 'reviewer', ref: 'abc' }
+    }
+    const parts = [
+      toolPart('call_launch', 'Agent', undefined, 'output-available', { prompt: 'Launch the review' }, launchOutput),
+      textPart('First round findings', 'call_launch'),
+      toolPart(
+        'call_queue',
+        'SendMessage',
+        undefined,
+        'output-available',
+        { to: 'af5051807ed7aaa30', summary: 'Reread files', message: 'Please reread the four files' },
+        queuedOutput
+      ),
+      textPart('Second round findings', 'call_launch')
+    ]
+    const messages = [message('m1', parts)]
+
+    const projection = buildAgentToolFlowProjection(messages, { m1: parts }, 'call_launch')
+
+    expect(projection.messages.map((item) => item.id)).toEqual([
+      'call_launch:agent-flow-prompt',
+      'call_launch:agent-flow-assistant',
+      'call_launch:agent-flow-resume-1',
+      'call_launch:agent-flow-assistant-1'
+    ])
+    const texts = (id: string) => projection.partsByMessageId[id].map((part) => (part as { text?: string }).text)
+    expect(texts('call_launch:agent-flow-resume-1')).toEqual(['Please reread the four files'])
+    expect(texts('call_launch:agent-flow-assistant-1')).toEqual(['Second round findings'])
+  })
+
+  // When the receipt and the tagged content share one row with the receipt first, the position
+  // split must consume the call id so the marker cannot split a second time.
+  // A sibling agent's marker (parent = its own root, receipt owned elsewhere) must not split this
+  // flow — the walk passes foreign detached rows before reaching the selected agent's receipt.
+  it('ignores a sibling agent marker when splitting rounds', () => {
+    const ownReceipt = {
+      success: true,
+      resumedAgentId: 'af5051807ed7aaa30',
+      pin: { id: 'af5051807ed7aaa30', name: 'reviewer', ref: 'a' }
+    }
+    const siblingMarker = {
+      type: 'text',
+      text: 'sibling agent round content',
+      providerMetadata: {
+        'claude-code': { parentToolCallId: 'call_sibling_root' },
+        cherry: { resumedViaCallId: 'call_send_sibling' }
+      }
+    } as unknown as CherryMessagePart
+    const parts = [
+      toolPart(
+        'call_launch',
+        'Agent',
+        undefined,
+        'output-available',
+        { prompt: 'Launch the review' },
+        'Async agent launched successfully.\nagentId: af5051807ed7aaa30 (internal metadata - do not mention to user.)'
+      ),
+      textPart('First round findings', 'call_launch'),
+      toolPart('call_sibling_root', 'Agent', undefined, 'output-available', { prompt: 'Sibling task' }, 'ok'),
+      siblingMarker,
+      toolPart(
+        'call_send',
+        'SendMessage',
+        undefined,
+        'output-available',
+        { to: 'af5051807ed7aaa30', message: 'Please finalize' },
+        ownReceipt
+      ),
+      {
+        type: 'text',
+        text: 'Second round findings',
+        providerMetadata: {
+          'claude-code': { parentToolCallId: 'call_launch' },
+          cherry: { resumedViaCallId: 'call_send' }
+        }
+      } as unknown as CherryMessagePart
+    ]
+    const messages = [message('m1', parts)]
+
+    const projection = buildAgentToolFlowProjection(messages, { m1: parts }, 'call_launch')
+
+    // Exactly one resume split: prompt2 lands before its own round, never after the sibling's.
+    expect(projection.messages.filter((item) => item.role === 'user')).toHaveLength(2)
+    expect(projection.messages.map((item) => item.id)).toEqual([
+      'call_launch:agent-flow-prompt',
+      'call_launch:agent-flow-assistant',
+      'call_launch:agent-flow-resume-1',
+      'call_launch:agent-flow-assistant-1'
+    ])
+  })
+
+  // A blank launch description must not suppress the prompt-based identity fallback.
+  it('falls back to the prompt when the launch description is blank', () => {
+    const partsByMessageId = {
+      m1: [
+        toolPart(
+          'call_launch',
+          'Agent',
+          undefined,
+          'output-available',
+          { description: '   ', prompt: 'Launch the review' },
+          'Async agent launched successfully.\nagentId: af5051807ed7aaa30'
+        ),
+        toolPart(
+          'call_resume',
+          'SendMessage',
+          undefined,
+          'output-available',
+          { to: 'af5051807ed7aaa30' },
+          { success: true, resumedAgentId: 'af5051807ed7aaa30' }
+        )
+      ]
+    }
+
+    expect(resolveFlowToolCallId('call_resume', partsByMessageId)).toEqual({
+      toolCallId: 'call_launch',
+      description: 'Launch the review'
+    })
+  })
+
+  // The adapter-stamped launch root resolves even when the launch row itself is paged out of the
+  // loaded window and the map scan cannot find it.
+  it('resolves a stamped receipt without its launch row in the window', () => {
+    const partsByMessageId = {
+      m2: [
+        {
+          ...toolPart(
+            'call_send',
+            'SendMessage',
+            undefined,
+            'output-available',
+            { to: 'af5051807ed7aaa30', summary: 'Finish it', message: 'Please finalize' },
+            { success: true, resumedAgentId: 'af5051807ed7aaa30' }
+          )
+        }
+      ]
+    }
+    const stamped = partsByMessageId.m2[0] as CherryMessagePart & {
+      callProviderMetadata: Record<string, Record<string, unknown>>
+    }
+    stamped.callProviderMetadata.cherry = { launchToolCallId: 'call_launch' }
+
+    expect(resolveFlowToolCallId('call_send', partsByMessageId)).toEqual({ toolCallId: 'call_launch' })
+  })
+
+  it('does not duplicate the resume prompt when the receipt precedes its tagged content', () => {
+    const marker = { 'claude-code': { parentToolCallId: 'call_launch' }, cherry: { resumedViaCallId: 'call_send' } }
+    const parts = [
+      toolPart(
+        'call_launch',
+        'Agent',
+        undefined,
+        'output-available',
+        { prompt: 'Launch the review' },
+        'Async agent launched successfully.\nagentId: af5051807ed7aaa30 (internal metadata - do not mention to user.)'
+      ),
+      toolPart(
+        'call_send',
+        'SendMessage',
+        undefined,
+        'output-available',
+        { to: 'af5051807ed7aaa30', message: 'Please finalize' },
+        { success: true, resumedAgentId: 'af5051807ed7aaa30' }
+      ),
+      {
+        type: 'text',
+        text: 'Second round findings',
+        providerMetadata: marker
+      } as unknown as CherryMessagePart
+    ]
+    const messages = [message('m1', parts)]
+
+    const projection = buildAgentToolFlowProjection(messages, { m1: parts }, 'call_launch')
+
+    const userMessages = projection.messages.filter((item) => item.role === 'user')
+    expect(userMessages).toHaveLength(2) // launch prompt + exactly one resume prompt
+    const texts = userMessages.map((item) => (item.parts[0] as { text?: string }).text)
+    expect(texts).toEqual(['Launch the review', 'Please finalize'])
+    // The first (empty) round emits no segment; the tagged content forms the single assistant one.
+    expect(projection.messages.filter((item) => item.role === 'assistant').map((item) => item.id)).toEqual([
+      'call_launch:agent-flow-assistant-1'
+    ])
+  })
+
+  // Oversized receipts arrive as deferred envelopes; the resolved output must still carry the
+  // agent id so the continuation splits the timeline.
+  it('splits resume rounds for a deferred launch receipt via the resolved output', () => {
+    const deferred = { $deferredToolResult: { topicId: 't1', messageId: 'm1', toolCallId: 'call_launch' } }
+    const parts = [
+      toolPart('call_launch', 'Agent', undefined, 'output-available', { prompt: 'Launch the review' }, deferred),
+      textPart('First round findings', 'call_launch'),
+      toolPart(
+        'call_resume',
+        'SendMessage',
+        undefined,
+        'output-available',
+        { to: 'af5051807ed7aaa30' },
+        { success: true, resumedAgentId: 'af5051807ed7aaa30' }
+      ),
+      textPart('Second round findings', 'call_launch')
+    ]
+    const messages = [message('m1', parts)]
+    const resolvedOutput =
+      'Async agent launched successfully.\nagentId: af5051807ed7aaa30 (internal metadata - do not mention to user.)'
+
+    const projection = buildAgentToolFlowProjection(messages, { m1: parts }, 'call_launch', resolvedOutput)
+
+    // The receipt splits the rounds even though this particular send carried no prompt text
+    // (no resume user message is rendered for it).
+    expect(projection.messages.map((item) => item.id)).toEqual([
+      'call_launch:agent-flow-prompt',
+      'call_launch:agent-flow-assistant',
+      'call_launch:agent-flow-assistant-1'
+    ])
   })
 
   it('uses a lazily resolved selected output and preserves child parts untouched', () => {
@@ -123,11 +473,12 @@ describe('agent right pane projections', () => {
     const parts = [selected, child]
     const messages = [message('m1', parts)]
 
-    const projection = buildAgentToolFlowProjection(messages, { m1: parts }, 'root', 'Loaded subagent summary')
+    // The launch receipt's own result text is no longer appended to the flow — it duplicates the
+    // agent's final message and goes stale across continuations.
+    const projection = buildAgentToolFlowProjection(messages, { m1: parts }, 'root')
 
     expect(projection.partsByMessageId['root:agent-flow-assistant']).toEqual([
-      expect.objectContaining({ toolCallId: 'child' }),
-      { type: 'text', text: 'Loaded subagent summary' }
+      expect.objectContaining({ toolCallId: 'child' })
     ])
   })
 
@@ -740,6 +1091,39 @@ describe('agent right pane projections', () => {
         taskType: 'local_bash',
         outputFile: '/tmp/bg-1.md'
       })
+    ])
+  })
+
+  // A SendMessage resume re-points lifecycle edges at the resuming call's id, while the resumed
+  // content keeps streaming under the launch id — the row's navigation anchor must stay there.
+  it('keeps the launch tool-use id when a resumed run reports a new one', () => {
+    const parts = [
+      {
+        type: 'data-agent-task-event',
+        data: {
+          event: 'started',
+          taskId: 'agent-1',
+          status: 'in_progress',
+          title: 'Review patch',
+          toolUseId: 'call_launch'
+        }
+      },
+      {
+        type: 'data-agent-task-event',
+        data: {
+          event: 'progress',
+          taskId: 'agent-1',
+          status: 'in_progress',
+          description: 'Resumed work',
+          toolUseId: 'call_resume'
+        }
+      }
+    ] as unknown as CherryMessagePart[]
+
+    const status = buildAgentRightPaneStatus([message('m1', parts)], { m1: parts })
+
+    expect(status.runTasks).toEqual([
+      expect.objectContaining({ id: 'agent-1', status: 'in_progress', toolUseId: 'call_launch' })
     ])
   })
 

--- a/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
@@ -8,10 +8,14 @@ import {
 import {
   type AgentToolOutput,
   AgentToolsType,
-  isBackgroundAgentOutput
+  getResumedAgentId,
+  isBackgroundAgentOutput,
+  resolveResumedAgent
 } from '@renderer/components/chat/messages/tools/shared/agentToolTypes'
 import {
+  getPartLaunchToolCallId,
   getPartParentToolCallId,
+  getPartResumeMarker,
   hasPartParentToolCallId,
   stripPartParentToolMetadata
 } from '@renderer/components/chat/messages/tools/toolParentMetadata'
@@ -247,11 +251,67 @@ function isTerminalToolState(state: string | undefined): boolean {
   return state === 'output-available' || state === 'output-error' || state === 'output-denied' || state === 'cancelled'
 }
 
+/**
+ * Follow a tool-call entry to the flow it represents. A surface that binds a resumed task to the
+ * SendMessage call id (e.g. a cold reconnect replaying resume edges) would otherwise open an empty
+ * flow — everything streaming under the launch root instead.
+ */
+export function resolveFlowToolCallId(
+  toolCallId: string,
+  partsByMessageId: Record<string, CherryMessagePart[]> | null
+): { toolCallId: string; description?: string } | undefined {
+  if (!partsByMessageId) return undefined
+  for (const parts of Object.values(partsByMessageId)) {
+    for (const part of parts) {
+      const record = part as { toolCallId?: unknown; output?: unknown }
+      if (typeof record.toolCallId !== 'string' || record.toolCallId !== toolCallId) continue
+      // The adapter-stamped launch root resolves even when the launch row itself has been paged
+      // out; the scan below stays as the fallback for unstamped history.
+      const stamped = getPartLaunchToolCallId(part)
+      if (stamped) {
+        const identity = resolveResumedAgent(record.output, partsByMessageId)
+        return { toolCallId: stamped, description: identity?.description }
+      }
+      // Receipt outputs are small inline JSON, so no deferred-envelope resolution is needed here
+      // (unlike launch receipts, whose resolved output the flow view prefers).
+      return resolveResumedAgent(record.output, partsByMessageId)
+    }
+  }
+  return undefined
+}
+
+/**
+ * The agent id a launch receipt reports — the trailer string or a structured field. Prefers the
+ * caller-resolved output so deferred (oversized) receipts still split resume rounds correctly.
+ */
+function extractLaunchedAgentId(part: CherryMessagePart | undefined, resolvedOutput?: unknown): string | undefined {
+  const output = resolvedOutput !== undefined ? resolvedOutput : part && (part as { output?: unknown }).output
+  if (typeof output === 'string') return /agentId[:\s]+([a-zA-Z0-9-]{16,})/.exec(output)?.[1]
+  if (isRecord(output)) {
+    const direct = output.agentId ?? output.agent_id
+    return typeof direct === 'string' && direct.length >= 16 ? direct : undefined
+  }
+  return undefined
+}
+
+/** Whether this part is a SendMessage receipt that resumed THIS agent — the round boundary. */
+function isResumeReceiptFor(part: CherryMessagePart, launchedAgentId: string): boolean {
+  const record = part as { toolName?: unknown; output?: unknown }
+  return record.toolName === AgentToolsType.SendMessage && getResumedAgentId(record.output) === launchedAgentId
+}
+
+/** The request to show between rounds — the sent message, falling back to its summary. */
+function getResumeReceiptPromptText(part: CherryMessagePart): string | undefined {
+  const input = (part as { input?: unknown }).input
+  const prompt = isRecord(input) ? (input.message ?? input.summary) : undefined
+  return typeof prompt === 'string' && prompt.trim() ? prompt.trim() : undefined
+}
+
 export function buildAgentToolFlowProjection(
   messages: CherryUIMessage[],
   partsByMessageId: Record<string, CherryMessagePart[]>,
   selectedToolCallId?: string,
-  selectedToolOutput?: unknown
+  resolvedSelectedOutput?: unknown
 ): AgentToolFlowProjection {
   const toolNodes: AgentToolFlowNode[] = []
   const childrenByParent = new Map<string, string[]>()
@@ -316,11 +376,131 @@ export function buildAgentToolFlowProjection(
       flowPartsByMessageId[promptMessage.id] = promptMessage.parts as CherryMessagePart[]
     }
 
-    const assistantParts: CherryMessagePart[] = []
+    // Content is segmented by the resume requests that continued this agent: each SendMessage
+    // receipt resolving to the launch splits the timeline, so its prompt lands between rounds.
+    // The launch receipt's own result text is NOT appended — it duplicates the agent's final
+    // message already present above and goes stale across continuations.
+    const launchedAgentId = extractLaunchedAgentId(selectedToolPart, resolvedSelectedOutput)
+    const isFlowActive = toolNodes.some(
+      (node) => selectedToolCallIds.has(node.toolCallId) && !isTerminalToolState(node.state)
+    )
+
+    // Content is split into rounds two ways: runtime-tagged parts (`cherry.resumedViaCallId`,
+    // authoritative and restart-safe — the host row usually predates the receipt row, so position
+    // alone cannot order them), or — for untagged history — the receipt's own walk position.
+    const receiptPrompts = new Map<string, string>()
+    // Markers belonging to sibling agents' continuations must not split this flow, so the set of
+    // this agent's own receipt call ids gates every marker-driven split.
+    const ownReceiptCallIds = new Set<string>()
+    if (launchedAgentId) {
+      for (const { parts } of messageEntries) {
+        for (const part of parts) {
+          const toolCallId = getToolCallId(part)
+          if (!toolCallId || receiptPrompts.has(toolCallId)) continue
+          if (!isToolUIPart(part) || getToolNameFromPart(part) !== AgentToolsType.SendMessage) continue
+          if (!isResumeReceiptFor(part, launchedAgentId)) continue
+          ownReceiptCallIds.add(toolCallId)
+          const prompt = getResumeReceiptPromptText(part)
+          if (prompt) receiptPrompts.set(toolCallId, prompt)
+        }
+      }
+    }
+
+    const segments: Array<{ parts: CherryMessagePart[] }> = [{ parts: [] }]
+    // The result text only fills a flow that has no streamed child parts at all (a runtime whose
+    // foreground calls emit no detachable content); Claude Code streams them even for foreground
+    // runs, so injecting there would duplicate the report and leak its agentId trailer. Background
+    // launch receipts are control metadata and must never surface; an unresolved deferred envelope
+    // has no text to show yet.
+    const hasDetachedFlow = messageEntries.some(({ parts }) =>
+      parts.some((part) => getPartParentToolCallId(part) === selectedToolCallId)
+    )
+    if (!hasDetachedFlow) {
+      const selectedOutput =
+        resolvedSelectedOutput !== undefined
+          ? resolvedSelectedOutput
+          : selectedToolPart
+            ? getToolPartOutput(selectedToolPart)
+            : undefined
+      const selectedOutputText =
+        isRecord(selectedOutput) && '$deferredToolResult' in selectedOutput
+          ? undefined
+          : textFromContent(selectedOutput)
+      const foregroundResultText = isBackgroundAgentLaunchReceipt(selectedOutput, selectedOutputText)
+        ? undefined
+        : selectedOutputText
+      if (foregroundResultText) {
+        segments[0].parts.push({ type: 'text', text: foregroundResultText } as CherryMessagePart)
+      }
+    }
+    let segmentIndex = 0
+    let emittedSegments = 0
+    let resumeCount = 0
+    const consumedMarkers = new Set<string>()
+    const emitSegment = (index: number) => {
+      const segment = segments[index]
+      if (segment.parts.length === 0 && !isFlowActive) return
+      const id = `${selectedToolCallId}:agent-flow-assistant${index === 0 ? '' : `-${index}`}`
+      const assistantMessage = {
+        id,
+        role: 'assistant',
+        parts: segment.parts,
+        metadata: {
+          createdAt: selectedCreatedAt,
+          status: isFlowActive ? 'pending' : 'success'
+        }
+      } as CherryUIMessage
+      flowMessages.push(assistantMessage)
+      flowPartsByMessageId[id] = segment.parts
+    }
     for (const { parts } of messageEntries) {
-      for (let partIndex = 0; partIndex < parts.length; partIndex++) {
-        const part = parts[partIndex]
+      for (const part of parts) {
         const toolCallId = getToolCallId(part)
+
+        // Runtime-tagged round boundary: the first marked part opens the new round. The matching
+        // receipt's prompt text (pre-scanned by call id) backfills the user message; when that
+        // receipt is walked later it must not split a second time. The adapter only stamps parts
+        // whose parent is this launch root, but sibling flows sharing the walk order need the
+        // receipt-set check too, so both gates guard against splitting on foreign markers.
+        const marker = launchedAgentId ? getPartResumeMarker(part) : undefined
+
+        // A resume receipt is not itself part of the flow, but for untagged content it marks where
+        // a new round starts. Skip if its call id was already consumed by a runtime marker.
+        const isResumeReceipt =
+          launchedAgentId &&
+          isToolUIPart(part) &&
+          isResumeReceiptFor(part, launchedAgentId) &&
+          !(toolCallId && consumedMarkers.has(toolCallId))
+
+        const markerOwnsThisFlow =
+          marker !== undefined &&
+          !consumedMarkers.has(marker) &&
+          (ownReceiptCallIds.has(marker) || getPartParentToolCallId(part) === selectedToolCallId)
+
+        if (markerOwnsThisFlow || isResumeReceipt) {
+          for (; emittedSegments <= segmentIndex; emittedSegments += 1) emitSegment(emittedSegments)
+          resumeCount += 1
+          if (marker) consumedMarkers.add(marker)
+          // A position-based split must also consume the receipt's call id, or a same-message
+          // tagged part would split a second time and duplicate the prompt message.
+          else if (isResumeReceipt && toolCallId) consumedMarkers.add(toolCallId)
+          segmentIndex += 1
+          segments.push({ parts: [] })
+          const promptText = marker !== undefined ? receiptPrompts.get(marker) : getResumeReceiptPromptText(part)
+          const resumeMessage = createFlowTextMessage(
+            `${selectedToolCallId}:agent-flow-resume-${resumeCount}`,
+            'user',
+            promptText,
+            selectedCreatedAt
+          )
+          if (resumeMessage) {
+            flowMessages.push(resumeMessage)
+            flowPartsByMessageId[resumeMessage.id] = resumeMessage.parts as CherryMessagePart[]
+          }
+          if (isResumeReceipt) continue
+          // A tagged part belongs to the new round — fall through to descendant inclusion.
+        }
+
         if (toolCallId) {
           if (toolCallId === selectedToolCallId || !selectedToolCallIds.has(toolCallId)) continue
         } else {
@@ -328,39 +508,10 @@ export function buildAgentToolFlowProjection(
           if (!parentToolCallId || !selectedToolCallIds.has(parentToolCallId)) continue
         }
 
-        assistantParts.push(getPartWithoutParentMetadata(part))
+        segments[segmentIndex].parts.push(getPartWithoutParentMetadata(part))
       }
     }
-
-    const selectedOutput =
-      selectedToolOutput !== undefined
-        ? selectedToolOutput
-        : selectedToolPart
-          ? getToolPartOutput(selectedToolPart)
-          : undefined
-    const selectedOutputText = textFromContent(selectedOutput)
-    // A detached Agent result is only a control receipt and may expose internal ids or paths. Its
-    // actual conversation already arrives through the child flow parts collected above.
-    const outputText = isBackgroundAgentLaunchReceipt(selectedOutput, selectedOutputText)
-      ? undefined
-      : selectedOutputText
-    if (outputText) assistantParts.push({ type: 'text', text: outputText } as CherryMessagePart)
-    const isFlowActive = toolNodes.some(
-      (node) => selectedToolCallIds.has(node.toolCallId) && !isTerminalToolState(node.state)
-    )
-    if (assistantParts.length || isFlowActive) {
-      const assistantMessage = {
-        id: `${selectedToolCallId}:agent-flow-assistant`,
-        role: 'assistant',
-        parts: assistantParts,
-        metadata: {
-          createdAt: selectedCreatedAt,
-          status: isFlowActive ? 'pending' : 'success'
-        }
-      } as CherryUIMessage
-      flowMessages.push(assistantMessage)
-      flowPartsByMessageId[assistantMessage.id] = assistantParts
-    }
+    for (; emittedSegments < segments.length; emittedSegments += 1) emitSegment(emittedSegments)
   }
 
   return {
@@ -502,7 +653,9 @@ function applyAgentTaskEvent(
 
   runTaskMap.set(data.taskId, {
     id: data.taskId,
-    toolUseId: data.toolUseId ?? existing?.toolUseId,
+    // First registration wins: SendMessage-resume edges carry the resuming call's id while
+    // content keeps streaming under the original launch tool-use id.
+    toolUseId: existing?.toolUseId ?? data.toolUseId,
     title,
     activeText: data.activeText ?? data.description ?? existing?.activeText,
     status,


### PR DESCRIPTION
### What this PR does

**Stacked chain — layer 3 of 3** (base = `main`; diff includes layers 1–2 until they merge, then converges). This PR makes the flow view show the continued sub-agent's **whole timeline**: every continuation's prompt interleaved between the agent's rounds, entry points resolved to the launch root, and no duplicated or leaked launch result text.

Before this PR:

- The flow view appended the launch result text into the timeline — duplicating the agent's final report and leaking internal metadata (the `agentId:` trailer and `<usage>` block).
- Resumed rounds merged into the first one: continuation prompts never appeared between rounds.
- A cold reconnect could bind a task entry to the resuming call id, opening an empty flow.

After this PR:

- Content is segmented by each `SendMessage` continuation: runtime-tagged parts (`cherry.resumedViaCallId`, adapter-stamped in layer 1) split rounds authoritatively, with the receipt's walk position as fallback for untagged history; each continuation's prompt is interleaved as a user message between rounds.
- Round splits are gated to the agent's own receipt ids (sibling agents' markers cannot split this flow) and consumed ids prevent double splits.
- The launch result text is **no longer appended** — it duplicated the final report; it survives only as the fallback when a flow has zero streamed child parts (verified against real DB exports: 47/48 foreground launches stream detached parts, so the fallback never fires on real Claude Code data).
- `resolveFlowToolCallId` redirects resuming call ids to the launch root at open time (adapter stamp first, cross-message scan fallback), and task binding is first-registration-wins.

### Why we need it and why it was done in this way

The flow IS the agent's whole timeline — the launch identity is the only stable identity across continuations, so every entry converges on it.

The following tradeoffs were made:

- Round splitting prefers runtime-tagged markers over walk position because the host row usually predates the receipt row, making position-based ordering wrong for tagged content.
- The result-text injection is gated on the **absence of any detached part** for the selected launch, preserving upstream's foreground-result semantics without duplicating reports.

The following alternatives were considered:

- Persisting a `taskId → launch toolCallId` map (schema change not justified for presentation state).
- Replaying the transcript on demand (needs a new lookup API).

Fixes #

### Breaking changes

NONE — all changes are additive to presentation; no schema, IPC or API surface changes.

## Stack

This PR depends on #20064 (layer 2, chat-stream presentation) and #20063 (layer 1, main-process routing). Its diff at creation includes layers 1-2 and converges to this layer only after both merge into main.

Depends on #20064

### Special notes for your reviewer

Stacked chain: this is the final layer; merge order is `pr-a` → `pr-b` → this PR. It depends on layer 2's shared primitives (`getResumedAgentId`, `resolveResumedAgent`, `getPartLaunchToolCallId`, `getPartResumeMarker`) and on layer 1's stamped metadata for the authoritative split path.

Regression tests cover: launch-id retention on resume edges, post-drain resumed chunks landing on the spawning message, entry resolution + redirect for both receipt forms, resume-prompt interleaving, queued-pin stamping end-to-end, first-wins resolver behavior, double-split prevention, and foreground/legacy/structured receipt hiding.

A known limitation remains documented in this chain's design: identity resolution scans only the loaded message window, degrading to pre-PR presentation (never a wrong redirect) when the launch part is paged out.

### Checklist

- [x] Branch: This PR targets `main` (stacked; diff converges to this layer after layers 1–2 merge)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The sub-agent flow view now shows the full run timeline: each continuation prompt appears between the agent's rounds (including across app restarts), every entry opens the correct flow, and duplicated/leaked result text no longer appears.
```


