### PR TITLE
fix(chat-scroll): preserve vertical scrolling in multi-model answers

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -812,9 +812,9 @@ describe('MessageGroup', () => {
   })
 
   it.each([
-    { name: 'line', deltaMode: WheelEvent.DOM_DELTA_LINE, deltaY: 3, expectedDeltaY: 48 },
-    { name: 'page', deltaMode: WheelEvent.DOM_DELTA_PAGE, deltaY: 1, expectedDeltaY: 300 }
-  ])('normalizes $name-mode vertical wheel input before forwarding it', ({ deltaMode, deltaY, expectedDeltaY }) => {
+    { name: 'line', deltaMode: WheelEvent.DOM_DELTA_LINE, deltaY: 3, expectedArgs: [48] },
+    { name: 'page', deltaMode: WheelEvent.DOM_DELTA_PAGE, deltaY: 1, expectedArgs: [300, 300] }
+  ])('normalizes $name-mode vertical wheel input before forwarding it', ({ deltaMode, deltaY, expectedArgs }) => {
     mocks.scrollByWheel.mockReturnValue(true)
     const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
 
@@ -831,39 +831,51 @@ describe('MessageGroup', () => {
 
     fireEvent(horizontalGroup, createEvent.wheel(horizontalGroup, { deltaMode, deltaX: 0.1, deltaY }))
 
-    expect(mocks.scrollByWheel).toHaveBeenCalledWith(expectedDeltaY)
+    expect(mocks.scrollByWheel).toHaveBeenCalledWith(...expectedArgs)
   })
 
   it.each([
-    { name: 'dominant horizontal input', deltaX: 160, deltaY: 4, shiftKey: false },
-    { name: 'shifted vertical input', deltaX: 0, deltaY: 160, shiftKey: true }
-  ])('supports $name on non-content areas in horizontal layout', ({ deltaX, deltaY, shiftKey }) => {
-    const parentWheel = vi.fn()
-    const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
+    { name: 'dominant horizontal input', deltaX: 160, deltaY: 4, shiftKey: false, expectedScrollLeft: 160 },
+    { name: 'shifted vertical input', deltaX: 0, deltaY: 160, shiftKey: true, expectedScrollLeft: 160 },
+    {
+      name: 'shifted page-mode vertical input',
+      deltaMode: WheelEvent.DOM_DELTA_PAGE,
+      deltaX: 0,
+      deltaY: 1,
+      shiftKey: true,
+      expectedScrollLeft: 500
+    }
+  ])(
+    'supports $name on non-content areas in horizontal layout',
+    ({ deltaMode = WheelEvent.DOM_DELTA_PIXEL, deltaX, deltaY, shiftKey, expectedScrollLeft }) => {
+      const parentWheel = vi.fn()
+      const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
 
-    const { container } = render(
-      <div onWheel={parentWheel}>
-        <MessageGroup messages={messages} />
-      </div>
-    )
+      const { container } = render(
+        <div onWheel={parentWheel}>
+          <MessageGroup messages={messages} />
+        </div>
+      )
 
-    const outerWrapper = container.querySelector('#message-msg-1') as HTMLElement
-    const horizontalGroup = outerWrapper.parentElement as HTMLElement
-    expect(horizontalGroup).not.toBeNull()
+      const outerWrapper = container.querySelector('#message-msg-1') as HTMLElement
+      const horizontalGroup = outerWrapper.parentElement as HTMLElement
+      expect(horizontalGroup).not.toBeNull()
 
-    setElementSize(horizontalGroup, {
-      clientWidth: 500,
-      scrollLeft: 0,
-      scrollWidth: 1000
-    })
+      setElementSize(horizontalGroup, {
+        clientHeight: 300,
+        clientWidth: 500,
+        scrollLeft: 0,
+        scrollWidth: 1000
+      })
 
-    const wheelEvent = createEvent.wheel(horizontalGroup, { deltaX, deltaY, shiftKey })
-    fireEvent(horizontalGroup, wheelEvent)
+      const wheelEvent = createEvent.wheel(horizontalGroup, { deltaMode, deltaX, deltaY, shiftKey })
+      fireEvent(horizontalGroup, wheelEvent)
 
-    expect(wheelEvent.defaultPrevented).toBe(true)
-    expect(parentWheel).not.toHaveBeenCalled()
-    expect(horizontalGroup.scrollLeft).toBe(160)
-  })
+      expect(wheelEvent.defaultPrevented).toBe(true)
+      expect(parentWheel).not.toHaveBeenCalled()
+      expect(horizontalGroup.scrollLeft).toBe(expectedScrollLeft)
+    }
+  )
 
   it.each([
     { name: 'line', deltaMode: WheelEvent.DOM_DELTA_LINE, deltaX: 3, expectedScrollLeft: 48 },

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -195,7 +195,7 @@ vi.mock('../list/MessageGroupMenuBar', () => ({
 }))
 
 vi.mock('../list/ScrollOwnershipContext', () => ({
-  useScrollRuntimeBoundary: () => ({ scrollByWheel: mocks.scrollByWheel }),
+  useScrollRuntimeBoundary: () => ({ getScrollContainer: () => null, scrollByWheel: mocks.scrollByWheel }),
   useScrollRuntimeNavigation: () => () => false
 }))
 
@@ -812,6 +812,29 @@ describe('MessageGroup', () => {
   })
 
   it.each([
+    { name: 'line', deltaMode: WheelEvent.DOM_DELTA_LINE, deltaY: 3, expectedDeltaY: 48 },
+    { name: 'page', deltaMode: WheelEvent.DOM_DELTA_PAGE, deltaY: 1, expectedDeltaY: 300 }
+  ])('normalizes $name-mode vertical wheel input before forwarding it', ({ deltaMode, deltaY, expectedDeltaY }) => {
+    mocks.scrollByWheel.mockReturnValue(true)
+    const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
+
+    const { container } = render(<MessageGroup messages={messages} />)
+
+    const outerWrapper = container.querySelector('#message-msg-1') as HTMLElement
+    const horizontalGroup = outerWrapper.parentElement as HTMLElement
+    setElementSize(horizontalGroup, {
+      clientHeight: 300,
+      clientWidth: 500,
+      scrollLeft: 0,
+      scrollWidth: 1000
+    })
+
+    fireEvent(horizontalGroup, createEvent.wheel(horizontalGroup, { deltaMode, deltaX: 0.1, deltaY }))
+
+    expect(mocks.scrollByWheel).toHaveBeenCalledWith(expectedDeltaY)
+  })
+
+  it.each([
     { name: 'dominant horizontal input', deltaX: 160, deltaY: 4, shiftKey: false },
     { name: 'shifted vertical input', deltaX: 0, deltaY: 160, shiftKey: true }
   ])('supports $name on non-content areas in horizontal layout', ({ deltaX, deltaY, shiftKey }) => {
@@ -840,6 +863,28 @@ describe('MessageGroup', () => {
     expect(wheelEvent.defaultPrevented).toBe(true)
     expect(parentWheel).not.toHaveBeenCalled()
     expect(horizontalGroup.scrollLeft).toBe(160)
+  })
+
+  it.each([
+    { name: 'line', deltaMode: WheelEvent.DOM_DELTA_LINE, deltaX: 3, expectedScrollLeft: 48 },
+    { name: 'page', deltaMode: WheelEvent.DOM_DELTA_PAGE, deltaX: 1, expectedScrollLeft: 500 }
+  ])('normalizes $name-mode horizontal wheel input before scrolling', ({ deltaMode, deltaX, expectedScrollLeft }) => {
+    const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
+
+    const { container } = render(<MessageGroup messages={messages} />)
+
+    const outerWrapper = container.querySelector('#message-msg-1') as HTMLElement
+    const horizontalGroup = outerWrapper.parentElement as HTMLElement
+    setElementSize(horizontalGroup, {
+      clientHeight: 300,
+      clientWidth: 500,
+      scrollLeft: 0,
+      scrollWidth: 1000
+    })
+
+    fireEvent(horizontalGroup, createEvent.wheel(horizontalGroup, { deltaMode, deltaX }))
+
+    expect(horizontalGroup.scrollLeft).toBe(expectedScrollLeft)
   })
 
   it('registers horizontal wheel handling as a native non-passive listener', () => {

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   editMessageBlocks: vi.fn(),
   resendUserMessageWithEdit: vi.fn(),
   scrollIntoView: vi.fn(),
+  scrollByWheel: vi.fn(() => false),
   setTimeoutTimer: vi.fn(),
   settings: vi.fn().mockReturnValue({
     multiModelMessageStyle: 'horizontal',
@@ -191,6 +192,11 @@ vi.mock('../frame/MessageAttachments', () => ({
 
 vi.mock('../list/MessageGroupMenuBar', () => ({
   default: mocks.MessageGroupMenuBar
+}))
+
+vi.mock('../list/ScrollOwnershipContext', () => ({
+  useScrollRuntimeBoundary: () => ({ scrollByWheel: mocks.scrollByWheel }),
+  useScrollRuntimeNavigation: () => () => false
 }))
 
 vi.mock('../MessageListProvider', () => ({
@@ -746,7 +752,7 @@ describe('MessageGroup', () => {
     expect(getComputedStyle(horizontalGroup).overflowY).toBe('hidden')
   })
 
-  it('prevents vertical wheel on non-content areas from bubbling to the outer chat scroll in horizontal layout', () => {
+  it('lets vertical wheel input on non-content areas bubble to the outer chat scroll in horizontal layout', () => {
     const parentWheel = vi.fn()
     const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
 
@@ -773,13 +779,50 @@ describe('MessageGroup', () => {
     const wheelEvent = createEvent.wheel(horizontalGroup, { deltaY: 120 })
     fireEvent(horizontalGroup, wheelEvent)
 
-    expect(parentWheel).not.toHaveBeenCalled()
+    expect(wheelEvent.defaultPrevented).toBe(false)
+    expect(parentWheel).toHaveBeenCalledOnce()
   })
 
-  it('supports horizontal wheel scrolling on non-content areas in horizontal layout', () => {
+  it('forwards dominant vertical trackpad input with a small horizontal delta to the outer scroll runtime', () => {
+    const parentWheel = vi.fn()
+    mocks.scrollByWheel.mockReturnValue(true)
     const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
 
-    const { container } = render(<MessageGroup messages={messages} />)
+    const { container } = render(
+      <div onWheel={parentWheel}>
+        <MessageGroup messages={messages} />
+      </div>
+    )
+
+    const outerWrapper = container.querySelector('#message-msg-1') as HTMLElement
+    const horizontalGroup = outerWrapper.parentElement as HTMLElement
+    setElementSize(horizontalGroup, {
+      clientWidth: 500,
+      scrollLeft: 0,
+      scrollWidth: 1000
+    })
+
+    const wheelEvent = createEvent.wheel(horizontalGroup, { deltaX: 2, deltaY: 120 })
+    fireEvent(horizontalGroup, wheelEvent)
+
+    expect(mocks.scrollByWheel).toHaveBeenCalledWith(120)
+    expect(wheelEvent.defaultPrevented).toBe(true)
+    expect(parentWheel).not.toHaveBeenCalled()
+    expect(horizontalGroup.scrollLeft).toBe(0)
+  })
+
+  it.each([
+    { name: 'dominant horizontal input', deltaX: 160, deltaY: 4, shiftKey: false },
+    { name: 'shifted vertical input', deltaX: 0, deltaY: 160, shiftKey: true }
+  ])('supports $name on non-content areas in horizontal layout', ({ deltaX, deltaY, shiftKey }) => {
+    const parentWheel = vi.fn()
+    const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
+
+    const { container } = render(
+      <div onWheel={parentWheel}>
+        <MessageGroup messages={messages} />
+      </div>
+    )
 
     const outerWrapper = container.querySelector('#message-msg-1') as HTMLElement
     const horizontalGroup = outerWrapper.parentElement as HTMLElement
@@ -791,10 +834,58 @@ describe('MessageGroup', () => {
       scrollWidth: 1000
     })
 
-    const wheelEvent = createEvent.wheel(horizontalGroup, { deltaX: 160 })
+    const wheelEvent = createEvent.wheel(horizontalGroup, { deltaX, deltaY, shiftKey })
     fireEvent(horizontalGroup, wheelEvent)
 
+    expect(wheelEvent.defaultPrevented).toBe(true)
+    expect(parentWheel).not.toHaveBeenCalled()
     expect(horizontalGroup.scrollLeft).toBe(160)
+  })
+
+  it('registers horizontal wheel handling as a native non-passive listener', () => {
+    const addEventListenerSpy = vi.spyOn(HTMLElement.prototype, 'addEventListener')
+
+    try {
+      render(
+        <MessageGroup messages={[createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]} />
+      )
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith('wheel', expect.any(Function), {
+        capture: true,
+        passive: false
+      })
+    } finally {
+      addEventListenerSpy.mockRestore()
+    }
+  })
+
+  it.each([
+    { name: 'left', deltaX: -160, scrollLeft: 0 },
+    { name: 'right', deltaX: 160, scrollLeft: 500 }
+  ])('releases horizontal wheel input at the $name boundary', ({ deltaX, scrollLeft }) => {
+    const parentWheel = vi.fn()
+    const messages = [createMessage('msg-1', 0, 'horizontal'), createMessage('msg-2', 1, 'horizontal')]
+
+    const { container } = render(
+      <div onWheel={parentWheel}>
+        <MessageGroup messages={messages} />
+      </div>
+    )
+
+    const outerWrapper = container.querySelector('#message-msg-1') as HTMLElement
+    const horizontalGroup = outerWrapper.parentElement as HTMLElement
+    setElementSize(horizontalGroup, {
+      clientWidth: 500,
+      scrollLeft,
+      scrollWidth: 1000
+    })
+
+    const wheelEvent = createEvent.wheel(horizontalGroup, { deltaX })
+    fireEvent(horizontalGroup, wheelEvent)
+
+    expect(wheelEvent.defaultPrevented).toBe(false)
+    expect(parentWheel).toHaveBeenCalledOnce()
+    expect(horizontalGroup.scrollLeft).toBe(scrollLeft)
   })
 
   it('preserves visible content overflow for non-horizontal layouts', () => {

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -25,6 +25,13 @@ import { useScrollRuntimeBoundary, useScrollRuntimeNavigation } from './ScrollOw
 
 const logger = loggerService.withContext('MessageGroup')
 const EMPTY_MESSAGE_PARTS: CherryMessagePart[] = []
+const WHEEL_LINE_HEIGHT_PX = 16
+
+function normalizeWheelDelta(delta: number, deltaMode: number, pageSize: number): number {
+  if (deltaMode === WheelEvent.DOM_DELTA_LINE) return delta * WHEEL_LINE_HEIGHT_PX
+  if (deltaMode === WheelEvent.DOM_DELTA_PAGE) return delta * pageSize
+  return delta
+}
 
 interface Props {
   messages: MessageListItem[]
@@ -73,7 +80,7 @@ const MessageGroup = ({
   const { setTimeoutTimer } = useTimer()
   const currentTabId = useCurrentTabId()
   const navigateWithScrollRuntime = useScrollRuntimeNavigation()
-  const { scrollByWheel } = useScrollRuntimeBoundary()
+  const { getScrollContainer, scrollByWheel } = useScrollRuntimeBoundary()
   const isMultiSelectMode = selection?.isMultiSelectMode ?? false
   const getMessageUiState = useCallback(
     (messageId: string) => messageUi.getMessageUiState?.(messageId) ?? {},
@@ -255,14 +262,17 @@ const MessageGroup = ({
       }
 
       const groupContainer = event.currentTarget as HTMLDivElement
+      const horizontalWheelDelta = normalizeWheelDelta(event.deltaX, event.deltaMode, groupContainer.clientWidth)
+      const verticalPageSize = getScrollContainer()?.clientHeight ?? groupContainer.clientHeight
+      const verticalWheelDelta = normalizeWheelDelta(event.deltaY, event.deltaMode, verticalPageSize)
       const horizontalDelta = event.shiftKey
-        ? event.deltaX || event.deltaY
-        : Math.abs(event.deltaX) > Math.abs(event.deltaY)
-          ? event.deltaX
+        ? horizontalWheelDelta || verticalWheelDelta
+        : Math.abs(horizontalWheelDelta) > Math.abs(verticalWheelDelta)
+          ? horizontalWheelDelta
           : 0
 
       if (horizontalDelta === 0) {
-        if (event.deltaX !== 0 && event.deltaY !== 0 && scrollByWheel(event.deltaY)) {
+        if (horizontalWheelDelta !== 0 && verticalWheelDelta !== 0 && scrollByWheel(verticalWheelDelta)) {
           event.preventDefault()
           event.stopPropagation()
         }
@@ -279,7 +289,7 @@ const MessageGroup = ({
         groupContainer.scrollLeft += horizontalDelta
       }
     },
-    [scrollByWheel]
+    [getScrollContainer, scrollByWheel]
   )
 
   useEffect(() => {

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -7,7 +7,7 @@ import { classNames } from '@renderer/utils/style'
 import type { MultiModelMessageStyle } from '@shared/data/preference/preferenceTypes'
 import type { CherryMessagePart } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
-import type { ComponentProps, ReactNode, WheelEvent as ReactWheelEvent } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import MessageItem from '../frame/MessageFrame'
@@ -21,7 +21,7 @@ import { defaultMessageRenderConfig, type MessageListItem, type MessageUiState }
 import { getEffectiveMultiModelMessageStyle, isAssistantMultiModelGroup } from '../utils/messageGroupLayout'
 import { isMessageListItemProcessing } from '../utils/messageListItem'
 import MessageGroupMenuBar from './MessageGroupMenuBar'
-import { useScrollRuntimeNavigation } from './ScrollOwnershipContext'
+import { useScrollRuntimeBoundary, useScrollRuntimeNavigation } from './ScrollOwnershipContext'
 
 const logger = loggerService.withContext('MessageGroup')
 const EMPTY_MESSAGE_PARTS: CherryMessagePart[] = []
@@ -73,6 +73,7 @@ const MessageGroup = ({
   const { setTimeoutTimer } = useTimer()
   const currentTabId = useCurrentTabId()
   const navigateWithScrollRuntime = useScrollRuntimeNavigation()
+  const { scrollByWheel } = useScrollRuntimeBoundary()
   const isMultiSelectMode = selection?.isMultiSelectMode ?? false
   const getMessageUiState = useCallback(
     (messageId: string) => messageUi.getMessageUiState?.(messageId) ?? {},
@@ -94,6 +95,7 @@ const MessageGroup = ({
   )
   const previousMessageIdsRef = useRef(messages.map((message) => message.id))
   const activeBranchSelectionQueueRef = useRef<Promise<void>>(Promise.resolve())
+  const horizontalGroupRef = useRef<HTMLDivElement>(null)
   const messageElementsRef = useRef<Map<string, HTMLElement>>(new Map())
 
   const registerRenderedMessageElement = useCallback(
@@ -245,32 +247,48 @@ const MessageGroup = ({
     return ''
   }, [messages])
 
-  const handleHorizontalGroupWheel = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
-    const target = event.target as HTMLElement | null
-    if (target?.closest('.message-content-container')) {
-      return
-    }
+  const handleHorizontalGroupWheel = useCallback(
+    (event: WheelEvent) => {
+      const target = event.target as HTMLElement | null
+      if (target?.closest('.message-content-container')) {
+        return
+      }
 
-    const groupContainer = event.currentTarget
-    const contentContainers = Array.from(groupContainer.querySelectorAll<HTMLElement>('.message-content-container'))
-    const hasInnerVerticalScroll = contentContainers.some(
-      (contentContainer) => contentContainer.scrollHeight > contentContainer.clientHeight + 1
-    )
-    const hasHorizontalScroll = groupContainer.scrollWidth > groupContainer.clientWidth + 1
-    const horizontalDelta = Math.abs(event.deltaX) > 0 ? event.deltaX : event.shiftKey ? event.deltaY : 0
+      const groupContainer = event.currentTarget as HTMLDivElement
+      const horizontalDelta = event.shiftKey
+        ? event.deltaX || event.deltaY
+        : Math.abs(event.deltaX) > Math.abs(event.deltaY)
+          ? event.deltaX
+          : 0
 
-    if (horizontalDelta !== 0 && hasHorizontalScroll) {
-      event.preventDefault()
-      event.stopPropagation()
-      groupContainer.scrollLeft += horizontalDelta
-      return
-    }
+      if (horizontalDelta === 0) {
+        if (event.deltaX !== 0 && event.deltaY !== 0 && scrollByWheel(event.deltaY)) {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+        return
+      }
 
-    if (hasInnerVerticalScroll) {
-      event.preventDefault()
-      event.stopPropagation()
-    }
-  }, [])
+      const maxScrollLeft = groupContainer.scrollWidth - groupContainer.clientWidth
+      const canScrollHorizontally =
+        horizontalDelta < 0 ? groupContainer.scrollLeft > 0 : groupContainer.scrollLeft < maxScrollLeft
+
+      if (canScrollHorizontally) {
+        event.preventDefault()
+        event.stopPropagation()
+        groupContainer.scrollLeft += horizontalDelta
+      }
+    },
+    [scrollByWheel]
+  )
+
+  useEffect(() => {
+    const groupContainer = horizontalGroupRef.current
+    if (!groupContainer || multiModelMessageStyle !== 'horizontal') return
+
+    groupContainer.addEventListener('wheel', handleHorizontalGroupWheel, { capture: true, passive: false })
+    return () => groupContainer.removeEventListener('wheel', handleHorizontalGroupWheel, true)
+  }, [handleHorizontalGroupWheel, multiModelMessageStyle])
 
   const renderMessage = useCallback(
     (message: MessageListItem, index: number) => {
@@ -358,9 +376,9 @@ const MessageGroup = ({
       id={messages[0].parentId ? `message-group-${messages[0].parentId}` : undefined}
       className={classNames([multiModelMessageStyle, { 'multi-select-mode': isMultiSelectMode }])}>
       <GridContainer
+        ref={horizontalGroupRef}
         $count={messageLength}
-        className={classNames([multiModelMessageStyle, { 'multi-select-mode': isMultiSelectMode }])}
-        onWheelCapture={multiModelMessageStyle === 'horizontal' ? handleHorizontalGroupWheel : undefined}>
+        className={classNames([multiModelMessageStyle, { 'multi-select-mode': isMultiSelectMode }])}>
         {messages.map(renderMessage)}
       </GridContainer>
       {isGrouped && (

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -266,15 +266,21 @@ const MessageGroup = ({
       const verticalPageSize = getScrollContainer()?.clientHeight ?? groupContainer.clientHeight
       const verticalWheelDelta = normalizeWheelDelta(event.deltaY, event.deltaMode, verticalPageSize)
       const horizontalDelta = event.shiftKey
-        ? horizontalWheelDelta || verticalWheelDelta
+        ? horizontalWheelDelta || normalizeWheelDelta(event.deltaY, event.deltaMode, groupContainer.clientWidth)
         : Math.abs(horizontalWheelDelta) > Math.abs(verticalWheelDelta)
           ? horizontalWheelDelta
           : 0
 
       if (horizontalDelta === 0) {
-        if (horizontalWheelDelta !== 0 && verticalWheelDelta !== 0 && scrollByWheel(verticalWheelDelta)) {
-          event.preventDefault()
-          event.stopPropagation()
+        if (horizontalWheelDelta !== 0 && verticalWheelDelta !== 0) {
+          const didScroll =
+            event.deltaMode === WheelEvent.DOM_DELTA_PAGE
+              ? scrollByWheel(verticalWheelDelta, Math.abs(verticalWheelDelta))
+              : scrollByWheel(verticalWheelDelta)
+          if (didScroll) {
+            event.preventDefault()
+            event.stopPropagation()
+          }
         }
         return
       }

--- a/src/renderer/components/chat/messages/list/ScrollOwnershipContext.tsx
+++ b/src/renderer/components/chat/messages/list/ScrollOwnershipContext.tsx
@@ -23,7 +23,7 @@ interface ScrollOwnership {
   requestReadingControl: (anchor: HTMLElement | null) => void
   scrollToElement: (element: HTMLElement, align?: 'start' | 'center') => void
   notifyWheelIntent?: (deltaY: number) => void
-  scrollByWheel?: (deltaY: number) => boolean
+  scrollByWheel?: (deltaY: number, maxDeltaY?: number) => boolean
 }
 
 const ScrollOwnershipContext = createContext<ScrollOwnership | null>(null)
@@ -34,8 +34,8 @@ export const VERTICAL_SCROLLABLE_OVERFLOW_PATTERN_SOURCE = 'auto|scroll|overlay'
 export const FORWARDED_WHEEL_MAX_DELTA_PX = 200
 const VERTICAL_SCROLLABLE_OVERFLOW_PATTERN = new RegExp(`^(?:${VERTICAL_SCROLLABLE_OVERFLOW_PATTERN_SOURCE})$`)
 
-export function clampForwardedWheelDelta(deltaY: number): number {
-  return Math.max(-FORWARDED_WHEEL_MAX_DELTA_PX, Math.min(FORWARDED_WHEEL_MAX_DELTA_PX, deltaY))
+export function clampForwardedWheelDelta(deltaY: number, maxDeltaY: number = FORWARDED_WHEEL_MAX_DELTA_PX): number {
+  return Math.max(-maxDeltaY, Math.min(maxDeltaY, deltaY))
 }
 
 export const ScrollOwnershipProvider = ({
@@ -51,7 +51,7 @@ export const ScrollOwnershipProvider = ({
   requestReadingControl?: (anchor: HTMLElement | null) => void
   scrollToElement?: (element: HTMLElement, align?: 'start' | 'center') => void
   notifyWheelIntent?: (deltaY: number) => void
-  scrollByWheel?: (deltaY: number) => boolean
+  scrollByWheel?: (deltaY: number, maxDeltaY?: number) => boolean
 }) => {
   const value = useMemo(
     () => ({ notifyWheelIntent, requestReadingControl, scrollByWheel, scrollContainerRef, scrollToElement }),
@@ -125,7 +125,7 @@ export function findScrollParent(element: HTMLElement | null): HTMLElement | nul
 export interface ScrollRuntimeBoundary {
   getScrollContainer(): HTMLElement | null
   notifyWheelIntent(deltaY: number): boolean
-  scrollByWheel(deltaY: number): boolean
+  scrollByWheel(deltaY: number, maxDeltaY?: number): boolean
 }
 
 /** Route embedded or portal scroll input through the owning message-list runtime. */
@@ -140,7 +140,13 @@ export function useScrollRuntimeBoundary(): ScrollRuntimeBoundary {
     },
     [ownership]
   )
-  const scrollByWheel = useCallback((deltaY: number) => ownership?.scrollByWheel?.(deltaY) ?? false, [ownership])
+  const scrollByWheel = useCallback(
+    (deltaY: number, maxDeltaY?: number) => {
+      if (!ownership?.scrollByWheel) return false
+      return maxDeltaY === undefined ? ownership.scrollByWheel(deltaY) : ownership.scrollByWheel(deltaY, maxDeltaY)
+    },
+    [ownership]
+  )
 
   return useMemo(
     () => ({ getScrollContainer, notifyWheelIntent, scrollByWheel }),

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -2705,6 +2705,20 @@ describe('useChatVirtualizerRuntime', () => {
     expect(scrollBy).toHaveBeenCalledWith({ top: boundedDeltaY })
   })
 
+  it('honors an explicit forwarded-wheel bound for page-mode input', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+    const scroller = runtime!.scrollerRef.current!
+    const scrollBy = vi.fn()
+    scroller.scrollBy = scrollBy
+
+    act(() => {
+      runtime!.scrollByWheel(480, 480)
+    })
+
+    expect(scrollBy).toHaveBeenCalledWith({ top: 480 })
+  })
+
   it('keeps following the real bottom when the viewport becomes shorter', () => {
     const callbacks: ResizeObserverCallback[] = []
     const restoreResizeObserver = installResizeObserverMock(callbacks)

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -133,7 +133,7 @@ export interface ChatVirtualizerRuntime<T> {
   /** Mark a wheel that will reach this viewport through native boundary chaining. */
   notifyWheelIntent(deltaY: number): void
   /** Apply a wheel forwarded from an isolated child document under this runtime's ownership. */
-  scrollByWheel(deltaY: number): boolean
+  scrollByWheel(deltaY: number, maxDeltaY?: number): boolean
   /**
    * Mark that a real user scroll input just happened. Wheel is wired through
    * `scrollerProps.onWheel`; the host calls this for pointer drags and
@@ -815,11 +815,11 @@ export function useChatVirtualizerRuntime<T>({
   )
 
   const scrollByWheel = useCallback(
-    (deltaY: number) => {
+    (deltaY: number, maxDeltaY?: number) => {
       const scroller = scrollerRef.current
       if (!scroller) return false
 
-      const boundedDeltaY = clampForwardedWheelDelta(deltaY)
+      const boundedDeltaY = clampForwardedWheelDelta(deltaY, maxDeltaY)
       notifyWheelIntent(boundedDeltaY)
       scroller.scrollBy({ top: boundedDeltaY })
       return true


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- Diagonal macOS trackpad gestures over a horizontal multi-model row could be latched by the horizontal scroller, preventing the outer message list from moving vertically.
- Horizontal wheel input was handled by a passive React listener, so the manual and native scroll paths could both apply the same delta.

After this PR:

- Dominant vertical diagonal gestures are routed through the existing message-list scroll runtime, while pure vertical wheel input continues to reach the outer list normally.
- Intentional horizontal and Shift+wheel gestures are consumed by a non-passive native listener only while the row can scroll in that direction; boundary input is released.

Fixes #19821

### Why we need it and why it was done in this way

The horizontal multi-model row and the outer message viewport compete for the same trackpad gesture. Using the existing scroll-ownership runtime preserves the message list's reading/follow state while ensuring a small horizontal component cannot trap a primarily vertical gesture.

The following tradeoffs were made:

- A native non-passive listener is attached only while the group uses horizontal layout, because cancelling the browser's horizontal default is required to avoid duplicate movement.
- Wheel events inside each model's own vertical content scroller remain untouched.

The following alternatives were considered:

- Letting diagonal events bubble without forwarding was insufficient because Chromium can latch the gesture to the nested horizontal scroller.
- Writing an ancestor's `scrollTop` directly was rejected because the message-list runtime owns scroll intent and anchor stability.

Links to places where the discussion took place: #19821

### Breaking changes

None.

### Special notes for your reviewer

Manual verification used a four-model horizontal answer group on macOS:

- `deltaX=80, deltaY=0` moved the row exactly 80 px instead of 160 px.
- `deltaX=2, deltaY=-120` kept the row at 0 and moved the outer list by -120 px.
- Left and right horizontal boundaries release the event.

Screenshot:

<img width="1502" height="1153" alt="Four-model answer layout after the scroll fix" src="https://github.com/user-attachments/assets/d2bffa44-56f3-4cbc-b4a0-ebb8906befba" />

Validation:

- `pnpm test:renderer src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx` (45/45)
- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed vertical trackpad scrolling over horizontal multi-model answers on macOS.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches nested scroll and wheel event handling in the chat message list; behavior is well-tested but incorrect routing could still affect scroll follow/reading mode on macOS trackpads.
> 
> **Overview**
> Fixes trackpad/wheel conflicts when scrolling over **horizontal multi-model** answer rows so primarily vertical gestures move the outer chat list instead of getting stuck on the row scroller.
> 
> **MessageGroup** drops the React `onWheelCapture` handler for a **native capture-phase, non-passive** `wheel` listener (horizontal layout only). Wheel deltas are **normalized** for line/page modes; **dominant horizontal** and **Shift+vertical** input scroll the row only while it has room, then **release** at the left/right edge. **Mostly vertical** diagonal input (small `deltaX`, large `deltaY`) is forwarded through **`scrollByWheel`** on the message-list scroll runtime; pure vertical wheel on non-content areas is **no longer prevented** and can bubble to the outer list. Events inside `.message-content-container` are unchanged.
> 
> **Scroll ownership / virtualizer**: `scrollByWheel` and `clampForwardedWheelDelta` accept an optional **`maxDeltaY`** so page-mode forwards can scroll a full viewport in one step. Tests cover forwarding, normalization, boundaries, and the non-passive listener registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c43ad6643171b0567b1b2ef123a4d3545dd4ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->