### PR TITLE
refactor(router): read page search from the route instead of a cast

### DIFF
--- a/src/renderer/components/layout/TabRouter.tsx
+++ b/src/renderer/components/layout/TabRouter.tsx
@@ -2,10 +2,22 @@ import { DialogPortalContainerProvider, PortalContainerProvider } from '@cherrys
 import { RouteErrorFallback } from '@renderer/components/layout/RouteErrorFallback'
 import { TabIdProvider } from '@renderer/components/layout/TabIdProvider'
 import { routeTree } from '@renderer/routeTree.gen'
+import type { AppRouter } from '@renderer/types/router'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router'
 import { Activity } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+
+// The annotation keeps this in step with the registered `AppRouter`: options that change the
+// router's type fail here instead of silently diverging from what pages are typed against.
+const createTabRouter = (url: string): AppRouter =>
+  createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [url] }),
+    // defaultErrorComponent contains a route render error to its tab; without it the
+    // error bubbles to the window-level boundary and tears down the whole window.
+    defaultErrorComponent: RouteErrorFallback
+  })
 
 interface TabRouterProps {
   tab: Tab
@@ -21,17 +33,8 @@ interface TabRouterProps {
  */
 export const TabRouter = ({ tab, isActive, onUrlChange }: TabRouterProps) => {
   // Create independent router instance per tab (only once)
-  const router = useMemo(() => {
-    const history = createMemoryHistory({ initialEntries: [tab.url] })
-    // defaultErrorComponent contains a route render error to its tab; without it the
-    // error bubbles to the window-level boundary and tears down the whole window.
-    return createRouter({
-      routeTree,
-      history,
-      defaultErrorComponent: RouteErrorFallback
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab.id])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const router = useMemo(() => createTabRouter(tab.url), [tab.id])
 
   // External retargets update tab.url before an async route can replace the outgoing page.
   // Cover that interval so teardown effects cannot repaint stale page loading UI.

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -32,6 +32,7 @@ import { useConversationShellPaneState } from '@renderer/hooks/useConversationSh
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { ResourceListRevealPayload } from '@renderer/services/resourceListRevealEvents'
 import { toast } from '@renderer/services/toast'
+import type { AppRouter } from '@renderer/types/router'
 import { buildAgentFileWorkspaceKey, buildAgentSessionTopicId } from '@renderer/utils/agentSession'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
@@ -40,7 +41,7 @@ import { isDataApiNotFoundError } from '@shared/data/api/errors'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import { AGENT_WORKSPACE_TYPE, type AgentSessionWorkspaceSource } from '@shared/data/api/schemas/agentWorkspaces'
 import type { TopicTabPosition } from '@shared/data/preference/preferenceTypes'
-import { useNavigate, useSearch } from '@tanstack/react-router'
+import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import type { PropsWithChildren } from 'react'
 import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -57,11 +58,11 @@ import {
   type FeedbackComposerLaunch,
   getFeedbackIntentGuardCacheKey
 } from './feedbackComposerLaunch'
-import { parseAgentRouteSearch } from './routeSearch'
 import type { CreateAgentSessionDefaults } from './types'
 import { useAgentConversationBootstrap } from './useAgentConversationBootstrap'
 
 const logger = loggerService.withContext('AgentPage')
+const agentsRouteApi = getRouteApi('/app/agents')
 type AgentConversationResourceKind = 'agent'
 const AGENT_CONVERSATION_RESOURCE_KINDS = ['agent'] as const satisfies readonly AgentConversationResourceKind[]
 
@@ -92,7 +93,7 @@ const AgentPage = () => {
   const [sessionDisplayMode, setSessionDisplayMode] = usePreference('agent.session.display_mode')
   const [panePosition, setPanePosition] = usePreference('agent.session.position')
   const isClassicSessionLayout = sessionDisplayMode === 'agent'
-  const routeSearch = parseAgentRouteSearch(useSearch({ strict: false }) as Record<string, unknown>)
+  const routeSearch = agentsRouteApi.useSearch<AppRouter>()
   const navigate = useNavigate()
   const { t } = useTranslation()
   const isFeedbackIntent = routeSearch.intent === 'feedback'

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -302,7 +302,7 @@ vi.mock('@renderer/data/hooks/useDataApi', async () => ({
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => agentPageMocks.navigate,
-  useSearch: () => agentPageMocks.routeSearch
+  getRouteApi: () => ({ useSearch: () => agentPageMocks.routeSearch })
 }))
 
 vi.mock('@renderer/components/chat/shell/ConversationShell', () => ({

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -35,13 +35,14 @@ import { mapApiTopicToRendererTopic, useActiveTopic, useTopicById, useTopicMutat
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { ResourceListRevealPayload } from '@renderer/services/resourceListRevealEvents'
 import { toast } from '@renderer/services/toast'
+import type { AppRouter } from '@renderer/types/router'
 import type { Topic } from '@renderer/types/topic'
 import { getTopicAssistantDisplayGroupId } from '@renderer/utils/chat/topicsHelpers'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
 import { cn } from '@renderer/utils/style'
 import { isDataApiNotFoundError } from '@shared/data/api/errors'
-import { useNavigate, useSearch } from '@tanstack/react-router'
+import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import type { FC, HTMLAttributes } from 'react'
 import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -53,12 +54,12 @@ import {
 } from './components/AssistantConversationPickerDialog'
 import { HomeTabRuntime } from './components/HomeTabRuntime'
 import { TopicRightPane } from './components/TopicRightPane'
-import { parseChatRouteSearch } from './routeSearch'
 import { Topics } from './Tabs/components/Topics'
 import HomeTabs from './Tabs/HomeTabs'
 import type { AddNewTopicPayload } from './types'
 
 const logger = loggerService.withContext('HomePage')
+const chatRouteApi = getRouteApi('/app/chat')
 const LAST_USED_ASSISTANT_CACHE_KEY = 'ui.chat.last_used_assistant_id'
 type AssistantConversationResourceKind = 'assistant'
 const ASSISTANT_CONVERSATION_RESOURCE_KINDS = [
@@ -88,7 +89,7 @@ const HomePage: FC = () => {
   const isClassicTopicLayout = topicDisplayMode === 'assistant'
   const [assistantPickerOpen, setAssistantPickerOpen] = useState(false)
 
-  const routeSearch = parseChatRouteSearch(useSearch({ strict: false }) as Record<string, unknown>)
+  const routeSearch = chatRouteApi.useSearch<AppRouter>()
   const navigate = useNavigate()
   const routeTopicId = routeSearch.topicId
   const routeAssistantId = routeSearch.assistantId

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -326,7 +326,7 @@ vi.mock('@renderer/hooks/useTopic', async () => {
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => homeMocks.navigate,
-  useSearch: () => homeMocks.routeSearch
+  getRouteApi: () => ({ useSearch: () => homeMocks.routeSearch })
 }))
 
 vi.mock('react-i18next', async (importOriginal) => ({

--- a/src/renderer/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/DataSettings.tsx
@@ -12,7 +12,8 @@ import {
   settingsSubmenuScrollClassName,
   settingsSubmenuSectionTitleClassName
 } from '@renderer/pages/settings/settingsStyles'
-import { useNavigate, useSearch } from '@tanstack/react-router'
+import type { AppRouter } from '@renderer/types/router'
+import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import { BookOpen, CloudUpload, FileText, FolderCog, FolderInput, Import, Server } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { type FC, lazy, Suspense } from 'react'
@@ -20,6 +21,8 @@ import { useTranslation } from 'react-i18next'
 
 import BasicDataSettings from './BasicDataSettings'
 import { DATA_PANEL_KEYS, type DataPanelKey, DEFAULT_DATA_PANEL } from './dataPanels'
+
+const dataRouteApi = getRouteApi('/settings/data')
 
 const ExportMenuOptions = lazy(() => import('./ExportMenuSettings'))
 const JoplinSettings = lazy(() => import('./JoplinSettings'))
@@ -45,10 +48,9 @@ const DataSettings: FC = () => {
   // The URL is the single source of truth for the active panel (search jumps
   // arrive as /settings/data?panel=<key>; menu clicks write it back with
   // replace). Unknown values were already dropped by the route schema.
-  const search = useSearch({ strict: false })
+  const search = dataRouteApi.useSearch<AppRouter>()
   const rawPanel = typeof search.panel === 'string' ? search.panel : undefined
-  const panelParam =
-    rawPanel && (DATA_PANEL_KEYS as readonly string[]).includes(rawPanel) ? (rawPanel as DataPanelKey) : undefined
+  const panelParam = rawPanel && (DATA_PANEL_KEYS as readonly string[]).includes(rawPanel) ? rawPanel : undefined
   const menu = panelParam ?? DEFAULT_DATA_PANEL
 
   const menuItems: DataMenuItem[] = [

--- a/src/renderer/pages/settings/McpSettings/McpServersList.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpServersList.tsx
@@ -17,11 +17,12 @@ import { useMcpServers } from '@renderer/hooks/useMcpServer'
 import { ipcApi } from '@renderer/ipc'
 import EnvironmentDependencies from '@renderer/pages/settings/DependenciesSettings/EnvironmentDependencies'
 import { toast } from '@renderer/services/toast'
+import type { AppRouter } from '@renderer/types/router'
 import { matchKeywordsInString } from '@renderer/utils/match'
 import type { CreateMcpServerDto } from '@shared/data/api/schemas/mcpServers'
 import type { ProtocolMcpInstallRequest } from '@shared/data/types/mcpProtocolInstall'
 import type { McpServer } from '@shared/data/types/mcpServer'
-import { useNavigate, useSearch } from '@tanstack/react-router'
+import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import { Check, ChevronDown, Filter, Plus } from 'lucide-react'
 import type { FC } from 'react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
@@ -33,6 +34,7 @@ import McpServerCard from './McpServerCard'
 import QuickCreateMcpServerDialog from './QuickCreateMcpServerDialog'
 
 const logger = loggerService.withContext('McpServersList')
+const mcpServersRouteApi = getRouteApi('/settings/mcp/servers')
 
 type ImportMethod = 'json' | 'dxt' | 'mcpb'
 type McpServerFilter = 'all' | 'enabled' | 'disabled' | 'stdio' | 'sse' | 'streamableHttp' | 'builtin'
@@ -50,9 +52,7 @@ const McpServersList: FC = () => {
   const { mcpServers, addMcpServer, reorderMcpServers, refetch } = useMcpServers()
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const search = useSearch({ strict: false }) as {
-    protocolInstallRequestId?: string
-  }
+  const search = mcpServersRouteApi.useSearch<AppRouter>()
   const [isAddModalVisible, setIsAddModalVisible] = useState(false)
   const [isAddMenuOpen, setIsAddMenuOpen] = useState(false)
   const [isFilterMenuOpen, setIsFilterMenuOpen] = useState(false)

--- a/src/renderer/pages/settings/McpSettings/McpSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettings.tsx
@@ -14,6 +14,7 @@ import { ipcApi } from '@renderer/ipc'
 import McpDescription from '@renderer/pages/settings/McpSettings/McpDescription'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
+import type { AppRouter } from '@renderer/types/router'
 import type { McpTool } from '@renderer/types/tool'
 import { formatMcpError } from '@renderer/utils/error'
 import { cn } from '@renderer/utils/style'
@@ -21,7 +22,7 @@ import type { UpdateMcpServerDto } from '@shared/data/api/schemas/mcpServers'
 import type { McpServer, McpServerType } from '@shared/data/types/mcpServer'
 import type { McpPrompt, McpResource } from '@shared/types/mcp'
 import { isInMemoryBuiltinMcpServer } from '@shared/utils/mcp'
-import { useNavigate, useParams, useSearch } from '@tanstack/react-router'
+import { getRouteApi, useNavigate, useParams } from '@tanstack/react-router'
 import { ArrowLeft, SaveIcon } from 'lucide-react'
 import React, { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -49,6 +50,7 @@ import { useMcpServerTrust } from './useMcpServerTrust'
 import { toUpdateMcpServerDto } from './utils'
 
 const logger = loggerService.withContext('McpSettings')
+const mcpSettingsRouteApi = getRouteApi('/settings/mcp/settings/$serverId')
 
 type TabKey = 'settings' | 'description' | 'logs' | 'tools' | 'prompts' | 'resources'
 type McpTabItem = {
@@ -57,7 +59,6 @@ type McpTabItem = {
   children: React.ReactNode
 }
 type McpToolsCacheKey = `mcp.tools.${string}`
-type McpSettingsSearch = { autoEnable?: 'true' }
 
 const mcpToolsCacheKey = (serverId: string): McpToolsCacheKey => `mcp.tools.${serverId}`
 
@@ -71,7 +72,7 @@ interface McpSettingsContentProps {
 
 const McpSettingsContent: React.FC<McpSettingsContentProps> = ({ server, updateMcpServer }) => {
   const { t } = useTranslation()
-  const search = useSearch({ strict: false }) as McpSettingsSearch
+  const search = mcpSettingsRouteApi.useSearch<AppRouter>()
   const serverId = server.id
   const [initialFormValues] = useState(() => toMcpFormDefaultValues(server))
 

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpServersList.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpServersList.test.tsx
@@ -38,8 +38,8 @@ vi.mock('@renderer/ipc', () => ({
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mocks.navigate,
-  useSearch: () => ({
-    protocolInstallRequestId: mocks.protocolInstallRequestId
+  getRouteApi: () => ({
+    useSearch: () => ({ protocolInstallRequestId: mocks.protocolInstallRequestId })
   })
 }))
 

--- a/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/McpSettings.test.tsx
@@ -38,7 +38,7 @@ vi.mock('@renderer/hooks/useMcpServer', async (importOriginal) => ({
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mocks.navigate,
   useParams: () => ({ serverId: currentServer.id }),
-  useSearch: () => currentSearch
+  getRouteApi: () => ({ useSearch: () => currentSearch })
 }))
 
 vi.mock('@renderer/services/popup', () => ({

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSettingsPage.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { Alert, Button, Spinner } from '@cherrystudio/ui'
 import { usePersistCache } from '@data/hooks/useCache'
 import { useProviders } from '@renderer/hooks/useProvider'
+import type { AppRouter } from '@renderer/types/router'
 import { isProviderSettingsListVisibleProvider } from '@renderer/utils/providerSettings'
 import type { Provider } from '@shared/data/types/provider'
 import { useNavigate, useSearch } from '@tanstack/react-router'
@@ -13,12 +14,6 @@ import { useProviderDeepLinkImport } from './hooks/useProviderDeepLinkImport'
 import { ProviderList } from './ProviderList'
 import ProviderSetting from './ProviderSetting'
 
-interface ProviderSettingsSearch {
-  addProviderData?: string
-  filter?: string
-  id?: string
-}
-
 interface PendingApiSetup {
   providerId: string
   initialStep: ProviderApiSetupInitialStep
@@ -29,7 +24,7 @@ interface ProviderSettingsContentProps {
 }
 
 function ProviderSettingsContent({ rawProviders }: ProviderSettingsContentProps) {
-  const search = useSearch({ strict: false }) as ProviderSettingsSearch
+  const search = useSearch<AppRouter, undefined, false>({ strict: false })
   const navigate = useNavigate()
   const [lastSelectedProviderId, setLastSelectedProviderId] = usePersistCache(
     'settings.provider.last_selected_provider_id'

--- a/src/renderer/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/pages/settings/ShortcutSettings.tsx
@@ -32,6 +32,7 @@ import {
 import { shortcutAnchorId } from '@renderer/pages/settings/shortcut.search'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
+import type { AppRouter } from '@renderer/types/router'
 import { scrollIntoView } from '@renderer/utils/dom'
 import { isMac, platform } from '@renderer/utils/platform'
 import { cn } from '@renderer/utils/style'
@@ -48,7 +49,7 @@ import {
   type ShortcutBinding,
   type ShortcutToken
 } from '@shared/utils/shortcut'
-import { useSearch } from '@tanstack/react-router'
+import { getRouteApi } from '@tanstack/react-router'
 import { isEmpty } from 'es-toolkit/compat'
 import { ChevronDown, ListFilter, MoreHorizontal, Undo2 } from 'lucide-react'
 import type { FC, KeyboardEvent as ReactKeyboardEvent } from 'react'
@@ -56,6 +57,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('ShortcutSettings')
+const shortcutRouteApi = getRouteApi('/settings/shortcut')
 
 const isBindingEqual = (a: ShortcutBinding, b: ShortcutBinding): boolean =>
   a.length === b.length && a.every((key, index) => key === b[index])
@@ -106,7 +108,7 @@ const ShortcutSettings: FC = () => {
 
   // `?command=<id>` arrives from pages that own a feature but not its shortcut, so landing
   // here mid-list would leave the user hunting. Highlight fades; the scroll stays put.
-  const { command: focusedCommand } = useSearch({ strict: false }) as { command?: CommandId }
+  const { command: focusedCommand } = shortcutRouteApi.useSearch<AppRouter>()
   const focusedRowRef = useRef<HTMLDivElement | null>(null)
   const [focusFaded, setFocusFaded] = useState(false)
 

--- a/src/renderer/pages/settings/__tests__/ShortcutSettings.test.tsx
+++ b/src/renderer/pages/settings/__tests__/ShortcutSettings.test.tsx
@@ -38,7 +38,7 @@ vi.mock('@renderer/hooks/useTheme', () => ({
 // throws. Tests set this to choose which row (if any) arrives focused.
 const { routerSearch } = vi.hoisted(() => ({ routerSearch: { current: {} as { command?: string } } }))
 vi.mock('@tanstack/react-router', () => ({
-  useSearch: () => routerSearch.current
+  getRouteApi: () => ({ useSearch: () => routerSearch.current })
 }))
 
 // jsdom ships no scrollIntoView, and the focused row calls it on mount.

--- a/src/renderer/routes/settings/provider.tsx
+++ b/src/renderer/routes/settings/provider.tsx
@@ -8,8 +8,8 @@ export const providerSettingsSearchSchema = z.object({
   // and normalize back to the string the downstream consumer (JSON.parse) expects.
   addProviderData: z
     .union([z.string(), z.record(z.string(), z.unknown())])
-    .optional()
-    .transform((value) => (value == null || typeof value === 'string' ? value : JSON.stringify(value))),
+    .transform((value) => (typeof value === 'string' ? value : JSON.stringify(value)))
+    .optional(),
   filter: z.string().optional(),
   id: z.string().optional()
 })

--- a/src/renderer/types/router.ts
+++ b/src/renderer/types/router.ts
@@ -1,0 +1,19 @@
+import type { routeTree } from '@renderer/routeTree.gen'
+import type { createRouter } from '@tanstack/react-router'
+
+/**
+ * The app's router type. `TabRouter` annotates its factory with this, so a router built with
+ * non-default options fails there rather than drifting from what is registered here.
+ *
+ * Pass it explicitly — `useSearch<AppRouter>()`. Left to its `RegisteredRouter` default, the
+ * type argument re-enters the `Register` -> route tree -> `Route<Register>` cycle, and
+ * TypeScript breaks that cycle by falling back to `any` at whichever call sites it reaches
+ * mid-resolution: the search type silently degrades with nothing failing to report it.
+ */
+export type AppRouter = ReturnType<typeof createRouter<typeof routeTree>>
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: AppRouter
+  }
+}


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`HomePage` and `AgentPage` asked the router for an untyped search bag, cast it into shape, and re-ran the parser the route's `validateSearch` had already run:

```ts
const routeSearch = parseChatRouteSearch(useSearch({ strict: false }) as Record<string, unknown>)
```

After this PR:

```ts
const chatRouteApi = getRouteApi('/app/chat')
// ...
const routeSearch = chatRouteApi.useSearch<AppRouter>()
```

The cast and the second parse are gone. `parseChatRouteSearch` / `parseAgentRouteSearch` stay exactly where they were — they remain the implementation of each route's `validateSearch`.

Four settings pages that had the same shape (`DataSettings`, `McpServersList`, `McpSettings`, `ShortcutSettings`) get the same treatment, and `ProviderSettingsPage` drops its cast while keeping `strict: false`.

Fixes #20105

### Why we need it and why it was done in this way

None of these pages can render outside its own route — each is referenced only by its own route file — so `strict: false` was not protecting anything. `getRouteApi` is the documented way to reach a route's own hooks from a component that the route file imports; importing the `Route` export back would be a circular import. The exception is `ProviderSettingsPage`: the onboarding flow builds its own root router around it (`OnboardingPage.tsx`), so its route is genuinely not matched there. It keeps the loose lookup and only loses the cast.

Two prerequisites had to be dealt with first, and they are the bulk of the diff.

**1. The app never registered a router type.** TanStack's docs call registration required — without it `RegisteredRouter` degrades to `AnyRouter` and every route-id-addressed API (`getRouteApi`, `useSearch({ from })`, `navigate({ to })`) silently returns `any`. This app had no registration because routers are built per tab in `TabRouter`, so there is no module-level instance to declare. `src/renderer/types/router.ts` now registers the tab factory's return type, so the registered type follows whatever options `TabRouter` actually passes.

**2. The registered type has to be passed explicitly.** Registration alone is not enough here. `useSearch()`'s type parameter defaults to `RegisteredRouter`, and resolving that default re-enters a cycle: `Register` → the route tree → `Route<Register, …>` (routes are parameterized by `Register`). TypeScript breaks the cycle by falling back to `any` at whichever call sites it reaches mid-resolution, so the same call typed correctly in one page and silently degraded to `any` in another, with nothing failing to report it. `useSearch<AppRouter>()` bypasses the default and resolves the same type in every file.

This was not theoretical: an intermediate version of this branch that relied on the default removed `ShortcutSettings`' cast and replaced it with `any`, and `typecheck` stayed green throughout.

Registration also exposed one latent bug: `routes/settings/provider.tsx` declared `addProviderData` with `.optional()` before `.transform()`, which makes the output key **required**, forcing `search` onto every `navigate({ to: '/settings/provider' })` — 10 type errors across 5 files once the types became real. Reordering to `.transform().optional()` fixes the schema.

The following tradeoffs were made:

- Registering the router is broader than the linked issue asked for, but the issue's premise ("the type of a page's search comes from a cast instead of from its route") is unreachable without it. It also means `Link` / `navigate` / `redirect` are type-checked app-wide now, which is how the provider schema bug surfaced.
- Passing `<AppRouter>` at each call site is noise, but the alternative is a type guarantee that holds by accident and can flip on an unrelated edit.
- `AppRouter` lives in `src/renderer/types/router.ts` and is derived from the generated route tree, not from `TabRouter`'s factory, so the types bucket never reaches up into a component. `TabRouter` annotates its factory with `AppRouter` instead: the edge points downward, and options that would change the router's type fail there rather than drifting from what pages are typed against (verified by adding `defaultStructuralSharing: true`, which errors on the annotation). Every import of it is `import type`, so none of this adds a runtime edge (verified on the esbuild output).

The following alternatives were considered:

- `getRouteApi` without registering the router: rejected, it degrades the pages to `any`.
- Registering but relying on the `RegisteredRouter` default: rejected for the reason above.
- Reworking `ProviderSettingsPage` to take its search as a prop from the route (the `routes/settings/model.tsx` pattern), which would let it drop `strict: false` entirely: out of scope here.

Links to places where the discussion took place: #20105

### Breaking changes

None. The same search values reach every page, and the provider route accepts and normalizes exactly the same inputs.

### Special notes for your reviewer

- Start at `src/renderer/types/router.ts` — the `declare module` block is the load-bearing part; everything else follows from it.
- **A green `typecheck` does not prove this change works.** The failure mode is a silent degradation to `any`. Each of the 7 call sites was verified individually against a clean build (`rm -rf .tsbuildinfo`) by assigning the result to an incompatible type and reading the reported type back. All 7 report their route's own search type: `HomePage` `{ assistantId?, topicId?, view? }`, `AgentPage` `{ agentId?, intent?, sessionId?, view? }`, `DataSettings` `{ panel? }`, `McpServersList` `{ protocolInstallRequestId? }`, `McpSettings` `{ autoEnable? }`, `ShortcutSettings` `{ command? }`, `ProviderSettingsPage` the full optional union that `strict: false` implies.
- `SettingsSearchBox` and `SettingsFocusUrl` keep `strict: false` untouched: both are rendered by the settings layout across every settings route, so there is no single route id to address.
- Unrelated observation made while reading `TabRouter`: each tab keeps a history stack that no UI can reach. Filed separately as #20107, not addressed here.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```

