### PR TITLE
fix(translate): restore Qwen MT target language

### DIFF
--- a/docs/references/ai/translation.md
+++ b/docs/references/ai/translation.md
@@ -86,7 +86,11 @@ none of `feature.translate.*`.)
 
 Qwen-MT receives the source text directly plus provider-scoped
 `translation_options` with automatic source detection and the mapped target
-language. Unsupported target languages fail before the stream is opened.
+language. The 31-language Lite model is validated against its narrower set;
+other supported variants use the 92-language set. Flash and Lite request
+incremental output, while cumulative Plus and Turbo chunks are normalized to
+deltas before renderer delivery. Unsupported target languages fail before the
+stream is opened.
 
 ## Home message persistence
 

--- a/docs/references/ai/translation.md
+++ b/docs/references/ai/translation.md
@@ -84,6 +84,10 @@ not configure. (Layout-preserving PDF translation does not go through this
 route: `PdfTranslationService` drives BabelDoc via the API gateway and reads
 none of `feature.translate.*`.)
 
+Qwen-MT receives the source text directly plus provider-scoped
+`translation_options` with automatic source detection and the mapped target
+language. Unsupported target languages fail before the stream is opened.
+
 ## Home message persistence
 
 Home chat owns the message projection through its existing chat write boundary:

--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 
+import { createAnthropic } from '@ai-sdk/anthropic'
 import { createOpenAI } from '@ai-sdk/openai'
 import type { LanguageModelV3CallOptions } from '@ai-sdk/provider'
 import type { ProviderOptions } from '@ai-sdk/provider-utils'
