### PR TITLE
refactor(conversation-view): remove the message-only conversation view

### DIFF
--- a/src/renderer/components/ResourceViewSourceProvider.tsx
+++ b/src/renderer/components/ResourceViewSourceProvider.tsx
@@ -9,12 +9,7 @@ import {
   useRawAssistantTopicsSource
 } from '@renderer/hooks/resourceViewSources'
 import { useTabs } from '@renderer/hooks/tab'
-import {
-  getSidebarApp,
-  isMessageOnlyConversationUrl,
-  type SidebarAppId,
-  tabBelongsToApp
-} from '@renderer/utils/sidebar'
+import { getSidebarApp, type SidebarAppId, tabBelongsToApp } from '@renderer/utils/sidebar'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -35,12 +30,7 @@ export function shouldLoadResourceViewSource(
   if (!app) return false
 
   const activeTab = tabs.find((tab) => tab.id === activeTabId)
-  return Boolean(
-    activeTab?.type === 'route' &&
-      !activeTab.isDormant &&
-      tabBelongsToApp(app, activeTab.url) &&
-      !isMessageOnlyConversationUrl(activeTab.url)
-  )
+  return Boolean(activeTab?.type === 'route' && !activeTab.isDormant && tabBelongsToApp(app, activeTab.url))
 }
 
 function useCommittedAssistantTopicsSource(enabled: boolean, retainDerivedView: boolean): AssistantTopicsSource {
@@ -207,13 +197,7 @@ export function ResourceViewSourceProvider({ children }: { children: ReactNode }
   const retainAssistantTopicsView = useMemo(() => {
     const app = getSidebarApp('assistants')
     if (!app) return false
-    return tabs.some(
-      (tab) =>
-        tab.type === 'route' &&
-        !tab.isDormant &&
-        tabBelongsToApp(app, tab.url) &&
-        !isMessageOnlyConversationUrl(tab.url)
-    )
+    return tabs.some((tab) => tab.type === 'route' && !tab.isDormant && tabBelongsToApp(app, tab.url))
   }, [tabs])
   const agentSessionsEnabled = useMemo(
     () => shouldLoadResourceViewSource(tabs, activeTabId, 'agents'),

--- a/src/renderer/components/__tests__/ResourceViewSourceProvider.test.tsx
+++ b/src/renderer/components/__tests__/ResourceViewSourceProvider.test.tsx
@@ -1,7 +1,4 @@
-import {
-  ResourceViewSourceProvider,
-  shouldLoadResourceViewSource
-} from '@renderer/components/ResourceViewSourceProvider'
+import { ResourceViewSourceProvider } from '@renderer/components/ResourceViewSourceProvider'
 import type * as ResourceViewSourcesModule from '@renderer/hooks/resourceViewSources'
 import {
   type AgentSessionsSource,
@@ -337,9 +334,8 @@ describe('ResourceViewSourceProvider', () => {
     expect(screen.getByTestId('session-pins')).toHaveTextContent('session-1')
   })
 
-  it('loads only the source owned by the active non-dormant, non-message-only route tab', () => {
+  it('loads only the source owned by the active non-dormant route tab', () => {
     sourceMocks.tabs = [
-      createTab('chat-message', '/app/chat?topicId=topic-1&view=message'),
       createTab('agent-dormant', '/app/agents?sessionId=session-1', true),
       createTab('chat', '/app/chat?topicId=topic-2')
     ]
@@ -349,12 +345,5 @@ describe('ResourceViewSourceProvider', () => {
 
     expect(sourceMocks.assistantEnabled.at(-1)).toBe(true)
     expect(sourceMocks.agentEnabled.at(-1)).toBe(false)
-    expect(
-      shouldLoadResourceViewSource(
-        [createTab('malformed-message', '/app/chat?view=message')],
-        'malformed-message',
-        'assistants'
-      )
-    ).toBe(true)
   })
 })

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -15,7 +15,6 @@ import {
   getSidebarApp,
   getSidebarFavoriteKey,
   getSidebarMenuPath,
-  isMessageOnlyConversationUrl,
   resolveSidebarActiveItem,
   tabBelongsToApp
 } from '@renderer/utils/sidebar'
@@ -192,13 +191,9 @@ export default function Sidebar({
       if (!options?.inNewTab) {
         // Conversation apps: any owned tab is already "there" — its URL carries its own
         // conversation, and re-entering through the route interceptor would just rebind
-        // it. Message-only viewers are not an app entry, so they navigate like any
-        // foreign tab. Apps without sub-instances keep exact-URL matching.
+        // it. Apps without sub-instances keep exact-URL matching.
         const isActiveTarget =
-          !!activeTab &&
-          (app.conversationRoute
-            ? tabBelongsToApp(app, activeTab.url) && !isMessageOnlyConversationUrl(activeTab.url)
-            : activeTab.url === path)
+          !!activeTab && (app.conversationRoute ? tabBelongsToApp(app, activeTab.url) : activeTab.url === path)
         if (isActiveTarget) return
       }
 

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -897,26 +897,6 @@ describe('app Sidebar', () => {
     expect(mocks.openTab).not.toHaveBeenCalled()
   })
 
-  it('navigates a message-only viewer of the same app back to the app entry', () => {
-    mocks.sidebarFavorites = [appFavorite('agents')]
-    mocks.activeTab = {
-      id: 'viewer',
-      type: 'route',
-      url: '/app/agents?sessionId=session-1&view=message',
-      title: 'Session 1'
-    }
-
-    render(<Sidebar />)
-    fireEvent.click(screen.getByTestId('sidebar-item-agents'))
-
-    expect(mocks.updateTab).toHaveBeenCalledWith('viewer', {
-      url: '/app/agents',
-      title: 'Work',
-      icon: undefined,
-      metadata: undefined
-    })
-  })
-
   it('clears route-specific metadata when reusing the active tab', () => {
     mocks.sidebarFavorites = [appFavorite('translate')]
     mocks.activeTab = {

--- a/src/renderer/hooks/__tests__/useConversationShellPaneState.test.tsx
+++ b/src/renderer/hooks/__tests__/useConversationShellPaneState.test.tsx
@@ -6,7 +6,6 @@ import { useConversationShellPaneState } from '../useConversationShellPaneState'
 import { WindowFrameContext } from '../useWindowFrame'
 
 interface HarnessProps {
-  isMessageOnlyView?: boolean
   persistedPaneOpen?: boolean
 }
 
@@ -22,9 +21,8 @@ function renderPaneState({
   windowFrame?: 'window'
 } = {}) {
   const rendered = renderHook(
-    ({ isMessageOnlyView = false, persistedPaneOpen = true }: HarnessProps) =>
+    ({ persistedPaneOpen = true }: HarnessProps) =>
       useConversationShellPaneState({
-        isMessageOnlyView,
         persistedPaneOpen,
         setPersistedPaneOpen,
         onManualPaneOpen
@@ -70,22 +68,6 @@ describe('useConversationShellPaneState', () => {
     act(() => result.current.setShellPaneOpen(true))
     expect(result.current.shellPaneOpen).toBe(true)
     expect(setPersistedPaneOpen).not.toHaveBeenCalled()
-  })
-
-  it('forces the pane closed and disables toggling in message-only view', () => {
-    const onManualPaneOpen = vi.fn()
-    const { result, setPersistedPaneOpen } = renderPaneState({
-      initialProps: { isMessageOnlyView: true, persistedPaneOpen: true },
-      onManualPaneOpen
-    })
-
-    expect(result.current.shellPaneOpen).toBe(false)
-
-    act(() => result.current.toggleShellPane())
-    expect(result.current.shellPaneOpen).toBe(false)
-    expect(result.current.paneManualToggle).toBeUndefined()
-    expect(setPersistedPaneOpen).not.toHaveBeenCalled()
-    expect(onManualPaneOpen).not.toHaveBeenCalled()
   })
 
   it('closes on auto-collapse without touching the preference and reopens on the next explicit open', () => {

--- a/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
+++ b/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
@@ -42,6 +42,15 @@ describe('findClosableConversationTabIds', () => {
     ])
   })
 
+  it('matches a tab restored with the legacy message-only view param by its conversation key', () => {
+    const tabs: Tab[] = [
+      { id: 'legacy', type: 'route', url: '/app/chat?topicId=topic-a&view=message', title: 'Topic A' },
+      { id: 'active', type: 'route', url: '/app/chat?topicId=topic-b', title: 'Topic B' }
+    ]
+
+    expect(findClosableConversationTabIds(tabs, 'active', 'assistants', ['topic-a'])).toEqual(['legacy'])
+  })
+
   it.each(activeConversationCases)('keeps the active matching %s tab open', (_label, appId, key, baseUrl, queryKey) => {
     const tabs: Tab[] = [
       { id: 'active', type: 'route', url: `${baseUrl}?${queryKey}=${key}`, title: 'Active' },

--- a/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
+++ b/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
@@ -20,7 +20,6 @@ describe('findClosableConversationTabIds', () => {
     const tabs: Tab[] = [
       { id: 'topic-a-tab', type: 'route', url: '/app/chat?topicId=topic-a', title: 'Topic A' },
       { id: 'topic-b-tab', type: 'route', url: '/app/chat?topicId=topic-b', title: 'Topic B' },
-      { id: 'message', type: 'route', url: '/app/chat?view=message&topicId=topic-a', title: 'Message' },
       { id: 'session', type: 'route', url: '/app/agents?sessionId=topic-a', title: 'Session' }
     ]
 

--- a/src/renderer/hooks/useConversationShellPaneState.ts
+++ b/src/renderer/hooks/useConversationShellPaneState.ts
@@ -4,14 +4,12 @@ import { useCallback, useState } from 'react'
 import { useWindowFrame } from './useWindowFrame'
 
 interface UseConversationShellPaneStateOptions {
-  isMessageOnlyView: boolean
   persistedPaneOpen: boolean
   setPersistedPaneOpen: (open: boolean) => void | Promise<unknown>
   onManualPaneOpen?: () => void
 }
 
 export function useConversationShellPaneState({
-  isMessageOnlyView,
   persistedPaneOpen,
   setPersistedPaneOpen,
   onManualPaneOpen
@@ -21,7 +19,7 @@ export function useConversationShellPaneState({
   const [autoCollapsedPane, setAutoCollapsedPane] = useState(false)
   const [paneManualToggle, setPaneManualToggle] = useState<PaneManualToggleSignal>()
   const requestedPaneOpen = isWindowFrame ? detachedPaneOpen : persistedPaneOpen
-  const shellPaneOpen = !isMessageOnlyView && requestedPaneOpen && !autoCollapsedPane
+  const shellPaneOpen = requestedPaneOpen && !autoCollapsedPane
 
   const setShellPaneOpen = useCallback(
     (open: boolean) => {
@@ -44,12 +42,10 @@ export function useConversationShellPaneState({
   )
 
   const toggleShellPane = useCallback(() => {
-    if (isMessageOnlyView) return
-
     const nextOpen = !shellPaneOpen
     setShellPaneOpenManually(nextOpen)
     if (nextOpen) onManualPaneOpen?.()
-  }, [isMessageOnlyView, onManualPaneOpen, setShellPaneOpenManually, shellPaneOpen])
+  }, [onManualPaneOpen, setShellPaneOpenManually, shellPaneOpen])
 
   const handlePaneAutoCollapseChange = useCallback((collapsed: boolean) => {
     setAutoCollapsedPane(collapsed)

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -560,20 +560,9 @@ export interface UseActiveTopicOptions {
   activeTopicId: string | null
   /** Write back when initialTopic or setActiveTopic fires. */
   setActiveTopicId: (id: string | null) => void
-  /**
-   * Pass `true` for callers that don't want any reconciliation or visible
-   * activeTopic (e.g. message-only view loads its target via `useTopicById`).
-   * In passive mode the hook becomes a no-op except for tracking `pendingTopic`.
-   */
-  passive?: boolean
 }
 
-export function useActiveTopic({
-  initialTopic,
-  activeTopicId,
-  setActiveTopicId,
-  passive = false
-}: UseActiveTopicOptions) {
+export function useActiveTopic({ initialTopic, activeTopicId, setActiveTopicId }: UseActiveTopicOptions) {
   // Resolve the active topic by id (like `useActiveSession`) rather than scanning the
   // loadAll `/topics` list. The entry route chooses the id without waiting for topic
   // history pagination; this hook then loads only that active row while the rail keeps
@@ -582,7 +571,7 @@ export function useActiveTopic({
     topic: apiActiveTopic,
     isLoading: isActiveTopicQueryLoading,
     error
-  } = useTopicById(passive || !activeTopicId ? undefined : activeTopicId)
+  } = useTopicById(activeTopicId || undefined)
   // NOT_FOUND is authoritative even if SWR still exposes cached data or a matching optimistic
   // topic. Otherwise cross-window deletion can strand HomePage on a stale active topic.
   const isNotFound = isDataApiNotFoundError(error)
@@ -599,23 +588,21 @@ export function useActiveTopic({
   const hasAppliedInitialTopicRef = useRef(false)
 
   useEffect(() => {
-    if (passive) return
     if (!initialTopic) return
     setPendingTopic((prev) => prev ?? initialTopic)
     if (hasAppliedInitialTopicRef.current) return
 
     hasAppliedInitialTopicRef.current = true
     if (activeTopicId !== initialTopic.id) setActiveTopicId(initialTopic.id)
-  }, [activeTopicId, initialTopic, passive, setActiveTopicId])
+  }, [activeTopicId, initialTopic, setActiveTopicId])
 
   const activeTopic = useMemo<RendererTopic | undefined>(() => {
-    if (passive) return undefined
     if (isNotFound) return undefined
     if (!activeTopicId) return pendingTopic
     if (queryTopic) return queryTopic
     if (pendingTopic?.id === activeTopicId) return pendingTopic
     return undefined
-  }, [activeTopicId, isNotFound, passive, pendingTopic, queryTopic])
+  }, [activeTopicId, isNotFound, pendingTopic, queryTopic])
 
   // Where the active topic resolved from. 'query' = persisted (fetched by id);
   // 'pending' = optimistic / temporary topic not yet persisted. Mirrors
@@ -630,14 +617,10 @@ export function useActiveTopic({
 
   const setActiveTopic = useCallback(
     (next: RendererTopic) => {
-      if (passive) {
-        setPendingTopic(next)
-        return
-      }
       setActiveTopicId(next.id)
       setPendingTopic(next)
     },
-    [passive, setActiveTopicId]
+    [setActiveTopicId]
   )
 
   // Clear the active topic entirely. Both `activeTopicId` and the in-memory `pendingTopic`
@@ -646,15 +629,14 @@ export function useActiveTopic({
   // was just deleted when creating its replacement fails.
   const clearActiveTopic = useCallback(() => {
     setPendingTopic(undefined)
-    if (!passive) setActiveTopicId(null)
-  }, [passive, setActiveTopicId])
+    setActiveTopicId(null)
+  }, [setActiveTopicId])
 
   useEffect(() => {
-    if (passive) return
     if (activeTopic) {
       void EventEmitter.emit(EVENT_NAMES.CHANGE_TOPIC, activeTopic)
     }
-  }, [activeTopic, passive])
+  }, [activeTopic])
 
   // Mirror `useActiveSession`: once the topic resolves (from the by-id query or the
   // pending fallback) we are no longer loading, even while a background revalidation runs.

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -1485,7 +1485,6 @@
   "help.star": "GitHub-Star",
   "help.title": "Hilfe",
   "help.whats_new": "Neuigkeiten",
-  "history.error.topic_not_found": "Thema existiert nicht",
   "history.records.agentTitle": "Agentenhistorie",
   "history.records.bulkDelete": "Stapel löschen",
   "history.records.bulkDeleteSessions.description": "{{count}} ausgewählte Aufgabe(n) löschen?",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -1485,7 +1485,6 @@
   "help.star": "Αστέρι στο GitHub",
   "help.title": "Βοήθεια",
   "help.whats_new": "Τι νέο υπάρχει",
-  "history.error.topic_not_found": "Το θέμα δεν υπάρχει",
   "history.records.agentTitle": "Ιστορικό Πράκτορα",
   "history.records.bulkDelete": "Διαγραφή Παρτίδας",
   "history.records.bulkDeleteSessions.description": "Διαγραφή {{count}} επιλεγμένης(-ών) εργασίας(-ών);",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1485,7 +1485,6 @@
   "help.star": "Star us on GitHub",
   "help.title": "Help",
   "help.whats_new": "What's new",
-  "history.error.topic_not_found": "Conversation not found",
   "history.records.agentTitle": "Agent History",
   "history.records.bulkDelete": "Batch Delete",
   "history.records.bulkDeleteSessions.description": "Delete {{count}} selected task(s)?",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -1485,7 +1485,6 @@
   "help.star": "Estrella en GitHub",
   "help.title": "Ayuda",
   "help.whats_new": "Novedades",
-  "history.error.topic_not_found": "El tema no existe",
   "history.records.agentTitle": "Historial del Agente",
   "history.records.bulkDelete": "Eliminación por lotes",
   "history.records.bulkDeleteSessions.description": "¿Eliminar {{count}} tarea(s) seleccionada(s)?",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -1485,7 +1485,6 @@
   "help.star": "Star sur GitHub",
   "help.title": "Aide",
   "help.whats_new": "Nouveautés",
-  "history.error.topic_not_found": "Le sujet n'existe pas",
   "history.records.agentTitle": "Historique de l'agent",
   "history.records.bulkDelete": "Suppression par lots",
   "history.records.bulkDeleteSessions.description": "Supprimer {{count}} tâche(s) sélectionnée(s) ?",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -1485,7 +1485,6 @@
   "help.star": "GitHubでスター",
   "help.title": "ヘルプ",
   "help.whats_new": "新機能",
-  "history.error.topic_not_found": "トピックが見つかりません",
   "history.records.agentTitle": "エージェント履歴",
   "history.records.bulkDelete": "バッチ削除",
   "history.records.bulkDeleteSessions.description": "選択したタスク {{count}} 件を削除しますか？",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -1485,7 +1485,6 @@
   "help.star": "Estrela no GitHub",
   "help.title": "Ajuda",
   "help.whats_new": "Novidades",
-  "history.error.topic_not_found": "Tópico inexistente",
   "history.records.agentTitle": "Histórico do Agente",
   "history.records.bulkDelete": "Eliminação em Lote",
   "history.records.bulkDeleteSessions.description": "Eliminar {{count}} tarefa(s) selecionada(s)?",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -1485,7 +1485,6 @@
   "help.star": "Stea pe GitHub",
   "help.title": "Ajutor",
   "help.whats_new": "Noutăți",
-  "history.error.topic_not_found": "Subiectul nu a fost găsit",
   "history.records.agentTitle": "Istoric agent",
   "history.records.bulkDelete": "Ștergere în lot",
   "history.records.bulkDeleteSessions.description": "Ștergi cele {{count}} sarcini selectate?",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -1485,7 +1485,6 @@
   "help.star": "Звезда на GitHub",
   "help.title": "Помощь",
   "help.whats_new": "Что нового",
-  "history.error.topic_not_found": "Топик не найден",
   "history.records.agentTitle": "История агента",
   "history.records.bulkDelete": "Пакетное удаление",
   "history.records.bulkDeleteSessions.description": "Удалить выбранное задание ({{count}})?",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -1485,7 +1485,6 @@
   "help.star": "GitHub'da yıldız ver",
   "help.title": "Yardım",
   "help.whats_new": "Yenilikler",
-  "history.error.topic_not_found": "Konuşma bulunamadı",
   "history.records.agentTitle": "Ajan Geçmişi",
   "history.records.bulkDelete": "Toplu Sil",
   "history.records.bulkDeleteSessions.description": "Seçilen {{count}} görev silinsin mi?",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -1485,7 +1485,6 @@
   "help.star": "Gắn sao trên GitHub",
   "help.title": "Trợ giúp",
   "help.whats_new": "Có gì mới",
-  "history.error.topic_not_found": "Không tìm thấy chủ đề",
   "history.records.agentTitle": "Lịch sử Agent",
   "history.records.bulkDelete": "Xóa hàng loạt",
   "history.records.bulkDeleteSessions.description": "Xóa {{count}} công việc đã chọn?",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1485,7 +1485,6 @@
   "help.star": "GitHub 点赞",
   "help.title": "帮助",
   "help.whats_new": "新功能",
-  "history.error.topic_not_found": "对话不存在",
   "history.records.agentTitle": "智能体历史记录",
   "history.records.bulkDelete": "批量删除",
   "history.records.bulkDeleteSessions.description": "将删除选中的 {{count}} 个任务。",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -1485,7 +1485,6 @@
   "help.star": "GitHub 按讚",
   "help.title": "幫助",
   "help.whats_new": "新功能",
-  "history.error.topic_not_found": "對話不存在",
   "history.records.agentTitle": "Agent 歷史",
   "history.records.bulkDelete": "批次刪除",
   "history.records.bulkDeleteSessions.description": "要刪除選中的 {{count}} 個任務嗎？",

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -21,7 +21,7 @@ import { ConversationResourceView } from '@renderer/components/resourceCatalog/c
 import { usePersistCache } from '@renderer/data/hooks/useCache'
 import { useInvalidateCache } from '@renderer/data/hooks/useDataApi'
 import { useAgents } from '@renderer/hooks/agent/useAgent'
-import { useActiveSession, useSession, useUpdateSession } from '@renderer/hooks/agent/useSession'
+import { useActiveSession, useUpdateSession } from '@renderer/hooks/agent/useSession'
 import { useAgentSessionsSource } from '@renderer/hooks/resourceViewSources'
 import { useCloseConversationTabs, useCurrentTabId } from '@renderer/hooks/tab'
 import { useClassicLayoutRightPaneOpen } from '@renderer/hooks/useClassicLayoutRightPaneOpen'
@@ -99,8 +99,7 @@ const AgentPage = () => {
   const currentTabId = useCurrentTabId()
   const routeSessionId = routeSearch.sessionId
   const routeAgentId = routeSearch.agentId
-  const isMessageOnlyView = routeSearch.view === 'message' && !!routeSessionId
-  const routeActiveSessionId = isMessageOnlyView ? null : (routeSessionId ?? null)
+  const routeActiveSessionId = routeSessionId ?? null
   // Shared full-list source for session UI plus exact latest/reusable lookups.
   const agentSessionsSource = useAgentSessionsSource()
   const { sessions: agentSessions, loadLatestSession, reuseOrCreateSession } = agentSessionsSource
@@ -113,15 +112,11 @@ const AgentPage = () => {
     toggleShellPane,
     handlePaneAutoCollapseChange
   } = useConversationShellPaneState({
-    isMessageOnlyView,
     persistedPaneOpen: showSidebar,
     setPersistedPaneOpen: setShowSidebar
   })
   const sessionListPosition: TopicTabPosition =
     !isWindowFrame && isClassicSessionLayout && panePosition === 'right' ? 'right' : 'left'
-  const { session: routeSession, isLoading: isRouteSessionLoading } = useSession(
-    isMessageOnlyView ? routeSessionId : null
-  )
   const { agents, isLoading: isAgentsLoading } = useAgents()
   const routeAgentExists = !!routeAgentId && agents.some((agent) => agent.id === routeAgentId)
   const [activeSessionId, setActiveSessionIdState] = useState<string | null>(() => routeActiveSessionId)
@@ -138,11 +133,11 @@ const AgentPage = () => {
     (id: string | null) => {
       ownerFallbackRequestIdRef.current += 1
       setActiveSessionIdState(id)
-      if (id && !isMessageOnlyView) {
+      if (id) {
         void navigate({ to: '/app/agents', search: { sessionId: id }, replace: true })
       }
     },
-    [isMessageOnlyView, navigate]
+    [navigate]
   )
   const [sessionPaneOpen, setSessionPaneOpen] = useClassicLayoutRightPaneOpen('agent', {
     enabled: isClassicSessionLayout,
@@ -201,19 +196,12 @@ const AgentPage = () => {
   const closeConversationTabs = useCloseConversationTabs()
   const { setSessionWorkspace } = useUpdateSession()
   useEffect(() => {
-    if (
-      activeSessionId ||
-      agents.length > 0 ||
-      isAgentsLoading ||
-      isFeedbackIntent ||
-      isMessageOnlyView ||
-      missingAgentSelection
-    ) {
+    if (activeSessionId || agents.length > 0 || isAgentsLoading || isFeedbackIntent || missingAgentSelection) {
       return
     }
 
     setMissingAgentSelection(true)
-  }, [activeSessionId, agents.length, isAgentsLoading, isFeedbackIntent, isMessageOnlyView, missingAgentSelection])
+  }, [activeSessionId, agents.length, isAgentsLoading, isFeedbackIntent, missingAgentSelection])
   const initialActiveSession = useMemo(
     () => (activeSessionId ? agentSessions.find((session) => session.id === activeSessionId) : undefined),
     [activeSessionId, agentSessions]
@@ -245,7 +233,7 @@ const AgentPage = () => {
   // this tab was dormant, or a rotted deep link). Recovery is a plain replace-navigation back
   // through the entry interceptor, which resolves the next target — no in-page state surgery.
   useEffect(() => {
-    if (isMessageOnlyView || isFeedbackIntent) return
+    if (isFeedbackIntent) return
     if (!routeSessionId || activeSessionId !== routeSessionId) return
     if (activeSession || isActiveSessionLoading) return
     if (!isDataApiNotFoundError(activeSessionError)) return
@@ -256,22 +244,20 @@ const AgentPage = () => {
     activeSessionId,
     isActiveSessionLoading,
     isFeedbackIntent,
-    isMessageOnlyView,
     reenterAgentRoute,
     routeSessionId
   ])
   const lastVisibleSessionRef = useRef<AgentSessionEntity | null>(null)
-  const visibleSession = isMessageOnlyView
-    ? routeSession
-    : (activeSession ??
-      (isActiveSessionLoading && lastVisibleSessionRef.current?.id === activeSessionId
-        ? lastVisibleSessionRef.current
-        : null))
+  const visibleSession =
+    activeSession ??
+    (isActiveSessionLoading && lastVisibleSessionRef.current?.id === activeSessionId
+      ? lastVisibleSessionRef.current
+      : null)
   const visibleAgentFromList = agents.find((agent) => agent.id === visibleSession?.agentId)
   const conversationBootstrap = useAgentConversationBootstrap({
     session: visibleSession ?? null,
-    sessionLoading: isMessageOnlyView ? isRouteSessionLoading : isActiveSessionLoading,
-    sessionSource: isMessageOnlyView && routeSession ? 'query' : isMessageOnlyView ? 'none' : activeSessionSource,
+    sessionLoading: isActiveSessionLoading,
+    sessionSource: activeSessionSource,
     agentHint: visibleAgentFromList
   })
   const visibleAgent = conversationBootstrap.resources.agent
@@ -292,7 +278,7 @@ const AgentPage = () => {
     if (missingAgentSelection) return 'missing-agent-selection'
     return 'empty'
   }, [missingAgentSelection, visibleSession?.id])
-  const conversationResourcesEnabled = !isMessageOnlyView && !isWindowFrame
+  const conversationResourcesEnabled = !isWindowFrame
   const {
     activeResourceKind,
     closeSurface,
@@ -323,7 +309,7 @@ const AgentPage = () => {
   }, [])
 
   const revealActiveSessionInResourceList = useEffectEvent(() => {
-    if (isMessageOnlyView || !activeSessionId) return
+    if (!activeSessionId) return
     const requestId = sessionRevealRequestIdRef.current + 1
     sessionRevealRequestIdRef.current = requestId
     setSessionRevealRequest({
@@ -347,7 +333,7 @@ const AgentPage = () => {
   // are distinguishable (every tab labels itself — not gated on active).
   // While the bound session is still loading, keep the tab's stored title/icon instead of stamping
   // a generic one.
-  const targetSessionId = isMessageOnlyView ? routeSessionId : (activeSessionId ?? undefined)
+  const targetSessionId = activeSessionId ?? undefined
   const { locateMessageId, requestLocate, clearLocate } = useConversationLocateRequest({
     activeConversationId: targetSessionId,
     visibleConversationId: visibleSession?.id
@@ -357,7 +343,6 @@ const AgentPage = () => {
   const [sessionPaneUserOpenIntentSeq, setSessionPaneUserOpenIntentSeq] = useState(0)
 
   useEffect(() => {
-    if (isMessageOnlyView) return
     if (!activeSession) return
 
     const signature = `${activeSession.id}:${activeSession.name}`
@@ -365,7 +350,7 @@ const AgentPage = () => {
 
     lastRecordedRecentSessionRef.current = signature
     recordGlobalSearchRecentEntry(createRecentSessionEntryFromSession(activeSession))
-  }, [activeSession, isMessageOnlyView])
+  }, [activeSession])
 
   useEffect(() => {
     if (activeSession) lastVisibleSessionRef.current = activeSession
@@ -923,7 +908,7 @@ const AgentPage = () => {
         revealRequest={sessionRevealRequest}
         onOpenHistoryRecords={isWindowFrame ? undefined : openHistoryRecords}
         onCreateSession={createAndActivateEmptySession}
-        onShowMissingAgentSelection={isMessageOnlyView ? undefined : showMissingAgentSelection}
+        onShowMissingAgentSelection={showMissingAgentSelection}
         onSetPanePosition={isWindowFrame ? undefined : setSessionListPosition}
         panePosition="left"
         manageAgentsActive={manageAgentsActive}
@@ -947,7 +932,7 @@ const AgentPage = () => {
               onActiveAgentDeleted={handleActiveAgentDeleted}
               revealRequest={sessionRevealRequest}
               onCreateSession={createAndActivateEmptySession}
-              onShowMissingAgentSelection={isMessageOnlyView ? undefined : showMissingAgentSelection}
+              onShowMissingAgentSelection={showMissingAgentSelection}
               onSetPanePosition={setSessionListPosition}
               panePosition="right"
               setActiveSessionId={setActiveSessionAndClearTransient}
@@ -964,7 +949,7 @@ const AgentPage = () => {
               <ConversationResourceView
                 kind={activeResourceKind}
                 toolbarLeading={
-                  !isMessageOnlyView && !isWindowFrame ? (
+                  !isWindowFrame ? (
                     <ConversationSidebarToggleButton
                       sidebarOpen={shellPaneOpen}
                       onSidebarToggle={toggleShellPane}
@@ -976,7 +961,7 @@ const AgentPage = () => {
             )
           }
         : null,
-    [activeResourceKind, isMessageOnlyView, isWindowFrame, shellPaneOpen, toggleShellPane]
+    [activeResourceKind, isWindowFrame, shellPaneOpen, toggleShellPane]
   )
   const historyRecordsCenter = historyRecordsActive
     ? {
@@ -984,12 +969,12 @@ const AgentPage = () => {
         content: (
           <HistoryRecordsView
             mode="agent"
-            open={historyRecordsActive && !isMessageOnlyView && !isWindowFrame}
+            open={historyRecordsActive && !isWindowFrame}
             activeRecordId={activeSessionId}
             onClose={closeHistoryRecords}
             onRecordSelect={handleHistoryRecordsSessionSelect}
             toolbarLeading={
-              !isMessageOnlyView && !isWindowFrame ? (
+              !isWindowFrame ? (
                 <ConversationSidebarToggleButton
                   sidebarOpen={shellPaneOpen}
                   onSidebarToggle={toggleShellPane}
@@ -1026,15 +1011,15 @@ const AgentPage = () => {
             onFileNavigationRequestChange={handleFileNavigationRequestChange}
             requestFileNavigation={requestFileNavigation}
             paneManualToggle={paneManualToggle}
-            showResourceListControls={!isMessageOnlyView}
+            showResourceListControls
             sidebarOpen={shellPaneOpen}
             onSidebarToggle={toggleShellPane}
-            missingAgentSelection={!isMessageOnlyView && missingAgentSelection && !visibleSession}
-            onCreateEmptySession={isMessageOnlyView ? undefined : createAndActivateEmptySession}
-            onMissingAgentSelectionAgentChange={isMessageOnlyView ? undefined : handleMissingAgentSelectionAgentChange}
-            onSessionWorkspaceChange={isMessageOnlyView ? undefined : replaceSessionWorkspace}
-            onVisibleAgentChange={isMessageOnlyView ? undefined : setLastUsedAgentId}
-            onVisibleWorkspaceChange={isMessageOnlyView ? undefined : setLastUsedWorkspaceId}
+            missingAgentSelection={missingAgentSelection && !visibleSession}
+            onCreateEmptySession={createAndActivateEmptySession}
+            onMissingAgentSelectionAgentChange={handleMissingAgentSelectionAgentChange}
+            onSessionWorkspaceChange={replaceSessionWorkspace}
+            onVisibleAgentChange={setLastUsedAgentId}
+            onVisibleWorkspaceChange={setLastUsedWorkspaceId}
             locateMessageId={locateMessageId}
             onLocateMessageHandled={handleLocateMessageHandled}
             selectingMissingAgent={selectingMissingAgent}

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -247,10 +247,6 @@ vi.mock('@renderer/hooks/agent/useAgent', () => ({
 
 vi.mock('@renderer/hooks/agent/useSession', () => {
   return {
-    useSession: () => ({
-      session: undefined,
-      isLoading: false
-    }),
     useUpdateSession: () => ({
       updateSession: agentPageMocks.updateSession,
       setSessionWorkspace: agentPageMocks.setSessionWorkspace

--- a/src/renderer/pages/agents/__tests__/routeSearch.test.ts
+++ b/src/renderer/pages/agents/__tests__/routeSearch.test.ts
@@ -27,6 +27,14 @@ describe('parseAgentRouteSearch', () => {
     })
   })
 
+  it('keeps the session of a tab restored with the legacy message-only view param', () => {
+    expect(parseAgentRouteSearch({ sessionId: 'session-1', view: 'message' })).toEqual({
+      agentId: undefined,
+      intent: undefined,
+      sessionId: 'session-1'
+    })
+  })
+
   it('drops non-string agentId values', () => {
     expect(parseAgentRouteSearch({ agentId: 7 })).toEqual({
       agentId: undefined,

--- a/src/renderer/pages/agents/__tests__/routeSearch.test.ts
+++ b/src/renderer/pages/agents/__tests__/routeSearch.test.ts
@@ -4,11 +4,10 @@ import { parseAgentRouteSearch } from '../routeSearch'
 
 describe('parseAgentRouteSearch', () => {
   it('accepts the feedback intent alongside existing search fields', () => {
-    expect(parseAgentRouteSearch({ intent: 'feedback', sessionId: 'session-1', view: 'message' })).toEqual({
+    expect(parseAgentRouteSearch({ intent: 'feedback', sessionId: 'session-1' })).toEqual({
       agentId: undefined,
       intent: 'feedback',
-      sessionId: 'session-1',
-      view: 'message'
+      sessionId: 'session-1'
     })
   })
 
@@ -16,8 +15,7 @@ describe('parseAgentRouteSearch', () => {
     expect(parseAgentRouteSearch({ agentId: 'agent-1' })).toEqual({
       agentId: 'agent-1',
       intent: undefined,
-      sessionId: undefined,
-      view: undefined
+      sessionId: undefined
     })
   })
 
@@ -25,8 +23,7 @@ describe('parseAgentRouteSearch', () => {
     expect(parseAgentRouteSearch({ agentId: 'agent-1', sessionId: 'session-1' })).toEqual({
       agentId: 'agent-1',
       intent: undefined,
-      sessionId: 'session-1',
-      view: undefined
+      sessionId: 'session-1'
     })
   })
 
@@ -34,8 +31,7 @@ describe('parseAgentRouteSearch', () => {
     expect(parseAgentRouteSearch({ agentId: 7 })).toEqual({
       agentId: undefined,
       intent: undefined,
-      sessionId: undefined,
-      view: undefined
+      sessionId: undefined
     })
   })
 
@@ -43,8 +39,7 @@ describe('parseAgentRouteSearch', () => {
     expect(parseAgentRouteSearch({ intent: 'other' })).toEqual({
       agentId: undefined,
       intent: undefined,
-      sessionId: undefined,
-      view: undefined
+      sessionId: undefined
     })
   })
 })

--- a/src/renderer/pages/agents/routeSearch.ts
+++ b/src/renderer/pages/agents/routeSearch.ts
@@ -1,17 +1,13 @@
-export const MESSAGE_VIEW = 'message' as const
-
 export type AgentRouteSearch = {
   agentId?: string
   intent?: 'feedback'
   sessionId?: string
-  view?: typeof MESSAGE_VIEW
 }
 
 export function parseAgentRouteSearch(search: Record<string, unknown>): AgentRouteSearch {
   const agentId = typeof search.agentId === 'string' ? search.agentId : undefined
   const intent = search.intent === 'feedback' ? 'feedback' : undefined
   const sessionId = typeof search.sessionId === 'string' ? search.sessionId : undefined
-  const view = search.view === MESSAGE_VIEW ? MESSAGE_VIEW : undefined
 
-  return { agentId, intent, sessionId, view }
+  return { agentId, intent, sessionId }
 }

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -2,10 +2,8 @@ import { cacheService } from '@data/CacheService'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import type { ResourcePaneConfig, ResourcePaneCountButtonProps } from '@renderer/components/chat/panes/Shell'
-import { EmptyState, LoadingState } from '@renderer/components/chat/primitives'
 import { AssistantResourceList } from '@renderer/components/chat/resourceList/AssistantResourceList'
 import type { ResourceListRevealRequest } from '@renderer/components/chat/resourceList/base'
-import { ChatAppShell } from '@renderer/components/chat/shell/ChatAppShell'
 import { ConversationSidebarToggleButton } from '@renderer/components/chat/shell/ConversationSidebarToggleButton'
 import type { ChatPanePosition } from '@renderer/components/chat/shell/paneLayout'
 import {
@@ -31,7 +29,7 @@ import { useConversationCenterSurface } from '@renderer/hooks/useConversationCen
 import { useConversationLocateRequest } from '@renderer/hooks/useConversationLocateRequest'
 import { useConversationShellPaneState } from '@renderer/hooks/useConversationShellPaneState'
 import { useModelById } from '@renderer/hooks/useModel'
-import { mapApiTopicToRendererTopic, useActiveTopic, useTopicById, useTopicMutations } from '@renderer/hooks/useTopic'
+import { mapApiTopicToRendererTopic, useActiveTopic, useTopicMutations } from '@renderer/hooks/useTopic'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { ResourceListRevealPayload } from '@renderer/services/resourceListRevealEvents'
 import { toast } from '@renderer/services/toast'
@@ -92,7 +90,6 @@ const HomePage: FC = () => {
   const navigate = useNavigate()
   const routeTopicId = routeSearch.topicId
   const routeAssistantId = routeSearch.assistantId
-  const isMessageOnlyView = routeSearch.view === 'message' && !!routeTopicId
   const handleManualPaneOpen = useCallback(() => {
     requestAnimationFrame(() => {
       void EventEmitter.emit(EVENT_NAMES.SHOW_ASSISTANTS)
@@ -107,7 +104,6 @@ const HomePage: FC = () => {
     toggleShellPane,
     handlePaneAutoCollapseChange
   } = useConversationShellPaneState({
-    isMessageOnlyView,
     persistedPaneOpen: showSidebar,
     setPersistedPaneOpen: setShowSidebar,
     onManualPaneOpen: handleManualPaneOpen
@@ -121,13 +117,6 @@ const HomePage: FC = () => {
   // Shared full-topics list source plus exact latest/reusable lookups.
   const assistantTopicsSource = useAssistantTopicsSource()
   const { topics: allTopics, loadLatestTopic, reuseOrCreateTopic } = assistantTopicsSource
-  const { topic: routeApiTopic, isLoading: isRouteTopicLoading } = useTopicById(
-    isMessageOnlyView ? routeTopicId : undefined
-  )
-  const routeTopic = useMemo(
-    () => (routeApiTopic ? mapApiTopicToRendererTopic(routeApiTopic) : undefined),
-    [routeApiTopic]
-  )
 
   const { createTopic, refreshTopics } = useTopicMutations()
   const {
@@ -173,7 +162,7 @@ const HomePage: FC = () => {
     [assistantIdSet, assistants, routeAssistantId, validLastUsedAssistantId]
   )
 
-  const routeActiveTopicId = isMessageOnlyView ? null : (routeTopicId ?? null)
+  const routeActiveTopicId = routeTopicId ?? null
   const [activeTopicId, setActiveTopicIdState] = useState<string | null>(() => routeActiveTopicId)
   // Page-initiated selection writes the tab URL — the conversation's sole identity channel —
   // and mirrors into state immediately so the UI doesn't wait a router round trip. Route-driven
@@ -183,11 +172,11 @@ const HomePage: FC = () => {
     (id: string | null) => {
       ownerFallbackRequestIdRef.current += 1
       setActiveTopicIdState(id)
-      if (id && !isMessageOnlyView) {
+      if (id) {
         void navigate({ to: '/app/chat', search: { topicId: id }, replace: true })
       }
     },
-    [isMessageOnlyView, navigate]
+    [navigate]
   )
 
   useLayoutEffect(() => {
@@ -207,10 +196,7 @@ const HomePage: FC = () => {
     topicSource: activeTopicSource
   } = useActiveTopic({
     activeTopicId,
-    setActiveTopicId,
-    // Message-only view loads its target via useTopicById; the active hook
-    // must not emit or expose a visible activeTopic.
-    passive: isMessageOnlyView
+    setActiveTopicId
   })
   const reenterChatRoute = useCallback(() => {
     clearActiveTopic()
@@ -220,33 +206,23 @@ const HomePage: FC = () => {
   // this tab was dormant, or a rotted deep link). Recovery is a plain replace-navigation back
   // through the entry interceptor, which resolves the next target — no in-page state surgery.
   useEffect(() => {
-    if (isMessageOnlyView) return
     if (!routeTopicId || activeTopicId !== routeTopicId) return
     if (activeTopic || isActiveTopicLoading) return
     if (!isDataApiNotFoundError(activeTopicError)) return
     reenterChatRoute()
-  }, [
-    activeTopic,
-    activeTopicError,
-    activeTopicId,
-    isActiveTopicLoading,
-    isMessageOnlyView,
-    reenterChatRoute,
-    routeTopicId
-  ])
+  }, [activeTopic, activeTopicError, activeTopicId, isActiveTopicLoading, reenterChatRoute, routeTopicId])
   const lastVisibleTopicRef = useRef<Topic | undefined>(undefined)
-  const visibleTopic = isMessageOnlyView
-    ? routeTopic
-    : (activeTopic ??
-      (isActiveTopicLoading && lastVisibleTopicRef.current?.id === activeTopicId
-        ? lastVisibleTopicRef.current
-        : undefined))
+  const visibleTopic =
+    activeTopic ??
+    (isActiveTopicLoading && lastVisibleTopicRef.current?.id === activeTopicId
+      ? lastVisibleTopicRef.current
+      : undefined)
   const requestComposerFocus = useComposerFocusRequest(visibleTopic?.id)
   const resourceConversationKey = useMemo(() => {
     if (visibleTopic?.id) return `topic:${visibleTopic.id}`
     return 'empty'
   }, [visibleTopic?.id])
-  const conversationResourcesEnabled = !isMessageOnlyView && !isWindowFrame
+  const conversationResourcesEnabled = !isWindowFrame
   const {
     activeResourceKind,
     closeSurface,
@@ -292,7 +268,7 @@ const HomePage: FC = () => {
   }, [])
 
   const revealActiveTopicInResourceList = useEffectEvent(() => {
-    if (isMessageOnlyView || !visibleTopic?.id) return
+    if (!visibleTopic?.id) return
     const requestId = topicRevealRequestIdRef.current + 1
     topicRevealRequestIdRef.current = requestId
     setTopicRevealRequest({
@@ -329,7 +305,7 @@ const HomePage: FC = () => {
   }, [allTopics, isClassicTopicLayout, topicListPosition, t, visibleAssistantId])
   // While the bound topic is still loading, keep the tab's stored title/icon instead of stamping
   // a generic one.
-  const targetTopicId = isMessageOnlyView ? routeTopicId : (activeTopicId ?? undefined)
+  const targetTopicId = activeTopicId ?? undefined
   const { locateMessageId, requestLocate, clearLocate } = useConversationLocateRequest({
     activeConversationId: targetTopicId,
     visibleConversationId: visibleTopic?.id
@@ -342,14 +318,13 @@ const HomePage: FC = () => {
   }, [activeTopic])
 
   useEffect(() => {
-    if (isMessageOnlyView) return
     if (!activeTopic) return
     const signature = `${activeTopic.id}:${activeTopic.name}`
     if (lastRecordedRecentTopicRef.current === signature) return
 
     lastRecordedRecentTopicRef.current = signature
     recordGlobalSearchRecentEntry(createRecentTopicEntryFromTopic(activeTopic))
-  }, [activeTopic, isMessageOnlyView])
+  }, [activeTopic])
 
   const [topicPaneUserOpenIntentSeq, setTopicPaneUserOpenIntentSeq] = useState(0)
   useCommandHandler('app.sidebar.toggle', toggleShellPane)
@@ -588,7 +563,7 @@ const HomePage: FC = () => {
                 kind={activeResourceKind}
                 onOpenAssistantChat={handleOpenAssistantChatFromLibrary}
                 toolbarLeading={
-                  !isMessageOnlyView && !isWindowFrame ? (
+                  !isWindowFrame ? (
                     <ConversationSidebarToggleButton
                       sidebarOpen={shellPaneOpen}
                       onSidebarToggle={toggleShellPane}
@@ -600,14 +575,7 @@ const HomePage: FC = () => {
             )
           }
         : null,
-    [
-      activeResourceKind,
-      shellPaneOpen,
-      handleOpenAssistantChatFromLibrary,
-      isMessageOnlyView,
-      isWindowFrame,
-      toggleShellPane
-    ]
+    [activeResourceKind, shellPaneOpen, handleOpenAssistantChatFromLibrary, isWindowFrame, toggleShellPane]
   )
   const historyRecordsCenter = historyRecordsActive
     ? {
@@ -615,12 +583,12 @@ const HomePage: FC = () => {
         content: (
           <HistoryRecordsView
             mode="assistant"
-            open={historyRecordsActive && !isMessageOnlyView && !isWindowFrame}
+            open={historyRecordsActive && !isWindowFrame}
             activeRecordId={activeTopicId}
             onClose={closeHistoryRecords}
             onRecordSelect={handleHistoryRecordsTopicSelect}
             toolbarLeading={
-              !isMessageOnlyView && !isWindowFrame ? (
+              !isWindowFrame ? (
                 <ConversationSidebarToggleButton
                   sidebarOpen={shellPaneOpen}
                   onSidebarToggle={toggleShellPane}
@@ -650,32 +618,6 @@ const HomePage: FC = () => {
     },
     [allTopics, setPanePosition, setShellPaneOpen, setTopicDisplayMode, setTopicPaneOpen, visibleTopic]
   )
-  // Message-only (detached) view has no rail: resolve its single target topic and show its own
-  // loading / not-found status. The normal view falls through to the loading shell below (which keeps
-  // the rail visible) instead of returning a blank frame.
-  if (isMessageOnlyView && !visibleTopic && !resourceCenter) {
-    return (
-      <>
-        <HomeTabRuntime
-          title={tabTitle}
-          emoji={visibleAssistant?.emoji}
-          preserveVisuals={preserveTabVisuals}
-          activeTopicId={activeTopic?.id}
-          activeTopicSource={activeTopicSource}
-        />
-        <Container id="home-page">
-          <ContentContainer>
-            <MessageOnlyStatus
-              loading={isRouteTopicLoading}
-              loadingLabel={t('common.loading')}
-              missingTitle={t('history.error.topic_not_found')}
-            />
-          </ContentContainer>
-        </Container>
-      </>
-    )
-  }
-
   // Classic layout = entity rail + right topic panel; modern layout = one left navigation panel (HomeTabs).
   const pane =
     isClassicTopicLayout && topicListPosition === 'right' ? (
@@ -711,7 +653,7 @@ const HomePage: FC = () => {
         }}
         clearActiveTopic={clearActiveTopicAndCloseResourceView}
         setActiveTopic={setActiveTopicAndCloseResourceView}
-        onNewTopic={isMessageOnlyView ? undefined : handleCreateEmptyTopic}
+        onNewTopic={handleCreateEmptyTopic}
         historyRecordsActive={historyRecordsActive}
         onOpenHistoryRecords={isWindowFrame ? undefined : openHistoryRecords}
         revealRequest={topicRevealRequest}
@@ -737,7 +679,7 @@ const HomePage: FC = () => {
               assistantIdFilter={visibleAssistantId ?? null}
               clearActiveTopic={clearActiveTopicAndCloseResourceView}
               setActiveTopic={setActiveTopicAndCloseResourceView}
-              onNewTopic={isMessageOnlyView ? undefined : handleCreateEmptyTopic}
+              onNewTopic={handleCreateEmptyTopic}
               onSetPanePosition={setTopicListPosition}
               panePosition="right"
               revealRequest={topicRevealRequest}
@@ -782,7 +724,7 @@ const HomePage: FC = () => {
         <ContentContainer $detached={isWindowFrame}>
           <Chat
             activeTopic={visibleTopic}
-            topicPending={isActiveTopicLoading || isRouteTopicLoading}
+            topicPending={isActiveTopicLoading}
             centerSurface={centerSurface}
             pane={pane}
             paneOpen={shellPaneOpen}
@@ -790,9 +732,9 @@ const HomePage: FC = () => {
             onPaneCollapse={() => setShellPaneOpenManually(false)}
             onPaneAutoCollapseChange={handlePaneAutoCollapseChange}
             paneManualToggle={paneManualToggle}
-            onNewTopic={isMessageOnlyView ? undefined : handleCreateEmptyTopic}
-            onCreateEmptyTopic={isMessageOnlyView ? undefined : handleCreateEmptyTopic}
-            showResourceListControls={!isMessageOnlyView}
+            onNewTopic={handleCreateEmptyTopic}
+            onCreateEmptyTopic={handleCreateEmptyTopic}
+            showResourceListControls
             sidebarOpen={shellPaneOpen}
             onSidebarToggle={toggleShellPane}
             locateMessageId={locateMessageId}
@@ -803,26 +745,6 @@ const HomePage: FC = () => {
         {assistantPickerDialog}
       </Container>
     </TopicRightPane.Scope>
-  )
-}
-
-type MessageOnlyStatusProps = {
-  loading: boolean
-  loadingLabel: string
-  missingTitle: string
-}
-
-function MessageOnlyStatus({ loading, loadingLabel, missingTitle }: MessageOnlyStatusProps) {
-  return (
-    <div className="flex h-[calc(100vh_-_var(--navbar-height)_-_6px)] flex-1 overflow-hidden rounded-tl-[10px] rounded-bl-[10px] bg-background">
-      <ChatAppShell
-        centerContent={
-          <div className="flex h-full min-h-0 flex-1 items-center justify-center px-6">
-            {loading ? <LoadingState label={loadingLabel} /> : <EmptyState compact title={missingTitle} />}
-          </div>
-        }
-      />
-    </div>
   )
 }
 

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -1,5 +1,4 @@
 import { cacheService } from '@data/CacheService'
-import type * as ChatPrimitives from '@renderer/components/chat/primitives'
 import { WindowFrameProvider } from '@renderer/components/chat/shell/WindowFrameContext'
 import { useCommandHandler } from '@renderer/hooks/command'
 import { DefaultPreferences } from '@shared/data/preference/preferenceSchemas'
@@ -50,7 +49,6 @@ const createdTopic: Topic = {
 const homeMocks = vi.hoisted(() => ({
   activeTopicOptions: undefined as
     | {
-        passive?: boolean
         activeTopicId?: string | null
         setActiveTopicId?: (id: string | null) => void
       }
@@ -98,8 +96,6 @@ const homeMocks = vi.hoisted(() => ({
   reuseOrCreateTopic: vi.fn(),
   navigate: vi.fn(),
   routeSearch: {} as Record<string, unknown>,
-  routeTopic: undefined as Topic | undefined,
-  routeTopicLoading: false,
   // Topics resolvable by id through `useTopicById` (resume-by-last-used reads it); an id
   // missing from the map behaves like a deleted topic.
   topicsById: new Map<string, Topic>(),
@@ -162,18 +158,6 @@ vi.mock('@renderer/data/hooks/useCache', async () => {
     }
   }
 })
-
-vi.mock('@renderer/components/chat/shell/ChatAppShell', () => ({
-  ChatAppShell: ({ centerContent }: { centerContent?: ReactNode }) => (
-    <div data-testid="message-only-shell">{centerContent}</div>
-  )
-}))
-
-vi.mock('@renderer/components/chat/primitives', async (importActual) => ({
-  ...(await importActual<typeof ChatPrimitives>()),
-  EmptyState: ({ title }: { title?: string }) => <div data-testid="empty-state">{title}</div>,
-  LoadingState: ({ label }: { label?: string }) => <div role="status">{label}</div>
-}))
 
 vi.mock('@renderer/components/resourceCatalog/catalog', () => ({
   ResourceCatalogView: ({
@@ -271,11 +255,7 @@ vi.mock('@renderer/hooks/useTopic', async () => {
       createTopic: homeMocks.createTopic,
       refreshTopics: homeMocks.refreshTopics
     }),
-    useActiveTopic: (options: {
-      activeTopicId: string | null
-      setActiveTopicId: (id: string | null) => void
-      passive?: boolean
-    }) => {
+    useActiveTopic: (options: { activeTopicId: string | null; setActiveTopicId: (id: string | null) => void }) => {
       const [activeTopic, setActiveTopic] = React.useState<Topic | undefined>(homeMocks.entryTopic)
       const commitActiveTopicId = options.setActiveTopicId
       const setActiveTopicId = React.useCallback(
@@ -288,17 +268,15 @@ vi.mock('@renderer/hooks/useTopic', async () => {
         },
         [commitActiveTopicId]
       )
-      const passive = options.passive
       const setActiveTopicValue = React.useCallback(
         (topic: Topic) => {
           homeMocks.activeTopicOverride = topic
           setActiveTopic(topic)
-          if (!passive) commitActiveTopicId(topic.id)
+          commitActiveTopicId(topic.id)
         },
-        [commitActiveTopicId, passive]
+        [commitActiveTopicId]
       )
       homeMocks.activeTopicOptions = {
-        passive: options.passive,
         activeTopicId: options.activeTopicId,
         setActiveTopicId
       }
@@ -317,8 +295,8 @@ vi.mock('@renderer/hooks/useTopic', async () => {
       }
     },
     useTopicById: (topicId?: string) => ({
-      topic: topicId ? (homeMocks.topicsById.get(topicId) ?? homeMocks.routeTopic) : undefined,
-      isLoading: homeMocks.routeTopicLoading,
+      topic: topicId ? homeMocks.topicsById.get(topicId) : undefined,
+      isLoading: false,
       error: undefined
     })
   }
@@ -336,8 +314,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
       ({
         'chat.home.welcome_title': 'Welcome',
         'chat.topics.title': '对话',
-        'common.loading': 'Loading...',
-        'history.error.topic_not_found': 'Conversation not found'
+        'common.loading': 'Loading...'
       })[key] ?? key
   })
 }))
@@ -722,8 +699,6 @@ describe('HomePage', () => {
     homeMocks.assistantsLoading = false
     homeMocks.assistantsRefreshing = false
     homeMocks.routeSearch = {}
-    homeMocks.routeTopic = undefined
-    homeMocks.routeTopicLoading = false
     homeMocks.topicsById.clear()
     // HomePage writes its write-only persist keys (topic expansion, global-search
     // recents) straight through cacheService, bypassing the hook mock below.
@@ -1892,55 +1867,6 @@ describe('HomePage', () => {
     expect(homeMocks.createTopic).not.toHaveBeenCalled()
   })
 
-  it('renders a message-only route topic without updating global chat state', () => {
-    homeMocks.entryTopic = undefined
-    homeMocks.preferenceValues.set('topic.tab.show', true)
-    homeMocks.routeSearch = { topicId: 'topic-message', view: 'message' }
-    homeMocks.routeTopic = {
-      ...initialTopic,
-      id: 'topic-message',
-      name: 'Message topic'
-    }
-
-    render(<HomePage />)
-
-    expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-message')
-    expect(screen.getByTestId('pane-open')).toHaveTextContent('false')
-    expect(screen.getByTestId('show-resource-list-controls')).toHaveTextContent('false')
-    expect(screen.queryByRole('button', { name: 'New topic' })).not.toBeInTheDocument()
-    expect(homeMocks.activeTopicOptions).toMatchObject({
-      passive: true,
-      activeTopicId: null
-    })
-    expect(homeMocks.setShowSidebar).not.toHaveBeenCalled()
-    expect(homeMocks.cacheSetPersist).not.toHaveBeenCalled()
-  })
-
-  it('shows a loading state for a message-only route topic while it is loading', () => {
-    homeMocks.entryTopic = undefined
-    homeMocks.routeSearch = { topicId: 'topic-message', view: 'message' }
-    homeMocks.routeTopicLoading = true
-
-    render(<HomePage />)
-
-    expect(screen.getByTestId('message-only-shell')).toBeInTheDocument()
-    expect(screen.getByRole('status')).toHaveTextContent('Loading...')
-    expect(screen.queryByTestId('active-topic')).not.toBeInTheDocument()
-    expect(homeMocks.setShowSidebar).not.toHaveBeenCalled()
-  })
-
-  it('shows a not-found state for a missing message-only route topic', () => {
-    homeMocks.entryTopic = undefined
-    homeMocks.routeSearch = { topicId: 'topic-message', view: 'message' }
-
-    render(<HomePage />)
-
-    expect(screen.getByTestId('message-only-shell')).toBeInTheDocument()
-    expect(screen.getByTestId('empty-state')).toHaveTextContent('Conversation not found')
-    expect(screen.queryByTestId('active-topic')).not.toBeInTheDocument()
-    expect(homeMocks.setShowSidebar).not.toHaveBeenCalled()
-  })
-
   it('creates a new topic from the selected assistant payload', async () => {
     homeMocks.assistants = [{ id: 'assistant-default' }, { id: 'assistant-2' }]
     homeMocks.createTopic.mockResolvedValue({ ...createdTopic, assistantId: 'assistant-2' })
@@ -2039,7 +1965,6 @@ describe('HomePage', () => {
     })
 
     expect(homeMocks.activeTopicOptions?.activeTopicId).toBe('topic-from-url')
-    expect(homeMocks.activeTopicOptions?.passive).toBe(false)
   })
 
   it('does not expose the previous topic while the new route topic is loading', async () => {

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -96,9 +96,6 @@ const homeMocks = vi.hoisted(() => ({
   reuseOrCreateTopic: vi.fn(),
   navigate: vi.fn(),
   routeSearch: {} as Record<string, unknown>,
-  // Topics resolvable by id through `useTopicById` (resume-by-last-used reads it); an id
-  // missing from the map behaves like a deleted topic.
-  topicsById: new Map<string, Topic>(),
   setShowSidebar: vi.fn(),
   topicPanelTopicsSource: undefined as unknown,
   isActiveTab: false
@@ -293,12 +290,7 @@ vi.mock('@renderer/hooks/useTopic', async () => {
         error: homeMocks.activeTopicError,
         topicSource: homeMocks.activeTopicSource
       }
-    },
-    useTopicById: (topicId?: string) => ({
-      topic: topicId ? homeMocks.topicsById.get(topicId) : undefined,
-      isLoading: false,
-      error: undefined
-    })
+    }
   }
 })
 
@@ -699,7 +691,6 @@ describe('HomePage', () => {
     homeMocks.assistantsLoading = false
     homeMocks.assistantsRefreshing = false
     homeMocks.routeSearch = {}
-    homeMocks.topicsById.clear()
     // HomePage writes its write-only persist keys (topic expansion, global-search
     // recents) straight through cacheService, bypassing the hook mock below.
     MockCacheUtils.resetMocks()

--- a/src/renderer/pages/home/__tests__/routeSearch.test.ts
+++ b/src/renderer/pages/home/__tests__/routeSearch.test.ts
@@ -6,32 +6,21 @@ describe('parseChatRouteSearch', () => {
   it('parses the sidebar assistantId for pinned entity entries', () => {
     expect(parseChatRouteSearch({ assistantId: 'assistant-1' })).toEqual({
       assistantId: 'assistant-1',
-      topicId: undefined,
-      view: undefined
+      topicId: undefined
     })
   })
 
   it('keeps assistantId alongside an explicit topic', () => {
     expect(parseChatRouteSearch({ assistantId: 'assistant-1', topicId: 'topic-1' })).toEqual({
       assistantId: 'assistant-1',
-      topicId: 'topic-1',
-      view: undefined
+      topicId: 'topic-1'
     })
   })
 
-  it('parses topic and message view', () => {
-    expect(parseChatRouteSearch({ topicId: 'topic-1', view: 'message' })).toEqual({
+  it('drops non-string assistantId values', () => {
+    expect(parseChatRouteSearch({ assistantId: 7 })).toEqual({
       assistantId: undefined,
-      topicId: 'topic-1',
-      view: 'message'
-    })
-  })
-
-  it('drops non-string assistantId values and unknown views', () => {
-    expect(parseChatRouteSearch({ assistantId: 7, view: 'other' })).toEqual({
-      assistantId: undefined,
-      topicId: undefined,
-      view: undefined
+      topicId: undefined
     })
   })
 })

--- a/src/renderer/pages/home/__tests__/routeSearch.test.ts
+++ b/src/renderer/pages/home/__tests__/routeSearch.test.ts
@@ -17,6 +17,13 @@ describe('parseChatRouteSearch', () => {
     })
   })
 
+  it('keeps the topic of a tab restored with the legacy message-only view param', () => {
+    expect(parseChatRouteSearch({ topicId: 'topic-1', view: 'message' })).toEqual({
+      assistantId: undefined,
+      topicId: 'topic-1'
+    })
+  })
+
   it('drops non-string assistantId values', () => {
     expect(parseChatRouteSearch({ assistantId: 7 })).toEqual({
       assistantId: undefined,

--- a/src/renderer/pages/home/routeSearch.ts
+++ b/src/renderer/pages/home/routeSearch.ts
@@ -1,15 +1,11 @@
-export const MESSAGE_VIEW = 'message' as const
-
 export type ChatRouteSearch = {
   assistantId?: string
   topicId?: string
-  view?: typeof MESSAGE_VIEW
 }
 
 export function parseChatRouteSearch(search: Record<string, unknown>): ChatRouteSearch {
   const assistantId = typeof search.assistantId === 'string' ? search.assistantId : undefined
   const topicId = typeof search.topicId === 'string' ? search.topicId : undefined
-  const view = search.view === MESSAGE_VIEW ? MESSAGE_VIEW : undefined
 
-  return { assistantId, topicId, view }
+  return { assistantId, topicId }
 }

--- a/src/renderer/routes/app/__tests__/conversation-entry.test.ts
+++ b/src/renderer/routes/app/__tests__/conversation-entry.test.ts
@@ -30,26 +30,30 @@ beforeEach(() => {
 })
 
 describe('conversation entry route guards', () => {
-  it('treats chat view=message without a topic id as a bare entry', async () => {
-    await chatBeforeLoad({ search: { view: 'message' } })
+  it('resolves the entry target for a bare chat entry', async () => {
+    mocks.resolveChatEntryTopicId.mockResolvedValue('topic-last')
 
-    expect(mocks.resolveChatEntryTopicId).toHaveBeenCalledTimes(1)
+    await expect(chatBeforeLoad({ search: {} })).rejects.toMatchObject({
+      options: { to: '/app/chat', search: { topicId: 'topic-last' }, replace: true }
+    })
   })
 
-  it('does not resolve an explicit message-only chat target', async () => {
-    await chatBeforeLoad({ search: { topicId: 'topic-a', view: 'message' } })
+  it('does not resolve a chat entry that already carries a topic id', async () => {
+    await chatBeforeLoad({ search: { topicId: 'topic-a' } })
 
     expect(mocks.resolveChatEntryTopicId).not.toHaveBeenCalled()
   })
 
-  it('treats agent view=message without a session id as a bare entry', async () => {
-    await agentBeforeLoad({ search: { view: 'message' } })
+  it('resolves the entry target for a bare agent entry', async () => {
+    mocks.resolveAgentEntrySessionId.mockResolvedValue('session-last')
 
-    expect(mocks.resolveAgentEntrySessionId).toHaveBeenCalledTimes(1)
+    await expect(agentBeforeLoad({ search: {} })).rejects.toMatchObject({
+      options: { to: '/app/agents', search: { sessionId: 'session-last' }, replace: true }
+    })
   })
 
-  it('does not resolve an explicit message-only agent target', async () => {
-    await agentBeforeLoad({ search: { sessionId: 'session-a', view: 'message' } })
+  it('does not resolve an agent entry that already carries a session id', async () => {
+    await agentBeforeLoad({ search: { sessionId: 'session-a' } })
 
     expect(mocks.resolveAgentEntrySessionId).not.toHaveBeenCalled()
   })

--- a/src/renderer/utils/__tests__/routeTitle.test.ts
+++ b/src/renderer/utils/__tests__/routeTitle.test.ts
@@ -147,7 +147,7 @@ describe('routeTitle', () => {
       expect(isTopLevelRoute('/app/chat')).toBe(true)
       expect(isTopLevelRoute('/app/agents')).toBe(true)
       expect(isTopLevelRoute('/app/release-notes')).toBe(true)
-      expect(isTopLevelRoute('/app/chat?topicId=123&view=message')).toBe(false)
+      expect(isTopLevelRoute('/app/chat?topicId=123')).toBe(false)
       expect(isTopLevelRoute('/app/agents#session')).toBe(false)
       expect(isTopLevelRoute('/app/chat/topic-123')).toBe(false)
     })

--- a/src/renderer/utils/__tests__/sidebar.test.ts
+++ b/src/renderer/utils/__tests__/sidebar.test.ts
@@ -9,7 +9,6 @@ import {
   getSidebarFavoriteItems,
   getSidebarMenuPath,
   getSidebarMiniAppFavoriteIds,
-  isMessageOnlyConversationUrl,
   removeSidebarEntityFavorite,
   removeSidebarMiniApp,
   reorderLaunchpadApps,
@@ -166,15 +165,6 @@ describe('sidebar config helpers', () => {
   it('does not mark the launchpad sidebar item active for concrete mini app routes', () => {
     expect(resolveSidebarActiveItem('/app/mini-app')).toBe('mini_app')
     expect(resolveSidebarActiveItem('/app/mini-app/qwen')).toBe('')
-  })
-
-  it('classifies a message-view URL as message-only only when it carries its conversation id', () => {
-    expect(isMessageOnlyConversationUrl('/app/chat?topicId=topic&view=message')).toBe(true)
-    expect(isMessageOnlyConversationUrl('/app/agents?sessionId=session&view=message')).toBe(true)
-    // Malformed: `view=message` without an id is a bare entry, not a message-only popup.
-    expect(isMessageOnlyConversationUrl('/app/chat?view=message')).toBe(false)
-    expect(isMessageOnlyConversationUrl('/app/agents?view=message')).toBe(false)
-    expect(isMessageOnlyConversationUrl('/app/chat?topicId=topic')).toBe(false)
   })
 })
 

--- a/src/renderer/utils/sidebar.ts
+++ b/src/renderer/utils/sidebar.ts
@@ -33,26 +33,11 @@ interface SidebarAppDefinition<Id extends SidebarFavorite = SidebarFavorite> {
   conversationRoute?: SidebarConversationRoute
 }
 
-function getNormalConversationSearchParamFromUrl(url: string, name: string): string | undefined {
+function getConversationSearchParamFromUrl(url: string, name: string): string | undefined {
   try {
-    const params = new URL(url, 'app://x').searchParams
-    if (params.get('view') === 'message') return undefined
-    return params.get(name) ?? undefined
+    return new URL(url, 'app://x').searchParams.get(name) ?? undefined
   } catch {
     return undefined
-  }
-}
-
-export function isMessageOnlyConversationUrl(url: string): boolean {
-  try {
-    const parsedUrl = new URL(url, 'app://x')
-    if (parsedUrl.searchParams.get('view') !== 'message') return false
-
-    if (parsedUrl.pathname === '/app/chat') return Boolean(parsedUrl.searchParams.get('topicId'))
-    if (parsedUrl.pathname === '/app/agents') return Boolean(parsedUrl.searchParams.get('sessionId'))
-    return false
-  } catch {
-    return false
   }
 }
 
@@ -65,7 +50,7 @@ const SIDEBAR_APP_DEFINITIONS = [
     id: 'agents',
     routePrefix: '/app/agents',
     conversationRoute: {
-      keyFromUrl: (url) => getNormalConversationSearchParamFromUrl(url, CONVERSATION_ROUTES.agent.keyParam),
+      keyFromUrl: (url) => getConversationSearchParamFromUrl(url, CONVERSATION_ROUTES.agent.keyParam),
       urlForKey: (key) => conversationRouteUrl({ conversationType: 'agent', conversationId: key })
     }
   },
@@ -75,7 +60,7 @@ const SIDEBAR_APP_DEFINITIONS = [
     // with ts-morph. `conversationRoute` below carries the same path from the shared contract.
     routePrefix: '/app/chat',
     conversationRoute: {
-      keyFromUrl: (url) => getNormalConversationSearchParamFromUrl(url, CONVERSATION_ROUTES.assistant.keyParam),
+      keyFromUrl: (url) => getConversationSearchParamFromUrl(url, CONVERSATION_ROUTES.assistant.keyParam),
       urlForKey: (key) => conversationRouteUrl({ conversationType: 'assistant', conversationId: key })
     }
   },


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: `?view=message` selected a focused, message-only conversation view — same route, same conversation, but the page pinned onto one message instead of following the conversation's active node, and hid the resource-list / shell-pane controls. Nothing under `src/` produced that URL any more, so the mode and all 75 references guarding against it were unreachable while still branching on every navigation.

After this PR: the mode and every consumer are gone. 32 files changed, +112 / −431.

- `view` / `MESSAGE_VIEW` removed from `pages/home/routeSearch.ts` and `pages/agents/routeSearch.ts`
- `isMessageOnlyView` and every branch on it removed from `HomePage` (−128 lines) and `AgentPage` (−77 lines), keeping the path taken today; this also removes the route-topic / route-session queries and the `MessageOnlyStatus` view that existed only for the mode
- `isMessageOnlyView` removed from `useConversationShellPaneState`
- `isMessageOnlyConversationUrl` removed, along with the `view === 'message'` guard in the sidebar key extractor (renamed `getNormalConversationSearchParamFromUrl` → `getConversationSearchParamFromUrl`, since "normal" no longer contrasts with anything) and their consumers in `Sidebar.tsx` and `ResourceViewSourceProvider.tsx`
- Orphaned by the deletion and removed with it: the `useActiveTopic` `passive` option (documented as message-only's; `HomePage` was its only caller) and the `history.error.topic_not_found` i18n key across all 13 locales (sole consumer was the removed status view)
- Tests covering the removed mode deleted rather than adapted

Fixes #20101

### Why we need it and why it was done in this way

No producer exists. The last one was `openTopicInNewTab`, switched to `buildChatTopicRouteUrl` in fc1ec36ca1 — because opening a topic in a new tab should keep its sidebar controls rather than enter the focused view. The use case it served is now served differently: global search's jump-to-message sets the topic's active node, opens a **normal** conversation tab, and emits a reveal event.

The cost of leaving it was concentrated in the two most branch-dense pages in the renderer, and it put a search parameter into page identity — the only place in the sidebar's route-identity family where that happened, so "which page is this tab on" could not be answered by the pathname alone.

The following tradeoffs were made:

- Four `conversation-entry` route tests were named after `view=message` but actually asserted the `beforeLoad` bare-entry / explicit-id contract, with `view` as incidental decoration. Deleting them outright would have dropped real coverage of `beforeLoad`, so they were rewritten in `view`-free form instead.
- `useActiveTopic`'s `passive` option and the `history.error.topic_not_found` key are outside the issue's checklist, but both were left with zero consumers by this change, so they are removed here rather than left as new dead code.

The following alternatives were considered: restoring a producer instead of deleting the mode — the issue's own reversal condition. fc1ec36ca1 removed the last caller for a reason specific to that caller, and jump-to-message now works without a focused mode, so there is nothing left for a producer to serve.

Links to places where the discussion took place: #20101 (surfaced while reviewing route-identity comparisons in #18940)

### Breaking changes

None. No URL the app can produce changes behavior.

A tab persisted from an older session (`ui.tab.normal_tabs`) is the one remaining source of a `view=message` url — a tab opened before fc1ec36ca1 and never closed is restored with its original url. Once `view` leaves the parser the parameter is simply ignored: `tabBelongsToApp` matches on pathname, `beforeLoad` short-circuits on the present `topicId` / `sessionId`, and `keyFromUrl` now returns that id instead of `undefined`, so the tab renders as an ordinary conversation and correctly owns its conversation key.

### Special notes for your reviewer

The issue notes one thing that would reverse this: if conversation navigation intends to restore a producer, the task is to add that entry point back rather than delete the mode. Worth a confirmation from whoever owns conversation navigation before this lands.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
