### PR TITLE
fix(agent-tools): label failed Bash results as errors

### DIFF
--- a/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
@@ -167,6 +167,7 @@ describe('AgentToolRenderer', () => {
     'message.tools.sections.output': 'Output',
     'message.tools.sections.prompt': 'Prompt',
     'message.tools.sections.input': 'Input',
+    'message.tools.status.error': 'Error',
     'agent.toolPermission.decisionDenied': 'Denied',
     'agent.toolPermission.reasonLabel': 'Reason for rejection (optional)',
     'agent.askUserQuestion.title': 'Questions from Agent',
@@ -1184,6 +1185,45 @@ describe('AgentToolRenderer', () => {
       expect(screen.getByTestId('collapse-content-Bash')).not.toBeVisible()
       expect(screen.queryByRole('button', { name: 'button.collapse' })).toBeNull()
       expect(screen.queryByRole('button', { name: 'code_block.expand' })).toBeNull()
+    })
+  })
+
+  describe('Bash result presentation', () => {
+    it('labels successful Bash results as output', async () => {
+      const user = userEvent.setup()
+      const toolResponse = createToolResponse({
+        tool: { id: 'Bash', name: 'Bash', description: 'Execute command', type: 'provider' },
+        status: 'done',
+        arguments: { command: 'pwd' },
+        response: '/workspace'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+      await user.click(screen.getByRole('button'))
+
+      const content = screen.getByTestId('collapse-content-Bash')
+      expect(content).toHaveTextContent('Output')
+      expect(content).toHaveTextContent('/workspace')
+    })
+
+    it('labels failed Bash execution details as an error instead of command output', async () => {
+      const user = userEvent.setup()
+      const errorText =
+        'sandbox escalation to "danger-full-access" is not strictly wider than this call\'s current "danger-full-access" mode'
+      const toolResponse = createToolResponse({
+        tool: { id: 'Bash', name: 'Bash', description: 'Execute command', type: 'provider' },
+        status: 'error',
+        arguments: { command: 'pwd' },
+        response: { isError: true, content: [{ type: 'text', text: errorText }] }
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+      await user.click(screen.getByRole('button'))
+
+      const content = screen.getByTestId('collapse-content-Bash')
+      expect(content).toHaveTextContent('Error')
+      expect(content).toHaveTextContent(errorText)
+      expect(content).not.toHaveTextContent('Output')
     })
   })
 

--- a/src/renderer/components/chat/messages/tools/agent/BashTool.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/BashTool.tsx
@@ -12,10 +12,12 @@ import { TerminalOutput } from './TerminalOutput'
 
 export function BashTool({
   input,
-  output
+  output,
+  hasError
 }: {
   input?: BashToolInputType
   output?: BashToolOutputType
+  hasError?: boolean
 }): ToolDisclosureItem {
   const { t } = useTranslation()
   const command = input?.command
@@ -37,7 +39,9 @@ export function BashTool({
         {/* Output 输出区域 */}
         {truncatedOutput ? (
           <div>
-            <div className="mb-1 font-medium text-muted-foreground text-xs">{t('message.tools.sections.output')}</div>
+            <div className="mb-1 font-medium text-muted-foreground text-xs">
+              {t(hasError ? 'message.tools.status.error' : 'message.tools.sections.output')}
+            </div>
             <TerminalOutput content={truncatedOutput} maxHeight="15rem" />
             {isTruncated && <TruncatedIndicator originalLength={originalLength} />}
           </div>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Failed Agent Bash tool calls displayed their tool or sandbox failure details under an `Output` heading, which made the failure look like shell process output.

After this PR:

Failed Agent Bash tool calls label their details as `Error`. Successful Bash results continue to use `Output`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19801

### Why we need it and why it was done in this way

The Bash renderer already receives the normalized `hasError` state from the shared Agent tool card. Reusing that state keeps the fix at the presentation boundary and avoids changing tool execution semantics.

The following tradeoffs were made:

- This PR corrects the misleading presentation only. It does not change the upstream DSH same-mode sandbox authorization behavior.

The following alternatives were considered:

- Suppressing same-mode sandbox requests in Cherry Studio was not included because the relevant DSH behavior is still being addressed upstream and is outside this renderer fix.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19801, https://github.com/anywhere-labs/dsh-desktop/issues/684, https://github.com/anywhere-labs/dsh-desktop/pull/687

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- `pnpm test:renderer src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx` (49 passed)
- `pnpm lint` (passed)
- `pnpm test:lint` (passed)

A real screenshot is not attached: during bounded isolated UI verification, the exact DSH same-mode sandbox failure could not be triggered credibly. The isolated development instance was then stopped and its CDP port was verified released. The component regression test covers both the failed `Error` label and the successful `Output` label without fabricating runtime evidence.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent Bash tool failures are now labeled as errors instead of command output.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only label change in the Bash tool renderer; no execution, auth, or data-handling logic is modified.
> 
> **Overview**
> Failed Agent **Bash** tool calls no longer show failure details under an **Output** heading. The Bash card now accepts the existing `hasError` flag from the shared tool card and switches the result section label to **Error** when the run failed; successful runs still use **Output**.
> 
> Regression tests in `AgentToolRenderer.test.tsx` cover both paths (done vs error status with structured error content), including a realistic sandbox authorization failure message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285ff923bef9f938d4b04f59740d8aba04aae8ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->