@@ -472,6 +473,60 @@ describe('buildAgentParams provider resolution', () => {
     expect(receivedCustomParameterSets).toEqual(expectedCustomParameterSets)
     expect(requestFetches[2]).toBe(requestFetches[0])
     expect(requestFetches[1]).not.toBe(requestFetches[0])
+  })
+
+  it('preserves caller raw body parameters through Anthropic request serialization', async () => {
+    let requestBody: Record<string, unknown> | undefined
+    const innerFetch: typeof globalThis.fetch = async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body))
+      throw new Error('request captured')
+    }
+    resolveProviderAiSdkConfigMock.mockResolvedValue({
+      config: { providerId: 'anthropic', providerSettings: { fetch: innerFetch } },
+      credentialReceipt: { attribution: 'unknown' }
+    })
+    const provider = makeProvider({
+      id: 'dashscope',
+      defaultChatEndpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: { adapterFamily: 'anthropic' }
+      }
+    })
+    const model = makeModel({
+      id: 'dashscope::qwen-mt-flash',
+      providerId: 'dashscope',
+      apiModelId: 'qwen-mt-flash',
+      endpointTypes: [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+    })
+    const rawBodyParameters = {
+      translation_options: { source_lang: 'auto', target_lang: 'English' },
+      incremental_output: true
+    }
+
+    const result = await buildAgentParams({
+      request: {
+        callOverrides: {
+          providerOptions: { anthropic: rawBodyParameters },
+          rawBodyParameters
+        }
+      },
+      signal: undefined,
+      provider,
+      model
+    })
+    const sdkModel = createAnthropic({
+      apiKey: 'sk-test',
+      baseURL: 'https://example.com/v1',
+      fetch: result.sdkConfig.providerSettings.fetch
+    }).languageModel(model.apiModelId!)
+
+    await expect(
+      sdkModel.doGenerate({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Translate this.' }] }],
+        providerOptions: result.options.providerOptions
+      })
+    ).rejects.toThrow('request captured')
+    expect(requestBody).toMatchObject(rawBodyParameters)
   })
 })
 

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -658,6 +658,12 @@ function buildAgentOptions(
 
   // Highest-precedence per-request overrides (assistant-less callers, e.g. the API gateway).
   const callOverrides = request.callOverrides
+  if (callOverrides?.rawBodyParameters && Object.keys(callOverrides.rawBodyParameters).length > 0) {
+    sdkConfig.providerSettings.fetch = createCustomParamsFetch(
+      sdkConfig.providerSettings.fetch ?? globalThis.fetch,
+      callOverrides.rawBodyParameters
+    )
+  }
   const overridden = applyCallOverrides({ standardParams, providerOptions }, callOverrides, model)
   standardParams = overridden.standardParams
   const effectiveProviderOptions = applyFastModeToProviderOptions(

--- a/src/main/ai/types/requests.ts
+++ b/src/main/ai/types/requests.ts
@@ -50,6 +50,8 @@ export interface CallOverrides {
   tools?: ToolSet
   toolChoice?: ToolChoice<ToolSet>
   providerOptions?: ProviderOptions
+  /** Vendor fields injected after AI SDK schema serialization. */
+  rawBodyParameters?: Record<string, unknown>
 }
 
 export interface AiBaseRequest {

--- a/src/main/services/translate/__tests__/translateService.test.ts
+++ b/src/main/services/translate/__tests__/translateService.test.ts
@@ -1,4 +1,4 @@
-import { MODEL_CAPABILITY } from '@shared/data/types/model'
+import { ENDPOINT_TYPE, MODEL_CAPABILITY } from '@shared/data/types/model'
 import type { TranslateLanguage } from '@shared/data/types/translate'
 import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -301,36 +301,73 @@ describe('translateService.open', () => {
     )
   })
 
-  it.each(['qwen-mt-plus', 'qwen-mt-turbo'])('normalizes cumulative %s chunks before renderer delivery', (modelId) => {
-    mockQwenMtModel(modelId)
+  it('uses the OpenAI runtime namespace for a DashScope Responses endpoint', () => {
+    mockQwenMtModel('qwen-mt-turbo')
+    getByProviderIdMock.mockReturnValue({
+      id: 'dashscope',
+      presetProviderId: 'dashscope',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_RESPONSES]: {
+          adapterFamily: 'openai',
+          baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1/'
+        }
+      }
+    })
     getByLangCodeMock.mockReturnValue(TARGET)
 
     translateService.open(fakeSender, {
-      streamId: `translate:${modelId}`,
+      streamId: 'translate:qwen-mt-responses',
       text: 'source',
       targetLangCode: 'en-us'
     })
 
-    const [streamInput] = streamPromptMock.mock.calls[0] as unknown as [{ listener: { onChunk(chunk: unknown): void } }]
-    streamInput.listener.onChunk({ type: 'text-delta', id: 'text-1', delta: 'Hello' })
-    streamInput.listener.onChunk({ type: 'text-delta', id: 'text-1', delta: 'Hello world' })
-
-    const rendererListener = webContentsListenerMocks.instances[0]
-    expect(rendererListener.onChunk).toHaveBeenNthCalledWith(
-      1,
-      { type: 'text-delta', id: 'text-1', delta: 'Hello' },
-      undefined,
-      undefined,
-      undefined
-    )
-    expect(rendererListener.onChunk).toHaveBeenNthCalledWith(
-      2,
-      { type: 'text-delta', id: 'text-1', delta: ' world' },
-      undefined,
-      undefined,
-      undefined
+    expect(streamPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callOverrides: expect.objectContaining({
+          providerOptions: {
+            openai: expect.objectContaining({ translation_options: expect.any(Object) })
+          }
+        })
+      })
     )
   })
+
+  it.each(['qwen-mt-plus', 'qwen-mt-turbo', 'qwen-mt-plus(free)'])(
+    'normalizes cumulative %s chunks before renderer delivery',
+    (modelId) => {
+      mockQwenMtModel(modelId)
+      getByLangCodeMock.mockReturnValue(TARGET)
+
+      translateService.open(fakeSender, {
+        streamId: `translate:${modelId}`,
+        text: 'source',
+        targetLangCode: 'en-us'
+      })
+
+      const [streamInput] = streamPromptMock.mock.calls[0] as unknown as [
+        { listener: { onChunk(chunk: unknown): void } }
+      ]
+      streamInput.listener.onChunk({ type: 'text-delta', id: 'text-1', delta: 'Hello' })
+      streamInput.listener.onChunk({ type: 'text-delta', id: 'text-1', delta: 'Hello world' })
+
+      const rendererListener = webContentsListenerMocks.instances[0]
+      expect(rendererListener.onChunk).toHaveBeenNthCalledWith(
+        1,
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        undefined,
+        undefined,
+        undefined
+      )
+      expect(rendererListener.onChunk).toHaveBeenNthCalledWith(
+        2,
+        { type: 'text-delta', id: 'text-1', delta: ' world' },
+        undefined,
+        undefined,
+        undefined
+      )
+    }
+  )
 
   it('rejects a Qwen MT target language that the model does not support', () => {
     mockQwenMtModel('qwen-mt-turbo')

--- a/src/main/services/translate/__tests__/translateService.test.ts
+++ b/src/main/services/translate/__tests__/translateService.test.ts
@@ -7,6 +7,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // tests/main.setup.ts. We only need to override `AiStreamManager` so we can
 // assert on the streamPrompt call.
 const streamPromptMock = vi.fn(() => ({ mode: 'started' as const, activeExecutions: [] }))
+const webContentsListenerMocks = vi.hoisted(() => ({
+  instances: [] as Array<{
+    id: string
+    onChunk: ReturnType<typeof vi.fn>
+    onDone: ReturnType<typeof vi.fn>
+    onPaused: ReturnType<typeof vi.fn>
+    onError: ReturnType<typeof vi.fn>
+    isAlive: ReturnType<typeof vi.fn>
+  }>
+}))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -33,12 +43,18 @@ vi.mock('@main/data/services/TranslateLanguageService', () => ({
 // `WebContentsListener` writes to `event.sender.send(...)` — stub it so the
 // test doesn't need a real WebContents.
 vi.mock('../../../ai/streamManager/listeners/WebContentsListener', () => ({
-  WebContentsListener: vi.fn().mockImplementation((sender: unknown, streamId: string) => ({
-    id: `wc:test:${streamId}`,
-    sender,
-    streamId,
-    onError: vi.fn()
-  }))
+  WebContentsListener: vi.fn().mockImplementation((_sender: unknown, streamId: string) => {
+    const listener = {
+      id: `wc:test:${streamId}`,
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onPaused: vi.fn(),
+      onError: vi.fn(),
+      isAlive: vi.fn(() => true)
+    }
+    webContentsListenerMocks.instances.push(listener)
+    return listener
+  })
 }))
 
 const { makeModel } = await import('../../../ai/__tests__/fixtures')
@@ -54,6 +70,16 @@ const TARGET: TranslateLanguage = {
 
 const fakeSender = { id: 1 } as unknown as Electron.WebContents
 
+function mockQwenMtModel(modelId: string, providerId = 'dashscope') {
+  MockMainPreferenceServiceUtils.setPreferenceValue('feature.translate.model_id', `${providerId}::${modelId}`)
+  getByKeyMock.mockReturnValue({
+    id: `${providerId}::${modelId}`,
+    providerId,
+    apiModelId: modelId,
+    name: modelId
+  })
+}
+
 beforeEach(() => {
   MockMainPreferenceServiceUtils.resetMocks()
   getByKeyMock.mockReset()
@@ -61,6 +87,7 @@ beforeEach(() => {
   getByLangCodeMock.mockReset()
   streamPromptMock.mockReset()
   streamPromptMock.mockReturnValue({ mode: 'started' as const, activeExecutions: [] })
+  webContentsListenerMocks.instances.length = 0
 })
 
 describe('translateService.resolveTranslatePayload', () => {
@@ -195,24 +222,23 @@ describe('translateService.open', () => {
     expect(listeners[0].id).toBe(`wc:test:${streamId}`)
   })
 
-  it('sends the Qwen MT target language through DashScope provider options', () => {
-    MockMainPreferenceServiceUtils.setPreferenceValue('feature.translate.model_id', 'dashscope::qwen-mt-turbo')
-    getByKeyMock.mockReturnValue({
-      id: 'dashscope::qwen-mt-turbo',
-      providerId: 'dashscope',
-      apiModelId: 'qwen-mt-turbo',
-      name: 'Qwen MT Turbo'
-    })
+  it.each([
+    ['zh-cn', 'Chinese (Simplified)', 'Chinese'],
+    ['zh', 'Chinese', 'Chinese'],
+    ['zh-tw', 'Chinese (Traditional)', 'Traditional Chinese'],
+    ['zh-yue', 'Cantonese', 'Cantonese']
+  ] as const)('maps %s (%s) to the Qwen MT target language %s', (targetLangCode, value, expectedTargetLanguage) => {
+    mockQwenMtModel('qwen-mt-turbo')
     getByLangCodeMock.mockReturnValue({
       ...TARGET,
-      langCode: 'zh-cn',
-      value: 'Chinese (Simplified)'
+      langCode: targetLangCode,
+      value
     })
 
     translateService.open(fakeSender, {
-      streamId: 'translate:qwen-mt',
+      streamId: `translate:qwen-mt-${targetLangCode}`,
       text: '原文',
-      targetLangCode: 'zh-cn'
+      targetLangCode
     })
 
     expect(streamPromptMock).toHaveBeenCalledWith(
@@ -223,7 +249,7 @@ describe('translateService.open', () => {
             dashscope: {
               translation_options: {
                 source_lang: 'auto',
-                target_lang: 'Chinese'
+                target_lang: expectedTargetLanguage
               }
             }
           }
@@ -232,14 +258,82 @@ describe('translateService.open', () => {
     )
   })
 
-  it('rejects a Qwen MT target language that the model does not support', () => {
-    MockMainPreferenceServiceUtils.setPreferenceValue('feature.translate.model_id', 'dashscope::qwen-mt-turbo')
-    getByKeyMock.mockReturnValue({
-      id: 'dashscope::qwen-mt-turbo',
-      providerId: 'dashscope',
-      apiModelId: 'qwen-mt-turbo',
-      name: 'Qwen MT Turbo'
+  it.each(['qwen-mt-flash', 'qwen-mt-lite'])('enables incremental output for %s', (modelId) => {
+    mockQwenMtModel(modelId)
+    getByLangCodeMock.mockReturnValue(TARGET)
+
+    translateService.open(fakeSender, {
+      streamId: `translate:${modelId}`,
+      text: 'source',
+      targetLangCode: 'en-us'
     })
+
+    expect(streamPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callOverrides: expect.objectContaining({
+          providerOptions: {
+            dashscope: expect.objectContaining({ incremental_output: true })
+          }
+        })
+      })
+    )
+  })
+
+  it('uses the DashScope runtime namespace for a preset-derived provider instance', () => {
+    mockQwenMtModel('qwen-mt-turbo', 'dashscope-copy')
+    getByProviderIdMock.mockReturnValue({ id: 'dashscope-copy', presetProviderId: 'dashscope' })
+    getByLangCodeMock.mockReturnValue(TARGET)
+
+    translateService.open(fakeSender, {
+      streamId: 'translate:qwen-mt-preset-copy',
+      text: 'source',
+      targetLangCode: 'en-us'
+    })
+
+    expect(streamPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callOverrides: expect.objectContaining({
+          providerOptions: {
+            dashscope: expect.objectContaining({ translation_options: expect.any(Object) })
+          }
+        })
+      })
+    )
+  })
+
+  it.each(['qwen-mt-plus', 'qwen-mt-turbo'])('normalizes cumulative %s chunks before renderer delivery', (modelId) => {
+    mockQwenMtModel(modelId)
+    getByLangCodeMock.mockReturnValue(TARGET)
+
+    translateService.open(fakeSender, {
+      streamId: `translate:${modelId}`,
+      text: 'source',
+      targetLangCode: 'en-us'
+    })
+
+    const [streamInput] = streamPromptMock.mock.calls[0] as unknown as [{ listener: { onChunk(chunk: unknown): void } }]
+    streamInput.listener.onChunk({ type: 'text-delta', id: 'text-1', delta: 'Hello' })
+    streamInput.listener.onChunk({ type: 'text-delta', id: 'text-1', delta: 'Hello world' })
+
+    const rendererListener = webContentsListenerMocks.instances[0]
+    expect(rendererListener.onChunk).toHaveBeenNthCalledWith(
+      1,
+      { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+      undefined,
+      undefined,
+      undefined
+    )
+    expect(rendererListener.onChunk).toHaveBeenNthCalledWith(
+      2,
+      { type: 'text-delta', id: 'text-1', delta: ' world' },
+      undefined,
+      undefined,
+      undefined
+    )
+  })
+
+  it('rejects a Qwen MT target language that the model does not support', () => {
+    mockQwenMtModel('qwen-mt-turbo')
     getByLangCodeMock.mockReturnValue({ ...TARGET, langCode: 'eo', value: 'Esperanto' })
 
     expect(() =>
@@ -247,6 +341,20 @@ describe('translateService.open', () => {
         streamId: 'translate:qwen-mt-unsupported',
         text: 'source',
         targetLangCode: 'eo' as any
+      })
+    ).toThrow('translate.error.not_supported')
+    expect(streamPromptMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects a target outside qwen-mt-lite's 31-language contract", () => {
+    mockQwenMtModel('qwen-mt-lite')
+    getByLangCodeMock.mockReturnValue({ ...TARGET, langCode: 'el', value: 'Greek' })
+
+    expect(() =>
+      translateService.open(fakeSender, {
+        streamId: 'translate:qwen-mt-lite-unsupported',
+        text: 'source',
+        targetLangCode: 'el'
       })
     ).toThrow('translate.error.not_supported')
     expect(streamPromptMock).not.toHaveBeenCalled()

--- a/src/main/services/translate/__tests__/translateService.test.ts
+++ b/src/main/services/translate/__tests__/translateService.test.ts
@@ -333,6 +333,38 @@ describe('translateService.open', () => {
     )
   })
 
+  it('uses the Anthropic runtime namespace for a DashScope Anthropic endpoint', () => {
+    mockQwenMtModel('qwen-mt-turbo')
+    getByProviderIdMock.mockReturnValue({
+      id: 'dashscope',
+      presetProviderId: 'dashscope',
+      defaultChatEndpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: {
+          adapterFamily: 'anthropic',
+          baseUrl: 'https://dashscope.aliyuncs.com/apps/anthropic'
+        }
+      }
+    })
+    getByLangCodeMock.mockReturnValue(TARGET)
+
+    translateService.open(fakeSender, {
+      streamId: 'translate:qwen-mt-anthropic',
+      text: 'source',
+      targetLangCode: 'en-us'
+    })
+
+    expect(streamPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callOverrides: expect.objectContaining({
+          providerOptions: {
+            anthropic: expect.objectContaining({ translation_options: expect.any(Object) })
+          }
+        })
+      })
+    )
+  })
+
   it.each(['qwen-mt-plus', 'qwen-mt-turbo', 'qwen-mt-plus(free)'])(
     'normalizes cumulative %s chunks before renderer delivery',
     (modelId) => {

--- a/src/main/services/translate/__tests__/translateService.test.ts
+++ b/src/main/services/translate/__tests__/translateService.test.ts
@@ -195,6 +195,63 @@ describe('translateService.open', () => {
     expect(listeners[0].id).toBe(`wc:test:${streamId}`)
   })
 
+  it('sends the Qwen MT target language through DashScope provider options', () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.translate.model_id', 'dashscope::qwen-mt-turbo')
+    getByKeyMock.mockReturnValue({
+      id: 'dashscope::qwen-mt-turbo',
+      providerId: 'dashscope',
+      apiModelId: 'qwen-mt-turbo',
+      name: 'Qwen MT Turbo'
+    })
+    getByLangCodeMock.mockReturnValue({
+      ...TARGET,
+      langCode: 'zh-cn',
+      value: 'Chinese (Simplified)'
+    })
+
+    translateService.open(fakeSender, {
+      streamId: 'translate:qwen-mt',
+      text: '原文',
+      targetLangCode: 'zh-cn'
+    })
+
+    expect(streamPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: '原文',
+        callOverrides: expect.objectContaining({
+          providerOptions: {
+            dashscope: {
+              translation_options: {
+                source_lang: 'auto',
+                target_lang: 'Chinese'
+              }
+            }
+          }
+        })
+      })
+    )
+  })
+
+  it('rejects a Qwen MT target language that the model does not support', () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.translate.model_id', 'dashscope::qwen-mt-turbo')
+    getByKeyMock.mockReturnValue({
+      id: 'dashscope::qwen-mt-turbo',
+      providerId: 'dashscope',
+      apiModelId: 'qwen-mt-turbo',
+      name: 'Qwen MT Turbo'
+    })
+    getByLangCodeMock.mockReturnValue({ ...TARGET, langCode: 'eo', value: 'Esperanto' })
+
+    expect(() =>
+      translateService.open(fakeSender, {
+        streamId: 'translate:qwen-mt-unsupported',
+        text: 'source',
+        targetLangCode: 'eo' as any
+      })
+    ).toThrow('translate.error.not_supported')
+    expect(streamPromptMock).not.toHaveBeenCalled()
+  })
+
   it('rejects a streamId that does not carry the translate prefix', async () => {
     expect(() =>
       translateService.open(fakeSender, {

--- a/src/main/services/translate/__tests__/translateService.test.ts
+++ b/src/main/services/translate/__tests__/translateService.test.ts
@@ -245,6 +245,12 @@ describe('translateService.open', () => {
       expect.objectContaining({
         prompt: '原文',
         callOverrides: expect.objectContaining({
+          rawBodyParameters: {
+            translation_options: {
+              source_lang: 'auto',
+              target_lang: expectedTargetLanguage
+            }
+          },
           providerOptions: {
             dashscope: {
               translation_options: {
@@ -271,6 +277,7 @@ describe('translateService.open', () => {
     expect(streamPromptMock).toHaveBeenCalledWith(
       expect.objectContaining({
         callOverrides: expect.objectContaining({
+          rawBodyParameters: expect.objectContaining({ incremental_output: true }),
           providerOptions: {
             dashscope: expect.objectContaining({ incremental_output: true })
           }

--- a/src/main/services/translate/translateService.ts
+++ b/src/main/services/translate/translateService.ts
@@ -32,7 +32,6 @@ import { translateLanguageService } from '@main/data/services/TranslateLanguageS
 import { isTranslateLangCode, type TranslateLangCode } from '@shared/data/preference/preferenceTypes'
 import {
   createUniqueModelId,
-  ENDPOINT_TYPE,
   isUniqueModelId,
   type Model,
   parseUniqueModelId,
@@ -435,11 +434,11 @@ export class TranslateService {
     }
     const uniqueModelId = createUniqueModelId(providerId, modelId)
     const resolvedEndpoint = resolveEffectiveEndpoint(provider, model)
+    const resolvedProviderOptionsKey = resolveEndpointProviderOptionsKey(provider, resolvedEndpoint)
     const providerOptionsKey =
-      matchesPreset(provider, SystemProviderIds.dashscope) &&
-      resolvedEndpoint.endpointType !== ENDPOINT_TYPE.OPENAI_RESPONSES
+      matchesPreset(provider, SystemProviderIds.dashscope) && resolvedProviderOptionsKey === provider.id
         ? SystemProviderIds.dashscope
-        : resolveEndpointProviderOptionsKey(provider, resolvedEndpoint)
+        : resolvedProviderOptionsKey
     const content = isQwenMTModel(model)
       ? text
       : preferenceService

--- a/src/main/services/translate/translateService.ts
+++ b/src/main/services/translate/translateService.ts
@@ -18,6 +18,7 @@
 
 import { application } from '@application'
 import { loggerService } from '@logger'
+import { resolveEffectiveEndpoint, resolveEndpointProviderOptionsKey } from '@main/ai/provider/endpoint'
 import type { CallOverrides } from '@main/ai/types'
 import { type GatedSampling, getTemperature, getTopP } from '@main/ai/utils/modelParameters'
 import {
@@ -29,11 +30,17 @@ import { modelService } from '@main/data/services/ModelService'
 import { providerService } from '@main/data/services/ProviderService'
 import { translateLanguageService } from '@main/data/services/TranslateLanguageService'
 import { isTranslateLangCode, type TranslateLangCode } from '@shared/data/preference/preferenceTypes'
-import type { Model } from '@shared/data/types/model'
-import { createUniqueModelId, isUniqueModelId, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
+import {
+  createUniqueModelId,
+  ENDPOINT_TYPE,
+  isUniqueModelId,
+  type Model,
+  parseUniqueModelId,
+  type UniqueModelId
+} from '@shared/data/types/model'
 import type { TranslateLanguage } from '@shared/data/types/translate'
 import type { ReasoningEffortOption } from '@shared/types/aiSdk'
-import { getRawModelId, isQwenMTModel } from '@shared/utils/model'
+import { getLowerBaseModelName, getRawModelId, isQwenMTModel } from '@shared/utils/model'
 import { matchesPreset } from '@shared/utils/provider'
 import { SystemProviderIds } from '@shared/utils/systemProviderId'
 import type { UIMessageChunk } from 'ai'
@@ -181,7 +188,7 @@ const QWEN_MT_LITE_LANGUAGE_CODES = new Set([
 ])
 
 function qwenMtModelId(model: Model): string {
-  return getRawModelId(model).toLowerCase().split('/').at(-1) ?? ''
+  return getLowerBaseModelName(getRawModelId(model))
 }
 
 function isQwenMtLiteModel(model: Model): boolean {
@@ -427,9 +434,12 @@ export class TranslateService {
       throw new Error(NOT_CONFIGURED_ERROR)
     }
     const uniqueModelId = createUniqueModelId(providerId, modelId)
-    const providerOptionsKey = matchesPreset(provider, SystemProviderIds.dashscope)
-      ? SystemProviderIds.dashscope
-      : model.providerId
+    const resolvedEndpoint = resolveEffectiveEndpoint(provider, model)
+    const providerOptionsKey =
+      matchesPreset(provider, SystemProviderIds.dashscope) &&
+      resolvedEndpoint.endpointType !== ENDPOINT_TYPE.OPENAI_RESPONSES
+        ? SystemProviderIds.dashscope
+        : resolveEndpointProviderOptionsKey(provider, resolvedEndpoint)
     const content = isQwenMTModel(model)
       ? text
       : preferenceService

--- a/src/main/services/translate/translateService.ts
+++ b/src/main/services/translate/translateService.ts
@@ -33,9 +33,18 @@ import type { Model } from '@shared/data/types/model'
 import { createUniqueModelId, isUniqueModelId, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import type { TranslateLanguage } from '@shared/data/types/translate'
 import type { ReasoningEffortOption } from '@shared/types/aiSdk'
-import { isQwenMTModel } from '@shared/utils/model'
+import { getRawModelId, isQwenMTModel } from '@shared/utils/model'
+import { matchesPreset } from '@shared/utils/provider'
+import { SystemProviderIds } from '@shared/utils/systemProviderId'
+import type { UIMessageChunk } from 'ai'
 
-import { WebContentsListener } from '../../ai/streamManager'
+import {
+  type StreamDoneResult,
+  type StreamErrorResult,
+  type StreamListener,
+  type StreamPausedResult,
+  WebContentsListener
+} from '../../ai/streamManager'
 
 const logger = loggerService.withContext('TranslateService')
 
@@ -43,6 +52,8 @@ const NOT_CONFIGURED_ERROR = 'translate.error.not_configured'
 const NOT_SUPPORTED_ERROR = 'translate.error.not_supported'
 
 const QWEN_MT_TARGET_LANGUAGES: Readonly<Record<string, string>> = {
+  zh: 'Chinese',
+  zh_tw: 'Traditional Chinese',
   en: 'English',
   ru: 'Russian',
   ja: 'Japanese',
@@ -135,11 +146,105 @@ const QWEN_MT_TARGET_LANGUAGES: Readonly<Record<string, string>> = {
   fa: 'Western Persian'
 }
 
-function resolveQwenMtTargetLanguage(language: TranslateLanguage): string | undefined {
-  if (language.langCode === 'zh-cn') return 'Chinese'
-  if (language.langCode === 'zh-tw') return 'Traditional Chinese'
-  if (language.langCode === 'zh-yue') return 'Cantonese'
-  return QWEN_MT_TARGET_LANGUAGES[language.langCode.split('-')[0]]
+const QWEN_MT_LITE_LANGUAGE_CODES = new Set([
+  'zh',
+  'zh_tw',
+  'en',
+  'ru',
+  'ja',
+  'ko',
+  'es',
+  'fr',
+  'pt',
+  'de',
+  'it',
+  'th',
+  'vi',
+  'id',
+  'ms',
+  'ar',
+  'hi',
+  'he',
+  'ur',
+  'bn',
+  'pl',
+  'nl',
+  'tr',
+  'km',
+  'cs',
+  'sv',
+  'hu',
+  'da',
+  'fi',
+  'tl',
+  'fa'
+])
+
+function qwenMtModelId(model: Model): string {
+  return getRawModelId(model).toLowerCase().split('/').at(-1) ?? ''
+}
+
+function isQwenMtLiteModel(model: Model): boolean {
+  return /^qwen-mt-lite(?:$|[-:])/.test(qwenMtModelId(model))
+}
+
+function isQwenMtIncrementalModel(model: Model): boolean {
+  return /^qwen-mt-(?:flash|lite)(?:$|[-:])/.test(qwenMtModelId(model))
+}
+
+function isQwenMtCumulativeModel(model: Model): boolean {
+  return /^qwen-mt-(?:plus|turbo)(?:$|[-:])/.test(qwenMtModelId(model))
+}
+
+function qwenMtLanguageCode(language: TranslateLanguage): string {
+  if (language.langCode === 'zh-cn' || language.langCode === 'zh') return 'zh'
+  if (language.langCode === 'zh-tw') return 'zh_tw'
+  if (language.langCode === 'zh-yue') return 'yue'
+  return language.langCode.split('-')[0]
+}
+
+function resolveQwenMtTargetLanguage(language: TranslateLanguage, model: Model): string | undefined {
+  const languageCode = qwenMtLanguageCode(language)
+  if (isQwenMtLiteModel(model) && !QWEN_MT_LITE_LANGUAGE_CODES.has(languageCode)) return undefined
+  if (isQwenMtLiteModel(model) && languageCode === 'fa') return 'Persian'
+  return QWEN_MT_TARGET_LANGUAGES[languageCode]
+}
+
+class CumulativeTextStreamListener implements StreamListener {
+  readonly id: string
+  private readonly previousTextById = new Map<string, string>()
+
+  constructor(private readonly delegate: StreamListener) {
+    this.id = delegate.id
+  }
+
+  onChunk(chunk: UIMessageChunk, sourceModelId?: UniqueModelId, anchorMessageId?: string, attemptId?: number): void {
+    if (chunk.type !== 'text-delta') {
+      this.delegate.onChunk(chunk, sourceModelId, anchorMessageId, attemptId)
+      return
+    }
+
+    const previousText = this.previousTextById.get(chunk.id) ?? ''
+    const delta = chunk.delta.slice(previousText.length)
+    this.previousTextById.set(chunk.id, chunk.delta)
+    if (delta) this.delegate.onChunk({ ...chunk, delta }, sourceModelId, anchorMessageId, attemptId)
+  }
+
+  onDone(result: StreamDoneResult): void | Promise<void> {
+    return this.delegate.onDone(result)
+  }
+
+  onPaused(result: StreamPausedResult): void | Promise<void> {
+    return this.delegate.onPaused(result)
+  }
+
+  onError(result: StreamErrorResult): void | Promise<void> {
+    return this.delegate.onError(result)
+  }
+
+  isAlive(): boolean {
+    return this.delegate.isAlive()
+  }
 }
 
 /**
@@ -189,6 +294,7 @@ interface ResolvedPayload {
   content: string
   /** Carried out so `open` can gate the sampling settings against this model's capabilities. */
   model: Model
+  providerOptionsKey: string
 }
 
 export class TranslateService {
@@ -207,17 +313,20 @@ export class TranslateService {
       throw new Error(`Invalid target language: ${req.targetLangCode}`)
     }
     const targetLanguage = translateLanguageService.getByLangCode(req.targetLangCode)
-    const { uniqueModelId, content, model } = this.resolveTranslatePayload(req.text, targetLanguage)
-    const { reasoningEffort, callOverrides } = this.resolveRequestParameters(model, targetLanguage)
+    const { uniqueModelId, content, model, providerOptionsKey } = this.resolveTranslatePayload(req.text, targetLanguage)
+    const { reasoningEffort, callOverrides } = this.resolveRequestParameters(model, targetLanguage, providerOptionsKey)
 
-    const wcListener = new WebContentsListener(sender, req.streamId)
+    const rendererListener = new WebContentsListener(sender, req.streamId)
+    const listener = isQwenMtCumulativeModel(model)
+      ? new CumulativeTextStreamListener(rendererListener)
+      : rendererListener
 
     const streamManager = application.get('AiStreamManager')
     streamManager.streamPrompt({
       streamId: req.streamId,
       uniqueModelId,
       prompt: content,
-      listener: wcListener,
+      listener,
       reasoningEffort,
       callOverrides
     })
@@ -253,7 +362,8 @@ export class TranslateService {
    */
   resolveRequestParameters(
     model: Model,
-    targetLanguage?: TranslateLanguage
+    targetLanguage?: TranslateLanguage,
+    providerOptionsKey = model.providerId
   ): { reasoningEffort: ReasoningEffortOption; callOverrides: CallOverrides } {
     const preferenceService = application.get('PreferenceService')
     const reasoningEffort = preferenceService.get('feature.translate.reasoning_effort')
@@ -269,11 +379,12 @@ export class TranslateService {
     const topP = getTopP(settings, model, reasoning)
     let providerOptions: CallOverrides['providerOptions']
     if (targetLanguage && isQwenMTModel(model)) {
-      const targetLang = resolveQwenMtTargetLanguage(targetLanguage)
+      const targetLang = resolveQwenMtTargetLanguage(targetLanguage, model)
       if (!targetLang) throw new Error(NOT_SUPPORTED_ERROR)
       providerOptions = {
-        [model.providerId]: {
-          translation_options: { source_lang: 'auto', target_lang: targetLang }
+        [providerOptionsKey]: {
+          translation_options: { source_lang: 'auto', target_lang: targetLang },
+          ...(isQwenMtIncrementalModel(model) && { incremental_output: true })
         }
       }
     }
@@ -316,6 +427,9 @@ export class TranslateService {
       throw new Error(NOT_CONFIGURED_ERROR)
     }
     const uniqueModelId = createUniqueModelId(providerId, modelId)
+    const providerOptionsKey = matchesPreset(provider, SystemProviderIds.dashscope)
+      ? SystemProviderIds.dashscope
+      : model.providerId
     const content = isQwenMTModel(model)
       ? text
       : preferenceService
@@ -324,7 +438,7 @@ export class TranslateService {
             placeholder === '{{target_language}}' ? targetLanguage.value : text
           )
 
-    return { uniqueModelId, content, model }
+    return { uniqueModelId, content, model, providerOptionsKey }
   }
 }
 

--- a/src/main/services/translate/translateService.ts
+++ b/src/main/services/translate/translateService.ts
@@ -40,6 +40,107 @@ import { WebContentsListener } from '../../ai/streamManager'
 const logger = loggerService.withContext('TranslateService')
 
 const NOT_CONFIGURED_ERROR = 'translate.error.not_configured'
+const NOT_SUPPORTED_ERROR = 'translate.error.not_supported'
+
+const QWEN_MT_TARGET_LANGUAGES: Readonly<Record<string, string>> = {
+  en: 'English',
+  ru: 'Russian',
+  ja: 'Japanese',
+  ko: 'Korean',
+  es: 'Spanish',
+  fr: 'French',
+  pt: 'Portuguese',
+  de: 'German',
+  it: 'Italian',
+  th: 'Thai',
+  vi: 'Vietnamese',
+  id: 'Indonesian',
+  ms: 'Malay',
+  ar: 'Arabic',
+  hi: 'Hindi',
+  he: 'Hebrew',
+  my: 'Burmese',
+  ta: 'Tamil',
+  ur: 'Urdu',
+  bn: 'Bengali',
+  pl: 'Polish',
+  nl: 'Dutch',
+  ro: 'Romanian',
+  tr: 'Turkish',
+  km: 'Khmer',
+  lo: 'Lao',
+  yue: 'Cantonese',
+  cs: 'Czech',
+  el: 'Greek',
+  sv: 'Swedish',
+  hu: 'Hungarian',
+  da: 'Danish',
+  fi: 'Finnish',
+  uk: 'Ukrainian',
+  bg: 'Bulgarian',
+  sr: 'Serbian',
+  te: 'Telugu',
+  af: 'Afrikaans',
+  hy: 'Armenian',
+  as: 'Assamese',
+  ast: 'Asturian',
+  eu: 'Basque',
+  be: 'Belarusian',
+  bs: 'Bosnian',
+  ca: 'Catalan',
+  ceb: 'Cebuano',
+  hr: 'Croatian',
+  arz: 'Egyptian Arabic',
+  et: 'Estonian',
+  gl: 'Galician',
+  ka: 'Georgian',
+  gu: 'Gujarati',
+  is: 'Icelandic',
+  jv: 'Javanese',
+  kn: 'Kannada',
+  kk: 'Kazakh',
+  lv: 'Latvian',
+  lt: 'Lithuanian',
+  lb: 'Luxembourgish',
+  mk: 'Macedonian',
+  mai: 'Maithili',
+  mt: 'Maltese',
+  mr: 'Marathi',
+  acm: 'Mesopotamian Arabic',
+  ary: 'Moroccan Arabic',
+  ars: 'Najdi Arabic',
+  ne: 'Nepali',
+  az: 'North Azerbaijani',
+  apc: 'North Levantine Arabic',
+  uz: 'Northern Uzbek',
+  nb: 'Norwegian Bokmål',
+  nn: 'Norwegian Nynorsk',
+  oc: 'Occitan',
+  or: 'Odia',
+  pag: 'Pangasinan',
+  scn: 'Sicilian',
+  sd: 'Sindhi',
+  si: 'Sinhala',
+  sk: 'Slovak',
+  sl: 'Slovenian',
+  ajp: 'South Levantine Arabic',
+  sw: 'Swahili',
+  tl: 'Tagalog',
+  acq: 'Ta’izzi-Adeni Arabic',
+  sq: 'Tosk Albanian',
+  aeb: 'Tunisian Arabic',
+  vec: 'Venetian',
+  war: 'Waray',
+  cy: 'Welsh',
+  fa: 'Western Persian'
+}
+
+function resolveQwenMtTargetLanguage(language: TranslateLanguage): string | undefined {
+  if (language.langCode === 'zh-cn') return 'Chinese'
+  if (language.langCode === 'zh-tw') return 'Traditional Chinese'
+  if (language.langCode === 'zh-yue') return 'Cantonese'
+  return QWEN_MT_TARGET_LANGUAGES[language.langCode.split('-')[0]]
+}
 
 /**
  * Namespaced prefix every translate stream uses for its `streamId` /
@@ -107,7 +208,7 @@ export class TranslateService {
     }
     const targetLanguage = translateLanguageService.getByLangCode(req.targetLangCode)
     const { uniqueModelId, content, model } = this.resolveTranslatePayload(req.text, targetLanguage)
-    const { reasoningEffort, callOverrides } = this.resolveRequestParameters(model)
+    const { reasoningEffort, callOverrides } = this.resolveRequestParameters(model, targetLanguage)
 
     const wcListener = new WebContentsListener(sender, req.streamId)
 
@@ -150,7 +251,10 @@ export class TranslateService {
    * re-projects against the endpoint the request actually uses. #19693 is the
    * exit — it moves this gate inside the pipeline, where both are known.
    */
-  resolveRequestParameters(model: Model): { reasoningEffort: ReasoningEffortOption; callOverrides: CallOverrides } {
+  resolveRequestParameters(
+    model: Model,
+    targetLanguage?: TranslateLanguage
+  ): { reasoningEffort: ReasoningEffortOption; callOverrides: CallOverrides } {
     const preferenceService = application.get('PreferenceService')
     const reasoningEffort = preferenceService.get('feature.translate.reasoning_effort')
     const settings = {
@@ -163,12 +267,23 @@ export class TranslateService {
     const reasoning = { kind: reasoningKindFor(reasoningEffort, model) }
     const temperature = getTemperature(settings, model, reasoning)
     const topP = getTopP(settings, model, reasoning)
+    let providerOptions: CallOverrides['providerOptions']
+    if (targetLanguage && isQwenMTModel(model)) {
+      const targetLang = resolveQwenMtTargetLanguage(targetLanguage)
+      if (!targetLang) throw new Error(NOT_SUPPORTED_ERROR)
+      providerOptions = {
+        [model.providerId]: {
+          translation_options: { source_lang: 'auto', target_lang: targetLang }
+        }
+      }
+    }
 
     return {
       reasoningEffort,
       callOverrides: {
         ...(temperature !== undefined && { temperature }),
-        ...(topP !== undefined && { topP })
+        ...(topP !== undefined && { topP }),
+        ...(providerOptions && { providerOptions })
       }
     }
   }

--- a/src/main/services/translate/translateService.ts
+++ b/src/main/services/translate/translateService.ts
@@ -384,14 +384,17 @@ export class TranslateService {
     const temperature = getTemperature(settings, model, reasoning)
     const topP = getTopP(settings, model, reasoning)
     let providerOptions: CallOverrides['providerOptions']
+    let rawBodyParameters: CallOverrides['rawBodyParameters']
     if (targetLanguage && isQwenMTModel(model)) {
       const targetLang = resolveQwenMtTargetLanguage(targetLanguage, model)
       if (!targetLang) throw new Error(NOT_SUPPORTED_ERROR)
+      const qwenMtParameters = {
+        translation_options: { source_lang: 'auto', target_lang: targetLang },
+        ...(isQwenMtIncrementalModel(model) && { incremental_output: true })
+      }
+      rawBodyParameters = qwenMtParameters
       providerOptions = {
-        [providerOptionsKey]: {
-          translation_options: { source_lang: 'auto', target_lang: targetLang },
-          ...(isQwenMtIncrementalModel(model) && { incremental_output: true })
-        }
+        [providerOptionsKey]: qwenMtParameters
       }
     }
 
@@ -400,7 +403,8 @@ export class TranslateService {
       callOverrides: {
         ...(temperature !== undefined && { temperature }),
         ...(topP !== undefined && { topP }),
-        ...(providerOptions && { providerOptions })
+        ...(providerOptions && { providerOptions }),
+        ...(rawBodyParameters && { rawBodyParameters })
       }
     }
   }

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Übersetzung fehlgeschlagen",
   "translate.error.languages_load_failed": "Fehler beim Laden der Übersetzungssprachen. Einige Funktionen sind möglicherweise nicht verfügbar.",
   "translate.error.not_configured": "Übersetzungsmodell nicht konfiguriert",
+  "translate.error.not_supported": "Qwen MT unterstützt die ausgewählte Zielsprache nicht",
   "translate.exchange.label": "Quell- und Zielsprache tauschen",
   "translate.files.drag_text": "Hierher ziehen und ablegen",
   "translate.files.error.check_type": "Fehler beim Überprüfen des Dateityps",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Η μετάφραση απέτυχε",
   "translate.error.languages_load_failed": "Αποτυχία φόρτωσης γλωσσών μετάφρασης. Ορισμένες λειτουργίες ενδέχεται να μην είναι διαθέσιμες.",
   "translate.error.not_configured": "Το μοντέλο μετάφρασης δεν είναι ρυθμισμένο",
+  "translate.error.not_supported": "Το Qwen MT δεν υποστηρίζει την επιλεγμένη γλώσσα-στόχο",
   "translate.exchange.label": "Ανταλλαγή γλώσσας πηγής και γλώσσας προορισμού",
   "translate.files.drag_text": "Σύρετε και αφήστε εδώ",
   "translate.files.error.check_type": "Παρουσιάστηκε σφάλμα κατά τον έλεγχο του τύπου αρχείου",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Translation failed",
   "translate.error.languages_load_failed": "Failed to load translate languages. Some features may be unavailable.",
   "translate.error.not_configured": "Translation model is not configured",
+  "translate.error.not_supported": "Qwen MT does not support the selected target language",
   "translate.exchange.label": "Swap the source and target languages",
   "translate.files.drag_text": "Drop here",
   "translate.files.error.check_type": "An error occurred while checking the file type",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Fallo en la traducción",
   "translate.error.languages_load_failed": "Error al cargar los idiomas de traducción. Algunas funciones podrían no estar disponibles.",
   "translate.error.not_configured": "El modelo de traducción no está configurado",
+  "translate.error.not_supported": "Qwen MT no admite el idioma de destino seleccionado",
   "translate.exchange.label": "Intercambiar el idioma de origen y el idioma de destino",
   "translate.files.drag_text": "Arrastrar y soltar aquí",
   "translate.files.error.check_type": "Se produjo un error al verificar el tipo de archivo",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "échec de la traduction",
   "translate.error.languages_load_failed": "Échec du chargement des langues de traduction. Certaines fonctionnalités peuvent être indisponibles.",
   "translate.error.not_configured": "le modèle de traduction n'est pas configuré",
+  "translate.error.not_supported": "Qwen MT ne prend pas en charge la langue cible sélectionnée",
   "translate.exchange.label": "Échanger la langue source et la langue cible",
   "translate.files.drag_text": "Glisser-déposer ici",
   "translate.files.error.check_type": "Une erreur s'est produite lors de la vérification du type de fichier",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "翻訳に失敗しました",
   "translate.error.languages_load_failed": "言語の読み込みに失敗しました。一部の機能が利用できない場合があります。",
   "translate.error.not_configured": "翻訳モデルが設定されていません",
+  "translate.error.not_supported": "Qwen MT は選択した翻訳先の言語をサポートしていません",
   "translate.exchange.label": "入力言語と出力言語を入れ替える",
   "translate.files.drag_text": "ここにドラッグ＆ドロップしてください",
   "translate.files.error.check_type": "ファイルタイプの確認中にエラーが発生しました",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Tradução falhou",
   "translate.error.languages_load_failed": "Falha ao carregar idiomas de tradução. Alguns recursos podem estar indisponíveis.",
   "translate.error.not_configured": "Modelo de tradução não configurado",
+  "translate.error.not_supported": "O Qwen MT não suporta o idioma de destino selecionado",
   "translate.exchange.label": "Trocar idioma de origem e idioma de destino",
   "translate.files.drag_text": "Arraste e solte aqui",
   "translate.files.error.check_type": "Ocorreu um erro ao verificar o tipo de ficheiro",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Traducerea a eșuat",
   "translate.error.languages_load_failed": "Nu s-au putut încărca limbile de traducere. Este posibil ca unele funcționalități să nu fie disponibile.",
   "translate.error.not_configured": "Modelul de traducere nu este configurat",
+  "translate.error.not_supported": "Qwen MT nu acceptă limba țintă selectată",
   "translate.exchange.label": "Schimbă limbile sursă și țintă",
   "translate.files.drag_text": "Trage aici",
   "translate.files.error.check_type": "A apărut o eroare la verificarea tipului de fișier",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Перевод не удалось",
   "translate.error.languages_load_failed": "Не удалось загрузить языки перевода. Некоторые функции могут быть недоступны.",
   "translate.error.not_configured": "Модель перевода не настроена",
+  "translate.error.not_supported": "Qwen MT не поддерживает выбранный целевой язык",
   "translate.exchange.label": "Поменяйте исходный и целевой языки местами",
   "translate.files.drag_text": "Перетащите сюда",
   "translate.files.error.check_type": "Ошибка при проверке типа файла",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Çeviri başarısız oldu",
   "translate.error.languages_load_failed": "Çeviri dilleri yüklenemedi. Bazı özellikler kullanılamayabilir.",
   "translate.error.not_configured": "Çeviri modeli yapılandırılmamış",
+  "translate.error.not_supported": "Qwen MT seçilen hedef dili desteklemiyor",
   "translate.exchange.label": "Kaynak ve hedef dilleri değiştir",
   "translate.files.drag_text": "Buraya bırakın",
   "translate.files.error.check_type": "Dosya türü kontrol edilirken bir hata oluştu",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "Dịch thất bại",
   "translate.error.languages_load_failed": "Không tải được ngôn ngữ dịch. Một số tính năng có thể không khả dụng.",
   "translate.error.not_configured": "Mô hình dịch chưa được cấu hình",
+  "translate.error.not_supported": "Qwen MT không hỗ trợ ngôn ngữ đích đã chọn",
   "translate.exchange.label": "Hoán đổi ngôn ngữ nguồn và ngôn ngữ đích",
   "translate.files.drag_text": "Thả vào đây",
   "translate.files.error.check_type": "Đã xảy ra lỗi khi kiểm tra loại tệp",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "翻译失败",
   "translate.error.languages_load_failed": "翻译模块初始化失败，部分功能可能不可用",
   "translate.error.not_configured": "翻译模型未配置",
+  "translate.error.not_supported": "Qwen MT 不支持所选目标语言",
   "translate.exchange.label": "交换源语言与目标语言",
   "translate.files.drag_text": "拖放到此处",
   "translate.files.error.check_type": "检查文件类型时发生错误",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -5144,6 +5144,7 @@
   "translate.error.failed": "翻譯失敗",
   "translate.error.languages_load_failed": "無法載入翻譯語言。部分功能可能無法使用。",
   "translate.error.not_configured": "翻譯模型未設定",
+  "translate.error.not_supported": "Qwen MT 不支援所選的目標語言",
   "translate.exchange.label": "交換來源語言與目標語言",
   "translate.files.drag_text": "拖曳到此處",
   "translate.files.error.check_type": "檢查檔案類型時發生錯誤",

--- a/src/renderer/utils/translate/__tests__/translateText.test.ts
+++ b/src/renderer/utils/translate/__tests__/translateText.test.ts
@@ -3,6 +3,7 @@ import type { TranslateLanguage } from '@shared/data/types/translate'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('i18next', () => ({
+  exists: (key: string) => key === 'translate.error.not_supported',
   t: (key: string) => `t(${key})`
 }))
 
@@ -273,6 +274,12 @@ describe('translateText (main-driven streaming)', () => {
       mockTranslateOpen.mockRejectedValueOnce(new Error('t(translate.error.not_configured)'))
       await expect(translateText('source', TARGET)).rejects.toThrow('t(translate.error.not_configured)')
       expect(mockListeners).toEqual({ chunk: [], done: [], error: [] })
+    })
+
+    it('localizes an app-owned error key returned by translate.open', async () => {
+      mockTranslateOpen.mockRejectedValueOnce(new Error('translate.error.not_supported'))
+
+      await expect(translateText('source', TARGET)).rejects.toThrow('t(translate.error.not_supported)')
     })
   })
 

--- a/src/renderer/utils/translate/__tests__/translateText.test.ts
+++ b/src/renderer/utils/translate/__tests__/translateText.test.ts
@@ -3,7 +3,7 @@ import type { TranslateLanguage } from '@shared/data/types/translate'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('i18next', () => ({
-  exists: (key: string) => key === 'translate.error.not_supported',
+  exists: (key: string) => key === 'translate.error.not_configured' || key === 'translate.error.not_supported',
   t: (key: string) => `t(${key})`
 }))
 
@@ -271,7 +271,7 @@ describe('translateText (main-driven streaming)', () => {
 
   describe('main-side failure', () => {
     it('rejects with the main error when translate.open throws (e.g. not configured)', async () => {
-      mockTranslateOpen.mockRejectedValueOnce(new Error('t(translate.error.not_configured)'))
+      mockTranslateOpen.mockRejectedValueOnce(new Error('translate.error.not_configured'))
       await expect(translateText('source', TARGET)).rejects.toThrow('t(translate.error.not_configured)')
       expect(mockListeners).toEqual({ chunk: [], done: [], error: [] })
     })

--- a/src/renderer/utils/translate/translateText.ts
+++ b/src/renderer/utils/translate/translateText.ts
@@ -1,11 +1,18 @@
 import { ipcApi } from '@renderer/ipc'
 import { isTranslateLangCode, type TranslateLangCode } from '@shared/data/preference/preferenceTypes'
 import type { TranslateLanguage } from '@shared/data/types/translate'
-import { t } from 'i18next'
+import { exists, t } from 'i18next'
 import { v4 as uuid } from 'uuid'
 
 /** Must stay in sync with main-side prefix (validated in `translateService.open`). */
 const TRANSLATE_STREAM_PREFIX = 'translate:'
+
+function toTranslateError(error: unknown): Error {
+  const source = error instanceof Error ? error : new Error(String(error))
+  const translated = new Error(exists(source.message) ? t(source.message) : source.message)
+  translated.name = source.name
+  return translated
+}
 
 /**
  * Translate `text` to `targetLanguage` via main's `translate.open` IPC.
@@ -94,7 +101,7 @@ export const translateText = async (
         cleanup()
         // Preserve error.name (e.g. 'AbortError') so downstream
         // `isAbortError(...)` classifies user stops correctly.
-        const err = new Error(error?.message ?? 'Translation stream error')
+        const err = toTranslateError(new Error(error?.message ?? 'Translation stream error'))
         if (error?.name) err.name = error.name
         reject(err)
       })
@@ -102,7 +109,7 @@ export const translateText = async (
 
     ipcApi.request('translate.open', { streamId, text, targetLangCode }).catch((openError: unknown) => {
       cleanup()
-      reject(openError instanceof Error ? openError : new Error(String(openError)))
+      reject(toTranslateError(openError))
     })
   })
 }

--- a/v2-refactor-temp/docs/ai/translate-on-main.md
+++ b/v2-refactor-temp/docs/ai/translate-on-main.md
@@ -19,8 +19,8 @@ renderer translateText
 ```
 
 Translation has no assistant, message history, tools, or chat
-`RequestFeature` stack. Qwen-MT receives raw text; other models receive the
-configured translation prompt.
+`RequestFeature` stack. Qwen-MT receives raw text plus its provider-scoped
+`translation_options`; other models receive the configured translation prompt.
 
 `translateService` remains a direct-import singleton. It owns no long-lived
 resource or persistent side effect; the lifecycle-owned IpcApi layer owns route
@@ -43,8 +43,6 @@ removed rather than optimized as an external store or Cache entry.
 
 ## Open questions
 
-- **Qwen-MT target language.** Current code sends raw text without a
-  `providerOptions.dashscope.translation_options.target_lang` override.
 - **Source-language detection.** `useDetectLang` remains renderer-owned.
 - **Translation history.** Text translation does not currently write
   `translate_history` rows.

--- a/v2-refactor-temp/docs/ai/translate-on-main.md
+++ b/v2-refactor-temp/docs/ai/translate-on-main.md
@@ -20,7 +20,9 @@ renderer translateText
 
 Translation has no assistant, message history, tools, or chat
 `RequestFeature` stack. Qwen-MT receives raw text plus its provider-scoped
-`translation_options`; other models receive the configured translation prompt.
+`translation_options`; Flash/Lite use incremental output and Plus/Turbo
+cumulative chunks are normalized before renderer delivery. Other models
+receive the configured translation prompt.
 
 `translateService` remains a direct-import singleton. It owns no long-lived
 resource or persistent side effect; the lifecycle-owned IpcApi layer owns route


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Qwen-MT translation sent raw source text without the complete provider contract. Plus and Turbo cumulative chunks were appended as deltas, Lite accepted unsupported targets, preset-derived DashScope instances used the wrong provider-options namespace, and unsupported-language errors could surface as raw i18n keys.

After this PR:

Translation maps app language codes to Qwen-MT target names, applies Lite's 31-language allowlist, requests incremental output for Flash and Lite, converts cumulative Plus and Turbo chunks to renderer deltas, uses the DashScope runtime namespace for preset-derived instances, and localizes recognized translation errors before display. Qwen-MT vendor fields are also re-injected after AI SDK request serialization so Anthropic Messages cannot drop them.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19701

### Why we need it and why it was done in this way

The v2 Main-process translation service owns the selected model, provider, target language, and stream listener. Enforcing each Qwen-MT variant's documented request and streaming contract at that boundary keeps provider-specific behavior out of the renderer while preserving the existing raw-text prompt path.

The following tradeoffs were made:

The supported language tables are explicit so invalid targets fail before a provider request. A small listener adapter converts only cumulative Qwen-MT text chunks; other chunk types and other models pass through unchanged. Renderer error localization is limited to keys known to i18next so provider error messages remain intact.

The following alternatives were considered:

Sending configured display names was rejected because custom labels are not stable provider values. Reintroducing renderer-side provider request construction was rejected because v2 intentionally owns model and provider parameters in Main. Treating every Qwen-MT stream as incremental was rejected because Plus and Turbo explicitly return cumulative text.

Links to places where the discussion took place: #19701 and https://www.alibabacloud.com/help/en/model-studio/machine-translation

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This changes translation results and error presentation but does not change component layout or styling. A credible Before/After screenshot requires a live configured DashScope Qwen-MT request; no additional Electron instance was started under the single-instance test constraint. The observable request, stream, and localized-error contracts are covered by focused automated tests.

Validation on Node 24.14.0:

- .pnpm test:main src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts src/main/services/translate/__tests__/translateService.test.ts. passed 117/117, including a real Anthropic SDK wire-body regression.
- `pnpm test:renderer src/renderer/utils/translate/__tests__/translateText.test.ts` passed 16/16.
- `pnpm lint` passed, including type checks, i18n validation, and formatting; ESLint reported only the repository's existing 45 warnings.
- `pnpm test:lint` passed with the same existing ESLint warnings.
- `pnpm docs:check` passed.
- `git diff --check` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Restore reliable Qwen-MT translation across model variants, normalize streaming output, and localize unsupported-language errors.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live translation requests, streaming semantics, and HTTP body shaping for assistant-less AI calls; scope is mostly translate and Qwen-MT, with regression tests on wire bodies and stream behavior.
> 
> **Overview**
> Restores the **Qwen-MT translation contract** in Main: source text is sent with provider-scoped `translation_options` (`source_lang: auto`, mapped `target_lang`), **Lite** targets are checked against a 31-language set, and unsupported languages throw **`translate.error.not_supported`** before streaming starts.
> 
> **Variant-specific behavior:** Flash/Lite set **`incremental_output`**; Plus/Turbo streams pass through a **`CumulativeTextStreamListener`** so cumulative text becomes renderer deltas. **`providerOptions`** use the resolved endpoint namespace (DashScope preset copies, OpenAI Responses, Anthropic Messages).
> 
> **AI pipeline:** `CallOverrides` gains **`rawBodyParameters`**, merged in **`buildAgentParams`** via the custom-params fetch wrapper so vendor fields (e.g. on Anthropic) are not dropped after SDK serialization.
> 
> **Renderer:** `translateText` localizes known Main error keys through i18next; new locale string for unsupported targets. Docs updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a865060a1a9e4403a64ea94bfe18d946e6fd2e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

