### PR TITLE
fix(api-gateway): distinguish provider failures from unavailable models

### DIFF
--- a/docs/references/api-gateway/README.md
+++ b/docs/references/api-gateway/README.md
@@ -198,10 +198,11 @@ A streaming request has two error regimes:
 
 - **Before commitment:** `processMessage` has not returned its `Response` yet.
   Adapter-generated startup frames remain buffered. A provider error rejects
-  with the original serialized error, so the route returns its real HTTP status
-  and dialect envelope (for example, HTTP 400 or 503). An idle-timeout pause
-  rejects as HTTP 504. AI SDK `start`, step, metadata, partial tool-input, and
-  tool-output chunks do not commit the response.
+  with a gateway-local copy carrying requested-route context, so the route
+  returns its real HTTP status and safe recovery guidance in the dialect
+  envelope (for example, HTTP 400 or 503). An idle-timeout pause rejects as HTTP
+  504. AI SDK `start`, step, metadata, partial tool-input, and tool-output chunks
+  do not commit the response.
 - **After commitment:** once text/reasoning output, an available tool call, a
   finish chunk, or clean completion commits HTTP 200, headers can no longer
   change. A later error or pause therefore emits the dialect's terminal SSE

--- a/docs/references/api-gateway/README.md
+++ b/docs/references/api-gateway/README.md
@@ -341,10 +341,12 @@ Built-in Elysia `VALIDATION` / `NOT_FOUND` / `PARSE` codes map to 400/404/400
 (422 for REST validation). Unknown provider/runtime errors are shaped by
 `transformAnthropicError` / `transformOpenAiError` — **status-driven**: they read
 `statusCode` off the AI-SDK `SerializedError`, so a provider 401/429/… keeps its
-real status and message instead of flattening to 500. Internal-error messages are
-gated behind `isDev`, and the AI-SDK error extras (`stack` / `url` /
-request+response bodies) are dropped — for both the JSON handlers and the
-streaming `buildStreamErrorFrame`.
+real status instead of flattening to 500. Gateway-originated provider errors also
+identify the provider/model and give status-specific recovery guidance; local
+missing, disabled, or unroutable models remain 400 address-resolution failures.
+Internal-error messages are gated behind `isDev`, and the AI-SDK error extras
+(`stack` / `url` / request+response bodies) are dropped — for both the JSON
+handlers and the streaming `buildStreamErrorFrame`.
 
 ## Key invariants
 

--- a/src/main/features/apiGateway/__tests__/proxyStream.parse.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.parse.test.ts
@@ -187,6 +187,24 @@ describe('processMessage model-id parsing', () => {
     expect(mockStreamPrompt).not.toHaveBeenCalled()
   })
 
