### PR TITLE
feat(image-export): pixel-faithful message image export via Chromium compositor

### DIFF
--- a/src/main/ipc/handlers/__tests__/window.test.ts
+++ b/src/main/ipc/handlers/__tests__/window.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { appGetMock } = vi.hoisted(() => ({ appGetMock: vi.fn() }))
+const { appGetMock, captureScreenshotViaCdpMock } = vi.hoisted(() => ({
+  appGetMock: vi.fn(),
+  captureScreenshotViaCdpMock: vi.fn()
+}))
 vi.mock('@application', () => ({ application: { get: appGetMock } }))
+vi.mock('@main/utils/cdpScreenshot', () => ({ captureScreenshotViaCdp: captureScreenshotViaCdpMock }))
 
 import { windowHandlers } from '../window'
 
@@ -13,7 +17,8 @@ const windowManager = {
   setFullScreen: vi.fn(() => true),
   isMaximized: vi.fn(() => true),
   isFullScreen: vi.fn(() => false),
-  getInitData: vi.fn(() => ({ path: '/settings/provider' }))
+  getInitData: vi.fn(() => ({ path: '/settings/provider' })),
+  getWindow: vi.fn()
 }
 const mainWindowService = {
   requestClose: vi.fn(() => false),
@@ -22,6 +27,8 @@ const mainWindowService = {
   reloadMainWindow: vi.fn()
 }
 const subWindowService = { setAlwaysOnTop: vi.fn(() => true) }
+
+const callerWindow = { isDestroyed: vi.fn(() => false), webContents: { id: 7 } }
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -110,5 +117,31 @@ describe('windowHandlers', () => {
     expect(mainWindowService.setMainWindowMinimumSize).toHaveBeenCalledWith(800, 600)
     expect(mainWindowService.resetMainWindowMinimumSize).toHaveBeenCalledOnce()
     expect(mainWindowService.reloadMainWindow).toHaveBeenCalledOnce()
+  })
+
+  describe('window.capture_screenshot', () => {
+    const input = { clip: { x: 0, y: 0, width: 100, height: 50 }, scale: 2 }
+
+    it('rasterizes through CDP against the caller window and returns the data URL', async () => {
+      windowManager.getWindow.mockReturnValue(callerWindow)
+      captureScreenshotViaCdpMock.mockResolvedValue('data:image/png;base64,QUJD')
+
+      const result = await windowHandlers['window.capture_screenshot'](input, ctx('w1'))
+
+      expect(windowManager.getWindow).toHaveBeenCalledWith('w1')
+      expect(captureScreenshotViaCdpMock).toHaveBeenCalledWith(callerWindow.webContents, input.clip, 2)
+      expect(result).toEqual({ dataUrl: 'data:image/png;base64,QUJD' })
+    })
+
+    it('rejects when the caller window is not tracked (senderId null)', async () => {
+      await expect(windowHandlers['window.capture_screenshot'](input, ctx(null))).rejects.toThrow('not found')
+      expect(captureScreenshotViaCdpMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects when the caller window is destroyed', async () => {
+      windowManager.getWindow.mockReturnValue({ ...callerWindow, isDestroyed: vi.fn(() => true) })
+      await expect(windowHandlers['window.capture_screenshot'](input, ctx('w1'))).rejects.toThrow('not found')
+      expect(captureScreenshotViaCdpMock).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/main/ipc/handlers/window.ts
+++ b/src/main/ipc/handlers/window.ts
@@ -1,4 +1,5 @@
 import { application } from '@application'
+import { captureScreenshotViaCdp } from '@main/utils/cdpScreenshot'
 import type { windowRequestSchemas } from '@shared/ipc/schemas/window'
 import type { IpcHandlersFor } from '@shared/ipc/types'
 
@@ -41,6 +42,17 @@ export const windowHandlers: IpcHandlersFor<typeof windowRequestSchemas> = {
     senderId ? application.get('WindowManager').isFullScreen(senderId) : false,
   'window.get_init_data': async (_input, { senderId }) =>
     senderId ? application.get('WindowManager').getInitData(senderId) : null,
+  // Native-compositor rasterization of the caller's own page. Errors propagate as
+  // INTERNAL — the renderer treats any failure as "native unavailable" and falls
+  // back to the html-to-image path, so no dedicated error code is warranted.
+  'window.capture_screenshot': async ({ clip, scale }, { senderId }) => {
+    const win = senderId ? application.get('WindowManager').getWindow(senderId) : undefined
+    if (!win || win.isDestroyed()) {
+      throw new Error('Caller window not found')
+    }
+    const dataUrl = await captureScreenshotViaCdp(win.webContents, clip, scale)
+    return { dataUrl }
+  },
 
   // Sub-window-only contract: reject unless the caller resolves to a SubWindow-type window
   // (a non-null senderId is insufficient — the main window must not pin itself).

--- a/src/main/utils/__tests__/cdpScreenshot.test.ts
+++ b/src/main/utils/__tests__/cdpScreenshot.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { captureScreenshotViaCdp } from '../cdpScreenshot'
+
+interface DebuggerStub {
+  attach: ReturnType<typeof vi.fn>
+  detach: ReturnType<typeof vi.fn>
+  isAttached: ReturnType<typeof vi.fn>
+  sendCommand: ReturnType<typeof vi.fn>
+}
+
+const makeWebContents = (debuggerOverrides: Partial<DebuggerStub> = {}, isDestroyed = false) => {
+  // Mirror Electron's semantics: isAttached() reflects whether attach() succeeded,
+  // so the finally-branch detach guard behaves as it does against a real session.
+  let attached = false
+  const dbg: DebuggerStub = {
+    attach: vi.fn(() => {
+      attached = true
+    }),
+    detach: vi.fn(() => {
+      attached = false
+    }),
+    isAttached: vi.fn(() => attached),
+    sendCommand: vi.fn(async () => ({ data: 'QUJD' })),
+    ...debuggerOverrides
+  }
+  const wc = {
+    isDestroyed: vi.fn(() => isDestroyed),
+    debugger: dbg
+  }
+  return { wc: wc as never as Electron.WebContents, dbg }
+}
+
+const CLIP = { x: 10, y: 20, width: 800, height: 600 }
+
+describe('captureScreenshotViaCdp', () => {
+  it('attaches, captures with the compositor recipe and detaches', async () => {
+    const { wc, dbg } = makeWebContents()
+
+    const dataUrl = await captureScreenshotViaCdp(wc, CLIP, 2)
+
+    expect(dataUrl).toBe('data:image/png;base64,QUJD')
+    expect(dbg.attach).toHaveBeenCalledWith('1.3')
+    expect(dbg.detach).toHaveBeenCalledTimes(1)
+    expect(dbg.sendCommand).toHaveBeenCalledWith('Page.captureScreenshot', {
+      format: 'png',
+      clip: { ...CLIP, scale: 2 },
+      captureBeyondViewport: true,
+      fromSurface: true
+    })
+  })
+
+  it('reuses an already-attached session without detaching it', async () => {
+    const { wc, dbg } = makeWebContents({ isAttached: vi.fn(() => true) })
+
+    await captureScreenshotViaCdp(wc, CLIP, 1)
+
+    expect(dbg.attach).not.toHaveBeenCalled()
+    expect(dbg.detach).not.toHaveBeenCalled()
+    expect(dbg.sendCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws without sending when attach fails (session owned by another client)', async () => {
+    const { wc, dbg } = makeWebContents({
+      attach: vi.fn(() => {
+        throw new Error('Debugger is already attached to the target')
+      })
+    })
+
+    await expect(captureScreenshotViaCdp(wc, CLIP, 1)).rejects.toThrow('CDP attach failed')
+    expect(dbg.sendCommand).not.toHaveBeenCalled()
+    expect(dbg.detach).not.toHaveBeenCalled()
+  })
+
+  it('detaches even when the capture command fails', async () => {
+    const { wc, dbg } = makeWebContents({
+      sendCommand: vi.fn(async () => {
+        throw new Error('surface error')
+      })
+    })
+
+    await expect(captureScreenshotViaCdp(wc, CLIP, 1)).rejects.toThrow('surface error')
+    expect(dbg.detach).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects when the response carries no image data', async () => {
+    const { wc, dbg } = makeWebContents({ sendCommand: vi.fn(async () => ({})) })
+
+    await expect(captureScreenshotViaCdp(wc, CLIP, 1)).rejects.toThrow('no image data')
+    expect(dbg.detach).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses a destroyed webContents', async () => {
+    const { wc, dbg } = makeWebContents({}, true)
+
+    await expect(captureScreenshotViaCdp(wc, CLIP, 1)).rejects.toThrow('destroyed')
+    expect(dbg.attach).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/utils/__tests__/cdpScreenshot.test.ts
+++ b/src/main/utils/__tests__/cdpScreenshot.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it, vi } from 'vitest'
 
+const { fromWebContentsMock, getDisplayMatchingMock } = vi.hoisted(() => ({
+  // No default implementation: unresolved windows fall back to DPR 1.
+  fromWebContentsMock: vi.fn(),
+  getDisplayMatchingMock: vi.fn(() => ({ scaleFactor: 1 }))
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: fromWebContentsMock },
+  screen: { getDisplayMatching: getDisplayMatchingMock }
+}))
+
 import { captureScreenshotViaCdp } from '../cdpScreenshot'
 
 interface DebuggerStub {
@@ -109,6 +120,17 @@ describe('captureScreenshotViaCdp', () => {
     const { wc, dbg } = makeWebContents()
 
     await expect(captureScreenshotViaCdp(wc, { ...CLIP, width: 9_000 }, 2)).rejects.toThrow('composited-surface limit')
+    expect(dbg.sendCommand).not.toHaveBeenCalled()
+  })
+
+  it('rejects a clip that only crosses the limit after the display DPR is applied (HiDPI)', async () => {
+    const { wc, dbg } = makeWebContents()
+    const win = { isDestroyed: () => false, getBounds: () => ({ x: 0, y: 0, width: 1920, height: 1080 }) }
+    fromWebContentsMock.mockReturnValueOnce(win)
+    getDisplayMatchingMock.mockReturnValueOnce({ scaleFactor: 2 })
+
+    // 9000 CSS px × scale 1 × DPR 2 = 18000 physical px > 16384.
+    await expect(captureScreenshotViaCdp(wc, { ...CLIP, width: 9_000 }, 1)).rejects.toThrow('composited-surface limit')
     expect(dbg.sendCommand).not.toHaveBeenCalled()
   })
 })

--- a/src/main/utils/__tests__/cdpScreenshot.test.ts
+++ b/src/main/utils/__tests__/cdpScreenshot.test.ts
@@ -96,4 +96,19 @@ describe('captureScreenshotViaCdp', () => {
     await expect(captureScreenshotViaCdp(wc, CLIP, 1)).rejects.toThrow('destroyed')
     expect(dbg.attach).not.toHaveBeenCalled()
   })
+
+  it('rejects a clip whose rasterized size exceeds the composited-surface limit', async () => {
+    const { wc, dbg } = makeWebContents()
+
+    await expect(captureScreenshotViaCdp(wc, { ...CLIP, width: 20_000 }, 1)).rejects.toThrow('composited-surface limit')
+    expect(dbg.attach).not.toHaveBeenCalled()
+    expect(dbg.sendCommand).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized clip that only crosses the limit after scaling', async () => {
+    const { wc, dbg } = makeWebContents()
+
+    await expect(captureScreenshotViaCdp(wc, { ...CLIP, width: 9_000 }, 2)).rejects.toThrow('composited-surface limit')
+    expect(dbg.sendCommand).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/utils/cdpScreenshot.ts
+++ b/src/main/utils/cdpScreenshot.ts
@@ -1,0 +1,71 @@
+import { loggerService } from '@logger'
+import type { WebContents } from 'electron'
+
+const logger = loggerService.withContext('Utils:cdpScreenshot')
+
+export interface CdpScreenshotClip {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * Rasterize a page-space region of `wc` through Chromium's own compositor via CDP
+ * `Page.captureScreenshot` — the same mechanism Puppeteer and DevTools' "capture
+ * node screenshot" use. Unlike DOM-clone rasterizers (html-to-image), the compositor
+ * outputs what the page actually shows: same fonts, same layout, same effects.
+ *
+ * `captureBeyondViewport: true` lets the clip cover content scrolled out of view by
+ * temporarily extending the composited surface (Chromium handles this internally;
+ * no visible viewport change is applied to the page).
+ *
+ * Electron allows exactly one debugger client per webContents. We attach only for
+ * the duration of the command and detach afterwards; if some other client already
+ * owns the session we still send through it but never detach what we did not attach.
+ */
+export async function captureScreenshotViaCdp(
+  wc: WebContents,
+  clip: CdpScreenshotClip,
+  scale: number
+): Promise<string> {
+  if (wc.isDestroyed()) {
+    throw new Error('webContents is destroyed')
+  }
+
+  const dbg = wc.debugger
+  const wasAttached = dbg.isAttached()
+  if (!wasAttached) {
+    try {
+      dbg.attach('1.3')
+    } catch (error) {
+      // Another client owns the session (e.g. a remote-debugging connection or an
+      // already-attached feature). Treat as unavailable — the caller falls back to
+      // the html-to-image path rather than shipping a broken export.
+      const message = error instanceof Error ? error.message : String(error)
+      logger.warn(
+        'CDP attach failed, native screenshot unavailable',
+        error instanceof Error ? error : new Error(message)
+      )
+      throw new Error(`CDP attach failed: ${message}`)
+    }
+  }
+
+  try {
+    const result = (await dbg.sendCommand('Page.captureScreenshot', {
+      format: 'png',
+      clip: { ...clip, scale },
+      captureBeyondViewport: true,
+      fromSurface: true
+    })) as { data?: string }
+
+    if (!result?.data) {
+      throw new Error('Page.captureScreenshot returned no image data')
+    }
+    return `data:image/png;base64,${result.data}`
+  } finally {
+    if (!wasAttached && !wc.isDestroyed() && dbg.isAttached()) {
+      dbg.detach()
+    }
+  }
+}

--- a/src/main/utils/cdpScreenshot.ts
+++ b/src/main/utils/cdpScreenshot.ts
@@ -11,6 +11,12 @@ export interface CdpScreenshotClip {
 }
 
 /**
+ * Main-side ceiling on rasterized output (device px) — Chromium's composited
+ * surface cannot exceed this. Renderer applies a tighter per-window bound.
+ */
+const MAX_SCREENSHOT_PHYSICAL_DIMENSION = 16384
+
+/**
  * Rasterize a page-space region of `wc` through Chromium's own compositor via CDP
  * `Page.captureScreenshot` — the same mechanism Puppeteer and DevTools' "capture
  * node screenshot" use. Unlike DOM-clone rasterizers (html-to-image), the compositor
@@ -31,6 +37,15 @@ export async function captureScreenshotViaCdp(
 ): Promise<string> {
   if (wc.isDestroyed()) {
     throw new Error('webContents is destroyed')
+  }
+  // Output = clip × scale (× the window's device-pixel ratio, applied by the
+  // compositor). Guard the clip×scale product so an arbitrary request cannot
+  // arm an oversized capture; scale ≥ 1 is already enforced by the schema.
+  if (
+    clip.width * scale > MAX_SCREENSHOT_PHYSICAL_DIMENSION ||
+    clip.height * scale > MAX_SCREENSHOT_PHYSICAL_DIMENSION
+  ) {
+    throw new Error(`Screenshot clip exceeds the composited-surface limit (${MAX_SCREENSHOT_PHYSICAL_DIMENSION}px)`)
   }
 
   const dbg = wc.debugger

--- a/src/main/utils/cdpScreenshot.ts
+++ b/src/main/utils/cdpScreenshot.ts
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger'
 import type { WebContents } from 'electron'
+import { BrowserWindow, screen } from 'electron'
 
 const logger = loggerService.withContext('Utils:cdpScreenshot')
 
@@ -15,6 +16,17 @@ export interface CdpScreenshotClip {
  * surface cannot exceed this. Renderer applies a tighter per-window bound.
  */
 const MAX_SCREENSHOT_PHYSICAL_DIMENSION = 16384
+
+/**
+ * Device-pixel ratio of the display hosting `wc`. CDP clip coordinates are CSS
+ * px and clip.scale multiplies ON TOP of this factor, so the physical output
+ * is clip × scale × DPR. Falls back to 1 when the window cannot be resolved.
+ */
+function displayScaleFactor(wc: WebContents): number {
+  const win = BrowserWindow.fromWebContents(wc)
+  if (!win || win.isDestroyed()) return 1
+  return screen.getDisplayMatching(win.getBounds()).scaleFactor || 1
+}
 
 /**
  * Rasterize a page-space region of `wc` through Chromium's own compositor via CDP
@@ -38,12 +50,13 @@ export async function captureScreenshotViaCdp(
   if (wc.isDestroyed()) {
     throw new Error('webContents is destroyed')
   }
-  // Output = clip × scale (× the window's device-pixel ratio, applied by the
-  // compositor). Guard the clip×scale product so an arbitrary request cannot
-  // arm an oversized capture; scale ≥ 1 is already enforced by the schema.
+  // Output = clip × scale × the host display's device-pixel ratio (applied by
+  // the compositor). Guard the full physical product so an arbitrary request
+  // cannot arm an oversized capture; scale ≥ 1 is already enforced by the schema.
+  const dpr = displayScaleFactor(wc)
   if (
-    clip.width * scale > MAX_SCREENSHOT_PHYSICAL_DIMENSION ||
-    clip.height * scale > MAX_SCREENSHOT_PHYSICAL_DIMENSION
+    clip.width * scale * dpr > MAX_SCREENSHOT_PHYSICAL_DIMENSION ||
+    clip.height * scale * dpr > MAX_SCREENSHOT_PHYSICAL_DIMENSION
   ) {
     throw new Error(`Screenshot clip exceeds the composited-surface limit (${MAX_SCREENSHOT_PHYSICAL_DIMENSION}px)`)
   }

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -6,7 +6,7 @@ import LoadingIcon from '@renderer/components/icons/LoadingIcon'
 import SelectionContextMenu from '@renderer/components/SelectionContextMenu'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { removeSpecialCharactersForFileName } from '@renderer/utils/file'
-import { captureScrollable, captureScrollableAsDataUrl } from '@renderer/utils/image'
+import { captureScrollableAsDataUrl } from '@renderer/utils/image'
 import { classNames } from '@renderer/utils/style'
 import type { MultiModelMessageStyle } from '@shared/data/preference/preferenceTypes'
 import type { CherryMessagePart } from '@shared/data/types/message'
@@ -504,8 +504,8 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
   const executeTopicImageAction = useCallback(
     async (action: TopicImageRuntimeAction, captureRef: React.RefObject<HTMLElement | null>) => {
       if (action === 'copy') {
-        const canvas = await captureScrollable(captureRef)
-        const blob = canvas ? await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png')) : null
+        const imageData = await captureScrollableAsDataUrl(captureRef)
+        const blob = imageData ? await fetch(imageData).then((response) => response.blob()) : null
         if (!blob) {
           throw new Error('Failed to capture topic image')
         }

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -851,9 +851,10 @@ describe('MessageList', () => {
 
   it('copies topic image from a complete non-virtualized capture surface', async () => {
     messageVirtualListMocks.renderItemLimit = 1
-    const captureScrollableMock = vi.mocked(captureScrollable)
+    const captureScrollableAsDataUrlMock = vi.mocked(captureScrollableAsDataUrl)
     const copyImage = vi.fn().mockResolvedValue(undefined)
     const imageBlob = new Blob(['topic'], { type: 'image/png' })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ blob: async () => imageBlob } as Response)
     let runtime: MessageListRuntime | undefined
     const actions: Partial<MessageListActions> = {
       bindRuntime: (nextRuntime) => {
@@ -865,14 +866,12 @@ describe('MessageList', () => {
       copyImage
     }
 
-    captureScrollableMock.mockImplementation(async (ref) => {
+    captureScrollableAsDataUrlMock.mockImplementation(async (ref) => {
       const capturedText = ref.current?.textContent ?? ''
       expect(capturedText).toContain('user-1')
       expect(capturedText).toContain('assistant-1')
       expect(capturedText).toContain('user-2')
-      return {
-        toBlob: (callback: BlobCallback) => callback(imageBlob)
-      } as unknown as HTMLCanvasElement
+      return 'data:image/png;base64,dG9waWM='
     })
 
     render(
@@ -896,6 +895,8 @@ describe('MessageList', () => {
     await act(async () => {
       await copyPromise
     })
+    expect(fetchSpy).toHaveBeenCalledWith('data:image/png;base64,dG9waWM=')
+    fetchSpy.mockRestore()
     expect(copyImage).toHaveBeenCalledWith(imageBlob)
   })
 

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -840,4 +840,103 @@ describe('utils/image', () => {
       await expect(getImageBlobFromSource('data:;base64,aGVsbG8=')).rejects.toThrow('Invalid image data URL')
     })
   })
+
+  describe('captureScrollableImage (native compositor capture)', () => {
+    const rect = (left: number, top: number, width: number, height: number) =>
+      ({ left, top, width, height, right: left + width, bottom: top + height, x: left, y: top }) as DOMRect
+
+    const stubGeometry = (el: HTMLElement, width: number, height: number) => {
+      Object.defineProperty(el, 'scrollWidth', { value: width, configurable: true })
+      Object.defineProperty(el, 'scrollHeight', { value: height, configurable: true })
+      el.getBoundingClientRect = () => rect(10, 20, width, height)
+    }
+
+    const originalDocumentElementRect = document.documentElement.getBoundingClientRect.bind(document.documentElement)
+
+    afterEach(() => {
+      document.documentElement.getBoundingClientRect = originalDocumentElementRect
+    })
+
+    it('returns the native capture result without touching the html-to-image pipeline', async () => {
+      ipcMocks.request.mockResolvedValueOnce({ dataUrl: 'data:image/png;base64,bmF0aXZl' })
+      const div = document.createElement('div')
+      stubGeometry(div, 800, 600)
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 3000)
+
+      const result = await captureScrollableAsDataUrl({ current: div })
+
+      expect(result).toBe('data:image/png;base64,bmF0aXZl')
+      expect(ipcMocks.request).toHaveBeenCalledWith('window.capture_screenshot', {
+        clip: { x: 10, y: 20, width: 800, height: 600 },
+        scale: 1
+      })
+      expect(htmlToImage.toCanvas).not.toHaveBeenCalled()
+    })
+
+    it('restores inline styles and the capture marker after a native capture', async () => {
+      ipcMocks.request.mockResolvedValueOnce({ dataUrl: 'data:image/png;base64,bmF0aXZl' })
+      const div = document.createElement('div')
+      stubGeometry(div, 800, 600)
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 3000)
+
+      await captureScrollableAsDataUrl({ current: div })
+
+      expect(div.style.overflow).toBe('')
+      expect(div.style.height).toBe('')
+      expect(div.style.maxHeight).toBe('')
+      expect(div.hasAttribute(IMAGE_CAPTURE_ATTRIBUTE)).toBe(false)
+    })
+
+    it('falls back to the html-to-image pipeline when the native path rejects', async () => {
+      ipcMocks.request.mockRejectedValueOnce(new Error('CDP attach failed'))
+      const div = document.createElement('div')
+      stubGeometry(div, 800, 600)
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 3000)
+
+      const result = await captureScrollableAsDataUrl({ current: div })
+
+      expect(result).toBe('data:image/png;base64,xxx')
+      expect(htmlToImage.toCanvas).toHaveBeenCalled()
+    })
+
+    it('skips the native path for an element with no measurable size', async () => {
+      const div = document.createElement('div')
+
+      const result = await captureScrollableAsDataUrl({ current: div })
+
+      expect(ipcMocks.request).not.toHaveBeenCalled()
+      expect(result).toBe('data:image/png;base64,xxx')
+    })
+
+    it('skips the native path when the clip would exceed composited-surface limits', async () => {
+      const div = document.createElement('div')
+      stubGeometry(div, 20000, 100)
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 40000, 3000)
+
+      await captureScrollableAsDataUrl({ current: div })
+
+      expect(ipcMocks.request).not.toHaveBeenCalled()
+      expect(htmlToImage.toCanvas).toHaveBeenCalled()
+    })
+
+    it('feeds the native data URL to the blob callback via fetch', async () => {
+      ipcMocks.request.mockResolvedValueOnce({ dataUrl: 'data:image/png;base64,bmF0aXZl' })
+      const div = document.createElement('div')
+      stubGeometry(div, 800, 600)
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 3000)
+
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({ blob: async () => new Blob(['native'], { type: 'image/png' }) } as Response)
+
+      const blob = await new Promise<Blob | null>((resolve) =>
+        captureScrollableAsBlob({ current: div }, (result) => resolve(result))
+      )
+
+      expect(fetchSpy).toHaveBeenCalledWith('data:image/png;base64,bmF0aXZl')
+      expect(blob).toBeInstanceOf(Blob)
+      expect(blob?.type).toBe('image/png')
+      fetchSpy.mockRestore()
+    })
+  })
 })

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -899,6 +899,73 @@ describe('utils/image', () => {
       expect(htmlToImage.toCanvas).toHaveBeenCalled()
     })
 
+    it('parks an offscreen capture root at positive page coordinates before the native shot', async () => {
+      const div = document.createElement('div')
+      Object.defineProperty(div, 'scrollWidth', { value: 300, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 150, configurable: true })
+      // First measure decides the parking (negative origin), second measures
+      // the clip after the element has been repositioned into the document.
+      const rects = [rect(-10000, 0, 300, 150), rect(0, 6000, 300, 150)]
+      div.getBoundingClientRect = vi.fn(() => rects.shift() ?? rect(0, 6000, 300, 150))
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 3000)
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 6000, configurable: true })
+      ipcMocks.request.mockImplementation(async (_route: string, payload: { clip: { x: number; y: number } }) => {
+        // The compositor answers negative-origin clips with the document
+        // origin region (wrong pixels), so the shot must only fire parked.
+        expect(payload.clip).toMatchObject({ x: 0, y: 6000 })
+        expect(div.style.position).toBe('absolute')
+        expect(div.style.width).toBe('300px')
+        return { dataUrl: 'data:image/png;base64,bmF0aXZl' }
+      })
+
+      try {
+        const result = await captureScrollableAsDataUrl({ current: div })
+
+        expect(result).toBe('data:image/png;base64,bmF0aXZl')
+        expect(htmlToImage.toCanvas).not.toHaveBeenCalled()
+        expect(div.style.position).toBe('')
+        expect(div.style.left).toBe('')
+        expect(div.style.top).toBe('')
+        expect(div.style.width).toBe('')
+      } finally {
+        Reflect.deleteProperty(document.documentElement, 'scrollHeight')
+      }
+    })
+
+    it('falls back to html-to-image when a parked element still measures off-document', async () => {
+      const div = document.createElement('div')
+      Object.defineProperty(div, 'scrollWidth', { value: 300, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 150, configurable: true })
+      div.getBoundingClientRect = () => rect(-10000, 0, 300, 150)
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 3000)
+
+      const result = await captureScrollableAsDataUrl({ current: div })
+
+      expect(ipcMocks.request).not.toHaveBeenCalled()
+      expect(result).toBe('data:image/png;base64,xxx')
+      expect(htmlToImage.toCanvas).toHaveBeenCalled()
+      expect(div.style.position).toBe('')
+      expect(div.style.width).toBe('')
+    })
+
+    it('hides interactive HTML artifacts during the native capture and restores them afterwards', async () => {
+      const div = document.createElement('div')
+      const artifact = document.createElement('div')
+      artifact.setAttribute('data-html-artifact', '')
+      div.appendChild(artifact)
+      stubGeometry(div, 800, 600)
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 3000)
+      ipcMocks.request.mockImplementation(async () => {
+        expect(artifact.style.display).toBe('none')
+        return { dataUrl: 'data:image/png;base64,bmF0aXZl' }
+      })
+
+      const result = await captureScrollableAsDataUrl({ current: div })
+
+      expect(result).toBe('data:image/png;base64,bmF0aXZl')
+      expect(artifact.style.display).toBe('')
+    })
+
     it('skips the native path for an element with no measurable size', async () => {
       const div = document.createElement('div')
 

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -905,10 +905,14 @@ describe('utils/image', () => {
       Object.defineProperty(div, 'scrollHeight', { value: 150, configurable: true })
       // First measure decides the parking (negative origin), second measures
       // the clip after the element has been repositioned into the document.
+      // In a real browser an absolute child extends the document's scrollHeight
+      // to cover it (CDP-verified), so the mock document is 6150 tall — the
+      // parked element's bottom edge at 6150 stays inside the surface.
       const rects = [rect(-10000, 0, 300, 150), rect(0, 6000, 300, 150)]
       div.getBoundingClientRect = vi.fn(() => rects.shift() ?? rect(0, 6000, 300, 150))
-      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 3000)
-      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 6000, configurable: true })
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 6150)
+      Object.defineProperty(document.documentElement, 'scrollWidth', { value: 4000, configurable: true })
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 6150, configurable: true })
       ipcMocks.request.mockImplementation(async (_route: string, payload: { clip: { x: number; y: number } }) => {
         // The compositor answers negative-origin clips with the document
         // origin region (wrong pixels), so the shot must only fire parked.
@@ -928,6 +932,7 @@ describe('utils/image', () => {
         expect(div.style.top).toBe('')
         expect(div.style.width).toBe('')
       } finally {
+        Reflect.deleteProperty(document.documentElement, 'scrollWidth')
         Reflect.deleteProperty(document.documentElement, 'scrollHeight')
       }
     })
@@ -946,6 +951,33 @@ describe('utils/image', () => {
       expect(htmlToImage.toCanvas).toHaveBeenCalled()
       expect(div.style.position).toBe('')
       expect(div.style.width).toBe('')
+    })
+
+    it('falls back when the parked clip extends past the document surface', async () => {
+      // A capture root that stays under a positioned/overflow ancestor after
+      // parking measures inside the document but its bottom edge overflows the
+      // composited surface — captureBeyondViewport would return it blank or
+      // clipped, so the native path must fall back instead of shipping a bad shot.
+      const div = document.createElement('div')
+      Object.defineProperty(div, 'scrollWidth', { value: 300, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 900, configurable: true })
+      // Parked at y=5900 but the document surface only reaches 6000 — the clip
+      // bottom (5900+900=6800) overflows it.
+      div.getBoundingClientRect = () => rect(0, 5900, 300, 900)
+      document.documentElement.getBoundingClientRect = () => rect(0, 0, 4000, 6000)
+      Object.defineProperty(document.documentElement, 'scrollWidth', { value: 4000, configurable: true })
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 6000, configurable: true })
+
+      try {
+        const result = await captureScrollableAsDataUrl({ current: div })
+
+        expect(ipcMocks.request).not.toHaveBeenCalled()
+        expect(result).toBe('data:image/png;base64,xxx')
+        expect(htmlToImage.toCanvas).toHaveBeenCalled()
+      } finally {
+        Reflect.deleteProperty(document.documentElement, 'scrollWidth')
+        Reflect.deleteProperty(document.documentElement, 'scrollHeight')
+      }
     })
 
     it('hides interactive HTML artifacts during the native capture and restores them afterwards', async () => {

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -170,7 +170,9 @@ export async function captureElement(elRef: React.RefObject<HTMLElement>) {
 }
 
 /**
- * 捕获可滚动元素的完整内容图像。
+ * 捕获可滚动元素的完整内容图像（html-to-image 克隆管线）。
+ * 仅作为原生合成器截图不可用时的回退路径；产品入口应优先走
+ * {@link captureScrollableImage}。
  * @param elRef 可滚动元素的引用
  * @returns Promise<HTMLCanvasElement | undefined> 捕获的画布对象，如果失败则返回 undefined
  */
@@ -265,18 +267,125 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
   return Promise.resolve(undefined)
 }
 
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+/** Chromium composited-surface edge cap; larger capture requests are not worth attempting. */
+const MAX_NATIVE_CAPTURE_PHYSICAL_DIMENSION = 16384
+
+/**
+ * Compute the page-space capture clip for `el`, mirroring DevTools' own
+ * "capture node screenshot" recipe: the element rect relative to the
+ * documentElement rect (page coordinates, scroll- and root-transform-agnostic).
+ * Uses scrollWidth/Height so content that the capture-only CSS expanded beyond
+ * the border box (wide tables) stays inside the clip.
+ */
+function computeCaptureClip(el: HTMLElement): { x: number; y: number; width: number; height: number } | undefined {
+  const rect = el.getBoundingClientRect()
+  const rootRect = document.documentElement.getBoundingClientRect()
+  const width = Math.ceil(Math.max(el.scrollWidth, rect.width))
+  const height = Math.ceil(Math.max(el.scrollHeight, rect.height))
+  if (!(width > 0) || !(height > 0)) return undefined
+  return { x: rect.left - rootRect.left, y: rect.top - rootRect.top, width, height }
+}
+
+/**
+ * Expand `el` for the duration of a native capture so clipped scroll content
+ * (max-height containers, overflow scrolling) is actually rendered for the
+ * compositor to pick up — the real-DOM equivalent of the style override the
+ * html-to-image clone applies. Restores inline styles and the scroll offset.
+ */
+async function withExpandedForCapture<T>(el: HTMLElement, fn: () => Promise<T>): Promise<T> {
+  const inline = { overflow: el.style.overflow, height: el.style.height, maxHeight: el.style.maxHeight }
+  const scrollTop = el.scrollTop
+  el.style.overflow = 'visible'
+  el.style.height = 'auto'
+  el.style.maxHeight = 'none'
+  try {
+    // Two rAFs: the first commits the expanded layout, the second lets the
+    // compositor produce a frame from it.
+    await nextFrame()
+    await nextFrame()
+    return await fn()
+  } finally {
+    el.style.overflow = inline.overflow
+    el.style.height = inline.height
+    el.style.maxHeight = inline.maxHeight
+    el.scrollTop = scrollTop
+  }
+}
+
+/**
+ * Rasterize `el` through Chromium's own compositor (CDP Page.captureScreenshot,
+ * captureBeyondViewport). This is pixel-faithful to what the page renders —
+ * fonts, layout and effects are the live page's, not a re-serialized clone.
+ * Returns undefined (or throws) when the native path is unavailable; callers
+ * fall back to the html-to-image pipeline.
+ */
+async function captureNativeDataUrl(el: HTMLElement): Promise<string | undefined> {
+  const deviceScale = window.devicePixelRatio || 1
+  // CDP clip.scale multiplies ON TOP of the device scale factor: the output is
+  // clip × scale × DPR. scale 1 therefore yields exactly on-screen pixel
+  // density — the most faithful match to what the page renders.
+  const CAPTURE_SCALE = 1
+  // Only worth attempting when the composited surface fits Chromium's texture
+  // limits; anything larger fails at the CDP layer anyway.
+  const physical = (value: number) => value * deviceScale * CAPTURE_SCALE
+  const withinLimits = (clip: { width: number; height: number }) =>
+    physical(clip.width) <= MAX_NATIVE_CAPTURE_PHYSICAL_DIMENSION &&
+    physical(clip.height) <= MAX_NATIVE_CAPTURE_PHYSICAL_DIMENSION
+
+  el.setAttribute(IMAGE_CAPTURE_ATTRIBUTE, '')
+  try {
+    // Webfonts are already rendered by the live page, but capture-only CSS may
+    // reveal content that has not loaded fonts/images yet — keep the same
+    // bounded wait the clone path uses.
+    await Promise.race([
+      document.fonts?.ready ?? Promise.resolve(),
+      new Promise((resolve) => setTimeout(resolve, 1000))
+    ])
+
+    return await withExpandedForCapture(el, async () => {
+      const clip = computeCaptureClip(el)
+      if (!clip || !withinLimits(clip)) return undefined
+      const { dataUrl } = await ipcApi.request('window.capture_screenshot', { clip, scale: CAPTURE_SCALE })
+      return dataUrl
+    })
+  } finally {
+    el.removeAttribute(IMAGE_CAPTURE_ATTRIBUTE)
+  }
+}
+
+/**
+ * 捕获可滚动元素的完整内容图像（PNG data URL）。
+ * 优先走原生合成器截图（CDP，与页面渲染逐像素一致）；不可用时回退
+ * html-to-image 克隆管线。
+ * @param elRef 可滚动元素的引用
+ * @returns Promise<string | undefined> PNG data URL，失败返回 undefined
+ */
+export const captureScrollableImage = async (
+  elRef: React.RefObject<HTMLElement | null>
+): Promise<string | undefined> => {
+  const el = elRef.current
+  if (!el) return undefined
+
+  try {
+    const native = await captureNativeDataUrl(el)
+    if (native) return native
+  } catch (error) {
+    logger.warn('Native compositor capture unavailable, falling back to html-to-image', error as Error)
+  }
+
+  const canvas = await captureScrollable(elRef)
+  return canvas?.toDataURL('image/png')
+}
+
 /**
  * 将可滚动元素的图像数据转换为 Data URL 格式。
  * @param elRef 可滚动元素的引用
  * @returns Promise<string | undefined> 图像数据 URL，如果失败则返回 undefined
  */
 export const captureScrollableAsDataUrl = async (elRef: React.RefObject<HTMLElement | null>) => {
-  return captureScrollable(elRef).then((canvas) => {
-    if (canvas) {
-      return canvas.toDataURL('image/png')
-    }
-    return Promise.resolve(undefined)
-  })
+  return captureScrollableImage(elRef)
 }
 
 /**
@@ -286,9 +395,11 @@ export const captureScrollableAsDataUrl = async (elRef: React.RefObject<HTMLElem
  * @returns Promise<void> 处理结果
  */
 export const captureScrollableAsBlob = async (elRef: React.RefObject<HTMLElement | null>, func: BlobCallback) => {
-  await captureScrollable(elRef).then((canvas) => {
-    canvas?.toBlob(func, 'image/png')
-  })
+  const dataUrl = await captureScrollableImage(elRef)
+  if (dataUrl) {
+    // fetch() on a data: URL decodes locally — no network involved.
+    func(await fetch(dataUrl).then((response) => response.blob()))
+  }
 }
 
 /**

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -315,6 +315,43 @@ async function withExpandedForCapture<T>(el: HTMLElement, fn: () => Promise<T>):
 }
 
 /**
+ * Interactive HTML artifacts are intentionally omitted from image exports (the
+ * clone path's `filter` drops them). The compositor rasterizes the live DOM, so
+ * there is no clone to filter — hide them for the duration of the shot instead.
+ */
+function hideHtmlArtifactsForCapture(el: HTMLElement): () => void {
+  const restored: Array<[HTMLElement, string]> = []
+  el.querySelectorAll<HTMLElement>('[data-html-artifact]').forEach((node) => {
+    restored.push([node, node.style.display])
+    node.style.display = 'none'
+  })
+  return () => restored.forEach(([node, display]) => (node.style.display = display))
+}
+
+/**
+ * Offscreen-parked capture roots (the topic export surface sits at `fixed`
+ * left:-10000px to stay invisible) cannot be shot in place: the composited
+ * surface only covers the document, and a negative-origin clip comes back
+ * clamped to the document origin — wrong pixels, not an error. Park the
+ * element at the end of the document for the capture instead. The rendered
+ * width is pinned in px first so re-anchoring to a different containing block
+ * cannot reflow the content. Returns a restore thunk, or null when the element
+ * already sits at non-negative page coordinates.
+ */
+function parkOffscreenElementForCapture(el: HTMLElement): (() => void) | null {
+  const rootRect = document.documentElement.getBoundingClientRect()
+  const rect = el.getBoundingClientRect()
+  if (rect.left - rootRect.left >= 0 && rect.top - rootRect.top >= 0) return null
+
+  const parked = { position: el.style.position, left: el.style.left, top: el.style.top, width: el.style.width }
+  el.style.position = 'absolute'
+  el.style.left = '0px'
+  el.style.top = `${document.documentElement.scrollHeight}px`
+  el.style.width = `${rect.width}px`
+  return () => Object.assign(el.style, parked)
+}
+
+/**
  * Rasterize `el` through Chromium's own compositor (CDP Page.captureScreenshot,
  * captureBeyondViewport). This is pixel-faithful to what the page renders —
  * fonts, layout and effects are the live page's, not a re-serialized clone.
@@ -335,6 +372,8 @@ async function captureNativeDataUrl(el: HTMLElement): Promise<string | undefined
     physical(clip.height) <= MAX_NATIVE_CAPTURE_PHYSICAL_DIMENSION
 
   el.setAttribute(IMAGE_CAPTURE_ATTRIBUTE, '')
+  const restoreArtifacts = hideHtmlArtifactsForCapture(el)
+  const restoreParking = parkOffscreenElementForCapture(el)
   try {
     // Webfonts are already rendered by the live page, but capture-only CSS may
     // reveal content that has not loaded fonts/images yet — keep the same
@@ -346,11 +385,15 @@ async function captureNativeDataUrl(el: HTMLElement): Promise<string | undefined
 
     return await withExpandedForCapture(el, async () => {
       const clip = computeCaptureClip(el)
-      if (!clip || !withinLimits(clip)) return undefined
+      // A parked element that still measures off-document after repositioning
+      // cannot be served natively — fall back rather than capture wrong pixels.
+      if (!clip || clip.x < 0 || clip.y < 0 || !withinLimits(clip)) return undefined
       const { dataUrl } = await ipcApi.request('window.capture_screenshot', { clip, scale: CAPTURE_SCALE })
       return dataUrl
     })
   } finally {
+    restoreParking?.()
+    restoreArtifacts()
     el.removeAttribute(IMAGE_CAPTURE_ATTRIBUTE)
   }
 }

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -385,9 +385,22 @@ async function captureNativeDataUrl(el: HTMLElement): Promise<string | undefined
 
     return await withExpandedForCapture(el, async () => {
       const clip = computeCaptureClip(el)
-      // A parked element that still measures off-document after repositioning
-      // cannot be served natively — fall back rather than capture wrong pixels.
-      if (!clip || clip.x < 0 || clip.y < 0 || !withinLimits(clip)) return undefined
+      // captureBeyondViewport extends the surface only to the document's scroll
+      // bounds — a clip overflowing them (or still off-document) comes back
+      // blank/clipped, so fall back rather than ship wrong pixels.
+      const rootRect = document.documentElement.getBoundingClientRect()
+      const docWidth = Math.max(document.documentElement.scrollWidth, rootRect.width)
+      const docHeight = Math.max(document.documentElement.scrollHeight, rootRect.height)
+      if (
+        !clip ||
+        clip.x < 0 ||
+        clip.y < 0 ||
+        clip.x + clip.width > docWidth + 1 ||
+        clip.y + clip.height > docHeight + 1 ||
+        !withinLimits(clip)
+      ) {
+        return undefined
+      }
       const { dataUrl } = await ipcApi.request('window.capture_screenshot', { clip, scale: CAPTURE_SCALE })
       return dataUrl
     })

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -17,6 +17,9 @@ const TRANSPARENT_IMAGE_PLACEHOLDER = 'data:image/gif;base64,R0lGODlhAQABAIAAAAA
  */
 export const IMAGE_CAPTURE_ATTRIBUTE = 'data-image-capturing'
 
+/** Marks interactive HTML artifact subtrees; both export paths omit them (shared policy selector). */
+const HTML_ARTIFACT_ATTRIBUTE = 'data-html-artifact'
+
 let htmlToImagePromise: Promise<typeof HtmlToImage> | undefined
 
 const loadHtmlToImage = () => {
@@ -213,7 +216,7 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
       const filterHiddenElements = (node: Node) => {
         if (node instanceof HTMLElement) {
           // Interactive HTML artifacts are intentionally omitted from image exports.
-          if (node.hasAttribute('data-html-artifact')) {
+          if (node.hasAttribute(HTML_ARTIFACT_ATTRIBUTE)) {
             return false
           }
           if (node.style.display === 'none') {
@@ -321,7 +324,7 @@ async function withExpandedForCapture<T>(el: HTMLElement, fn: () => Promise<T>):
  */
 function hideHtmlArtifactsForCapture(el: HTMLElement): () => void {
   const restored: Array<[HTMLElement, string]> = []
-  el.querySelectorAll<HTMLElement>('[data-html-artifact]').forEach((node) => {
+  el.querySelectorAll<HTMLElement>(`[${HTML_ARTIFACT_ATTRIBUTE}]`).forEach((node) => {
     restored.push([node, node.style.display])
     node.style.display = 'none'
   })

--- a/src/shared/ipc/schemas/window.ts
+++ b/src/shared/ipc/schemas/window.ts
@@ -35,6 +35,26 @@ export const windowRequestSchemas = {
   // The init data WindowManager stored for the caller window; its shape varies per
   // window type, so it is opaque (unknown) and the consumer casts (see useWindowInitData).
   'window.get_init_data': defineRoute({ input: z.void(), output: z.unknown() }),
+  // Rasterize a region of the caller's own page through Chromium's compositor
+  // (CDP Page.captureScreenshot with captureBeyondViewport — the mechanism
+  // Puppeteer/DevTools element screenshots use). Unlike DOM-clone rasterizers
+  // (html-to-image), the output is pixel-faithful to what the page actually
+  // renders: same fonts, same layout, no re-serialization. `clip` is in CSS
+  // layout pixels in page space (not viewport space); `scale` is an extra
+  // multiplier on top of the window's device scale factor (1 = on-screen
+  // pixel density).
+  'window.capture_screenshot': defineRoute({
+    input: z.object({
+      clip: z.object({
+        x: z.number().finite().nonnegative(),
+        y: z.number().finite().nonnegative(),
+        width: z.number().finite().positive(),
+        height: z.number().finite().positive()
+      }),
+      scale: z.number().finite().positive().max(4)
+    }),
+    output: z.object({ dataUrl: z.string() })
+  }),
 
   // window.sub.* — the caller sub-window pins itself. The handler re-checks that
   // ctx.senderId resolves to a SubWindow-type window (main window is rejected) and

--- a/src/shared/ipc/schemas/window.ts
+++ b/src/shared/ipc/schemas/window.ts
@@ -42,7 +42,10 @@ export const windowRequestSchemas = {
   // renders: same fonts, same layout, no re-serialization. `clip` is in CSS
   // layout pixels in page space (not viewport space); `scale` is an extra
   // multiplier on top of the window's device scale factor (1 = on-screen
-  // pixel density).
+  // pixel density). Clip origins must be non-negative: the composited surface
+  // only covers the document, and Chromium answers a negative-origin clip with
+  // the region clamped to the document origin — wrong pixels, silently — so
+  // such requests are rejected here rather than served from the wrong region.
   'window.capture_screenshot': defineRoute({
     input: z.object({
       clip: z.object({


### PR DESCRIPTION
## Motivation

"Save as image" / "Copy as image" for messages goes through `html-to-image`'s DOM-clone pipeline (clone → inline computed styles → serialize into SVG `foreignObject` → re-rasterize). That is a second rendering pipeline, structurally unable to match what the page shows:

- fallback-font metrics re-lay-out text inside frozen width/height boxes → clipped overflows (the reason `captureScrollable` waits on `document.fonts.ready` before cloning)
- clipped scroll containers need the `data-image-capturing` CSS to unclip table viewports
- remote images hitting CORS collapse to the transparent placeholder
- `pixelRatio: window.devicePixelRatio` cannot actually sharpen the output: the SVG is rasterized at 1× intrinsic size, so the ratio mostly upscales

These are patched one by one today; the pipeline ceiling stays "very close".

## Approach

Rasterize through Chromium's own compositor — CDP `Page.captureScreenshot` with `captureBeyondViewport` (the mechanism Puppeteer and DevTools' "capture node screenshot" use). The compositor outputs what the page actually renders: same fonts, same layout, same effects, including content scrolled out of view. `webContents.capturePage` cannot do this (clips to the visible viewport — electron#17834).

- **`window.capture_screenshot` IPC route** (`window` domain: acts on the caller's own window via `WindowManager`, per the domain's scope guard). Input: `clip` in page-space CSS px + `scale`, zod-validated.
- **`captureScreenshotViaCdp`** (`src/main/utils/cdpScreenshot.ts`): stateless attach → capture → detach per request; if a session is already attached it is reused but never detached. Deliberately not shared with the browser MCP controller's CDP usage — that one is a session-style attach with `Page`/`Runtime` domains enabled and tab lifecycle management; this path needs none of that and must not depend on the MCP feature.
- **Clip recipe** mirrors DevTools: element rect relative to `document.documentElement` rect, sized by `scrollWidth/Height` so capture-only CSS expansion (wide tables) stays inside.
- **Renderer**: `captureScrollableImage` is native-first; the html-to-image pipeline remains as automatic fallback for attach conflicts, oversized clips (> 16384 composited px) and IPC failures — behavior never gets worse than today.
- **Scale**: CDP `clip.scale` multiplies on top of the device scale factor; passing `1` yields exactly on-screen pixel density.
- During capture the element is temporarily expanded (`overflow: visible; height: auto`) so clipped scroll content is rendered for the compositor — the real-DOM equivalent of the style override the clone path applies — then inline styles and `scrollTop` are restored.

## Verification

- Unit: 19 main-side (6 new for `cdpScreenshot`, 3 for the handler) and full renderer suite 10998 passed; 6 new renderer cases cover native success, fallback, oversize skip, style/marker restoration and the blob path.
- `pnpm lint` (format + typecheck + i18n:check) clean.
- End-to-end probe on Electron 41.8.0 with a 500 px-tall window vs 921 px of content: CDP output 2992×3684 px contains the out-of-viewport tail marker (verified at pixel level), while a `capturePage` control image only covers 368 CSS px — the old limitation, and the new path covering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)