### PR TITLE
fix(right-pane): drop the close tooltip when the panel closes

### DIFF
--- a/packages/ui/src/components/primitives/__tests__/tooltip.test.tsx
+++ b/packages/ui/src/components/primitives/__tests__/tooltip.test.tsx
@@ -74,6 +74,25 @@ describe('Tooltip', () => {
       expect(screen.getByText('Trigger')).toBeInTheDocument()
     })
 
+    it('unmounts an open tooltip content immediately when isDisabled turns true', () => {
+      const { rerender } = render(
+        <Tooltip content="close-tip" isOpen>
+          <button type="button">Trigger</button>
+        </Tooltip>
+      )
+      expect(getTooltipContentElement('close-tip')).toBeInTheDocument()
+
+      rerender(
+        <Tooltip content="close-tip" isOpen isDisabled>
+          <button type="button">Trigger</button>
+        </Tooltip>
+      )
+
+      // Anchors hidden via display:none leave Radix tooltips parked at the viewport
+      // origin during their exit animation; disabling must drop the content at once.
+      expect(document.querySelector('[data-slot="tooltip-content"]')).not.toBeInTheDocument()
+    })
+
     it('uses title as fallback when content is not provided', () => {
       const { container } = render(
         <Tooltip title="title-tip">

--- a/src/renderer/components/chat/panes/Shell/RightPanel.tsx
+++ b/src/renderer/components/chat/panes/Shell/RightPanel.tsx
@@ -462,7 +462,10 @@ export function RightPanelHeaderControls({ canMaximize = false }: { canMaximize?
   return (
     <div className="flex shrink-0 items-center gap-0.5 [-webkit-app-region:no-drag]">
       {maximizeButton}
-      <Tooltip content={closeLabel} delay={800}>
+      {/* Closing hides the pane subtree via Activity (display:none), which zeroes the
+          trigger's rect; Radix then parks the still-exiting tooltip at the viewport
+          origin. Unmounting the tooltip as the panel closes removes that window. */}
+      <Tooltip content={closeLabel} delay={800} isDisabled={!state.presentationOpen}>
         <NavbarIcon tone="conversation" aria-label={closeLabel} onClick={actions.close}>
           <RightSidebarCollapseIcon />
         </NavbarIcon>

--- a/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
+++ b/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
@@ -26,7 +26,14 @@ const INSPECTOR_POLICY = getRightPaneWidthPolicy('inspector')
 const commandMock = vi.hoisted(() => ({ handler: undefined as (() => void) | undefined }))
 
 vi.mock('@cherrystudio/ui', () => ({
-  Tooltip: ({ children }: PropsWithChildren) => <>{children}</>
+  Tooltip: ({ children, content, isDisabled }: PropsWithChildren<{ content?: unknown; isDisabled?: boolean }>) => (
+    <div
+      data-testid="tooltip-trigger"
+      data-content={typeof content === 'string' ? content : undefined}
+      data-disabled={isDisabled ? 'true' : undefined}>
+      {children}
+    </div>
+  )
 }))
 
 vi.mock('@renderer/components/ErrorBoundary', async () => {
@@ -418,6 +425,26 @@ describe('RightPanel', () => {
 
     expect(screen.queryByTestId('shell-tab-list')).toBeNull()
     expect(screen.getByText('first:0')).toBeInTheDocument()
+  })
+
+  it('drops the close tooltip once the panel closes, so it cannot park at the viewport origin', () => {
+    render(
+      <Harness defaultOpen>
+        <RightPanelViewport>
+          <RightPanel />
+        </RightPanelViewport>
+      </Harness>
+    )
+
+    const closeTooltip = screen
+      .getAllByTestId('tooltip-trigger')
+      .find((node) => node.getAttribute('data-content') === 'common.close_sidebar')
+    expect(closeTooltip).not.toHaveAttribute('data-disabled')
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.close_sidebar' }))
+
+    expect(screen.getByTestId('right-pane-host')).toHaveAttribute('data-open', 'false')
+    expect(closeTooltip).toHaveAttribute('data-disabled', 'true')
   })
 
   it('keeps shell controls available when a content-composed panel fails to render', () => {

--- a/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
+++ b/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
@@ -436,15 +436,19 @@ describe('RightPanel', () => {
       </Harness>
     )
 
-    const closeTooltip = screen
-      .getAllByTestId('tooltip-trigger')
-      .find((node) => node.getAttribute('data-content') === 'common.close_sidebar')
-    expect(closeTooltip).not.toHaveAttribute('data-disabled')
+    const findCloseTooltip = () =>
+      screen
+        .getAllByTestId('tooltip-trigger')
+        .find((node) => node.getAttribute('data-content') === 'common.close_sidebar')
+    expect(findCloseTooltip()).not.toHaveAttribute('data-disabled')
 
     fireEvent.click(screen.getByRole('button', { name: 'common.close_sidebar' }))
 
     expect(screen.getByTestId('right-pane-host')).toHaveAttribute('data-open', 'false')
-    expect(closeTooltip).toHaveAttribute('data-disabled', 'true')
+    // Re-query after the close rather than reusing the pre-close node: the
+    // tooltip wrapper may remount on state change, which would make an
+    // assertion against the stale reference flaky even when behavior is right.
+    expect(findCloseTooltip()).toHaveAttribute('data-disabled', 'true')
   })
 
   it('keeps shell controls available when a content-composed panel fails to render', () => {


### PR DESCRIPTION
## Problem

In the agent chat, with the right pane open, hovering the close button shows its tooltip anchored correctly — but clicking it makes the tooltip jump to the top-left corner of the window before it fades out.

## Root cause

1. The close button's header is rendered inside the pane's content tree (`headerMode: 'content'`), which React preserves across close via `<Activity>` — hidden mode applies `display: none`.
2. Radix positions the tooltip portal with Floating UI, continuously re-measuring the trigger. Once the trigger gets `display: none`, its rect reads `(0,0,0,0)`, so the still-exiting tooltip is translated to the viewport origin. Radix's `hideWhenDetached` is off by default, so nothing hides it during that window.
3. The exit animation keeps the tooltip visible long enough for the jump to be plainly visible.

The same mechanism applies wherever a tooltip trigger ends up inside a subtree hidden by `Activity`, but the right-pane close button is the reproducible instance.

## Fix

Disable the close tooltip when the panel is not presented (`isDisabled={!state.presentationOpen}` in `RightPanelHeaderControls`). The `Tooltip` wrapper's disabled branch unmounts the whole Radix root — including the portaled content — in the same commit that closes the pane, so there is no exit-animation window in which the tooltip can be repositioned against a zeroed anchor. The tooltip returns automatically when the pane reopens.

## Tests

- `RightPanel.test.tsx`: the mocked `Tooltip` now surfaces `isDisabled`; new case asserts the close tooltip is disabled in the same commit that closes the pane.
- `packages/ui` `tooltip.test.tsx`: new case asserts an open tooltip's content is removed from the DOM immediately when `isDisabled` flips to true.

`pnpm lint` passes (format + typecheck + i18n:check); both affected test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)