### PR TITLE
fix(pi-runtime): honor Auto approval for Code Mode

### DIFF
--- a/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
@@ -1654,7 +1654,7 @@ describe('PiRuntimeConnection', () => {
       await conn.close()
     })
 
-    it('always prompts before running tool_exec, including in auto mode', async () => {
+    it('lets auto mode enter tool_exec so nested calls use their own approval policy', async () => {
       mocks.getAgent.mockReturnValue({
         id: 'agent-1',
         model: 'p::m',
@@ -1673,7 +1673,7 @@ describe('PiRuntimeConnection', () => {
       )
       await new Promise((resolve) => setTimeout(resolve, 0))
 
-      expect(toolApprovalRegistry.size()).toBe(1)
+      expect(toolApprovalRegistry.size()).toBe(0)
       await conn.close()
     })
   })

--- a/src/main/ai/runtime/pi/PiRuntimeConnection.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.ts
@@ -42,7 +42,7 @@ import {
   WEB_FETCH_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME
 } from '@shared/ai/builtinTools'
-import { PI_NATIVE_BUILTIN_TOOLS, PI_TOOL_EXEC_TOOL_NAME } from '@shared/ai/piBuiltinTools'
+import { PI_NATIVE_BUILTIN_TOOLS } from '@shared/ai/piBuiltinTools'
 import type { AgentPermissionMode } from '@shared/data/api/schemas/agents'
 import type { UniqueModelId } from '@shared/data/types/model'
 
@@ -101,7 +101,6 @@ const PI_AUTO_APPROVED_MCP_TOOLS = new Set(
   )
 )
 const PI_APPROVAL_REQUIRED_TOOLS = new Set([
-  PI_TOOL_EXEC_TOOL_NAME,
   ...listBuiltinToolPolicies({ approval: 'required' }).map(({ serverName, toolName }) =>
     buildPiMcpToolName(serverName, toolName)
   )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Pi agents in Auto permission mode stopped for approval at the outer `tool_exec` wrapper before any nested tool was evaluated, making Auto behave like the default mode for every Code Mode call.

After this PR:

Auto mode can enter the side-effect-free Code Mode wrapper. Each nested tool invocation still passes through the existing serialized authorizer and keeps its own disabled-tool, path, destructive-command, and explicit approval policy.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19376

### Why we need it and why it was done in this way

`tool_exec` orchestrates nested tool calls but does not perform their side effects itself. Removing it from the always-prompt set lets the existing permission-mode evaluator handle the wrapper while preserving per-tool authorization inside `createPiCodeModeTools`.

The following tradeoffs were made:

- Keep the change at the connection policy boundary, with no new mode-specific branch or policy abstraction.
- Preserve approval behavior in default, Auto-accept Edits, and Plan modes; only Auto reaches its existing allow path.

The following alternatives were considered:

- Special-case `tool_exec` only inside `requiresApproval()`. This duplicates mode policy and leaves the incorrect always-prompt classification in place.
- Approve the wrapper and bypass nested authorization. This was rejected because nested tools must retain their individual safety policy.

Links to places where the discussion took place: #19376

### Breaking changes

None.

### Special notes for your reviewer

- Draft PR #19591 also changes Pi permission internals, but currently keeps `tool_exec` in `PI_APPROVAL_REQUIRED_TOOLS`, classifying it as `sensitive-first-party`; Auto therefore still asks. Its eventual rebase must preserve this removal so `tool_exec` falls through to the `shell` category and Auto allows the wrapper.
- Regression evidence: the focused test failed on current `main` with approval registry size `1` instead of `0`, then passed after this change. The complete `PiRuntimeConnection.test.ts` suite passes 72/72.
- UI screenshot: N/A. This changes main-process runtime admission rather than rendered UI. No exact-workspace tracked Electron instance exists, and the available isolated development profile has no Pi Agent configured with a model. Reusing the user-owned packaged app would test a different build and would not be credible evidence. The connection-level RED/GREEN test exercises the approval registry directly.
- Validation: `pnpm lint`, `pnpm test:lint`, and `pnpm exec vitest run --project main src/main/ai/runtime/pi/PiRuntimeConnection.test.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Agent] Pi Auto permission mode no longer shows a redundant approval prompt before every Code Mode tool call.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent tool admission in Auto mode for Code Mode; nested tool safety still depends on the existing authorizer, but misclassification elsewhere could widen what runs without prompts.
> 
> **Overview**
> **Pi agents in Auto permission mode** no longer get a user approval prompt on every Code Mode call because the outer `tool_exec` wrapper was treated like a sensitive tool that always required confirmation.
> 
> `tool_exec` is **removed from** `PI_APPROVAL_REQUIRED_TOOLS` in `PiRuntimeConnection`, so admission follows the normal permission-mode path for that tool name instead of being hard-listed as approval-required. **Nested invocations inside Code Mode** still go through the existing authorizer in `createPiCodeModeTools`, so per-tool disabled rules, path checks, and approval policies are unchanged.
> 
> The MCP bridging test is updated to expect **no** pending approval in Auto mode when `tool_exec` is called (registry size `0` instead of `1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a908e17118cd126efcee37221431b3535cab3951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->