### PR TITLE
fix(chat-errors): recover from generic API 400 responses

### DIFF
--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -243,6 +243,23 @@ describe('ErrorBlock', () => {
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 
+  it('offers the active provider settings for a generic HTTP 400', async () => {
+    const user = userEvent.setup()
+    const navigateErrorTarget = vi.fn()
+    mocks.actions = { navigateErrorTarget }
+
+    render(
+      <ErrorBlock
+        partId="message-1-part-0"
+        error={{ name: 'AI_APICallError', message: 'Bad Request', stack: null, statusCode: 400 }}
+        message={message}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'error.diagnosis.go_to_settings' }))
+    expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
+  })
+
   it('uses injected diagnosis capability for unknown errors', async () => {
     const diagnoseMessageError = vi.fn().mockResolvedValue('AI summary')
     mocks.actions = {

--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -1,3 +1,4 @@
+import enUS from '@renderer/i18n/locales/en-us.json'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
@@ -8,8 +9,11 @@ import type { MessageListActions, MessageListItem } from '../../types'
 const mocks = vi.hoisted(() => ({
   actions: {} as MessageListActions,
   i18nKeys: new Set<string>(),
-  language: 'en'
+  language: 'en',
+  translations: new Map<string, string>()
 }))
+
+const GO_TO_SETTINGS_LABEL = enUS['error.diagnosis.go_to_settings']
 
 vi.mock('@cherrystudio/ui', () => ({
   Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
@@ -39,7 +43,7 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('react-i18next', () => ({
   Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string) => mocks.translations.get(key) ?? key,
     i18n: {
       language: mocks.language,
       exists: (key: string) => mocks.i18nKeys.has(key)
@@ -71,6 +75,8 @@ describe('ErrorBlock', () => {
     mocks.actions = {}
     mocks.i18nKeys.clear()
     mocks.language = 'en'
+    mocks.translations.clear()
+    mocks.translations.set('error.diagnosis.go_to_settings', GO_TO_SETTINGS_LABEL)
     vi.clearAllMocks()
   })
 
@@ -125,7 +131,7 @@ describe('ErrorBlock', () => {
     )
 
     expect(screen.getByText('error.diagnosis.auth')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
+    fireEvent.click(screen.getByText(GO_TO_SETTINGS_LABEL))
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 
@@ -204,7 +210,7 @@ describe('ErrorBlock', () => {
       })
     )
 
-    fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
+    fireEvent.click(screen.getByText(GO_TO_SETTINGS_LABEL))
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 
@@ -239,7 +245,7 @@ describe('ErrorBlock', () => {
     )
 
     expect(screen.getByText('error.diagnosis.auth')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('error.diagnosis.go_to_settings'))
+    fireEvent.click(screen.getByText(GO_TO_SETTINGS_LABEL))
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 
@@ -256,7 +262,7 @@ describe('ErrorBlock', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: 'error.diagnosis.go_to_settings' }))
+    await user.click(screen.getByRole('button', { name: GO_TO_SETTINGS_LABEL }))
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/provider?id=openai')
   })
 
@@ -327,7 +333,7 @@ describe('ErrorBlock', () => {
     )
 
     expect(screen.getByText('error.diagnosis.proxy')).toBeInTheDocument()
-    await user.click(screen.getByText('error.diagnosis.go_to_settings'))
+    await user.click(screen.getByText(GO_TO_SETTINGS_LABEL))
     expect(navigateErrorTarget).toHaveBeenCalledWith('/settings/general')
   })
 })

--- a/src/renderer/utils/__tests__/errorClassifier.test.ts
+++ b/src/renderer/utils/__tests__/errorClassifier.test.ts
@@ -55,6 +55,22 @@ describe('classifyError', () => {
     expect(result.category).toBe('auth')
   })
 
+  it('prefers an earlier specific diagnosis over the last attempt generic recovery', () => {
+    const result = classifyError(
+      makeRetryError({
+        lastError: { name: 'AI_APICallError', statusCode: 400 },
+        errors: [
+          { name: 'AI_APICallError', statusCode: 401 },
+          { name: 'AI_APICallError', statusCode: 400 }
+        ]
+      }),
+      'openai'
+    )
+
+    expect(result.category).toBe('auth')
+    expect(result.navTarget).toBe('/settings/provider?id=openai')
+  })
+
   it('keeps the outer classification when the wrapper itself is diagnosable', () => {
     const result = classifyError(
       makeRetryError({
@@ -80,6 +96,12 @@ describe('classifyError', () => {
 
     expect(result.category).toBe('unknown')
     expect(result.navTarget).toBe('/settings/provider?id=openai')
+  })
+
+  it('encodes the provider id in the generic HTTP 400 recovery target', () => {
+    const result = classifyError(makeError({ statusCode: 400 }), 'gateway&fallback#beta')
+
+    expect(result.navTarget).toBe('/settings/provider?id=gateway%26fallback%23beta')
   })
 
   // Auth

--- a/src/renderer/utils/__tests__/errorClassifier.test.ts
+++ b/src/renderer/utils/__tests__/errorClassifier.test.ts
@@ -66,6 +66,22 @@ describe('classifyError', () => {
     expect(result.category).toBe('rate_limit')
   })
 
+  it.each([
+    ['direct', makeError({ statusCode: 400 })],
+    [
+      'retry-wrapped',
+      makeRetryError({
+        lastError: { name: 'AI_APICallError', statusCode: 400 },
+        errors: [{ name: 'AI_APICallError', statusCode: 400 }]
+      })
+    ]
+  ])('offers provider settings recovery for a %s HTTP 400', (_kind, error) => {
+    const result = classifyError(error, 'openai')
+
+    expect(result.category).toBe('unknown')
+    expect(result.navTarget).toBe('/settings/provider?id=openai')
+  })
+
   // Auth
   it('classifies 401 as auth', () => {
     const result = classifyError(makeError({ statusCode: 401 }))

--- a/src/renderer/utils/errorClassifier.ts
+++ b/src/renderer/utils/errorClassifier.ts
@@ -315,11 +315,20 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
     return { category: 'parse', i18nKey: 'error.diagnosis.parse', navTarget: null }
   }
 
-  // A wrapper carries no status of its own — diagnose the first attempt that says something.
+  // A wrapper carries no status of its own — use the first nested attempt with a diagnosis or recovery path.
   for (const nested of unwrapNestedErrors(error)) {
     const nestedClassification = classifyError(nested, providerId)
-    if (nestedClassification.category !== 'unknown') {
+    if (nestedClassification.category !== 'unknown' || nestedClassification.navTarget) {
       return nestedClassification
+    }
+  }
+
+  // A generic 400 has no safe diagnosis, but its active provider settings remain a valid recovery path.
+  if (numStatus === 400) {
+    return {
+      category: 'unknown',
+      i18nKey: 'error.diagnosis.unknown',
+      navTarget: `/settings/provider${providerSuffix}`
     }
   }
 

--- a/src/renderer/utils/errorClassifier.ts
+++ b/src/renderer/utils/errorClassifier.ts
@@ -111,7 +111,7 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
 
   const status = errorBag.statusCode ?? errorBag.status
   const numStatus = typeof status === 'number' ? status : typeof status === 'string' ? parseInt(status, 10) : undefined
-  const providerSuffix = providerId ? `?id=${providerId}` : ''
+  const providerSuffix = providerId ? `?id=${encodeURIComponent(providerId)}` : ''
 
   const messageText = ((error.message as string) || '').toLowerCase()
   const responseBodyText = typeof errorBag.responseBody === 'string' ? errorBag.responseBody.toLowerCase() : ''
@@ -315,13 +315,16 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
     return { category: 'parse', i18nKey: 'error.diagnosis.parse', navTarget: null }
   }
 
-  // A wrapper carries no status of its own — use the first nested attempt with a diagnosis or recovery path.
+  // A wrapper carries no status of its own. Prefer any diagnosis over a generic recovery-only fallback.
+  let nestedRecovery: ErrorClassification | null = null
   for (const nested of unwrapNestedErrors(error)) {
     const nestedClassification = classifyError(nested, providerId)
-    if (nestedClassification.category !== 'unknown' || nestedClassification.navTarget) {
+    if (nestedClassification.category !== 'unknown') {
       return nestedClassification
     }
+    if (!nestedRecovery && nestedClassification.navTarget) nestedRecovery = nestedClassification
   }
+  if (nestedRecovery) return nestedRecovery
 
   // A generic 400 has no safe diagnosis, but its active provider settings remain a valid recovery path.
   if (numStatus === 400) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A normal-chat HTTP 400 without a safely recognizable provider cause remained an unknown error. The card explained that request or model settings might need correction, but offered no direct recovery action.

After this PR:

The generic 400 fallback keeps its unknown classification while linking directly to the active provider's settings. Retry wrappers propagate that recovery target, while more specific classifications such as content filtering, authentication, and model errors continue to take precedence.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Addresses #19946.

### Why we need it and why it was done in this way

The following tradeoffs were made:

HTTP 400 alone does not identify whether the provider rejected model options, request content, or another client-side field. The fallback therefore remains `unknown`, preserving optional AI diagnosis, and only adds the provider settings destination already supported by the error card.

The following alternatives were considered:

Adding a new invalid-request category and translations would duplicate the existing localized HTTP 400 guidance. Automatically retrying the unchanged request could repeat a deterministic client error, so this change exposes configuration recovery instead.

Links to places where the discussion took place: #19946, #20085

### Breaking changes

None.

### Special notes for your reviewer

- Regression evidence: with unchanged production code, the focused suite passed 83 tests and failed the three new contracts for direct 400 navigation, retry-wrapped 400 navigation, and the error-card settings button.
- Review follow-up: against the previous head, the two focused contracts for nested classification priority and provider-ID URL encoding failed with 75/77 passing; both pass on the current head.
- Validation: the focused renderer suite passed 88/88; `pnpm lint` and `pnpm test:lint` passed.
- This PR complements #20085, which preserves and presents safe provider details. It does not infer or display a provider-specific cause from the HTTP status alone.
- Screenshot unavailable: a credible normal-chat screenshot requires a real configured provider that safely and reliably returns a generic HTTP 400. The isolated workspace has no such provider scenario, and an injected or fabricated error card would not validate the production request path.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action for users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Chat] Add a provider settings recovery action to generic HTTP 400 errors.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to error-card navigation and classifier fallbacks for HTTP 400 and nested retries; no auth, payment, or request-sending logic changes.
> 
> **Overview**
> Generic chat **HTTP 400** errors that cannot be classified further still show as **unknown**, but the error card now offers **Go to settings** that opens the **active provider** (`/settings/provider?id=…`). Provider IDs in that link are **URL-encoded**.
> 
> **Retry-wrapped** failures keep preferring a **specific** nested diagnosis (e.g. auth on 401) over a later generic 400; when nested attempts only yield recovery targets without a category, the classifier **propagates** the first such `navTarget` instead of dropping it.
> 
> Tests were updated to use **localized** button labels in `ErrorBlock` specs and to cover 400 navigation, nested priority, and encoded provider IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ee9199934e12d7b6dfe6a4469d241c20a5d396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

