### PR TITLE
feat(scheduled-tasks): support multiple times per day in schedule presets

### DIFF
--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Täglich",
   "agent.tasks.schedule.hour": "Stunde",
   "agent.tasks.schedule.hourly": "Stündlich",
+  "agent.tasks.schedule.hours": "Stunden",
   "agent.tasks.schedule.interval": "Benutzerdefiniertes Intervall",
   "agent.tasks.schedule.intervalMinutes": "Intervall",
   "agent.tasks.schedule.invalid": "Geben Sie eine gültige Ausführungshäufigkeit ein.",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Καθημερινά",
   "agent.tasks.schedule.hour": "Ώρα",
   "agent.tasks.schedule.hourly": "Ωριαίος",
+  "agent.tasks.schedule.hours": "Ώρες",
   "agent.tasks.schedule.interval": "Προσαρμοσμένο διάστημα",
   "agent.tasks.schedule.intervalMinutes": "Διάστημα",
   "agent.tasks.schedule.invalid": "Εισάγετε μια έγκυρη συχνότητα εκτέλεσης.",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Daily",
   "agent.tasks.schedule.hour": "Hour",
   "agent.tasks.schedule.hourly": "Hourly",
+  "agent.tasks.schedule.hours": "Hours",
   "agent.tasks.schedule.interval": "Custom interval",
   "agent.tasks.schedule.intervalMinutes": "Interval",
   "agent.tasks.schedule.invalid": "Enter a valid execution frequency.",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Diario",
   "agent.tasks.schedule.hour": "Hora",
   "agent.tasks.schedule.hourly": "Por hora",
+  "agent.tasks.schedule.hours": "Horas",
   "agent.tasks.schedule.interval": "Intervalo personalizado",
   "agent.tasks.schedule.intervalMinutes": "Intervalo",
   "agent.tasks.schedule.invalid": "Introduzca una frecuencia de ejecución válida.",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Quotidien",
   "agent.tasks.schedule.hour": "Heure",
   "agent.tasks.schedule.hourly": "Par heure",
+  "agent.tasks.schedule.hours": "Heures",
   "agent.tasks.schedule.interval": "Intervalle personnalisé",
   "agent.tasks.schedule.intervalMinutes": "Intervalle",
   "agent.tasks.schedule.invalid": "Entrez une fréquence d'exécution valide.",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "毎日",
   "agent.tasks.schedule.hour": "時間",
   "agent.tasks.schedule.hourly": "毎時",
+  "agent.tasks.schedule.hours": "時",
   "agent.tasks.schedule.interval": "カスタム間隔",
   "agent.tasks.schedule.intervalMinutes": "インターバル",
   "agent.tasks.schedule.invalid": "有効な実行頻度を入力してください。",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Diário",
   "agent.tasks.schedule.hour": "Hora",
   "agent.tasks.schedule.hourly": "Por hora",
+  "agent.tasks.schedule.hours": "Horas",
   "agent.tasks.schedule.interval": "Intervalo personalizado",
   "agent.tasks.schedule.intervalMinutes": "Intervalo",
   "agent.tasks.schedule.invalid": "Introduza uma frequência de execução válida.",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Zilnic",
   "agent.tasks.schedule.hour": "Oră",
   "agent.tasks.schedule.hourly": "Orară",
+  "agent.tasks.schedule.hours": "Ore",
   "agent.tasks.schedule.interval": "Interval personalizat",
   "agent.tasks.schedule.intervalMinutes": "Interval",
   "agent.tasks.schedule.invalid": "Introdu o frecvență de execuție validă.",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Ежедневно",
   "agent.tasks.schedule.hour": "Час",
   "agent.tasks.schedule.hourly": "Почасовой",
+  "agent.tasks.schedule.hours": "Часы",
   "agent.tasks.schedule.interval": "Пользовательский интервал",
   "agent.tasks.schedule.intervalMinutes": "Интервал",
   "agent.tasks.schedule.invalid": "Введите допустимую частоту выполнения.",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Günlük",
   "agent.tasks.schedule.hour": "Saat",
   "agent.tasks.schedule.hourly": "Saatlik",
+  "agent.tasks.schedule.hours": "Saat",
   "agent.tasks.schedule.interval": "Özel aralık",
   "agent.tasks.schedule.intervalMinutes": "Aralık",
   "agent.tasks.schedule.invalid": "Geçerli bir çalıştırma sıklığı girin.",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "Hàng ngày",
   "agent.tasks.schedule.hour": "Giờ",
   "agent.tasks.schedule.hourly": "Hàng giờ",
+  "agent.tasks.schedule.hours": "Giờ",
   "agent.tasks.schedule.interval": "Khoảng thời gian tùy chỉnh",
   "agent.tasks.schedule.intervalMinutes": "Khoảng thời gian",
   "agent.tasks.schedule.invalid": "Nhập tần suất thực thi hợp lệ.",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "每天",
   "agent.tasks.schedule.hour": "小时",
   "agent.tasks.schedule.hourly": "每小时",
