### PR TITLE
fix(agent-sessions): show agents without tasks

### DIFF
--- a/src/renderer/components/chat/resourceList/AgentResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/AgentResourceList.tsx
@@ -189,6 +189,7 @@ export function AgentResourceList({
     entities,
     resources: sessionItems,
     getResourceParentId: getSessionAgentId,
+    showEntitiesWithoutResources: true,
     activeEntityId: activeAgentId,
     isLoading: isAgentsLoading || isLoading || isLoadingAll || !isFullyLoaded || isPinsLoading,
     isError: !!(agentsError || sessionsError),

--- a/src/renderer/components/chat/resourceList/AgentResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/AgentResourceList.tsx
@@ -42,10 +42,6 @@ const AGENT_ENTITY_ICON_TYPE_ACTION_ID = 'agent-entity.icon-type'
 const AGENT_ENTITY_DELETE_ACTION_ID = 'agent-entity.delete'
 const AGENT_ENTITY_TOGGLE_SIDEBAR_ACTION_ID = 'agent-entity.toggle-sidebar'
 
-type SessionListItem = AgentSessionEntity & {
-  pinned?: boolean
-}
-
 type AgentResourceListProps = {
   activeAgentId?: string | null
   dataEnabled?: boolean
@@ -89,8 +85,6 @@ export function AgentResourceList({
   const [sessionDisplayMode, setSessionDisplayMode] = usePreference('agent.session.display_mode')
   const { agents, isLoading: isAgentsLoading, error: agentsError, refetch: refetchAgents } = useAgents()
   const {
-    sessions,
-    pinIdBySessionId,
     isLoading,
     isLoadingAll,
     isFullyLoaded,
@@ -116,10 +110,6 @@ export function AgentResourceList({
   const isAgentPinActionDisabled = isAgentPinsLoading || isAgentPinsRefreshing || isAgentPinsMutating
   const { agentFavoriteIds: sidebarAgentFavoriteIds, toggleAgent, removeAgent } = useSidebarFavorites()
   const sidebarAgentFavoriteIdSet = useMemo(() => new Set(sidebarAgentFavoriteIds), [sidebarAgentFavoriteIds])
-  const sessionItems = useMemo<SessionListItem[]>(
-    () => sessions.map((session) => ({ ...session, pinned: pinIdBySessionId.has(session.id) })),
-    [pinIdBySessionId, sessions]
-  )
   const handleActivationError = useCallback(
     (error: unknown) => {
       logger.error('Failed to activate agent resource from classic-layout rail', { error })
@@ -167,9 +157,8 @@ export function AgentResourceList({
     [agentPinnedIdSet, agents, assistantIconType, defaultModelId, handleCreateSession, t]
   )
 
-  const getSessionAgentId = useCallback((session: SessionListItem) => session.agentId, [])
   const handlePickSession = useCallback(
-    (session: SessionListItem) => onSelectSession(session.id, session),
+    (session: AgentSessionEntity) => onSelectSession(session.id, session),
     [onSelectSession]
   )
   const reorderAgentEntity = useCallback(
@@ -187,9 +176,6 @@ export function AgentResourceList({
   )
   const { items, listStatus, selectedId, handleSelect, handleReorder } = useResourceEntityRail({
     entities,
-    resources: sessionItems,
-    getResourceParentId: getSessionAgentId,
-    showEntitiesWithoutResources: true,
     activeEntityId: activeAgentId,
     isLoading: isAgentsLoading || isLoading || isLoadingAll || !isFullyLoaded || isPinsLoading,
     isError: !!(agentsError || sessionsError),

--- a/src/renderer/components/chat/resourceList/AssistantResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/AssistantResourceList.tsx
@@ -249,6 +249,11 @@ export function AssistantResourceList({
     (topic: Topic) => getAssistantEntityId(topic.assistantId),
     [getAssistantEntityId]
   )
+  const entityIdsWithTopics = useMemo(() => new Set(topics.map(getTopicAssistantId)), [getTopicAssistantId, topics])
+  const visibleEntities = useMemo(
+    () => entities.filter((entity) => entityIdsWithTopics.has(entity.id)),
+    [entities, entityIdsWithTopics]
+  )
   const loadLatestTopicForAssistant = useCallback(
     async (assistantId: string) => {
       const topic = await loadLatestTopic(assistantId === UNLINKED_ASSISTANT_ENTITY_ID ? null : assistantId)
@@ -286,9 +291,7 @@ export function AssistantResourceList({
   )
 
   const { items, listStatus, selectedId, handleSelect, handleReorder } = useResourceEntityRail({
-    entities,
-    resources: topics,
-    getResourceParentId: getTopicAssistantId,
+    entities: visibleEntities,
     activeEntityId: activeAssistantEntityId,
     isLoading:
       isAssistantsLoading ||

--- a/src/renderer/components/chat/resourceList/ResourceEntityRail.tsx
+++ b/src/renderer/components/chat/resourceList/ResourceEntityRail.tsx
@@ -29,7 +29,7 @@ export type ResourceEntityRailItem = {
   reorderable?: boolean
   /**
    * When true, a *visible* entity floats into the "已固定" section at the top and cannot be dragged.
-   * It does not affect whether the owning rail shows entities without resources.
+   * It does not affect item visibility.
    */
   pinned?: boolean
   /** Canonical assistant group. Only consulted when `groupByGroup` is enabled. */

--- a/src/renderer/components/chat/resourceList/ResourceEntityRail.tsx
+++ b/src/renderer/components/chat/resourceList/ResourceEntityRail.tsx
@@ -29,7 +29,7 @@ export type ResourceEntityRailItem = {
   reorderable?: boolean
   /**
    * When true, a *visible* entity floats into the "已固定" section at the top and cannot be dragged.
-   * It does not affect visibility — an entity with no resources stays hidden whether pinned or not.
+   * It does not affect whether the owning rail shows entities without resources.
    */
   pinned?: boolean
   /** Canonical assistant group. Only consulted when `groupByGroup` is enabled. */

--- a/src/renderer/components/chat/resourceList/__tests__/EntityResourceListActions.test.tsx
+++ b/src/renderer/components/chat/resourceList/__tests__/EntityResourceListActions.test.tsx
@@ -56,7 +56,8 @@ const preferenceMocks = vi.hoisted(() => ({
 }))
 
 const resourceEntityRailMocks = vi.hoisted(() => ({
-  collapsedGroupId: 'resource-entity-rail:section:["group","group-work"]'
+  collapsedGroupId: 'resource-entity-rail:section:["group","group-work"]',
+  showEntitiesWithoutResources: undefined as boolean | undefined
 }))
 
 const tabsContextMocks = vi.hoisted(() => ({
@@ -141,17 +142,22 @@ vi.mock('@renderer/components/resourceCatalog/dialogs/edit', () => ({
 vi.mock('@renderer/components/chat/resourceList/useResourceEntityRail', () => ({
   useResourceEntityRail: ({
     activeEntityId,
-    entities
+    entities,
+    showEntitiesWithoutResources
   }: {
     activeEntityId?: string | null
     entities: ResourceEntityRailItem[]
-  }) => ({
-    handleReorder: vi.fn(),
-    handleSelect: vi.fn(),
-    items: entities,
-    listStatus: 'idle',
-    selectedId: activeEntityId ?? null
-  })
+    showEntitiesWithoutResources?: boolean
+  }) => {
+    resourceEntityRailMocks.showEntitiesWithoutResources = showEntitiesWithoutResources
+    return {
+      handleReorder: vi.fn(),
+      handleSelect: vi.fn(),
+      items: entities,
+      listStatus: 'idle',
+      selectedId: activeEntityId ?? null
+    }
+  }
 }))
 
 vi.mock('@renderer/components/chat/resourceList/ResourceEntityRail', () => ({
@@ -416,6 +422,7 @@ describe('classic layout entity resource list actions', () => {
     preferenceMocks.values.clear()
     preferenceMocks.setPreference.mockClear()
     preferenceMocks.setSortType.mockClear()
+    resourceEntityRailMocks.showEntitiesWithoutResources = undefined
     assistantDataMocks.topics = [
       { id: 'topic-1', assistantId: 'assistant-1', name: 'Topic 1' },
       { id: 'topic-2', assistantId: 'assistant-2', name: 'Topic 2' }
@@ -499,6 +506,20 @@ describe('classic layout entity resource list actions', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'chat.conversation.new' })[0])
 
     expect(onCreateTopic).toHaveBeenCalledWith('assistant-1')
+  })
+
+  it('keeps agents without sessions eligible for the classic rail', () => {
+    render(
+      <AgentResourceList
+        activeAgentId="agent-1"
+        agentSessionsSource={createAgentSessionsSource({ sessions: [] })}
+        onSelectSession={vi.fn()}
+        onCreateSession={vi.fn()}
+        onShowMissingAgentSelection={vi.fn()}
+      />
+    )
+
+    expect(resourceEntityRailMocks.showEntitiesWithoutResources).toBe(true)
   })
 
   it('clears assistant topics from the classic layout assistant context menu', async () => {

--- a/src/renderer/components/chat/resourceList/__tests__/EntityResourceListActions.test.tsx
+++ b/src/renderer/components/chat/resourceList/__tests__/EntityResourceListActions.test.tsx
@@ -56,8 +56,7 @@ const preferenceMocks = vi.hoisted(() => ({
 }))
 
 const resourceEntityRailMocks = vi.hoisted(() => ({
-  collapsedGroupId: 'resource-entity-rail:section:["group","group-work"]',
-  showEntitiesWithoutResources: undefined as boolean | undefined
+  collapsedGroupId: 'resource-entity-rail:section:["group","group-work"]'
 }))
 
 const tabsContextMocks = vi.hoisted(() => ({
@@ -139,27 +138,6 @@ vi.mock('@renderer/components/resourceCatalog/dialogs/edit', () => ({
   ResourceEditDialogHost: () => null
 }))
 
-vi.mock('@renderer/components/chat/resourceList/useResourceEntityRail', () => ({
-  useResourceEntityRail: ({
-    activeEntityId,
-    entities,
-    showEntitiesWithoutResources
-  }: {
-    activeEntityId?: string | null
-    entities: ResourceEntityRailItem[]
-    showEntitiesWithoutResources?: boolean
-  }) => {
-    resourceEntityRailMocks.showEntitiesWithoutResources = showEntitiesWithoutResources
-    return {
-      handleReorder: vi.fn(),
-      handleSelect: vi.fn(),
-      items: entities,
-      listStatus: 'idle',
-      selectedId: activeEntityId ?? null
-    }
-  }
-}))
-
 vi.mock('@renderer/components/chat/resourceList/ResourceEntityRail', () => ({
   ResourceEntityRail: ({
     collapsedState,
@@ -171,6 +149,7 @@ vi.mock('@renderer/components/chat/resourceList/ResourceEntityRail', () => ({
     onContextMenuAction,
     onGroupReorder,
     onReorder,
+    onSelect,
     reorderEnabled = true,
     selectedId,
     selectionSuppressed
@@ -184,6 +163,7 @@ vi.mock('@renderer/components/chat/resourceList/ResourceEntityRail', () => ({
     onContextMenuAction?: (item: ResourceEntityRailItem, action: ResolvedAction) => void | Promise<void>
     onGroupReorder?: (groupId: string, anchor: { before: string }) => void | Promise<void>
     onReorder?: unknown
+    onSelect: (item: ResourceEntityRailItem) => void | Promise<void>
     reorderEnabled?: boolean
     selectedId?: string | null
     selectionSuppressed?: boolean
@@ -215,6 +195,7 @@ vi.mock('@renderer/components/chat/resourceList/ResourceEntityRail', () => ({
           return (
             <section key={item.id} aria-label={item.name} title={item.tooltip}>
               {item.icon}
+              <button type="button" aria-label={`Select ${item.name}`} onClick={() => void onSelect(item)} />
               <div data-testid={`${item.id}-context-menu`}>
                 {renderedActions.map((action) => (
                   <button
@@ -422,7 +403,6 @@ describe('classic layout entity resource list actions', () => {
     preferenceMocks.values.clear()
     preferenceMocks.setPreference.mockClear()
     preferenceMocks.setSortType.mockClear()
-    resourceEntityRailMocks.showEntitiesWithoutResources = undefined
     assistantDataMocks.topics = [
       { id: 'topic-1', assistantId: 'assistant-1', name: 'Topic 1' },
       { id: 'topic-2', assistantId: 'assistant-2', name: 'Topic 2' }
@@ -508,18 +488,28 @@ describe('classic layout entity resource list actions', () => {
     expect(onCreateTopic).toHaveBeenCalledWith('assistant-1')
   })
 
-  it('keeps agents without sessions eligible for the classic rail', () => {
+  it('shows and activates an agent without sessions', async () => {
+    const createdSession = { id: 'session-created', agentId: 'agent-1', name: 'Created Session' }
+    const onCreateSession = vi.fn().mockResolvedValue(createdSession)
+    const onSelectSession = vi.fn()
+
     render(
       <AgentResourceList
         activeAgentId="agent-1"
         agentSessionsSource={createAgentSessionsSource({ sessions: [] })}
-        onSelectSession={vi.fn()}
-        onCreateSession={vi.fn()}
+        onSelectSession={onSelectSession}
+        onCreateSession={onCreateSession}
         onShowMissingAgentSelection={vi.fn()}
       />
     )
 
-    expect(resourceEntityRailMocks.showEntitiesWithoutResources).toBe(true)
+    expect(screen.getByRole('region', { name: 'Agent 1' })).toBeInTheDocument()
+    expect(screen.getByTestId('resource-entity-rail')).toHaveAttribute('data-selected-id', 'agent-1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select Agent 1' }))
+
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledExactlyOnceWith('agent-1'))
+    expect(onSelectSession).toHaveBeenCalledExactlyOnceWith('session-created', createdSession)
   })
 
   it('clears assistant topics from the classic layout assistant context menu', async () => {
@@ -613,6 +603,7 @@ describe('classic layout entity resource list actions', () => {
     expect(unlinkedAssistantRegion).toBeInTheDocument()
     expect(unlinkedAssistantRegion).toHaveAttribute('title', 'chat.topics.group.unknown_assistant_tip')
     expect(assistantRegion).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: 'Assistant 2' })).not.toBeInTheDocument()
     expect(
       assistantRegion.compareDocumentPosition(unlinkedAssistantRegion) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()

--- a/src/renderer/components/chat/resourceList/__tests__/useResourceEntityRail.test.tsx
+++ b/src/renderer/components/chat/resourceList/__tests__/useResourceEntityRail.test.tsx
@@ -69,8 +69,6 @@ function renderRail(overrides: Partial<Parameters<typeof useResourceEntityRail<T
     {
       initialProps: {
         entities: ENTITIES,
-        resources: RESOURCES,
-        getResourceParentId: (resource) => resource.entityId,
         activeEntityId: 'assistant-a',
         isLoading: false,
         isError: false,
@@ -99,32 +97,10 @@ describe('useResourceEntityRail', () => {
   })
 
   it('shows loading only while there are no confirmed entity rows', () => {
-    const { result } = renderRail({ isLoading: true, resources: [] })
+    const { result } = renderRail({ isLoading: true, entities: [] })
 
     expect(result.current.listStatus).toBe('loading')
     expect(result.current.items).toEqual([])
-  })
-
-  it('hides a brand-new entity that owns no resources while keeping the others shown', () => {
-    const { result } = renderRail({
-      entities: [...ENTITIES, { id: 'assistant-c', name: 'Assistant C', icon: 'C', orderKey: 'c' }],
-      // assistant-c owns no resources yet; only a and b do.
-      resources: RESOURCES
-    })
-
-    expect(result.current.items.map((item) => item.id)).toEqual(['assistant-a', 'assistant-b'])
-  })
-
-  it('shows and selects an entity without resources when the owner list opts in', () => {
-    const { result } = renderRail({
-      activeEntityId: 'assistant-c',
-      entities: [...ENTITIES, { id: 'assistant-c', name: 'Assistant C', icon: 'C', orderKey: 'c' }],
-      resources: RESOURCES,
-      showEntitiesWithoutResources: true
-    })
-
-    expect(result.current.items.map((item) => item.id)).toEqual(['assistant-a', 'assistant-b', 'assistant-c'])
-    expect(result.current.selectedId).toBe('assistant-c')
   })
 
   it('updates selection while keeping the list mounted during loading', () => {
@@ -135,8 +111,6 @@ describe('useResourceEntityRail', () => {
 
     rerender({
       entities: ENTITIES,
-      resources: RESOURCES,
-      getResourceParentId: (resource) => resource.entityId,
       activeEntityId: 'assistant-b',
       isLoading: true,
       isError: false,
@@ -177,11 +151,6 @@ describe('useResourceEntityRail', () => {
         { id: 'assistant-a', name: 'Assistant A', icon: 'A', orderKey: 'a' },
         { id: 'assistant-b', name: 'Assistant B', icon: 'B', orderKey: 'b', pinned: true },
         { id: 'assistant-c', name: 'Assistant C', icon: 'C', orderKey: 'c' }
-      ],
-      resources: [
-        { id: 'topic-a', entityId: 'assistant-a', updatedAt: 3 },
-        { id: 'topic-b', entityId: 'assistant-b', updatedAt: 2 },
-        { id: 'topic-c', entityId: 'assistant-c', updatedAt: 1 }
       ]
     })
 
@@ -246,8 +215,6 @@ describe('useResourceEntityRail', () => {
 
     rerender({
       entities: ENTITIES,
-      resources: RESOURCES,
-      getResourceParentId: (resource) => resource.entityId,
       activeEntityId: 'assistant-a',
       isLoading: false,
       isError: false,

--- a/src/renderer/components/chat/resourceList/__tests__/useResourceEntityRail.test.tsx
+++ b/src/renderer/components/chat/resourceList/__tests__/useResourceEntityRail.test.tsx
@@ -115,6 +115,18 @@ describe('useResourceEntityRail', () => {
     expect(result.current.items.map((item) => item.id)).toEqual(['assistant-a', 'assistant-b'])
   })
 
+  it('shows and selects an entity without resources when the owner list opts in', () => {
+    const { result } = renderRail({
+      activeEntityId: 'assistant-c',
+      entities: [...ENTITIES, { id: 'assistant-c', name: 'Assistant C', icon: 'C', orderKey: 'c' }],
+      resources: RESOURCES,
+      showEntitiesWithoutResources: true
+    })
+
+    expect(result.current.items.map((item) => item.id)).toEqual(['assistant-a', 'assistant-b', 'assistant-c'])
+    expect(result.current.selectedId).toBe('assistant-c')
+  })
+
   it('updates selection while keeping the list mounted during loading', () => {
     const { result, rerender } = renderRail({ isLoading: true, activeEntityId: 'assistant-a' })
 

--- a/src/renderer/components/chat/resourceList/useResourceEntityRail.ts
+++ b/src/renderer/components/chat/resourceList/useResourceEntityRail.ts
@@ -12,11 +12,13 @@ import { useOwnerResourceActivation } from './useOwnerResourceActivation'
 export type ResourceEntityRailReorderAnchor = ReturnType<typeof buildResourceListItemDropAnchor>
 
 type UseResourceEntityRailParams<TEntity extends ResourceEntityRailItem, TResource> = {
-  /** Every entity (already mapped to a rail item). The hook filters to those with resources and orders them. */
+  /** Every entity, already mapped to a rail item. */
   entities: readonly TEntity[]
-  /** Every resource for the current scope; an entity is only visible while it owns at least one. */
+  /** Every resource for the current scope. */
   resources: readonly TResource[]
   getResourceParentId: (resource: TResource) => string | null | undefined
+  /** Show entities that do not own a resource yet. Defaults to the assistant-compatible hidden behavior. */
+  showEntitiesWithoutResources?: boolean
   activeEntityId?: string | null
   isLoading: boolean
   isError: boolean
@@ -39,15 +41,15 @@ type UseResourceEntityRailResult<TEntity> = {
 }
 
 /**
- * Shared behavior for the classic-layout entity rail (assistants / agents): only entities that own
- * resources are shown, ordered by `orderKey` with optimistic drag reordering, clicking enters the
- * latest resource (or creates a blank resource), and reordering persists the real `orderKey`. Data fetching,
- * pins, deletion, and context menus stay in the per-variant component.
+ * Shared behavior for the classic-layout entity rail (assistants / agents): entities are optionally
+ * filtered by resource ownership, ordered by `orderKey` with optimistic drag reordering, and activate
+ * their latest resource (or create one). Variant components own data, pins, deletion, and context menus.
  */
 export function useResourceEntityRail<TEntity extends ResourceEntityRailItem, TResource>({
   entities,
   resources,
   getResourceParentId,
+  showEntitiesWithoutResources = false,
   activeEntityId,
   isLoading,
   isError,
@@ -87,7 +89,9 @@ export function useResourceEntityRail<TEntity extends ResourceEntityRailItem, TR
   }, [orderSignature])
 
   const items = useMemo<TEntity[]>(() => {
-    const filtered = entities.filter((entity) => entityIdsWithResources.has(entity.id))
+    const filtered = showEntitiesWithoutResources
+      ? entities
+      : entities.filter((entity) => entityIdsWithResources.has(entity.id))
     const ordered = [...filtered].sort((a, b) => compareResourceOrderKey(a.orderKey, b.orderKey))
     let base = ordered
     if (optimisticOrderIds) {
@@ -104,10 +108,10 @@ export function useResourceEntityRail<TEntity extends ResourceEntityRailItem, TR
     const pinned = base.filter((entity) => entity.pinned)
     if (pinned.length === 0) return base
     return [...pinned, ...base.filter((entity) => !entity.pinned)]
-  }, [entities, entityIdsWithResources, optimisticOrderIds])
+  }, [entities, entityIdsWithResources, optimisticOrderIds, showEntitiesWithoutResources])
 
   const listStatus: ResourceListStatus = isError ? 'error' : isLoading && items.length === 0 ? 'loading' : 'idle'
-  const selectedId = activeEntityId && entityIdsWithResources.has(activeEntityId) ? activeEntityId : null
+  const selectedId = activeEntityId && items.some((item) => item.id === activeEntityId) ? activeEntityId : null
 
   const handleReorder = useCallback(
     async (payload: ResourceListReorderPayload) => {

--- a/src/renderer/components/chat/resourceList/useResourceEntityRail.ts
+++ b/src/renderer/components/chat/resourceList/useResourceEntityRail.ts
@@ -12,13 +12,8 @@ import { useOwnerResourceActivation } from './useOwnerResourceActivation'
 export type ResourceEntityRailReorderAnchor = ReturnType<typeof buildResourceListItemDropAnchor>
 
 type UseResourceEntityRailParams<TEntity extends ResourceEntityRailItem, TResource> = {
-  /** Every entity, already mapped to a rail item. */
+  /** Every visible entity, already mapped to a rail item. */
   entities: readonly TEntity[]
-  /** Every resource for the current scope. */
-  resources: readonly TResource[]
-  getResourceParentId: (resource: TResource) => string | null | undefined
-  /** Show entities that do not own a resource yet. Defaults to the assistant-compatible hidden behavior. */
-  showEntitiesWithoutResources?: boolean
   activeEntityId?: string | null
   isLoading: boolean
   isError: boolean
@@ -41,15 +36,12 @@ type UseResourceEntityRailResult<TEntity> = {
 }
 
 /**
- * Shared behavior for the classic-layout entity rail (assistants / agents): entities are optionally
- * filtered by resource ownership, ordered by `orderKey` with optimistic drag reordering, and activate
- * their latest resource (or create one). Variant components own data, pins, deletion, and context menus.
+ * Shared behavior for the classic-layout entity rail (assistants / agents): entities are ordered by
+ * `orderKey` with optimistic drag reordering and activate their latest resource (or create one).
+ * Variant components own visibility, data, pins, deletion, and context menus.
  */
 export function useResourceEntityRail<TEntity extends ResourceEntityRailItem, TResource>({
   entities,
-  resources,
-  getResourceParentId,
-  showEntitiesWithoutResources = false,
   activeEntityId,
   isLoading,
   isError,
@@ -75,10 +67,6 @@ export function useResourceEntityRail<TEntity extends ResourceEntityRailItem, TR
     cancelOwnerResourceActivation()
   }, [activeEntityId, cancelOwnerResourceActivation])
 
-  const entityIdsWithResources = useMemo(
-    () => new Set(resources.map(getResourceParentId).filter((id): id is string => !!id)),
-    [getResourceParentId, resources]
-  )
   const orderSignature = useMemo(
     () => entities.map((entity) => `${entity.id}:${entity.orderKey ?? ''}`).join('|'),
     [entities]
@@ -89,10 +77,7 @@ export function useResourceEntityRail<TEntity extends ResourceEntityRailItem, TR
   }, [orderSignature])
 
   const items = useMemo<TEntity[]>(() => {
-    const filtered = showEntitiesWithoutResources
-      ? entities
-      : entities.filter((entity) => entityIdsWithResources.has(entity.id))
-    const ordered = [...filtered].sort((a, b) => compareResourceOrderKey(a.orderKey, b.orderKey))
+    const ordered = [...entities].sort((a, b) => compareResourceOrderKey(a.orderKey, b.orderKey))
     let base = ordered
     if (optimisticOrderIds) {
       const byId = new Map(ordered.map((entity) => [entity.id, entity]))
@@ -108,7 +93,7 @@ export function useResourceEntityRail<TEntity extends ResourceEntityRailItem, TR
     const pinned = base.filter((entity) => entity.pinned)
     if (pinned.length === 0) return base
     return [...pinned, ...base.filter((entity) => !entity.pinned)]
-  }, [entities, entityIdsWithResources, optimisticOrderIds, showEntitiesWithoutResources])
+  }, [entities, optimisticOrderIds])
 
   const listStatus: ResourceListStatus = isError ? 'error' : isLoading && items.length === 0 ? 'loading' : 'idle'
   const selectedId = activeEntityId && items.some((item) => item.id === activeEntityId) ? activeEntityId : null


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

When the session position was set to the right, agents without any tasks were filtered out of the left agent rail and could not be opened.

After this PR:

The agent rail keeps taskless agents visible and selectable, while assistant rails retain their existing resource-based filtering behavior.

Result screenshot:

<img width="960" height="600" alt="Taskless agent remains visible with right-side tasks" src="https://github.com/user-attachments/assets/d39ad6fe-7aa1-4b55-83c5-9869cc8dbae4" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20078

### Why we need it and why it was done in this way

Each rail now owns its visibility policy before passing visible entities to the shared behavior hook. `AgentResourceList` passes every loaded agent so a taskless agent can create its first task; `AssistantResourceList` keeps filtering assistants by topic ownership as before.

The following tradeoffs were made:

The agent rail now renders every loaded agent even when no task belongs to it, which is the expected behavior for creating and entering an agent's first task.

The following alternatives were considered:

Adding an agent-specific policy flag to the shared hook was rejected because resource visibility belongs to the owning rail rather than shared ordering and activation behavior.

Links to places where the discussion took place: #20078

### Breaking changes

None.

### Special notes for your reviewer

- Focused tests: 43 passed across `EntityResourceListActions.test.tsx` and `useResourceEntityRail.test.tsx`.
- The component regression uses the real shared hook and proves a taskless agent is rendered, selected, and creates/enters its first session when activated.
- `pnpm lint`: passed.
- `pnpm test:lint`: passed.
- UI verification used an isolated `CherryStudioissue-20078` profile and confirmed `No-session Agent` is visible with the right-side `Tasks` pane.
- The review follow-up changes internal ownership and regression coverage only; visual output is unchanged, so the existing verified result screenshot remains current.
- PR #19777 also changes `AgentResourceList.tsx` and `EntityResourceListActions.test.tsx`; this PR intentionally limits overlap to taskless-agent visibility and its regression coverage.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08/)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for this narrowly scoped bug fix.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If this PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed taskless agents disappearing from the agent list when sessions are displayed on the right.
```