+  it('identifies a disabled local provider and the recovery action before routing', async () => {
+    mockGetProvider.mockReturnValue({ id: 'openrouter', name: 'OpenRouter', isEnabled: false })
+
+    await expect(
+      processMessage({
+        params: { model: 'openrouter:deepseek/deepseek-v4-flash-0731', messages: [] } as any,
+        inputFormat: 'anthropic',
+        outputFormat: 'anthropic'
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      message:
+        'Model "openrouter:deepseek/deepseek-v4-flash-0731" is not available through the API gateway. Check that provider "openrouter" and model "deepseek/deepseek-v4-flash-0731" are enabled and gateway-routable.'
+    })
+    expect(mockListModels).not.toHaveBeenCalled()
+    expect(mockStreamPrompt).not.toHaveBeenCalled()
+  })
+
   it('splits on the first colon for a simple provider:model', async () => {
     mockAvailableModel('openai', 'gpt-4')
     expect(await resolveValid('openai:gpt-4')).toBe(createUniqueModelId('openai', 'gpt-4'))

--- a/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
@@ -781,6 +781,42 @@ describe('processMessage (error & pause)', () => {
     expect(error).toEqual(originalError)
   })
 
+  it('does not report an earlier retry status when lastError has no HTTP status', async () => {
+    const { response, listener } = await startStreaming()
+    const terminalError = { name: 'Error', message: 'connection closed', stack: null }
+    const error = {
+      name: 'AI_RetryError',
+      message: 'Failed after 2 attempts',
+      stack: null,
+      lastError: terminalError,
+      errors: [{ name: 'AI_APICallError', message: 'unavailable', stack: null, statusCode: 503 }, terminalError]
+    }
+
+    void listener.onError({ status: 'error', error } as any)
+
+    await expect(response).rejects.toBe(error)
+  })
+
+  it('uses only the final errors entry when a serialized retry error omits lastError', async () => {
+    const { response, listener } = await startStreaming()
+    const error = {
+      name: 'AI_RetryError',
+      message: 'Failed after 2 attempts',
+      stack: null,
+      errors: [
+        { name: 'AI_APICallError', message: 'unavailable', stack: null, statusCode: 503 },
+        { name: 'AI_APICallError', message: 'rate limited', stack: null, statusCode: 429 }
+      ]
+    }
+
+    void listener.onError({ status: 'error', error } as any)
+
+    await expect(response).rejects.toMatchObject({
+      statusCode: 429,
+      gatewayErrorKind: 'upstream_provider'
+    })
+  })
+
   it('streaming: an error after commitment emits a dialect error frame, not the raw SerializedError', async () => {
     const { response, listener } = await startStreaming()
     commit(listener)

--- a/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
@@ -731,7 +731,7 @@ describe('processMessage (streaming)', () => {
 })
 
 describe('processMessage (error & pause)', () => {
-  it('rejects the original provider error before semantic commitment', async () => {
+  it('rejects the original provider error with gateway context before semantic commitment', async () => {
     const { response, listener } = await startStreaming()
     const error = { name: 'AI_APICallError', message: 'Provider rejected the request', stack: null, statusCode: 400 }
 
@@ -739,6 +739,12 @@ describe('processMessage (error & pause)', () => {
     void listener.onError({ status: 'error', error } as any)
 
     await expect(response).rejects.toBe(error)
+    expect(error).toMatchObject({
+      statusCode: 400,
+      gatewayErrorKind: 'upstream_provider',
+      providerId: 'openai',
+      modelId: 'gpt-4'
+    })
   })
 
   it('streaming: an error after commitment emits a dialect error frame, not the raw SerializedError', async () => {
@@ -761,7 +767,10 @@ describe('processMessage (error & pause)', () => {
 
     const text = await readAll(res.body)
     expect(text).toContain('"error"')
-    expect(text).toContain('Provider rejected the request')
+    expect(text).toContain(
+      'Provider \\"openai\\" rate limited model \\"gpt-4\\". Retry later or check the provider quota.'
+    )
+    expect(text).not.toContain('Provider rejected the request')
     expect(text).not.toContain('secret stack')
     expect(text).not.toContain('SECRET PROMPT')
     expect(text).not.toContain('secret body')
@@ -802,6 +811,41 @@ describe('processMessage (error & pause)', () => {
     } as any)
 
     await expect(resPromise).rejects.toMatchObject({ statusCode: 401 })
+  })
+
+  it('streaming Agent request preserves a pre-commit upstream 401 with safe provider and model context', async () => {
+    useGatewayModel('deepseek/deepseek-v4-flash-0731', ENDPOINT_TYPE.OPENAI_CHAT, 'openrouter')
+    mockIsInternalAgentRequest.mockReturnValue(true)
+    const resPromise = processMessage({
+      params: {
+        model: 'openrouter:deepseek/deepseek-v4-flash-0731',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello' }],
+        stream: true
+      },
+      inputFormat: 'anthropic',
+      outputFormat: 'anthropic',
+      requestHeaders: new Headers({ 'x-cherry-internal-usage-token': 'proof' })
+    })
+    await vi.waitFor(() => expect(captured.listener).toBeDefined())
+
+    void captured.listener!.onError({
+      status: 'error',
+      error: {
+        name: 'AI_APICallError',
+        message: 'User not found',
+        stack: 'secret stack',
+        statusCode: 401,
+        url: 'https://openrouter.ai/api/v1/chat/completions',
+        requestBodyValues: { messages: ['SECRET REQUEST'] }
+      }
+    } as any)
+
+    await expect(resPromise).rejects.toMatchObject({
+      statusCode: 401,
+      providerId: 'openrouter',
+      modelId: 'deepseek/deepseek-v4-flash-0731'
+    })
   })
 
   it('non-streaming: an idle-timeout pause rejects with a 504 (truncation is not a 200)', async () => {

--- a/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
@@ -731,20 +731,26 @@ describe('processMessage (streaming)', () => {
 })
 
 describe('processMessage (error & pause)', () => {
-  it('rejects the original provider error with gateway context before semantic commitment', async () => {
+  it('rejects a gateway-local copy without mutating the stream manager error', async () => {
     const { response, listener } = await startStreaming()
     const error = { name: 'AI_APICallError', message: 'Provider rejected the request', stack: null, statusCode: 400 }
+    const originalError = structuredClone(error)
 
     listener.onChunk({ type: 'start' } as any)
     void listener.onError({ status: 'error', error } as any)
 
-    await expect(response).rejects.toBe(error)
-    expect(error).toMatchObject({
+    const rejected = await response.then(
+      () => undefined,
+      (reason: unknown) => reason
+    )
+    expect(rejected).not.toBe(error)
+    expect(rejected).toMatchObject({
       statusCode: 400,
       gatewayErrorKind: 'upstream_provider',
-      providerId: 'openai',
-      modelId: 'gpt-4'
+      requestedProviderId: 'openai',
+      requestedModelId: 'gpt-4'
     })
+    expect(error).toEqual(originalError)
   })
 
   it('streaming: an error after commitment emits a dialect error frame, not the raw SerializedError', async () => {
@@ -768,7 +774,7 @@ describe('processMessage (error & pause)', () => {
     const text = await readAll(res.body)
     expect(text).toContain('"error"')
     expect(text).toContain(
-      'Provider \\"openai\\" rate limited model \\"gpt-4\\". Retry later or check the provider quota.'
+      'Gateway request for \\"openai:gpt-4\\" received an upstream rate limit. Check the requested route, any configured fallback, and provider quota before retrying.'
     )
     expect(text).not.toContain('Provider rejected the request')
     expect(text).not.toContain('secret stack')
@@ -843,8 +849,8 @@ describe('processMessage (error & pause)', () => {
 
     await expect(resPromise).rejects.toMatchObject({
       statusCode: 401,
-      providerId: 'openrouter',
-      modelId: 'deepseek/deepseek-v4-flash-0731'
+      requestedProviderId: 'openrouter',
+      requestedModelId: 'deepseek/deepseek-v4-flash-0731'
     })
   })
 

--- a/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
@@ -814,7 +814,7 @@ describe('processMessage (error & pause)', () => {
   })
 
   it('streaming Agent request preserves a pre-commit upstream 401 with safe provider and model context', async () => {
-    useGatewayModel('deepseek/deepseek-v4-flash-0731', ENDPOINT_TYPE.OPENAI_CHAT, 'openrouter')
+    useGatewayModel('deepseek/deepseek-v4-flash-0731', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, 'openrouter')
     mockIsInternalAgentRequest.mockReturnValue(true)
     const resPromise = processMessage({
       params: {

--- a/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
@@ -753,6 +753,34 @@ describe('processMessage (error & pause)', () => {
     expect(error).toEqual(originalError)
   })
 
+  it('preserves the terminal upstream status from a serialized retry error', async () => {
+    const { response, listener } = await startStreaming()
+    const terminalError = {
+      name: 'AI_APICallError',
+      message: 'rate limited',
+      stack: null,
+      statusCode: 429
+    }
+    const error = {
+      name: 'AI_RetryError',
+      message: 'Failed after 3 attempts',
+      stack: null,
+      lastError: terminalError,
+      errors: [{ name: 'AI_APICallError', message: 'unavailable', stack: null, statusCode: 503 }, terminalError]
+    }
+    const originalError = structuredClone(error)
+
+    void listener.onError({ status: 'error', error } as any)
+
+    await expect(response).rejects.toMatchObject({
+      statusCode: 429,
+      gatewayErrorKind: 'upstream_provider',
+      requestedProviderId: 'openai',
+      requestedModelId: 'gpt-4'
+    })
+    expect(error).toEqual(originalError)
+  })
+
   it('streaming: an error after commitment emits a dialect error frame, not the raw SerializedError', async () => {
     const { response, listener } = await startStreaming()
     commit(listener)

--- a/src/main/features/apiGateway/errors.ts
+++ b/src/main/features/apiGateway/errors.ts
@@ -12,13 +12,18 @@ const GATEWAY_PROVIDER_ERROR_KIND = 'upstream_provider'
 
 type GatewayErrorContext = Parameters<ErrorHandler<{ DATA_API: DataApiError }>>[0]
 
-export function attachGatewayProviderContext(
+export function withGatewayProviderContext(
   error: SerializedError,
   providerId: string,
   modelId: string
 ): SerializedError {
   if (typeof error.statusCode !== 'number') return error
-  return Object.assign(error, { gatewayErrorKind: GATEWAY_PROVIDER_ERROR_KIND, providerId, modelId })
+  return {
+    ...error,
+    gatewayErrorKind: GATEWAY_PROVIDER_ERROR_KIND,
+    requestedProviderId: providerId,
+    requestedModelId: modelId
+  }
 }
 
 const messageOf = (error: unknown, fallback: string): string =>
@@ -96,8 +101,8 @@ function extractError(error: unknown): {
   status?: number
   message?: string
   type?: string
-  providerId?: string
-  modelId?: string
+  requestedProviderId?: string
+  requestedModelId?: string
   isGatewayProviderError: boolean
 } {
   if (error === null || typeof error !== 'object') return { isGatewayProviderError: false }
@@ -107,8 +112,8 @@ function extractError(error: unknown): {
     message?: unknown
     error?: { type?: unknown; message?: unknown }
     gatewayErrorKind?: unknown
-    providerId?: unknown
-    modelId?: unknown
+    requestedProviderId?: unknown
+    requestedModelId?: unknown
   }
   // Prefer `status` (HTTP libs / OpenAI APIError), then `statusCode` (AI-SDK APICallError / SerializedError).
   const status = typeof e.status === 'number' ? e.status : typeof e.statusCode === 'number' ? e.statusCode : undefined
@@ -116,28 +121,31 @@ function extractError(error: unknown): {
   const message =
     typeof e.error?.message === 'string' ? e.error.message : typeof e.message === 'string' ? e.message : undefined
   const type = typeof e.error?.type === 'string' ? e.error.type : undefined
-  const providerId = typeof e.providerId === 'string' && e.providerId.length > 0 ? e.providerId : undefined
-  const modelId = typeof e.modelId === 'string' && e.modelId.length > 0 ? e.modelId : undefined
+  const requestedProviderId =
+    typeof e.requestedProviderId === 'string' && e.requestedProviderId.length > 0 ? e.requestedProviderId : undefined
+  const requestedModelId =
+    typeof e.requestedModelId === 'string' && e.requestedModelId.length > 0 ? e.requestedModelId : undefined
   return {
     status,
     message,
     type,
-    providerId,
-    modelId,
+    requestedProviderId,
+    requestedModelId,
     isGatewayProviderError: e.gatewayErrorKind === GATEWAY_PROVIDER_ERROR_KIND
   }
 }
 
-function gatewayProviderMessage(status: number, providerId: string, modelId: string): string {
+function gatewayProviderMessage(status: number, requestedProviderId: string, requestedModelId: string): string {
+  const requestedAddress = `${requestedProviderId}:${requestedModelId}`
   let summary: string
   if (status === 401) {
-    summary = `Provider "${providerId}" authentication failed for model "${modelId}". Check the provider credentials and account access.`
+    summary = `Gateway request for "${requestedAddress}" received an upstream authentication failure. Check the requested route, any configured fallback, and account access.`
   } else if (status === 403) {
-    summary = `Provider "${providerId}" denied access to model "${modelId}". Check the account and model permissions.`
+    summary = `Gateway request for "${requestedAddress}" received an upstream access denial. Check the requested route, any configured fallback, and model permissions.`
   } else if (status === 429) {
-    summary = `Provider "${providerId}" rate limited model "${modelId}". Retry later or check the provider quota.`
+    summary = `Gateway request for "${requestedAddress}" received an upstream rate limit. Check the requested route, any configured fallback, and provider quota before retrying.`
   } else {
-    summary = `Provider "${providerId}" request failed for model "${modelId}" (HTTP ${status}). Check the provider status and model access.`
+    summary = `Gateway request for "${requestedAddress}" failed upstream (HTTP ${status}). Check the requested route, any configured fallback, and model access.`
   }
   return summary
 }
@@ -151,11 +159,16 @@ function gatewayProviderMessage(status: number, providerId: string, modelId: str
 function safeMessage(
   status: number | undefined,
   message: string | undefined,
-  context?: { isGatewayProviderError: boolean; providerId?: string; modelId?: string }
+  context?: { isGatewayProviderError: boolean; requestedProviderId?: string; requestedModelId?: string }
 ): string {
   const fallback = 'Internal server error'
-  if (status !== undefined && context?.isGatewayProviderError && context.providerId && context.modelId) {
-    return gatewayProviderMessage(status, context.providerId, context.modelId)
+  if (
+    status !== undefined &&
+    context?.isGatewayProviderError &&
+    context.requestedProviderId &&
+    context.requestedModelId
+  ) {
+    return gatewayProviderMessage(status, context.requestedProviderId, context.requestedModelId)
   }
   if (status !== undefined) return message && message.length > 0 ? message : fallback
   return isDev && message && message.length > 0 ? message : fallback

--- a/src/main/features/apiGateway/errors.ts
+++ b/src/main/features/apiGateway/errors.ts
@@ -26,15 +26,11 @@ function findHttpStatus(error: unknown, seen = new Set<object>()): number | unde
   if (typeof candidate.status === 'number') return candidate.status
   if (typeof candidate.statusCode === 'number') return candidate.statusCode
 
-  const terminalStatus = findHttpStatus(candidate.lastError, seen) ?? findHttpStatus(candidate.cause, seen)
-  if (terminalStatus !== undefined) return terminalStatus
-  if (!Array.isArray(candidate.errors)) return undefined
-
-  for (let index = candidate.errors.length - 1; index >= 0; index -= 1) {
-    const status = findHttpStatus(candidate.errors[index], seen)
-    if (status !== undefined) return status
+  if ('lastError' in candidate) return findHttpStatus(candidate.lastError, seen)
+  if (Array.isArray(candidate.errors) && candidate.errors.length > 0) {
+    return findHttpStatus(candidate.errors[candidate.errors.length - 1], seen)
   }
-  return undefined
+  return findHttpStatus(candidate.cause, seen)
 }
 
 export function withGatewayProviderContext(

--- a/src/main/features/apiGateway/errors.ts
+++ b/src/main/features/apiGateway/errors.ts
@@ -2,13 +2,24 @@ import { loggerService } from '@logger'
 import { isDev } from '@main/core/platform'
 import { ErrorCode, JSONRPC_VERSION } from '@modelcontextprotocol/sdk/types.js'
 import { DataApiError } from '@shared/data/api/errors'
+import type { SerializedError } from '@shared/types/error'
 import type { ErrorHandler } from 'elysia'
 
 import type { OutputFormat } from './adapters'
 
 const logger = loggerService.withContext('ApiGatewayErrors')
+const GATEWAY_PROVIDER_ERROR_KIND = 'upstream_provider'
 
 type GatewayErrorContext = Parameters<ErrorHandler<{ DATA_API: DataApiError }>>[0]
+
+export function attachGatewayProviderContext(
+  error: SerializedError,
+  providerId: string,
+  modelId: string
+): SerializedError {
+  if (typeof error.statusCode !== 'number') return error
+  return Object.assign(error, { gatewayErrorKind: GATEWAY_PROVIDER_ERROR_KIND, providerId, modelId })
+}
 
 const messageOf = (error: unknown, fallback: string): string =>
   error instanceof Error && error.message ? error.message : fallback
@@ -77,20 +88,27 @@ function googleStatusName(status: number): string {
 }
 
 /**
- * Best-effort `{ status, message, type }` from any thrown value — a real `Error`,
- * an OpenAI / AI-SDK error, or a `SerializedError` plain object (carrying
- * `statusCode` / `message`, as produced by `AiStreamManager.onError` and thrown by
- * `processMessage`). Reads only status/message/type; the AI-SDK `APICallError`
- * extras (`stack`, `url`, `requestBodyValues`, `responseBody`, `responseHeaders`)
- * are intentionally ignored so they never reach the client.
+ * Best-effort status, message, type, and gateway provider context from any thrown
+ * value. AI-SDK `APICallError` extras (`stack`, `url`, request/response bodies and
+ * headers) are intentionally ignored so they never reach the client.
  */
-function extractError(error: unknown): { status?: number; message?: string; type?: string } {
-  if (error === null || typeof error !== 'object') return {}
+function extractError(error: unknown): {
+  status?: number
+  message?: string
+  type?: string
+  providerId?: string
+  modelId?: string
+  isGatewayProviderError: boolean
+} {
+  if (error === null || typeof error !== 'object') return { isGatewayProviderError: false }
   const e = error as {
     status?: unknown
     statusCode?: unknown
     message?: unknown
     error?: { type?: unknown; message?: unknown }
+    gatewayErrorKind?: unknown
+    providerId?: unknown
+    modelId?: unknown
   }
   // Prefer `status` (HTTP libs / OpenAI APIError), then `statusCode` (AI-SDK APICallError / SerializedError).
   const status = typeof e.status === 'number' ? e.status : typeof e.statusCode === 'number' ? e.statusCode : undefined
@@ -98,18 +116,47 @@ function extractError(error: unknown): { status?: number; message?: string; type
   const message =
     typeof e.error?.message === 'string' ? e.error.message : typeof e.message === 'string' ? e.message : undefined
   const type = typeof e.error?.type === 'string' ? e.error.type : undefined
-  return { status, message, type }
+  const providerId = typeof e.providerId === 'string' && e.providerId.length > 0 ? e.providerId : undefined
+  const modelId = typeof e.modelId === 'string' && e.modelId.length > 0 ? e.modelId : undefined
+  return {
+    status,
+    message,
+    type,
+    providerId,
+    modelId,
+    isGatewayProviderError: e.gatewayErrorKind === GATEWAY_PROVIDER_ERROR_KIND
+  }
+}
+
+function gatewayProviderMessage(status: number, providerId: string, modelId: string): string {
+  let summary: string
+  if (status === 401) {
+    summary = `Provider "${providerId}" authentication failed for model "${modelId}". Check the provider credentials and account access.`
+  } else if (status === 403) {
+    summary = `Provider "${providerId}" denied access to model "${modelId}". Check the account and model permissions.`
+  } else if (status === 429) {
+    summary = `Provider "${providerId}" rate limited model "${modelId}". Retry later or check the provider quota.`
+  } else {
+    summary = `Provider "${providerId}" request failed for model "${modelId}" (HTTP ${status}). Check the provider status and model access.`
+  }
+  return summary
 }
 
 /**
- * Resolve the client-facing message. Provider errors (those carrying a real HTTP
- * status) surface their own message — that's the v1 passthrough behaviour, and the
- * message is not the leak this guards against (the AI-SDK extras are, and those are
- * dropped in `extractError`). Unexpected internal errors (no status) are gated
- * behind `isDev` so internal detail never ships to clients in production.
+ * Resolve the client-facing message. Tagged gateway provider failures use only
+ * status and gateway-owned context because upstream text may echo private request
+ * content. Untagged status errors keep the compatibility passthrough; unexpected
+ * internal errors are gated behind `isDev`.
  */
-function safeMessage(status: number | undefined, message: string | undefined): string {
+function safeMessage(
+  status: number | undefined,
+  message: string | undefined,
+  context?: { isGatewayProviderError: boolean; providerId?: string; modelId?: string }
+): string {
   const fallback = 'Internal server error'
+  if (status !== undefined && context?.isGatewayProviderError && context.providerId && context.modelId) {
+    return gatewayProviderMessage(status, context.providerId, context.modelId)
+  }
   if (status !== undefined) return message && message.length > 0 ? message : fallback
   return isDev && message && message.length > 0 ? message : fallback
 }
@@ -133,7 +180,7 @@ function transformAnthropicError(error: unknown): {
   statusCode: number
   errorResponse: { type: 'error'; error: { type: string; message: string; requestId?: string } }
 } {
-  const { status, message, type } = extractError(error)
+  const { status, message, type, ...context } = extractError(error)
   const statusCode = status ?? 500
   const errorType = type ?? anthropicTypeForStatus(statusCode)
   const requestId =
@@ -142,7 +189,10 @@ function transformAnthropicError(error: unknown): {
       : undefined
   return {
     statusCode,
-    errorResponse: { type: 'error', error: { type: errorType, message: safeMessage(status, message), requestId } }
+    errorResponse: {
+      type: 'error',
+      error: { type: errorType, message: safeMessage(status, message, context), requestId }
+    }
   }
 }
 
@@ -166,10 +216,10 @@ function transformOpenAiError(error: unknown): {
   statusCode: number
   errorResponse: { error: { message: string; type: string; code: string } }
 } {
-  const { status, message } = extractError(error)
+  const { status, message, ...context } = extractError(error)
   const statusCode = status ?? 500
   const { type, code } = openaiTypeAndCodeForStatus(statusCode)
-  return { statusCode, errorResponse: { error: { message: safeMessage(status, message), type, code } } }
+  return { statusCode, errorResponse: { error: { message: safeMessage(status, message, context), type, code } } }
 }
 
 /**
@@ -182,9 +232,9 @@ function transformGoogleError(error: unknown): {
   statusCode: number
   errorResponse: { error: { code: number; message: string; status: string } }
 } {
-  const { status, message } = extractError(error)
+  const { status, message, ...context } = extractError(error)
   const statusCode = status ?? 500
-  return { statusCode, errorResponse: googleEnvelope(statusCode, safeMessage(status, message)) }
+  return { statusCode, errorResponse: googleEnvelope(statusCode, safeMessage(status, message, context)) }
 }
 
 /**

--- a/src/main/features/apiGateway/errors.ts
+++ b/src/main/features/apiGateway/errors.ts
@@ -12,14 +12,41 @@ const GATEWAY_PROVIDER_ERROR_KIND = 'upstream_provider'
 
 type GatewayErrorContext = Parameters<ErrorHandler<{ DATA_API: DataApiError }>>[0]
 
+function findHttpStatus(error: unknown, seen = new Set<object>()): number | undefined {
+  if (error === null || typeof error !== 'object' || seen.has(error)) return undefined
+  seen.add(error)
+
+  const candidate = error as {
+    status?: unknown
+    statusCode?: unknown
+    lastError?: unknown
+    cause?: unknown
+    errors?: unknown
+  }
+  if (typeof candidate.status === 'number') return candidate.status
+  if (typeof candidate.statusCode === 'number') return candidate.statusCode
+
+  const terminalStatus = findHttpStatus(candidate.lastError, seen) ?? findHttpStatus(candidate.cause, seen)
+  if (terminalStatus !== undefined) return terminalStatus
+  if (!Array.isArray(candidate.errors)) return undefined
+
+  for (let index = candidate.errors.length - 1; index >= 0; index -= 1) {
+    const status = findHttpStatus(candidate.errors[index], seen)
+    if (status !== undefined) return status
+  }
+  return undefined
+}
+
 export function withGatewayProviderContext(
   error: SerializedError,
   providerId: string,
   modelId: string
 ): SerializedError {
-  if (typeof error.statusCode !== 'number') return error
+  const statusCode = findHttpStatus(error)
+  if (statusCode === undefined) return error
   return {
     ...error,
+    statusCode,
     gatewayErrorKind: GATEWAY_PROVIDER_ERROR_KIND,
     requestedProviderId: providerId,
     requestedModelId: modelId

--- a/src/main/features/apiGateway/proxyStream.ts
+++ b/src/main/features/apiGateway/proxyStream.ts
@@ -29,7 +29,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import type { InputFormat, InputParamsMap, ISseFormatter, IStreamAdapter, OutputFormat } from './adapters'
 import { MessageConverterFactory, StreamAdapterFactory } from './adapters'
-import { attachGatewayProviderContext, buildStreamErrorFrame } from './errors'
+import { buildStreamErrorFrame, withGatewayProviderContext } from './errors'
 import { googleReasoningCache, openRouterReasoningCache } from './reasoningCache'
 import { appendInternalAgentContinuation } from './utils/agentContinuation'
 import { normalizeAnthropicToolHistory } from './utils/anthropicToolHistory'
@@ -362,7 +362,7 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
             return sseListener.onPaused(result)
           },
           onError: (result) => {
-            const error = attachGatewayProviderContext(result.error, providerId, modelId)
+            const error = withGatewayProviderContext(result.error, providerId, modelId)
             if (startupState !== 'pending') return sseListener.onError({ ...result, error })
 
             fail(error)
@@ -456,7 +456,7 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
       })
       rejectDone(streamInterruptedError())
     },
-    onError: (result) => rejectDone(attachGatewayProviderContext(result.error, providerId, modelId)),
+    onError: (result) => rejectDone(withGatewayProviderContext(result.error, providerId, modelId)),
     isAlive: () => !aborted
   }
 

--- a/src/main/features/apiGateway/proxyStream.ts
+++ b/src/main/features/apiGateway/proxyStream.ts
@@ -29,7 +29,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import type { InputFormat, InputParamsMap, ISseFormatter, IStreamAdapter, OutputFormat } from './adapters'
 import { MessageConverterFactory, StreamAdapterFactory } from './adapters'
-import { buildStreamErrorFrame } from './errors'
+import { attachGatewayProviderContext, buildStreamErrorFrame } from './errors'
 import { googleReasoningCache, openRouterReasoningCache } from './reasoningCache'
 import { appendInternalAgentContinuation } from './utils/agentContinuation'
 import { normalizeAnthropicToolHistory } from './utils/anthropicToolHistory'
@@ -362,11 +362,12 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
             return sseListener.onPaused(result)
           },
           onError: (result) => {
-            if (startupState !== 'pending') return sseListener.onError(result)
+            const error = attachGatewayProviderContext(result.error, providerId, modelId)
+            if (startupState !== 'pending') return sseListener.onError({ ...result, error })
 
-            fail(result.error)
+            fail(error)
             try {
-              onError?.(result.error)
+              onError?.(error)
             } finally {
               complete()
             }
@@ -455,7 +456,7 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
       })
       rejectDone(streamInterruptedError())
     },
-    onError: (result) => rejectDone(result.error),
+    onError: (result) => rejectDone(attachGatewayProviderContext(result.error, providerId, modelId)),
     isAlive: () => !aborted
   }
 

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -361,15 +361,15 @@ describe('API gateway routes (integration)', () => {
       expect(body.error.type).toBe('forbidden_error')
     })
 
-    it('messages: an upstream 401 identifies provider/model and gives an authentication recovery action', async () => {
+    it('messages: an upstream 401 reports the requested route without attributing the failing fallback', async () => {
       mockProcessMessage.mockRejectedValueOnce({
         name: 'Error',
         message: 'User not found',
         stack: null,
         statusCode: 401,
         gatewayErrorKind: 'upstream_provider',
-        providerId: 'openrouter',
-        modelId: 'deepseek/deepseek-v4-flash-0731',
+        requestedProviderId: 'openrouter',
+        requestedModelId: 'deepseek/deepseek-v4-flash-0731',
         requestBodyValues: { messages: ['SECRET REQUEST'] }
       })
       const { status, body } = await read(
@@ -382,7 +382,7 @@ describe('API gateway routes (integration)', () => {
       expect(body.type).toBe('error') // Anthropic envelope
       expect(body.error.type).toBe('authentication_error')
       expect(body.error.message).toBe(
-        'Provider "openrouter" authentication failed for model "deepseek/deepseek-v4-flash-0731". Check the provider credentials and account access.'
+        'Gateway request for "openrouter:deepseek/deepseek-v4-flash-0731" received an upstream authentication failure. Check the requested route, any configured fallback, and account access.'
       )
       expect(JSON.stringify(body)).not.toContain('User not found')
       expect(JSON.stringify(body)).not.toContain('SECRET REQUEST')
@@ -405,15 +405,15 @@ describe('API gateway routes (integration)', () => {
       expect(body.error.message).toBe('Maximum context length exceeded')
     })
 
-    it('chat: an upstream 503 keeps its status and gives provider/model recovery context', async () => {
+    it('chat: an upstream 503 reports the requested route without attributing the failing fallback', async () => {
       mockProcessMessage.mockRejectedValueOnce({
         name: 'AI_APICallError',
         message: 'Service unavailable',
         stack: null,
         statusCode: 503,
         gatewayErrorKind: 'upstream_provider',
-        providerId: 'openrouter',
-        modelId: 'deepseek/deepseek-v4-flash-0731'
+        requestedProviderId: 'openrouter',
+        requestedModelId: 'deepseek/deepseek-v4-flash-0731'
       })
       const { status, body } = await read(
         await post(app, '/v1/chat/completions', {
@@ -425,7 +425,7 @@ describe('API gateway routes (integration)', () => {
       expect(status).toBe(503)
       expect(body.error.type).toBe('server_error')
       expect(body.error.message).toBe(
-        'Provider "openrouter" request failed for model "deepseek/deepseek-v4-flash-0731" (HTTP 503). Check the provider status and model access.'
+        'Gateway request for "openrouter:deepseek/deepseek-v4-flash-0731" failed upstream (HTTP 503). Check the requested route, any configured fallback, and model access.'
       )
       expect(JSON.stringify(body)).not.toContain('Service unavailable')
     })

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -361,15 +361,31 @@ describe('API gateway routes (integration)', () => {
       expect(body.error.type).toBe('forbidden_error')
     })
 
-    it('messages: a 401 SerializedError → Anthropic 401 authentication envelope', async () => {
-      mockProcessMessage.mockRejectedValueOnce({ name: 'Error', message: 'bad key', stack: null, statusCode: 401 })
+    it('messages: an upstream 401 identifies provider/model and gives an authentication recovery action', async () => {
+      mockProcessMessage.mockRejectedValueOnce({
+        name: 'Error',
+        message: 'User not found',
+        stack: null,
+        statusCode: 401,
+        gatewayErrorKind: 'upstream_provider',
+        providerId: 'openrouter',
+        modelId: 'deepseek/deepseek-v4-flash-0731',
+        requestBodyValues: { messages: ['SECRET REQUEST'] }
+      })
       const { status, body } = await read(
-        await post(app, '/v1/messages', { model: 'anthropic:claude', messages: [{ role: 'user', content: 'hi' }] })
+        await post(app, '/v1/messages', {
+          model: 'openrouter:deepseek/deepseek-v4-flash-0731',
+          messages: [{ role: 'user', content: 'hi' }]
+        })
       )
       expect(status).toBe(401)
       expect(body.type).toBe('error') // Anthropic envelope
       expect(body.error.type).toBe('authentication_error')
-      expect(body.error.message).toBe('bad key')
+      expect(body.error.message).toBe(
+        'Provider "openrouter" authentication failed for model "deepseek/deepseek-v4-flash-0731". Check the provider credentials and account access.'
+      )
+      expect(JSON.stringify(body)).not.toContain('User not found')
+      expect(JSON.stringify(body)).not.toContain('SECRET REQUEST')
     })
 
     it('messages: a non-retryable provider 400 → Anthropic 400 invalid-request envelope', async () => {
@@ -387,6 +403,31 @@ describe('API gateway routes (integration)', () => {
       expect(body.type).toBe('error')
       expect(body.error.type).toBe('invalid_request_error')
       expect(body.error.message).toBe('Maximum context length exceeded')
+    })
+
+    it('chat: an upstream 503 keeps its status and gives provider/model recovery context', async () => {
+      mockProcessMessage.mockRejectedValueOnce({
+        name: 'AI_APICallError',
+        message: 'Service unavailable',
+        stack: null,
+        statusCode: 503,
+        gatewayErrorKind: 'upstream_provider',
+        providerId: 'openrouter',
+        modelId: 'deepseek/deepseek-v4-flash-0731'
+      })
+      const { status, body } = await read(
+        await post(app, '/v1/chat/completions', {
+          model: 'openrouter:deepseek/deepseek-v4-flash-0731',
+          messages: [{ role: 'user', content: 'hi' }]
+        })
+      )
+
+      expect(status).toBe(503)
+      expect(body.error.type).toBe('server_error')
+      expect(body.error.message).toBe(
+        'Provider "openrouter" request failed for model "deepseek/deepseek-v4-flash-0731" (HTTP 503). Check the provider status and model access.'
+      )
+      expect(JSON.stringify(body)).not.toContain('Service unavailable')
     })
 
     it('responses: an internal error with no status → 500 with the message gated out', async () => {

--- a/src/main/features/apiGateway/utils/__tests__/models.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/models.test.ts
@@ -79,6 +79,12 @@ describe('api gateway model listing', () => {
     expect(response.data.map((model) => model.id)).toEqual(['openai:gpt-4o'])
   })
 
+  it('guides clients using the reserved CherryAI alias to the advertised model list', () => {
+    expect(() => resolveGatewayModelAddress(`${CHERRYAI_PROVIDER_ID}:${CHERRYAI_DEFAULT_MODEL_ID}`)).toThrow(
+      'Model "cherryai:qwen" is a reserved managed alias and is not available through the API gateway. Select an enabled gateway model from /v1/models.'
+    )
+  })
+
   it('surfaces the resolved model record for provider-option translation', () => {
     const resolvedModel = {
       id: 'openai::gpt-4o',

--- a/src/main/features/apiGateway/utils/models.ts
+++ b/src/main/features/apiGateway/utils/models.ts
@@ -41,6 +41,12 @@ export interface ResolvedGatewayModelAddress {
   model: Model
 }
 
+function unavailableModelError(modelAddress: string, providerId: string, apiModelId: string): Error {
+  return new Error(
+    `Model "${modelAddress}" is not available through the API gateway. Check that provider "${providerId}" and model "${apiModelId}" are enabled and gateway-routable.`
+  )
+}
+
 /** Enabled providers from the data layer (`ProviderService`, not Redux). */
 function getAvailableProviders(): Provider[] {
   try {
@@ -102,13 +108,13 @@ export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly 
   try {
     provider = providerService.getByProviderId(providerId)
   } catch {
-    throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
+    throw unavailableModelError(modelAddress, providerId, apiModelId)
   }
   if (!provider.isEnabled || isExternalCliProvider(provider)) {
-    throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
+    throw unavailableModelError(modelAddress, providerId, apiModelId)
   }
   if (!allowAgentOnly && isAgentOnlyProvider(provider, getAppEdition())) {
-    throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
+    throw unavailableModelError(modelAddress, providerId, apiModelId)
   }
 
   const model = modelService.list({ providerId, enabled: true }).find((candidate) => {
@@ -117,7 +123,7 @@ export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly 
     return candidateApiModelId === apiModelId
   })
   if (!model) {
-    throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
+    throw unavailableModelError(modelAddress, providerId, apiModelId)
   }
 
   return { providerId, apiModelId, uniqueModelId: model.id, provider, model }

--- a/src/main/features/apiGateway/utils/models.ts
+++ b/src/main/features/apiGateway/utils/models.ts
@@ -101,7 +101,9 @@ export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly 
   const providerId = modelAddress.slice(0, sepIdx)
   const apiModelId = modelAddress.slice(sepIdx + 1)
   if (isManagedCherryAiDefaultModel(providerId, apiModelId)) {
-    throw new Error('CherryAI managed default model is not available through the API gateway')
+    throw new Error(
+      `Model "${modelAddress}" is a reserved managed alias and is not available through the API gateway. Select an enabled gateway model from /v1/models.`
+    )
   }
 
   let provider: Provider


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Agent gateway model-resolution failures and upstream provider failures lacked enough safe context for callers to choose the right recovery action. Local disabled or unroutable models returned a generic unavailable message, while an upstream OpenRouter 401 preserved its status but exposed only arbitrary provider text without identifying the routed provider/model.

After this PR:

Local missing, disabled, and unroutable models remain HTTP 400 failures and explicitly direct callers to check the selected provider/model. Provider failures carrying an upstream HTTP status preserve that status and protocol error type, identify the safe provider/model IDs, and return status-specific recovery guidance for authentication, access, rate limits, and other failures. Arbitrary upstream text and AI SDK request/response details are omitted from client envelopes.

Fixes #20054

### Why we need it and why it was done in this way

Agent clients need to distinguish a local routing/configuration problem from a request that reached the provider and failed there. The stream listener already receives structured `statusCode` metadata, so the fix attaches an explicit gateway-owned provider-error marker and resolved model context before the existing dialect transformers run. The transformers continue to own OpenAI, Anthropic, and Gemini status mapping.

The following tradeoffs were made:

- Tagged gateway provider errors no longer expose raw upstream messages because OpenRouter may derive them from arbitrary `metadata.raw` response content.
- Provider/model IDs remain visible because they come from the caller's already validated gateway address and are required for recovery.

The following alternatives were considered:

- Inferring authentication or rate-limit failures from message text was rejected because HTTP status is already structured and reliable.
- Returning AI SDK error objects directly was rejected because they contain URLs, request bodies, response bodies, headers, and stack data.
- Refactoring the shared application-wide error hierarchy was rejected because the gateway boundary can classify these failures locally.

Links to places where the discussion took place: #20054

### Breaking changes

None. HTTP statuses and protocol error types are preserved; only gateway error messages become safer and more actionable.

### Special notes for your reviewer

Regression evidence:

- RED on unchanged `main`: the new local disabled-model, upstream Agent 401 context, and safe recovery-message assertions all failed; the other 102 focused tests passed.
- `pnpm exec vitest run --project main src/main/features/apiGateway/__tests__/proxyStream.parse.test.ts src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts` (106/106)
- `pnpm lint`
- `pnpm test:lint`
- `pnpm docs:check`
- `git diff --check`

The validation host used Node 26.5.0 and emitted the repository engine-range warning; all listed gates completed successfully.

Screenshot: N/A. This changes external HTTP/SSE error envelopes consumed by Agent/API clients and does not change an in-app visual surface. The result states are covered by route and stream regression tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Agent API gateway errors so local unavailable models and upstream provider authentication, access, rate-limit, or service failures are clearly distinguished without exposing private request details.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-visible error messages and streaming/JSON envelopes at the gateway boundary; behavior is well-tested but Agent/API clients may depend on former upstream error text.
> 
> **Overview**
> The API gateway now separates **local routing problems** from **upstream provider failures** in HTTP/SSE error responses, without leaking raw provider text or AI SDK request/response extras.
> 
> **Local model resolution** still returns HTTP 400, but messages name the `providerId:apiModelId` address and tell callers to verify the provider/model are enabled and gateway-routable; the reserved CherryAI managed alias explicitly points clients at `/v1/models`.
> 
> **Upstream failures** (when the stream reports an HTTP status) are wrapped in a gateway-local copy via `withGatewayProviderContext` in `processMessage`—the original `AiStreamManager` error is not mutated. Tagged errors keep the real status (including terminal status from `AI_RetryError` / `lastError` / final `errors[]` entry) and expose safe recovery copy that cites the **requested** route, not fallback internals. Dialect transformers and streaming `buildStreamErrorFrame` replace upstream messages for tagged failures with status-specific guidance (auth, access, rate limit, etc.) while untagged status errors still passthrough provider messages (e.g. context-length 400).
> 
> Docs and regression tests cover disabled providers, pre/post-commit streaming, Agent OpenRouter 401, and route integration envelopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7acf3e5684a6569cd37c8d92683f556a4bb28a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->