+  "agent.tasks.schedule.hours": "小时",
   "agent.tasks.schedule.interval": "自定义间隔",
   "agent.tasks.schedule.intervalMinutes": "间隔时长",
   "agent.tasks.schedule.invalid": "请填写有效的执行频率。",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -342,6 +342,7 @@
   "agent.tasks.schedule.daily": "每日",
   "agent.tasks.schedule.hour": "小時",
   "agent.tasks.schedule.hourly": "每小時",
+  "agent.tasks.schedule.hours": "小時",
   "agent.tasks.schedule.interval": "自訂間隔",
   "agent.tasks.schedule.intervalMinutes": "間隔",
   "agent.tasks.schedule.invalid": "請輸入有效的執行頻率。",

--- a/src/renderer/pages/settings/TasksSettings.tsx
+++ b/src/renderer/pages/settings/TasksSettings.tsx
@@ -196,17 +196,27 @@ const parseScheduleDate = (value: string) => {
   return Number.isNaN(date.getTime()) ? undefined : date
 }
 
-const parseTime = (value: string) => {
-  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim())
-  if (!match) return null
-  const hour = Number(match[1])
-  const minute = Number(match[2])
-  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null
-  return { hour, minute }
+// Canonical value for the time presets: a sorted, deduped 'HH:MM,HH:MM…' list
+// sharing one minute — per-entry minutes would cross-product into extra cron firings.
+const parseTimes = (value: string): { hours: string[]; minute: string } | null => {
+  const matches = value.split(',').map((part) => /^(\d{1,2}):(\d{2})$/.exec(part.trim()))
+  if (matches.some((match) => match === null)) return null
+
+  const minute = matches[0]![2]
+  if (Number(minute) > 59 || matches.some((match) => match![2] !== minute)) return null
+
+  const hours = matches.map((match) => Number(match![1]))
+  if (hours.some((hour) => hour > 23)) return null
+
+  const uniqueSorted = [...new Set(hours)].sort((a, b) => a - b)
+  return { hours: uniqueSorted.map((hour) => String(hour).padStart(2, '0')), minute }
 }
 
