### PR TITLE
fix(agent-session): serialize model switch teardown

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -961,21 +961,12 @@ export class AgentSessionRuntimeService extends BaseService {
       if (connectionAttempt) fallbackClosings.push(connectionAttempt)
       closing = Promise.allSettled(fallbackClosings).then(() => undefined)
     }
-    const combinedClosing = Promise.allSettled(priorClosing ? [priorClosing.promise, closing] : [closing]).then(
-      () => undefined
-    )
-    const barrier = {
-      promise: combinedClosing.finally(() => {
-        if (this.closingSessions.get(sessionId) === barrier) this.closingSessions.delete(sessionId)
-      }),
-      resumeToken: entry.lastResumeToken ?? priorClosing?.resumeToken
-    }
-    this.closingSessions.set(sessionId, barrier)
+    const barrier = this.trackSessionClosing(sessionId, closing, entry.lastResumeToken)
     if (this.entries.get(sessionId) === entry) {
       this.entries.delete(sessionId)
       this._onRuntimeIdle.fire({ sessionId })
     }
-    return barrier.promise
+    return barrier
   }
 
   /**
@@ -3199,7 +3190,27 @@ export class AgentSessionRuntimeService extends BaseService {
 
   private closeConnectionAsync(entry: AgentSessionRuntimeEntry): void {
     const connection = this.closeConnection(entry)
-    void this.closeRuntimeConnection(connection, entry.sessionId)
+    if (!connection) return
+    void this.trackSessionClosing(
+      entry.sessionId,
+      this.closeRuntimeConnection(connection, entry.sessionId),
+      entry.lastResumeToken
+    )
+  }
+
+  private trackSessionClosing(sessionId: string, closing: Promise<void>, resumeToken?: string): Promise<void> {
+    const priorClosing = this.closingSessions.get(sessionId)
+    const combinedClosing = Promise.allSettled(priorClosing ? [priorClosing.promise, closing] : [closing]).then(
+      () => undefined
+    )
+    const barrier = {
+      promise: combinedClosing.finally(() => {
+        if (this.closingSessions.get(sessionId) === barrier) this.closingSessions.delete(sessionId)
+      }),
+      resumeToken: resumeToken ?? priorClosing?.resumeToken
+    }
+    this.closingSessions.set(sessionId, barrier)
+    return barrier.promise
   }
 
   private closeRuntimeConnection(connection: AgentRuntimeConnection | undefined, sessionId: string): Promise<void> {

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -1626,13 +1626,13 @@ export class AgentSessionRuntimeService extends BaseService {
     if (this.runtimeStatus(entry) === 'active') this.refreshContextUsage(entry, connection)
     this.refreshSupportedCommands(entry, connection)
     const connectionLoop = this.runConnectionLoop(entry, connection).finally(() => {
-      void this.closeRuntimeConnection(connection, entry.sessionId)
       if (this.currentConnection(entry) === connection) {
-        this.resetConnectionRuntimeState(entry, connection)
-        this.applyRuntimeStateEvent(entry, { type: 'connection-disconnected', connection })
+        this.closeConnectionAsync(entry)
         if (entry.runtimeState.queue.length > 0 && !this.liveTurn(entry)) {
           this.requestRuntimeLaunch(entry, 'queued-turn')
         }
+      } else {
+        void this.closeRuntimeConnection(connection, entry.sessionId)
       }
       if (entry.connectionLoop === connectionLoop) entry.connectionLoop = undefined
     })

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -1360,7 +1360,8 @@ describe('AgentSessionRuntimeService', () => {
     const firstConnection = {
       events: firstEvents.iterable,
       send: vi.fn(),
-      close: vi.fn(() => firstClose.promise)
+      close: vi.fn(() => firstClose.promise),
+      reconcile: vi.fn().mockResolvedValue('rebuild')
     }
     const secondConnection = {
       events: secondEvents.iterable,
@@ -1400,6 +1401,7 @@ describe('AgentSessionRuntimeService', () => {
       { model: switchedModelId },
       { id: 'agent-1', model: switchedModelId }
     )
+    expect(firstConnection.reconcile).toHaveBeenCalledWith(expect.objectContaining({ modelId: switchedModelId }))
 
     const second = service.beginTurn({
       ...baseTurnInput,
@@ -3924,6 +3926,74 @@ describe('AgentSessionRuntimeService', () => {
     events.push({ type: 'chunk', chunk: { type: 'text-delta', id: 't', delta: 'late' } })
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(getEntry(service).runtimeState.execution).toMatchObject({ kind: 'turn', stream: 'awaiting-persistence' })
+  })
+
+  it('waits for a failed runtime connection to close before starting its replacement', async () => {
+    const runtimeFailure = createDeferred<void>()
+    const firstClose = createDeferred<void>()
+    const firstConnection = {
+      events: {
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'resume-token', token: 'resume-after-runtime-failure' }
+          await runtimeFailure.promise
+          throw new Error('runtime loop failed')
+        }
+      },
+      send: vi.fn(),
+      close: vi.fn(() => firstClose.promise)
+    }
+    const secondConnection = {
+      events: createAsyncQueue<any>().iterable,
+      send: vi.fn(),
+      close: vi.fn()
+    }
+    const connect = vi.fn().mockResolvedValueOnce(firstConnection).mockResolvedValueOnce(secondConnection)
+    runtimeDriverRegistry.register({
+      type: 'test-runtime',
+      capabilities: ['agent-session'],
+      connect,
+      validateSession: vi.fn(),
+      listAvailableTools: vi.fn().mockResolvedValue([])
+    })
+    const service = new AgentSessionRuntimeService()
+    const first = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+    const firstReader = service
+      .openTurnStream({ sessionId: 'session-1', turnId: first.turnId, signal: new AbortController().signal })
+      .getReader()
+
+    await expect(firstReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await vi.waitFor(() => expect(firstConnection.send).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(service.inspect('session-1')).toMatchObject({ resumeToken: 'resume-after-runtime-failure' })
+    )
+
+    runtimeFailure.resolve()
+    await expect(firstReader.read()).rejects.toThrow('runtime loop failed')
+    await vi.waitFor(() => expect(firstConnection.close).toHaveBeenCalledOnce())
+    terminalListener(first).onError({ status: 'error', isTopicDone: true })
+
+    const second = service.beginTurn({
+      ...baseTurnInput,
+      assistantMessageId: 'assistant-2',
+      userMessage: userMessage('user-2')
+    })
+    const secondReader = service
+      .openTurnStream({ sessionId: 'session-1', turnId: second.turnId, signal: new AbortController().signal })
+      .getReader()
+
+    await expect(secondReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(connect).toHaveBeenCalledOnce()
+    expect(secondConnection.send).not.toHaveBeenCalled()
+
+    firstClose.resolve()
+
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(2))
+    expect(connect).toHaveBeenLastCalledWith(expect.objectContaining({ resumeToken: 'resume-after-runtime-failure' }))
+    await vi.waitFor(() => expect(secondConnection.send).toHaveBeenCalledOnce())
+    void service.closeSession('session-1')
+    await firstReader.cancel().catch(() => undefined)
+    await secondReader.cancel().catch(() => undefined)
   })
 
   it('passes trace context to the runtime driver and keeps the connection warm across turns', async () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -1354,13 +1354,16 @@ describe('AgentSessionRuntimeService', () => {
   })
 
   it('reconnects an idle runtime when the agent model changes before the next turn', async () => {
+    const firstEvents = createAsyncQueue<any>()
+    const secondEvents = createAsyncQueue<any>()
+    const firstClose = createDeferred<void>()
     const firstConnection = {
-      events: createAsyncQueue<any>().iterable,
+      events: firstEvents.iterable,
       send: vi.fn(),
-      close: vi.fn()
+      close: vi.fn(() => firstClose.promise)
     }
     const secondConnection = {
-      events: createAsyncQueue<any>().iterable,
+      events: secondEvents.iterable,
       send: vi.fn(),
       close: vi.fn()
     }
@@ -1382,6 +1385,14 @@ describe('AgentSessionRuntimeService', () => {
     const firstReader = firstStream.getReader()
     await expect(firstReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
     await vi.waitFor(() => expect(firstConnection.send).toHaveBeenCalled())
+    firstEvents.push({ type: 'resume-token', token: 'resume-with-tool-history' })
+    firstEvents.push({ type: 'chunk', chunk: { type: 'tool-input-start', toolCallId: 'tool-1' } })
+    await vi.waitFor(() =>
+      expect(service.inspect('session-1')).toMatchObject({
+        resumeToken: 'resume-with-tool-history',
+        activeToolCount: 1
+      })
+    )
 
     void terminalListener(first).onDone({ status: 'success', isTopicDone: true })
     await (service as any).handleAgentUpdated(
@@ -1404,13 +1415,22 @@ describe('AgentSessionRuntimeService', () => {
     const secondReader = secondStream.getReader()
 
     await expect(secondReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(connect).toHaveBeenCalledOnce()
+    expect(secondConnection.send).not.toHaveBeenCalled()
+
+    firstClose.resolve()
+
     await vi.waitFor(() =>
       expect(secondConnection.send).toHaveBeenCalledWith({ message: userMessage('user-2'), systemReminder: false })
     )
 
     expect(firstConnection.close).toHaveBeenCalled()
     expect(connect).toHaveBeenNthCalledWith(1, expect.objectContaining({ modelId: baseTurnInput.modelId }))
-    expect(connect).toHaveBeenNthCalledWith(2, expect.objectContaining({ modelId: switchedModelId }))
+    expect(connect).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ modelId: switchedModelId, resumeToken: 'resume-with-tool-history' })
+    )
     expect(firstConnection.send).toHaveBeenCalledTimes(1)
 
     await firstReader.cancel().catch(() => undefined)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Changing an Agent's model rebuilt its idle runtime connection without tracking the asynchronous teardown. An immediate next turn could open the replacement connection with the same resume token before the previous runtime finished closing, allowing two runtime generations to overlap on the same conversation state and lose prior context.

After this PR:

Model-triggered runtime rebuilds use the existing per-session close barrier. The replacement connection waits for the prior runtime to finish closing, then resumes with the same token and preserved multi-turn/tool history.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19843

### Why we need it and why it was done in this way

Runtime drivers own native conversation and tool state behind an opaque resume token. The host must therefore serialize runtime generations before handing that token to a replacement connection. Reusing the existing session close barrier keeps this invariant common to Claude Code, Pi, and DSH instead of adding driver-specific timing behavior.

The following tradeoffs were made:

- The first turn after a model switch now waits for the previous runtime's graceful close to finish.

The following alternatives were considered:

- Replaying only Cherry's persisted messages was rejected because it cannot reconstruct runtime-owned tool and task state.
- Driver-specific delays were rejected because elapsed time cannot prove that the previous runtime released its session resources.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19843

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Regression test confirmed RED on current `main`: the replacement `driver.connect()` ran while the prior connection's deferred `close()` was unresolved.
- The test covers a completed Agent turn with tool activity and a resume token, a model switch, and an immediate follow-up.
- Validation: `pnpm test:main src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts` (161/161), `pnpm lint`, and `pnpm test:lint`.
- No screenshot is included because this changes main-process runtime synchronization only and has no visual UI state.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Agent conversations losing prior context when switching models before the next turn.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes main-process connection lifecycle ordering around resume tokens; incorrect serialization could still cause context loss or delayed turns, but behavior is covered by new runtime service tests.
> 
> **Overview**
> Fixes overlapping agent runtime generations when a model change (or connection rebuild) tears down the idle connection and the next turn connects immediately with the same resume token.
> 
> **Teardown is now tracked on the per-session close barrier.** A new `trackSessionClosing` helper centralizes the existing `closingSessions` logic (chaining prior closes, preserving resume tokens). `closeSession` and `closeConnectionAsync` route async `connection.close()` work through it, and the connection loop’s cleanup uses `closeConnectionAsync` for the active connection instead of fire-and-forget close plus inline state reset.
> 
> **`ensureConnection` already awaits that barrier**, so replacement `driver.connect()` runs only after the previous runtime finishes closing, then resumes with the preserved token and tool history.
> 
> Tests cover an idle model switch with tool activity (deferred `connect` until `close` resolves) and a failed runtime loop before the next turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4336dea9bfb35d730f98bdecc8d2911e40df64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->