### PR TITLE
fix(claude-code): key the bash loop guard on the original command for rtk rewrites

### DIFF
--- a/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
@@ -52,6 +52,7 @@ export class ClaudeCodeSessionStateService extends BaseService {
   private readonly toolPolicySnapshots = new Map<string, ToolPolicySnapshot>()
   private readonly mcpSessionCatalogStates = new Map<string, McpSessionCatalogState>()
   private readonly bashOutcomes = new Map<string, BashOutcome[]>()
+  private readonly bashRewriteOrigins = new Map<string, Map<string, string>>()
 
   getToolApprovalEmitterHolder(sessionId: string): ToolApprovalEmitterHolder {
     let holder = this.toolApprovalEmitters.get(sessionId)
@@ -161,12 +162,35 @@ export class ClaudeCodeSessionStateService extends BaseService {
     this.bashOutcomes.delete(this.bashScopeKey(sessionId, agentId))
   }
 
+  /**
+   * An rtk-rewritten Bash call reaches PostToolUse carrying the rewritten command while the guard
+   * evaluated the original. Keyed by tool_use_id so the recorder files the outcome under the
+   * command the guard will see on the next retry.
+   */
+  recordBashRewriteOrigin(sessionId: string, toolUseId: string, originalCommand: string): void {
+    let origins = this.bashRewriteOrigins.get(sessionId)
+    if (!origins) {
+      origins = new Map()
+      this.bashRewriteOrigins.set(sessionId, origins)
+    }
+    origins.set(toolUseId, originalCommand)
+  }
+
+  takeBashRewriteOrigin(sessionId: string, toolUseId: string): string | undefined {
+    const origins = this.bashRewriteOrigins.get(sessionId)
+    if (!origins) return undefined
+    const original = origins.get(toolUseId)
+    origins.delete(toolUseId)
+    return original
+  }
+
   disposeToolPolicySnapshot(sessionId: string): void {
     this.toolPolicySnapshots.delete(sessionId)
     // Subagent scopes key as `${sessionId} ${agentId}` — sweep them with the parent.
     for (const key of [...this.bashOutcomes.keys()]) {
       if (key === sessionId || key.startsWith(`${sessionId} `)) this.bashOutcomes.delete(key)
     }
+    this.bashRewriteOrigins.delete(sessionId)
     this.mcpSessionCatalogStates.get(sessionId)?.subscription?.dispose()
     this.mcpSessionCatalogStates.delete(sessionId)
   }
@@ -243,6 +267,7 @@ export class ClaudeCodeSessionStateService extends BaseService {
     this.steerHolders.clear()
     this.toolPolicySnapshots.clear()
     this.bashOutcomes.clear()
+    this.bashRewriteOrigins.clear()
     for (const state of [...this.mcpSessionCatalogStates.values()]) state.subscription?.dispose()
     this.mcpSessionCatalogStates.clear()
   }

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeSessionStateService.ts
@@ -181,6 +181,7 @@ export class ClaudeCodeSessionStateService extends BaseService {
     if (!origins) return undefined
     const original = origins.get(toolUseId)
     origins.delete(toolUseId)
+    if (origins.size === 0) this.bashRewriteOrigins.delete(sessionId)
     return original
   }
 

--- a/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
@@ -149,6 +149,7 @@ describe('bashOutcomeHook', () => {
   let bashOutcomeHook: HookCallback
   let toolGuardHook: HookCallback
   let rtkRewriteHook: HookCallback
+  let postToolBatchHooks: HookCallback[]
   let subagentStopHook: HookCallback
 
   beforeEach(() => {
@@ -173,6 +174,7 @@ describe('bashOutcomeHook', () => {
     // PreToolUse: [toolGuardHook, skillDependencyAdvisoryHook, agentsMdHook, rtkRewriteHook, steerHook].
     toolGuardHook = hooks!.PreToolUse![0].hooks[0]
     rtkRewriteHook = hooks!.PreToolUse![0].hooks[3]
+    postToolBatchHooks = hooks!.PostToolBatch!.flatMap(({ hooks }) => hooks)
     // PostToolUse: [postToolTimingHook, bashOutcomeHook] — the outcome hook is the second entry.
     bashOutcomeHook = hooks!.PostToolUse![0].hooks[1]
     subagentStopHook = hooks!.SubagentStop![0].hooks[0]
@@ -271,6 +273,94 @@ describe('bashOutcomeHook', () => {
 
   const recordedCommands = () =>
     (bashOutcomesOf(svc, SESSION) as { command: string }[] | undefined)?.map((e) => e.command)
+
+  const pendingOrigins = () =>
+    (svc as unknown as { bashRewriteOrigins: Map<string, Map<string, string>> }).bashRewriteOrigins
+
+  const finishBatch = (toolUseId: string, agentId?: string) =>
+    Promise.all(
+      postToolBatchHooks.map((hook) =>
+        hook(
+          {
+            hook_event_name: 'PostToolBatch',
+            tool_calls: [{ tool_name: 'Bash', tool_input: { command: 'git status' }, tool_use_id: toolUseId }],
+            ...(agentId ? { agent_id: agentId } : {})
+          } as never,
+          undefined,
+          {} as never
+        )
+      )
+    )
+
+  it.each([undefined, 'agent-1'])('releases denied rewrites after each batch in scope %s', async (agentId) => {
+    for (let i = 0; i < BASH_NO_PROGRESS_HARD_THRESHOLD * 2; i++) {
+      const toolUseId = `tu-denied-${i}`
+      vi.mocked(evaluateToolGuards).mockResolvedValueOnce({ effect: 'deny', reason: 'Loop', ruleId: 'test' })
+      const [guard] = await Promise.all([
+        toolGuardHook(
+          {
+            hook_event_name: 'PreToolUse',
+            tool_name: 'Bash',
+            tool_input: { command: 'git status' },
+            tool_use_id: toolUseId,
+            ...(agentId ? { agent_id: agentId } : {})
+          } as never,
+          toolUseId,
+          {} as never
+        ),
+        rewriteViaRtk('git status', 'rtk git status', toolUseId)
+      ])
+      expect(guard).toMatchObject({ hookSpecificOutput: { permissionDecision: 'deny' } })
+
+      await finishBatch(toolUseId, agentId)
+
+      expect(pendingOrigins().size).toBe(0)
+    }
+    expect(bashOutcomesOf(svc, SESSION)).toBeUndefined()
+  })
+
+  it('batch cleanup preserves an outstanding call from another batch', async () => {
+    await rewriteViaRtk('git status', 'rtk git status', 'tu-pending')
+    await rewriteViaRtk('git status', 'rtk git status', 'tu-denied')
+
+    await finishBatch('tu-denied', 'agent-1')
+
+    expect(svc.takeBashRewriteOrigin(SESSION, 'tu-denied')).toBeUndefined()
+    await fire({
+      ...bashSuccess({ stdout: 'clean' }),
+      tool_input: { command: 'rtk git status' },
+      tool_use_id: 'tu-pending'
+    })
+    expect(recordedCommands()).toEqual(['git status'])
+    expect(pendingOrigins().size).toBe(0)
+  })
+
+  it.each(['dispose', 'onStop', 'onDestroy'] as const)(
+    'an in-flight rewrite cannot repopulate session state after %s',
+    async (cleanup) => {
+      const rewrite = Promise.withResolvers<string | null>()
+      vi.mocked(rtkRewrite).mockReturnValueOnce(rewrite.promise)
+      const pending = rtkRewriteHook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'git status' },
+          tool_use_id: 'tu-late'
+        } as never,
+        'tu-late',
+        {} as never
+      )
+
+      if (cleanup === 'dispose') svc.disposeToolPolicySnapshot(SESSION)
+      else await (svc as unknown as Record<'onStop' | 'onDestroy', () => Promise<void>>)[cleanup]()
+      expect(pendingOrigins().size).toBe(0)
+
+      rewrite.resolve('rtk git status')
+      await pending
+
+      expect(pendingOrigins().size).toBe(0)
+    }
+  )
 
   it('files an rtk-rewritten call under the original command, so the guard the model retries against sees the run', async () => {
     const original = 'git status'

--- a/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/bashOutcomeRecording.test.ts
@@ -34,6 +34,7 @@ vi.mock('../guardRules', () => ({ CLAUDE_TOOL_GUARD_RULES: [] }))
 vi.mock('../skillDependencies', () => ({ SKILL_TOOL_NAME: 'Skill', checkSkillRuntimeDependencies: vi.fn() }))
 
 import { evaluateToolGuards } from '@main/ai/toolApproval/toolGuards'
+import { rtkRewrite } from '@main/utils/rtk'
 
 import { BASH_HISTORY_LIMIT, BASH_NO_PROGRESS_HARD_THRESHOLD, BASH_NO_PROGRESS_THRESHOLD } from '../bashNoProgress'
 import { ClaudeCodeSessionStateService } from '../ClaudeCodeSessionStateService'
@@ -147,6 +148,7 @@ describe('bashOutcomeHook', () => {
   const svc = new ClaudeCodeSessionStateService()
   let bashOutcomeHook: HookCallback
   let toolGuardHook: HookCallback
+  let rtkRewriteHook: HookCallback
   let subagentStopHook: HookCallback
 
   beforeEach(() => {
@@ -170,6 +172,7 @@ describe('bashOutcomeHook', () => {
     })
     // PreToolUse: [toolGuardHook, skillDependencyAdvisoryHook, agentsMdHook, rtkRewriteHook, steerHook].
     toolGuardHook = hooks!.PreToolUse![0].hooks[0]
+    rtkRewriteHook = hooks!.PreToolUse![0].hooks[3]
     // PostToolUse: [postToolTimingHook, bashOutcomeHook] — the outcome hook is the second entry.
     bashOutcomeHook = hooks!.PostToolUse![0].hooks[1]
     subagentStopHook = hooks!.SubagentStop![0].hooks[0]
@@ -250,6 +253,84 @@ describe('bashOutcomeHook', () => {
 
     expect(svc.getBashNoProgressRun(SESSION, 'npx tsc --noEmit')).toBeUndefined()
     expect(bashOutcomesOf(svc, SESSION)).toBeUndefined()
+  })
+
+  const rewriteViaRtk = async (original: string, rewritten: string, toolUseId: string) => {
+    vi.mocked(rtkRewrite).mockResolvedValueOnce(rewritten)
+    await rtkRewriteHook(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: original },
+        tool_use_id: toolUseId
+      } as never,
+      toolUseId,
+      {} as never
+    )
+  }
+
+  const recordedCommands = () =>
+    (bashOutcomesOf(svc, SESSION) as { command: string }[] | undefined)?.map((e) => e.command)
+
+  it('files an rtk-rewritten call under the original command, so the guard the model retries against sees the run', async () => {
+    const original = 'git status'
+    const rewritten = 'rtk git status'
+    for (let i = 0; i < BASH_NO_PROGRESS_THRESHOLD; i++) {
+      const toolUseId = `tu-rtk-${i}`
+      await rewriteViaRtk(original, rewritten, toolUseId)
+      await fire({ ...bashSuccess({ stdout: 'clean' }), tool_input: { command: rewritten }, tool_use_id: toolUseId })
+    }
+
+    expect(svc.getBashNoProgressRun(SESSION, original)).toBe(BASH_NO_PROGRESS_THRESHOLD)
+    expect(svc.getBashNoProgressRun(SESSION, rewritten)).toBeUndefined()
+
+    const result = (await toolGuardHook(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: original },
+        tool_use_id: 'tu-next'
+      } as never,
+      undefined,
+      {} as never
+    )) as { hookSpecificOutput?: { additionalContext?: string } }
+    expect(result.hookSpecificOutput?.additionalContext).toContain('Loop warning')
+  })
+
+  it('a rewrite origin is consumed once, by its own tool_use_id only', async () => {
+    await rewriteViaRtk('git status', 'rtk git status', 'tu-rewritten')
+
+    await fire({ ...bashSuccess({ stdout: 'x' }), tool_input: { command: 'ls' }, tool_use_id: 'tu-plain' })
+    await fire({
+      ...bashSuccess({ stdout: 'x' }),
+      tool_input: { command: 'rtk git status' },
+      tool_use_id: 'tu-rewritten'
+    })
+    await fire({
+      ...bashSuccess({ stdout: 'x' }),
+      tool_input: { command: 'rtk git status' },
+      tool_use_id: 'tu-rewritten'
+    })
+
+    expect(recordedCommands()).toEqual(['ls', 'git status', 'rtk git status'])
+  })
+
+  it('dispose drops rewrite origins that never reached PostToolUse', async () => {
+    await rewriteViaRtk('git status', 'rtk git status', 'tu-denied')
+
+    svc.disposeToolPolicySnapshot(SESSION)
+
+    expect(svc.takeBashRewriteOrigin(SESSION, 'tu-denied')).toBeUndefined()
+    expect((svc as unknown as { bashRewriteOrigins: Map<string, unknown> }).bashRewriteOrigins.size).toBe(0)
+  })
+
+  it('the shutdown sweep drops rewrite origins with every other session map', async () => {
+    await rewriteViaRtk('git status', 'rtk git status', 'tu-denied')
+
+    await (svc as unknown as { onStop(): Promise<void> }).onStop()
+
+    expect(svc.takeBashRewriteOrigin(SESSION, 'tu-denied')).toBeUndefined()
+    expect((svc as unknown as { bashRewriteOrigins: Map<string, unknown> }).bashRewriteOrigins.size).toBe(0)
   })
 
   it('breaks the run when a mutating tool completes between verifier runs', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/hooks.steer.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/hooks.steer.test.ts
@@ -55,7 +55,7 @@ async function fireEvent(
 ): Promise<HookJSONOutput> {
   const outputs: HookJSONOutput[] = []
   for (const hook of hooksFor(event)) {
-    const out = await hook({ hook_event_name: event, ...payload } as never, undefined, {
+    const out = await hook({ hook_event_name: event, tool_calls: [], ...payload } as never, undefined, {
       signal: new AbortController().signal
     })
     if (Object.keys(out).length > 0) outputs.push(out)

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -159,10 +159,14 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
     const command = toolInput?.command
     if (typeof command !== 'string' || !command.trim()) return {}
 
-    const rewritten = await rtkRewrite(command)
-    if (!rewritten) return {}
-    logger.info('rtk rewrote Bash command', { original: command, rewritten })
+    // Register before yielding so an in-flight rewrite cannot recreate state after teardown.
     sessionState().recordBashRewriteOrigin(sessionId, input.tool_use_id, command)
+    const rewritten = await rtkRewrite(command)
+    if (!rewritten) {
+      sessionState().takeBashRewriteOrigin(sessionId, input.tool_use_id)
+      return {}
+    }
+    logger.info('rtk rewrote Bash command', { original: command, rewritten })
     return { hookSpecificOutput: { hookEventName: 'PreToolUse', updatedInput: { ...toolInput, command: rewritten } } }
   }
 
@@ -206,6 +210,13 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
 
   const steerHook: HookCallback = async (input) => takePendingSteer('PreToolUse', input)
   const postToolBatchSteerHook: HookCallback = async (input) => takePendingSteer('PostToolBatch', input)
+
+  const bashRewriteCleanupHook: HookCallback = async (input) => {
+    if (input.hook_event_name !== 'PostToolBatch') return {}
+    // Denied calls have no PostToolUse event; consume only this batch's leftovers.
+    for (const call of input.tool_calls) sessionState().takeBashRewriteOrigin(sessionId, call.tool_use_id)
+    return {}
+  }
 
   const agentsMdHook = ctx.agentsMdLoader.createPreToolUseHook()
 
@@ -295,7 +306,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
     PreToolUse: [{ hooks: [toolGuardHook, skillDependencyAdvisoryHook, agentsMdHook, rtkRewriteHook, steerHook] }],
     PostToolUse: [{ hooks: [postToolTimingHook, bashOutcomeHook] }],
     PostToolUseFailure: [{ hooks: [postToolTimingHook, bashOutcomeHook] }],
-    PostToolBatch: [{ hooks: [postToolBatchSteerHook] }],
+    PostToolBatch: [{ hooks: [postToolBatchSteerHook, bashRewriteCleanupHook] }],
     SubagentStop: [{ hooks: [subagentStopHook] }]
   }
 }

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -162,6 +162,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
     const rewritten = await rtkRewrite(command)
     if (!rewritten) return {}
     logger.info('rtk rewrote Bash command', { original: command, rewritten })
+    sessionState().recordBashRewriteOrigin(sessionId, input.tool_use_id, command)
     return { hookSpecificOutput: { hookEventName: 'PreToolUse', updatedInput: { ...toolInput, command: rewritten } } }
   }
 
@@ -239,8 +240,9 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       return {}
     }
 
-    const command = (input.tool_input as { command?: unknown } | undefined)?.command
-    if (typeof command !== 'string') return {}
+    const executedCommand = (input.tool_input as { command?: unknown } | undefined)?.command
+    if (typeof executedCommand !== 'string') return {}
+    const command = sessionState().takeBashRewriteOrigin(sessionId, input.tool_use_id) ?? executedCommand
 
     if (input.hook_event_name === 'PostToolUseFailure') {
       if (input.is_interrupt === true) {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The `bash-repeat-no-progress` guard checked history under the command the model issued (PreToolUse), while `bashOutcomeHook` recorded outcomes under the command rtk substituted through `updatedInput` (PostToolUse receives the rewritten input). The two sides never shared a history key, so for every command rtk rewrites (`git status`, `ls`, `grep`, common test runners) the loop guard never warned and never denied.

After this PR:

`rtkRewriteHook` records the original command per `tool_use_id`, and `bashOutcomeHook` files the outcome under that original. Rewritten and non-rewritten calls now accumulate under the same identity the guard evaluates, so the soft warning and hard deny fire again. The per-session origin map is consumed on read. PostToolBatch clears leftover entries by tool_use_id, including denied calls, without affecting calls in other batches. Origins are registered before awaiting rtk so a late rewrite cannot recreate state after session disposal or service shutdown; empty session maps are removed immediately.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The origin is tracked in `ClaudeCodeSessionStateService` keyed by `tool_use_id` rather than merging the rtk rewrite into the guard hook. The guard and mechanical rewrite hooks remain independent and run in parallel, so guard evaluation does not wait for the rtk subprocess.
- Cleanup follows the SDK batch-completion event. This keeps denied-call records bounded to their batch while preserving pending calls in parallel batches; no timer or capacity-based eviction can discard a still-needed origin.

The following alternatives were considered:

- Carrying the original command as an extra field inside `updatedInput`: it would flow to PostToolUse for free but leaks an internal field into the model-visible tool input and depends on the Bash schema tolerating unknown keys.
- Evaluating the guard against the rewritten command: the guard runs in parallel with the rewrite and cannot see its result without re-running rtk.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/20082#discussion_r3941674474

### Breaking changes

None.

### Special notes for your reviewer

Pi's runtime is unaffected: it has no loop guard and rewrites the command in place before approval, so there is no pre/post identity split there.

Verification run locally:

- Added six regression cases for denied batches in parent/subagent scopes, parallel-batch isolation, and rewrites completing after dispose, stop, or destroy. All six failed before the fix and passed afterward.
- `pnpm exec vitest run --project main` for `bashOutcomeRecording.test.ts`, `hooks.steer.test.ts`, `settingsBuilder.test.ts`, `guardRules.test.ts`, and `bashNoProgress.test.ts` → 235 passed.
- `pnpm lint` → passed (existing ESLint warnings in unrelated files).
- `pnpm test:lint` → passed (no oxlint warnings; existing ESLint warnings in unrelated files).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Restore Claude Code's repeat-command loop guard when RTK rewrites Bash commands.
```