-const formatTime = (hour: number, minute: number) =>
-  `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+const formatTimes = (hours: string[], minute: string) =>
+  [...new Set(hours)]
+    .sort()
+    .map((hour) => `${hour}:${minute}`)
+    .join(',')
 
 export function triggerToFormState(trigger: Trigger): Omit<ScheduleFormState, 'timeoutMinutes'> {
   if (trigger.kind === 'interval') {
@@ -236,15 +246,18 @@ export function triggerToFormState(trigger: Trigger): Omit<ScheduleFormState, 't
   }
 
   const minute = Number(minutePart)
-  const hour = Number(hourPart)
+  const hourParts = hourPart.split(',')
   const hasValidTime =
-    Number.isInteger(minute) && minute >= 0 && minute <= 59 && Number.isInteger(hour) && hour >= 0 && hour <= 23
+    Number.isInteger(minute) &&
+    minute >= 0 &&
+    minute <= 59 &&
+    hourParts.every((part) => /^\d{1,2}$/.test(part) && Number(part) <= 23)
 
   if (!hasValidTime || dayOfMonth !== '*' || month !== '*') {
     return { kind: 'cron', value: trigger.expr, weekday: '1' }
   }
 
-  const value = formatTime(hour, minute)
+  const value = hourParts.map((part) => `${part.padStart(2, '0')}:${String(minute).padStart(2, '0')}`).join(',')
   if (dayOfWeek === '*') return { kind: 'daily', value, weekday: '1' }
   if (dayOfWeek === '1-5') return { kind: 'weekdays', value, weekday: '1' }
   if (/^[0-6]$/.test(dayOfWeek)) return { kind: 'weekly', value, weekday: dayOfWeek }
@@ -270,9 +283,9 @@ export function formStateToTrigger(schedule: ScheduleFormState): Trigger | null 
     return expr ? { kind: 'cron', expr } : null
   }
 
-  const time = parseTime(schedule.value)
-  if (!time) return null
-  const prefix = `${time.minute} ${time.hour} * *`
+  const times = parseTimes(schedule.value)
+  if (!times || times.hours.length === 0) return null
+  const prefix = `${Number(times.minute)} ${times.hours.map(Number).join(',')} * *`
 
   if (schedule.kind === 'daily') return { kind: 'cron', expr: `${prefix} *` }
   if (schedule.kind === 'weekdays') return { kind: 'cron', expr: `${prefix} 1-5` }
@@ -287,7 +300,7 @@ function scheduleForKind(kind: ScheduleKind, current: ScheduleFormState): Schedu
     case 'daily':
     case 'weekdays':
     case 'weekly':
-      return { ...current, kind, value: parseTime(current.value) ? current.value : '09:00' }
+      return { ...current, kind, value: parseTimes(current.value) ? current.value : '09:00' }
     case 'interval':
     case 'once':
     case 'cron':
@@ -467,17 +480,19 @@ const TaskCardRunStatus: FC<{ task: ScheduledTaskListItem }> = ({ task }) => {
 
 function getTriggerSummary(trigger: Trigger, t: TFunction) {
   const schedule = triggerToFormState(trigger)
+  // Time presets may hold a comma-joined list; space it out for display.
+  const time = schedule.value.split(',').join(', ')
   switch (schedule.kind) {
     case 'hourly':
       return t('agent.tasks.schedule.summary.hourly')
     case 'daily':
-      return t('agent.tasks.schedule.summary.daily', { time: schedule.value })
+      return t('agent.tasks.schedule.summary.daily', { time })
     case 'weekdays':
-      return t('agent.tasks.schedule.summary.weekdays', { time: schedule.value })
+      return t('agent.tasks.schedule.summary.weekdays', { time })
     case 'weekly':
       return t('agent.tasks.schedule.summary.weekly', {
         weekday: getWeekdayLabel(schedule.weekday, t),
-        time: schedule.value
+        time
       })
     case 'interval':
       return t('agent.tasks.schedule.summary.interval', { count: Number(schedule.value) })
@@ -494,34 +509,28 @@ const TaskTimeSelect: FC<{
   onChange: (value: string) => void
 }> = ({ value, disabled, onChange }) => {
   const { t } = useTranslation()
-  const { hour, minute } = parseTime(value) ?? { hour: 9, minute: 0 }
-  const hourValue = String(hour).padStart(2, '0')
-  const minuteValue = String(minute).padStart(2, '0')
+  const { hours, minute } = parseTimes(value) ?? { hours: ['09'], minute: '00' }
 
   return (
     <RowFlex role="group" aria-label={t('agent.tasks.schedule.time')} className="items-center gap-2">
-      <Select
-        value={hourValue}
+      <Combobox
+        multiple
+        searchable={false}
+        width={160}
+        aria-label={t('agent.tasks.schedule.hours')}
+        placeholder={t('agent.tasks.schedule.hours')}
         disabled={disabled}
-        onValueChange={(nextHour) => onChange(`${nextHour}:${minuteValue}`)}>
-        <SelectTrigger aria-label={t('agent.tasks.schedule.hour')}>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            {SCHEDULE_HOURS.map((option) => (
-              <SelectItem key={option} value={option}>
-                {option}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+        options={SCHEDULE_HOURS.map((hour) => ({ value: hour, label: hour }))}
+        value={hours}
+        onChange={(next) => {
+          if (Array.isArray(next)) onChange(formatTimes(next, minute))
+        }}
+      />
       <InputGroupText aria-hidden="true">:</InputGroupText>
       <Select
-        value={minuteValue}
+        value={minute}
         disabled={disabled}
-        onValueChange={(nextMinute) => onChange(`${hourValue}:${nextMinute}`)}>
+        onValueChange={(nextMinute) => onChange(formatTimes(hours, nextMinute))}>
         <SelectTrigger aria-label={t('agent.tasks.schedule.minute')}>
           <SelectValue />
         </SelectTrigger>

--- a/src/renderer/pages/settings/TasksSettings.tsx
+++ b/src/renderer/pages/settings/TasksSettings.tsx
@@ -257,7 +257,12 @@ export function triggerToFormState(trigger: Trigger): Omit<ScheduleFormState, 't
     return { kind: 'cron', value: trigger.expr, weekday: '1' }
   }
 
-  const value = hourParts.map((part) => `${part.padStart(2, '0')}:${String(minute).padStart(2, '0')}`).join(',')
+  // Canonical form: sorted, deduped (matches parseTimes/formatTimes so the UI
+  // multi-select never disagrees with the value it renders).
+  const value = formatTimes(
+    hourParts.map((part) => part.padStart(2, '0')),
+    String(minute).padStart(2, '0')
+  )
   if (dayOfWeek === '*') return { kind: 'daily', value, weekday: '1' }
   if (dayOfWeek === '1-5') return { kind: 'weekdays', value, weekday: '1' }
   if (/^[0-6]$/.test(dayOfWeek)) return { kind: 'weekly', value, weekday: dayOfWeek }

--- a/src/renderer/pages/settings/TasksSettings.tsx
+++ b/src/renderer/pages/settings/TasksSettings.tsx
@@ -514,7 +514,12 @@ const TaskTimeSelect: FC<{
   onChange: (value: string) => void
 }> = ({ value, disabled, onChange }) => {
   const { t } = useTranslation()
-  const { hours, minute } = parseTimes(value) ?? { hours: ['09'], minute: '00' }
+  // An empty preset means the user cleared every hour; render no selection so the
+  // UI agrees with the empty form value (which blocks saving until repopulated).
+  // A non-empty value that fails to parse is unexpected, so fall back to the
+  // default selection rather than rendering a blank, uneditable control.
+  const { hours, minute } =
+    parseTimes(value) ?? (value === '' ? { hours: [], minute: '00' } : { hours: ['09'], minute: '00' })
 
   return (
     <RowFlex role="group" aria-label={t('agent.tasks.schedule.time')} className="items-center gap-2">

--- a/src/renderer/pages/settings/TasksSettings.tsx
+++ b/src/renderer/pages/settings/TasksSettings.tsx
@@ -508,7 +508,7 @@ function getTriggerSummary(trigger: Trigger, t: TFunction) {
   }
 }
 
-const TaskTimeSelect: FC<{
+export const TaskTimeSelect: FC<{
   value: string
   disabled?: boolean
   onChange: (value: string) => void
@@ -527,7 +527,14 @@ const TaskTimeSelect: FC<{
   // selection keeps the minute the user did not edit (e.g. 18:30 -> clear 18 ->
   // pick 20 yields 20:30, not 20:00). While no hour is selected the minute
   // stays a local preview only: the form value remains '' and saving is blocked.
-  const [rememberedMinute, setRememberedMinute] = useState('00')
+  // Seed the retained minute from the mounted value: lastValue starts equal to
+  // value, so the update block below never runs on the first render and a
+  // fresh/remounted selector loading a non-zero-minute schedule would otherwise
+  // fall back to 00 once every hour is cleared.
+  const [rememberedMinute, setRememberedMinute] = useState(() => {
+    const parsed = parseTimes(value)
+    return parsed && parsed.hours.length > 0 ? parsed.minute : '00'
+  })
   const [lastValue, setLastValue] = useState(value)
   if (value !== lastValue) {
     setLastValue(value)

--- a/src/renderer/pages/settings/TasksSettings.tsx
+++ b/src/renderer/pages/settings/TasksSettings.tsx
@@ -521,6 +521,21 @@ const TaskTimeSelect: FC<{
   const { hours, minute } =
     parseTimes(value) ?? (value === '' ? { hours: [], minute: '00' } : { hours: ['09'], minute: '00' })
 
+  // The minute is encoded inside the comma-joined value, so clearing the last
+  // hour would otherwise discard it (formatTimes([], '30') === ''). Track the
+  // last committed minute in state so re-picking an hour after clearing every
+  // selection keeps the minute the user did not edit (e.g. 18:30 -> clear 18 ->
+  // pick 20 yields 20:30, not 20:00). While no hour is selected the minute
+  // stays a local preview only: the form value remains '' and saving is blocked.
+  const [rememberedMinute, setRememberedMinute] = useState('00')
+  const [lastValue, setLastValue] = useState(value)
+  if (value !== lastValue) {
+    setLastValue(value)
+    const parsed = parseTimes(value)
+    if (parsed && parsed.hours.length > 0) setRememberedMinute(parsed.minute)
+  }
+  const displayMinute = hours.length > 0 ? minute : rememberedMinute
+
   return (
     <RowFlex role="group" aria-label={t('agent.tasks.schedule.time')} className="items-center gap-2">
       <Combobox
@@ -533,14 +548,22 @@ const TaskTimeSelect: FC<{
         options={SCHEDULE_HOURS.map((hour) => ({ value: hour, label: hour }))}
         value={hours}
         onChange={(next) => {
-          if (Array.isArray(next)) onChange(formatTimes(next, minute))
+          if (Array.isArray(next)) onChange(formatTimes(next, displayMinute))
         }}
       />
       <InputGroupText aria-hidden="true">:</InputGroupText>
       <Select
-        value={minute}
+        value={displayMinute}
         disabled={disabled}
-        onValueChange={(nextMinute) => onChange(formatTimes(hours, nextMinute))}>
+        onValueChange={(nextMinute) => {
+          if (hours.length === 0) {
+            // No hour selected: the minute cannot live in the value string, so
+            // keep it only as the preview for the next hour selection.
+            setRememberedMinute(nextMinute)
+            return
+          }
+          onChange(formatTimes(hours, nextMinute))
+        }}>
         <SelectTrigger aria-label={t('agent.tasks.schedule.minute')}>
           <SelectValue />
         </SelectTrigger>

--- a/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
@@ -360,6 +360,7 @@ vi.mock('@cherrystudio/ui', () => {
             key={option.value}
             type="button"
             disabled={disabled}
+            aria-pressed={multiple && Array.isArray(value) ? value.includes(option.value) : undefined}
             onClick={() => {
               if (!multiple) {
                 onChange?.(option.value)
@@ -759,6 +760,21 @@ describe('scheduled task frequency conversion', () => {
       name: 'one time',
       form: { kind: 'once', value: '2026-08-01T09:30:00.000Z', weekday: '1', timeoutMinutes },
       trigger: { kind: 'once', at: 1_785_576_600_000 }
+    },
+    {
+      name: 'daily with multiple times',
+      form: { kind: 'daily', value: '09:30,18:30', weekday: '1', timeoutMinutes },
+      trigger: { kind: 'cron', expr: '30 9,18 * * *' }
+    },
+    {
+      name: 'daily with unsorted duplicate times',
+      form: { kind: 'daily', value: '18:30,09:30,18:30', weekday: '1', timeoutMinutes },
+      trigger: { kind: 'cron', expr: '30 9,18 * * *' }
+    },
+    {
+      name: 'weekly with multiple times',
+      form: { kind: 'weekly', value: '07:45,19:45', weekday: '3', timeoutMinutes },
+      trigger: { kind: 'cron', expr: '45 7,19 * * 3' }
     }
   ] satisfies Array<{ name: string; form: ScheduleFormState; trigger: Record<string, unknown> }>)(
     'converts the $name preset to the existing Trigger contract',
@@ -766,6 +782,30 @@ describe('scheduled task frequency conversion', () => {
       expect(formStateToTrigger(form)).toEqual(trigger)
     }
   )
+
+  it('rejects a time list whose entries disagree on the minute', () => {
+    // Cron fields are independent, so 09:00 + 18:30 would cross-product into
+    // four firings; the form must refuse instead of silently over-firing.
+    expect(formStateToTrigger({ kind: 'daily', value: '09:00,18:30', weekday: '1', timeoutMinutes: '' })).toBeNull()
+  })
+
+  it('recognizes a multi-time Cron as the matching preset with all times', () => {
+    expect(triggerToFormState({ kind: 'cron', expr: '30 9,18 * * *' })).toEqual({
+      kind: 'daily',
+      value: '09:30,18:30',
+      weekday: '1'
+    })
+    expect(triggerToFormState({ kind: 'cron', expr: '45 7,19 * * 1-5' })).toEqual({
+      kind: 'weekdays',
+      value: '07:45,19:45',
+      weekday: '1'
+    })
+  })
+
+  it('keeps a Cron with per-field minute lists on the custom path', () => {
+    // '0,30 9 * * *' is valid but cannot come from the shared-minute presets.
+    expect(triggerToFormState({ kind: 'cron', expr: '0,30 9 * * *' }).kind).toBe('cron')
+  })
 
   it.each([
     [{ kind: 'cron' as const, expr: '0 * * * *' }, 'hourly'],
@@ -1096,10 +1136,8 @@ describe('TasksSettings routing and creation', () => {
       'daily'
     )
     const timeSelect = within(dialog).getByRole('group', { name: 'agent.tasks.schedule.time' })
-    expect(within(timeSelect).getByRole('combobox', { name: 'agent.tasks.schedule.hour' })).toHaveAttribute(
-      'data-value',
-      '09'
-    )
+    expect(within(timeSelect).getByRole('button', { name: '09' })).toHaveAttribute('aria-pressed', 'true')
+    expect(within(timeSelect).getByRole('button', { name: '18' })).toHaveAttribute('aria-pressed', 'false')
     expect(within(timeSelect).getByRole('combobox', { name: 'agent.tasks.schedule.minute' })).toHaveAttribute(
       'data-value',
       '00'
@@ -1147,14 +1185,11 @@ describe('TasksSettings routing and creation', () => {
 
     const dialog = screen.getByRole('dialog')
     const timeSelect = within(dialog).getByRole('group', { name: 'agent.tasks.schedule.time' })
-    const [hourOptions, minuteOptions] = within(timeSelect).getAllByRole('listbox')
-    fireEvent.click(within(hourOptions).getByRole('option', { name: '18' }))
-    fireEvent.click(within(minuteOptions).getByRole('option', { name: '05' }))
+    fireEvent.click(within(timeSelect).getByRole('button', { name: '18' }))
+    fireEvent.click(within(timeSelect).getByRole('option', { name: '05' }))
 
-    expect(within(timeSelect).getByRole('combobox', { name: 'agent.tasks.schedule.hour' })).toHaveAttribute(
-      'data-value',
-      '18'
-    )
+    expect(within(timeSelect).getByRole('button', { name: '09' })).toHaveAttribute('aria-pressed', 'true')
+    expect(within(timeSelect).getByRole('button', { name: '18' })).toHaveAttribute('aria-pressed', 'true')
     expect(within(timeSelect).getByRole('combobox', { name: 'agent.tasks.schedule.minute' })).toHaveAttribute(
       'data-value',
       '05'
@@ -1245,6 +1280,37 @@ describe('TasksSettings routing and creation', () => {
     )
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(taskMutationMocks.refetchTasks).not.toHaveBeenCalled()
+  })
+
+  it('creates a daily task with multiple times', async () => {
+    navigationMocks.taskId = undefined
+    taskMutationMocks.createTask.mockResolvedValue({ ...taskDataMock.defaultTask, id: 'task-new' })
+
+    render(<TasksSettings />)
+
+    await screen.findByRole('link', { name: /Daily task/ })
+    fireEvent.click(screen.getByRole('button', { name: 'settings.scheduledTasks.newTask' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'settings.scheduledTasks.manualCreate' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'agent.channels.bindAgent' })).toHaveTextContent('Agent One')
+    )
+    fireEvent.change(screen.getByRole('textbox', { name: 'agent.tasks.name.label' }), {
+      target: { value: 'Review code' }
+    })
+    fireEvent.change(screen.getByLabelText('agent.tasks.prompt.label'), { target: { value: 'Review the repository' } })
+
+    const timeSelect = within(screen.getByRole('dialog')).getByRole('group', { name: 'agent.tasks.schedule.time' })
+    fireEvent.click(within(timeSelect).getByRole('button', { name: '18' }))
+    fireEvent.click(screen.getByRole('button', { name: 'agent.tasks.save' }))
+
+    await waitFor(() =>
+      expect(taskMutationMocks.createTask).toHaveBeenCalledWith(
+        'agent-1',
+        expect.objectContaining({
+          trigger: { kind: 'cron', expr: '0 9,18 * * *' }
+        })
+      )
+    )
   })
 })
 
@@ -1370,6 +1436,28 @@ describe('TasksSettings detail behavior', () => {
     await waitFor(() => expect(screen.getByText('Server-normalized task name')).toBeInTheDocument())
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(taskMutationMocks.refetchTasks).not.toHaveBeenCalled()
+  })
+
+  it('projects a multi-time Cron trigger into the edit Dialog as preset selections', async () => {
+    taskDataMock.task = { ...taskDataMock.defaultTask, trigger: { kind: 'cron', expr: '30 9,18 * * *' } }
+
+    render(<TasksSettings />)
+
+    await screen.findByText('Daily task')
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByRole('combobox', { name: 'agent.tasks.frequency.label' })).toHaveAttribute(
+      'data-value',
+      'daily'
+    )
+    const timeSelect = within(dialog).getByRole('group', { name: 'agent.tasks.schedule.time' })
+    expect(within(timeSelect).getByRole('button', { name: '09' })).toHaveAttribute('aria-pressed', 'true')
+    expect(within(timeSelect).getByRole('button', { name: '18' })).toHaveAttribute('aria-pressed', 'true')
+    expect(within(timeSelect).getByRole('combobox', { name: 'agent.tasks.schedule.minute' })).toHaveAttribute(
+      'data-value',
+      '30'
+    )
   })
 
   it('persists the simplified interval editor through the shared edit Dialog', async () => {

--- a/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
@@ -1327,6 +1327,37 @@ describe('TasksSettings routing and creation', () => {
       )
     )
   })
+
+  it('does not keep a stale hour selected when the last hour is cleared', async () => {
+    navigationMocks.taskId = undefined
+    taskMutationMocks.createTask.mockResolvedValue({ ...taskDataMock.defaultTask, id: 'task-new' })
+
+    render(<TasksSettings />)
+
+    await screen.findByRole('link', { name: /Daily task/ })
+    fireEvent.click(screen.getByRole('button', { name: 'settings.scheduledTasks.newTask' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'settings.scheduledTasks.manualCreate' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'agent.channels.bindAgent' })).toHaveTextContent('Agent One')
+    )
+    fireEvent.change(screen.getByRole('textbox', { name: 'agent.tasks.name.label' }), {
+      target: { value: 'Review code' }
+    })
+    fireEvent.change(screen.getByLabelText('agent.tasks.prompt.label'), { target: { value: 'Review the repository' } })
+
+    const timeSelect = within(screen.getByRole('dialog')).getByRole('group', { name: 'agent.tasks.schedule.time' })
+    const nineButton = within(timeSelect).getByRole('button', { name: '09' })
+    expect(nineButton).toHaveAttribute('aria-pressed', 'true')
+
+    // Clearing the default 09 is the only selected hour — the control must render
+    // empty (not silently keep 09 selected) and the empty schedule must block saving.
+    fireEvent.click(nineButton)
+    await waitFor(() => expect(nineButton).toHaveAttribute('aria-pressed', 'false'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'agent.tasks.save' }))
+    await waitFor(() => expect(screen.getByText('agent.tasks.schedule.invalid')).toBeInTheDocument())
+    expect(taskMutationMocks.createTask).not.toHaveBeenCalled()
+  })
 })
 
 describe('TasksSettings detail behavior', () => {

--- a/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
@@ -1358,6 +1358,58 @@ describe('TasksSettings routing and creation', () => {
     await waitFor(() => expect(screen.getByText('agent.tasks.schedule.invalid')).toBeInTheDocument())
     expect(taskMutationMocks.createTask).not.toHaveBeenCalled()
   })
+
+  it('keeps the shared minute when the last hour is cleared and a new one is picked', async () => {
+    navigationMocks.taskId = undefined
+    taskMutationMocks.createTask.mockResolvedValue({ ...taskDataMock.defaultTask, id: 'task-new' })
+
+    render(<TasksSettings />)
+
+    await screen.findByRole('link', { name: /Daily task/ })
+    fireEvent.click(screen.getByRole('button', { name: 'settings.scheduledTasks.newTask' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'settings.scheduledTasks.manualCreate' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'agent.channels.bindAgent' })).toHaveTextContent('Agent One')
+    )
+    fireEvent.change(screen.getByRole('textbox', { name: 'agent.tasks.name.label' }), {
+      target: { value: 'Review code' }
+    })
+    fireEvent.change(screen.getByLabelText('agent.tasks.prompt.label'), { target: { value: 'Review the repository' } })
+
+    const timeSelect = within(screen.getByRole('dialog')).getByRole('group', { name: 'agent.tasks.schedule.time' })
+    // Start from 09:00, add 18 and move the shared minute to 30 -> 09:30,18:30.
+    fireEvent.click(within(timeSelect).getByRole('button', { name: '18' }))
+    fireEvent.click(within(timeSelect).getByRole('option', { name: '30' }))
+    expect(within(timeSelect).getByRole('combobox', { name: 'agent.tasks.schedule.minute' })).toHaveAttribute(
+      'data-value',
+      '30'
+    )
+
+    // Remove 18, then remove 09 — clearing every hour must not reset the minute
+    // the user never edited: the control keeps showing 30 as a local preview.
+    fireEvent.click(within(timeSelect).getByRole('button', { name: '18' }))
+    fireEvent.click(within(timeSelect).getByRole('button', { name: '09' }))
+    await waitFor(() =>
+      expect(within(timeSelect).getByRole('button', { name: '09' })).toHaveAttribute('aria-pressed', 'false')
+    )
+    expect(within(timeSelect).getByRole('combobox', { name: 'agent.tasks.schedule.minute' })).toHaveAttribute(
+      'data-value',
+      '30'
+    )
+
+    // Picking 20 afterwards must re-use the retained minute (20:30), not reset to 20:00.
+    fireEvent.click(within(timeSelect).getByRole('button', { name: '20' }))
+    fireEvent.click(screen.getByRole('button', { name: 'agent.tasks.save' }))
+
+    await waitFor(() =>
+      expect(taskMutationMocks.createTask).toHaveBeenCalledWith(
+        'agent-1',
+        expect.objectContaining({
+          trigger: { kind: 'cron', expr: '30 20 * * *' }
+        })
+      )
+    )
+  })
 })
 
 describe('TasksSettings detail behavior', () => {

--- a/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
@@ -802,6 +802,21 @@ describe('scheduled task frequency conversion', () => {
     })
   })
 
+  it('normalizes an unsorted or duplicated hour list to the canonical form', () => {
+    // The cron hour list preserves the author's order and duplicates; the preset
+    // value must be sorted + deduped to match what parseTimes/formatTimes render.
+    expect(triggerToFormState({ kind: 'cron', expr: '30 18,9 * * *' })).toEqual({
+      kind: 'daily',
+      value: '09:30,18:30',
+      weekday: '1'
+    })
+    expect(triggerToFormState({ kind: 'cron', expr: '30 9,18,9 * * *' })).toEqual({
+      kind: 'daily',
+      value: '09:30,18:30',
+      weekday: '1'
+    })
+  })
+
   it('keeps a Cron with per-field minute lists on the custom path', () => {
     // '0,30 9 * * *' is valid but cannot come from the shared-minute presets.
     expect(triggerToFormState({ kind: 'cron', expr: '0,30 9 * * *' }).kind).toBe('cron')

--- a/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/TasksSettings.test.tsx
@@ -6,7 +6,12 @@ import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import TasksSettings, { formStateToTrigger, type ScheduleFormState, triggerToFormState } from '../TasksSettings'
+import TasksSettings, {
+  formStateToTrigger,
+  type ScheduleFormState,
+  TaskTimeSelect,
+  triggerToFormState
+} from '../TasksSettings'
 
 type TranslationFunction = (key: string, values?: Record<string, unknown>) => string
 
@@ -1804,5 +1809,42 @@ describe('TasksSettings detail behavior', () => {
     fireEvent.click(screen.getByRole('button', { name: 'common.more' }))
     expect(screen.queryByRole('menuitem', { name: 'agent.tasks.run' })).not.toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'agent.tasks.delete.label' })).toBeInTheDocument()
+  })
+})
+
+describe('TaskTimeSelect minute retention on fresh mount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    translationMock.t = (key: string) => key
+  })
+
+  it('keeps a non-zero minute when a freshly mounted editor clears its only hour and re-picks', () => {
+    // Regression for the cherry-review blocking finding: TaskTimeSelect that
+    // mounts directly onto a non-zero-minute value (18:30) — no value-diff
+    // update ever runs — must seed its retained minute from that first value.
+    // Otherwise clearing the only hour drops the minute to 00 and re-picking
+    // 20 produces 20:00 instead of the intended 20:30.
+    const onChange = vi.fn()
+    const { rerender } = render(<TaskTimeSelect value="18:30" onChange={onChange} />)
+
+    const timeSelect = screen.getByRole('group', { name: 'agent.tasks.schedule.time' })
+    const minuteSelect = within(timeSelect).getByRole('combobox', { name: 'agent.tasks.schedule.minute' })
+    expect(minuteSelect).toHaveAttribute('data-value', '30')
+
+    const eighteenButton = within(timeSelect).getByRole('button', { name: '18' })
+    expect(eighteenButton).toHaveAttribute('aria-pressed', 'true')
+
+    // Clear the only hour; the minute must remain 30 as a local preview.
+    fireEvent.click(eighteenButton)
+    expect(onChange).toHaveBeenLastCalledWith('')
+    expect(minuteSelect).toHaveAttribute('data-value', '30')
+
+    // Controlled parent commits the cleared value; component stays mounted.
+    rerender(<TaskTimeSelect value="" onChange={onChange} />)
+    expect(minuteSelect).toHaveAttribute('data-value', '30')
+
+    // Re-picking 20 must reuse the retained minute -> 20:30, not 20:00.
+    fireEvent.click(within(timeSelect).getByRole('button', { name: '20' }))
+    expect(onChange).toHaveBeenLastCalledWith('20:30')
   })
 })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- The daily / weekdays / weekly schedule presets accept a single time of day. Running the same task at, say, 09:00 and 18:00 requires duplicate tasks, or asking the agent to author a cron expression — which the settings form then displays as an uneditable "Custom schedule" placeholder.
- Editing such an agent-authored multi-time task offers no way to see or adjust its times from the UI.

After this PR:

- The time control of the daily / weekdays / weekly presets accepts multiple hours with a shared minute (multi-select combobox), persisted as a cron hour list such as `0 9,18 * * *` — a shape the croner-based scheduler and the agent-facing `cron` tool already support end to end.
- Multi-time cron expressions project back into the preset controls when editing: an agent-authored task like `30 9,18 * * *` now opens as "Daily, hours 09 + 18, minute 30" instead of a read-only custom label, and round-trips losslessly.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

"Run this every morning and evening" is a natural scheduled-task request that previously had no UI path. The backend contract (`Trigger` = cron expression) is unchanged; the presets remain a bidirectional projection of cron, now covering hour lists — the same "presets over one expressive format" architecture used by n8n's Schedule Trigger and Home Assistant's time trigger (`at:` accepting a list).

The following tradeoffs were made:

- All times of one preset share a single minute. Cron fields are independent, so per-entry minutes would cross-product into extra firings (09:00 + 18:30 would fire at 09:00, 09:30, 18:00 and 18:30). A shared minute keeps the preset honest about what the underlying cron can express; mismatched-minute expressions fall back to the read-only custom display, never to an over-firing rewrite.
- Raw cron authoring stays out of the form, respecting the deliberate simplification in #17332.

The following alternatives were considered:

- Re-adding a raw cron expression input — previously rejected in #17332 as not understandable for most users.
- Multiple triggers per schedule row (systemd `OnCalendar=` lines / Home Assistant trigger lists) — strictly more expressive, but requires scheduler schema changes and overlaps with the in-flight interval re-anchoring in #18684.

Links to places where the discussion took place: N/A

### Breaking changes

None. Existing single-time tasks load, display, and save exactly as before.

### Special notes for your reviewer

- `pnpm test:renderer src/renderer/pages/settings/__tests__/TasksSettings.test.tsx`: 56/56 pass. New coverage: hour-list ⇄ preset conversion both directions, rejection of mismatched-minute lists (cross-product guard), multi-time task creation through the dialog, and edit-dialog projection of an existing multi-time cron trigger.
- `pnpm lint` (format + typecheck + i18n check) and `pnpm test:lint` pass; the 45 oxlint warnings are pre-existing and none touch the changed files.
- One new i18n key (`agent.tasks.schedule.hours`), synced and translated for all 13 locales.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every-9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Scheduled tasks: the daily, weekdays, and weekly presets now support multiple times per day (e.g. 09:00 and 18:00), and agent-created multi-time schedules become editable in the settings form.
```
