### PR TITLE
fix(browser-mcp): mute hidden and inactive pages

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/browser.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/browser.test.ts
@@ -33,6 +33,7 @@ vi.mock('electron', () => {
   const createWebContents = () => ({
     debugger: debuggerObj,
     setUserAgent: vi.fn(),
+    setAudioMuted: vi.fn(),
     getURL: vi.fn(() => 'https://example.com/'),
     getTitle: vi.fn(() => 'Example Title'),
     loadURL: vi.fn(async () => {}),
@@ -54,6 +55,9 @@ vi.mock('electron', () => {
 
   class MockBrowserWindow {
     private destroyed = false
+    private visible = false
+    private minimized = false
+    private handlers = new Map<string, Array<(...args: unknown[]) => void>>()
     public webContents = createWebContents()
     public isDestroyed = vi.fn(() => this.destroyed)
     public close = vi.fn(() => {
@@ -62,12 +66,34 @@ vi.mock('electron', () => {
     public destroy = vi.fn(() => {
       this.destroyed = true
     })
-    public on = vi.fn()
+    public on = vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      const listeners = this.handlers.get(event) ?? []
+      listeners.push(listener)
+      this.handlers.set(event, listeners)
+      return this
+    })
     public setBrowserView = vi.fn()
     public addBrowserView = vi.fn()
     public removeBrowserView = vi.fn()
     public getContentSize = vi.fn(() => [1200, 800])
-    public show = vi.fn()
+    public isVisible = vi.fn(() => this.visible)
+    public isMinimized = vi.fn(() => this.minimized)
+    public show = vi.fn(() => {
+      this.visible = true
+      this.handlers.get('show')?.forEach((listener) => listener())
+    })
+    public hide = vi.fn(() => {
+      this.visible = false
+      this.handlers.get('hide')?.forEach((listener) => listener())
+    })
+    public minimize = vi.fn(() => {
+      this.minimized = true
+      this.handlers.get('minimize')?.forEach((listener) => listener())
+    })
+    public restore = vi.fn(() => {
+      this.minimized = false
+      this.handlers.get('restore')?.forEach((listener) => listener())
+    })
 
     constructor() {
       windows.push(this)
@@ -328,6 +354,59 @@ describe('CdpBrowserController', () => {
 
       await controller.switchTab(false, result1.tabId)
       await controller.switchTab(false, result2.tabId)
+    })
+
+    it('mutes hidden tabs and unmutes only the active tab while its window is visible', async () => {
+      const controller = new CdpBrowserController()
+      const { view } = await controller.createTab()
+      const window = Array.from(managedWindows.values())[0]
+
+      expect(view.webContents.setAudioMuted).toHaveBeenLastCalledWith(true)
+      expect(vi.mocked(view.webContents.setAudioMuted).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(view.webContents.setUserAgent).mock.invocationCallOrder[0]
+      )
+
+      window.show()
+      expect(view.webContents.setAudioMuted).toHaveBeenLastCalledWith(false)
+
+      window.minimize()
+      expect(view.webContents.setAudioMuted).toHaveBeenLastCalledWith(true)
+
+      window.restore()
+      expect(view.webContents.setAudioMuted).toHaveBeenLastCalledWith(false)
+
+      window.hide()
+      expect(view.webContents.setAudioMuted).toHaveBeenLastCalledWith(true)
+    })
+
+    it('keeps inactive tabs muted when switching the active tab', async () => {
+      const controller = new CdpBrowserController()
+      const { tabId: firstTabId, view: firstView } = await controller.createTab(false, true)
+      const { tabId: secondTabId, view: secondView } = await controller.createTab(false, true)
+
+      expect(firstView.webContents.setAudioMuted).toHaveBeenLastCalledWith(false)
+      expect(secondView.webContents.setAudioMuted).toHaveBeenLastCalledWith(true)
+
+      await controller.switchTab(false, secondTabId)
+
+      expect(firstView.webContents.setAudioMuted).toHaveBeenLastCalledWith(true)
+      expect(secondView.webContents.setAudioMuted).toHaveBeenLastCalledWith(false)
+
+      await controller.switchTab(false, firstTabId)
+
+      expect(firstView.webContents.setAudioMuted).toHaveBeenLastCalledWith(false)
+      expect(secondView.webContents.setAudioMuted).toHaveBeenLastCalledWith(true)
+    })
+
+    it('unmutes the replacement when the active tab closes in a visible window', async () => {
+      const controller = new CdpBrowserController()
+      const { tabId: firstTabId, view: firstView } = await controller.createTab(false, true)
+      const { view: secondView } = await controller.createTab(false, true)
+
+      await controller.closeTab(false, firstTabId)
+
+      expect(firstView.webContents.setAudioMuted).toHaveBeenLastCalledWith(true)
+      expect(secondView.webContents.setAudioMuted).toHaveBeenLastCalledWith(false)
     })
 
     it('throws error when switching to non-existent tab', async () => {

--- a/src/main/ai/mcp/servers/browser/controller.ts
+++ b/src/main/ai/mcp/servers/browser/controller.ts
@@ -85,12 +85,24 @@ export class CdpBrowserController {
     }
   }
 
+  private syncAudioState(windowInfo: WindowInfo) {
+    const windowCanPlayAudio =
+      !windowInfo.window.isDestroyed() && windowInfo.window.isVisible() && !windowInfo.window.isMinimized()
+
+    for (const tab of windowInfo.tabs.values()) {
+      if (!tab.view.webContents.isDestroyed()) {
+        tab.view.webContents.setAudioMuted(!windowCanPlayAudio || tab.id !== windowInfo.activeTabId)
+      }
+    }
+  }
+
   private closeTabInternal(windowInfo: WindowInfo, tabId: string) {
     try {
       const tab = windowInfo.tabs.get(tabId)
       if (!tab) return
 
       if (!tab.view.webContents.isDestroyed()) {
+        tab.view.webContents.setAudioMuted(true)
         if (tab.view.webContents.debugger.isAttached()) {
           tab.view.webContents.debugger.detach()
         }
@@ -418,6 +430,14 @@ export class CdpBrowserController {
         const info = this.windows.get(windowKey)
         if (info) this.updateViewBounds(info)
       })
+      const syncAudioState = () => {
+        const info = this.windows.get(windowKey)
+        if (info) this.syncAudioState(info)
+      }
+      windowInfo.window.on('show', syncAudioState)
+      windowInfo.window.on('hide', syncAudioState)
+      windowInfo.window.on('minimize', syncAudioState)
+      windowInfo.window.on('restore', syncAudioState)
 
       logger.info('Created new window', { windowKey, privateMode })
     } else if (showWindow && !windowInfo.window.isDestroyed()) {
@@ -474,6 +494,7 @@ export class CdpBrowserController {
       }
     })
 
+    view.webContents.setAudioMuted(true)
     view.webContents.setUserAgent(userAgent)
 
     const windowKey = windowInfo.windowKey
@@ -494,6 +515,7 @@ export class CdpBrowserController {
           }
         }
       }
+      this.syncAudioState(windowInfo)
       this.sendTabBarUpdate(windowInfo)
     })
 
@@ -547,6 +569,7 @@ export class CdpBrowserController {
       this.updateViewBounds(windowInfo)
     }
 
+    this.syncAudioState(windowInfo)
     this.sendTabBarUpdate(windowInfo)
     logger.info('Created new tab', { windowKey, tabId, privateMode })
     return { tabId, view }
@@ -754,6 +777,7 @@ export class CdpBrowserController {
             }
           }
         }
+        this.syncAudioState(windowInfo)
         this.sendTabBarUpdate(windowInfo)
       }
       logger.info('Browser CDP tab reset', { windowKey, tabId })
@@ -951,6 +975,7 @@ export class CdpBrowserController {
       this.updateViewBounds(windowInfo)
     }
 
+    this.syncAudioState(windowInfo)
     this.touchTab(windowKey, tabId)
     this.sendTabBarUpdate(windowInfo)
     logger.info('Switched active tab', { windowKey, tabId, privateMode })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Hidden MCP browser windows and inactive browser tabs could keep playing audible media in the background.

After this PR:

Browser tabs start muted. Only the active tab in a visible, non-minimized MCP browser window is unmuted; audio state is synchronized when the window is shown, hidden, minimized, restored, when tabs switch, and when the active tab is replaced.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19858

### Why we need it and why it was done in this way

Removing an inactive `BrowserView` from its window does not destroy its `webContents`, so media can continue playing. The controller now owns one audio-state invariant and reapplies it at each window and tab lifecycle transition.

The following tradeoffs were made:

Background pages remain alive for existing browser automation behavior, but are muted whenever they are not both active and visibly presented.

The following alternatives were considered:

Destroying inactive tabs was rejected because it would discard browsing state and break multi-tab reuse. Blocking autoplay globally was rejected because visible active pages may legitimately need audio.

Links to places where the discussion took place: #19858

### Breaking changes

None.

### Special notes for your reviewer

Audio lifecycle state cannot be represented credibly in a static screenshot. Runtime behavior is covered by regression tests for initial hidden state, show/hide, minimize/restore, inactive tabs, tab switches, and active-tab replacement.

Validation:

- `pnpm test:main src/main/ai/mcp/servers/__tests__/browser.test.ts --maxWorkers=1 --no-file-parallelism` (31 tests passed)
- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Browser MCP] Prevent hidden or inactive built-in browser pages from playing audible media.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to MCP built-in browser audio via `setAudioMuted`; no auth or data-path changes, with behavior locked by unit tests.
> 
> **Overview**
> Fixes background audio from MCP browser tabs whose `webContents` stay alive when views are hidden or deprioritized.
> 
> **`CdpBrowserController`** now enforces a single rule via `syncAudioState`: only the **active** tab in a **visible, non-minimized** window is unmuted; everything else is muted. New tabs start muted; closing a tab mutes it explicitly. Audio is re-synced on window show/hide/minimize/restore, tab create/destroy, tab switch, and when the active tab is replaced after close or reset.
> 
> **Tests** extend the Electron mocks (`setAudioMuted`, visibility/minimize events) and add regression coverage for hidden windows, tab switching, and active-tab replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e043e3b1b79de0622a95f32f2fb0d24eb87fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->