### PR TITLE
fix(translate): route copy feedback to the pane that was copied

### DIFF
--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -242,7 +242,8 @@ const TranslatePage: FC = () => {
     loggerContext: 'TranslatePage',
     onResponse: smoothUpdate
   })
-  const [copied, setCopied] = useTemporaryValue(false, 2000)
+  const [inputCopied, setInputCopied] = useTemporaryValue(false, 2000)
+  const [outputCopied, setOutputCopied] = useTemporaryValue(false, 2000)
   const [historyOpen, setHistoryOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [detectedLanguage, setDetectedLanguage] = useState<TranslateLangCode | null>(null)
@@ -330,32 +331,26 @@ const TranslatePage: FC = () => {
     [setTranslateInput, setTranslateOutput]
   )
 
-  const copy = useCallback(
-    async (value: string) => {
-      await navigator.clipboard.writeText(value)
-      setCopied(true)
-    },
-    [setCopied]
-  )
-
   const onCopyInput = useCallback(async () => {
     if (!translateInput) return
     try {
-      await copy(translateInput)
+      await navigator.clipboard.writeText(translateInput)
+      setInputCopied(true)
     } catch (error) {
       logger.error('Failed to copy source text:', error as Error)
       toast.error(t('common.copy_failed'))
     }
-  }, [copy, t, translateInput])
+  }, [setInputCopied, t, translateInput])
 
   const onCopyOutput = useCallback(async () => {
     try {
-      await copy(translateOutput)
+      await navigator.clipboard.writeText(translateOutput)
+      setOutputCopied(true)
     } catch (error) {
       logger.error('Failed to copy text to clipboard:', error as Error)
       toast.error(t('common.copy_failed'))
     }
-  }, [copy, t, translateOutput])
+  }, [setOutputCopied, t, translateOutput])
 
   const onExportOutputToNotes = useCallback(() => {
     const translationResult = translateOutput.trim()
@@ -388,7 +383,8 @@ const TranslatePage: FC = () => {
           'auto-copy',
           async () => {
             try {
-              await copy(translated)
+              await navigator.clipboard.writeText(translated)
+              setOutputCopied(true)
             } catch (error) {
               logger.error('Failed to auto copy translated text', error as Error)
               toast.error(t('translate.error.auto_copy_failed'))
@@ -405,7 +401,7 @@ const TranslatePage: FC = () => {
         targetLanguage: actualTargetLanguage
       })
     },
-    [addHistory, autoCopy, copy, isTranslating, runTranslate, setTimeoutTimer, smoothReset, t]
+    [addHistory, autoCopy, isTranslating, runTranslate, setOutputCopied, setTimeoutTimer, smoothReset, t]
   )
 
   // Off the translation critical path: a failed detection or patch just leaves
@@ -1062,7 +1058,7 @@ const TranslatePage: FC = () => {
                           translatedContent={translateOutput}
                           enableMarkdown={enableMarkdown}
                           translating={isTranslating || isDetecting || isPdfTextExtracting}
-                          copied={copied}
+                          copied={outputCopied}
                           onCopy={onCopyOutput}
                           onExportToNotes={onExportOutputToNotes}
                           onScroll={outputScrollHandler}
@@ -1095,6 +1091,7 @@ const TranslatePage: FC = () => {
                 onPaste={onPaste}
                 onDrop={onDrop}
                 onSelectFile={handleSelectFile}
+                copied={inputCopied}
                 onCopy={onCopyInput}
                 onCancelOcr={clearOcrJob}
                 disabled={isTranslating || isDetecting || isProcessing || isOcrRunning}
@@ -1108,7 +1105,7 @@ const TranslatePage: FC = () => {
                 translatedContent={translateOutput}
                 enableMarkdown={enableMarkdown}
                 translating={isTranslating || isDetecting}
-                copied={copied}
+                copied={outputCopied}
                 onCopy={onCopyOutput}
                 onExportToNotes={onExportOutputToNotes}
                 onScroll={outputScrollHandler}

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -175,10 +175,6 @@ vi.mock('@renderer/hooks/useModel', () => ({
   })
 }))
 
-vi.mock('@renderer/hooks/useTemporaryValue', () => ({
-  useTemporaryValue: () => [false, vi.fn()]
-}))
-
 vi.mock('@renderer/hooks/useTimer', () => ({
   useTimer: () => ({ setTimeoutTimer: translateCoreMock.setTimeoutTimer })
 }))
@@ -318,6 +314,8 @@ vi.mock('../components/TranslateInputPane', () => ({
     onSelectFile,
     onDrop,
     onCancelOcr,
+    copied,
+    onCopy,
     disabled,
     ocrProcessing
   }: {
@@ -328,6 +326,8 @@ vi.mock('../components/TranslateInputPane', () => ({
     onSelectFile: () => void
     onDrop: (event: React.DragEvent<HTMLDivElement>) => void
     onCancelOcr: () => void
+    copied: boolean
+    onCopy: () => void
     disabled?: boolean
     ocrProcessing?: boolean
   }) => {
@@ -343,6 +343,8 @@ vi.mock('../components/TranslateInputPane', () => ({
           onPaste={onPaste}
         />
         <button type="button" aria-label="translate.files.upload" onClick={onSelectFile} />
+        <button type="button" aria-label="input.copy" onClick={onCopy} />
+        <span data-testid="translate-input-copied">{String(copied)}</span>
         {ocrProcessing && (
           <div data-testid="translate-input-ocr-processing">
             ocr.processing
@@ -379,15 +381,21 @@ vi.mock('../components/TranslateOutputPane', () => ({
   default: ({
     translating,
     translatedContent,
+    copied,
+    onCopy,
     onExportToNotes
   }: {
     translating: boolean
     translatedContent: string
+    copied: boolean
+    onCopy: () => void
     onExportToNotes?: () => void | Promise<void>
   }) => (
     <div data-testid="translate-output-pane">
       {translating && <span>translate.processing</span>}
       <span data-testid="translate-output-content">{translatedContent}</span>
+      <button type="button" aria-label="output.copy" onClick={onCopy} />
+      <span data-testid="translate-output-copied">{String(copied)}</span>
       <button type="button" aria-label="notes.save" onClick={() => void onExportToNotes?.()} />
     </div>
   )
@@ -1653,6 +1661,18 @@ describe('TranslatePage', () => {
     })
 
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('translated text')
+  })
+
+  it('shows the copied feedback on the input pane rather than the output pane', async () => {
+    const { rerender } = render(<TranslatePage />)
+    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
+    rerender(<TranslatePage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'input.copy' }))
+
+    await waitFor(() => expect(screen.getByTestId('translate-input-copied')).toHaveTextContent('true'))
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith('hello')
+    expect(screen.getByTestId('translate-output-copied')).toHaveTextContent('false')
   })
 
   it('keeps the current target language when reusing history with a null target language', async () => {

--- a/src/renderer/pages/translate/components/TranslateInputPane.tsx
+++ b/src/renderer/pages/translate/components/TranslateInputPane.tsx
@@ -6,7 +6,7 @@ import uploadPptIcon from '@renderer/assets/images/translate/upload-ppt.svg'
 import uploadTextIcon from '@renderer/assets/images/translate/upload-text.svg'
 import uploadWordIcon from '@renderer/assets/images/translate/upload-word.svg'
 import { useDrag } from '@renderer/hooks/useDrag'
-import { Copy, LoaderCircle, X } from 'lucide-react'
+import { Check, Copy, LoaderCircle, X } from 'lucide-react'
 import type { KeyboardEvent, Ref } from 'react'
 import { useCallback, useLayoutEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -22,6 +22,7 @@ type Props = {
   onPaste: (event: React.ClipboardEvent<HTMLTextAreaElement>) => void
   onDrop: (event: React.DragEvent<HTMLDivElement>) => void
   onSelectFile: () => void
+  copied: boolean
   onCopy: () => void
   onCancelOcr: () => void
   disabled: boolean
@@ -38,6 +39,7 @@ const TranslateInputPane = ({
   onPaste,
   onDrop,
   onSelectFile,
+  copied,
   onCopy,
   onCancelOcr,
   disabled,
@@ -96,7 +98,7 @@ const TranslateInputPane = ({
           disabled={!text}
           aria-label={t('common.copy')}
           className="absolute top-4 right-3">
-          <Copy size={14} />
+          {copied ? <Check size={14} className="text-foreground" /> : <Copy size={14} />}
         </IconButton>
       </div>
       {!text && (

--- a/src/renderer/pages/translate/components/__tests__/TranslateInputPane.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateInputPane.test.tsx
@@ -45,6 +45,7 @@ const baseProps = () => ({
   onPaste: vi.fn(),
   onDrop: vi.fn(),
   onSelectFile: vi.fn(),
+  copied: false,
   onCopy: vi.fn(),
   onCancelOcr: vi.fn(),
   disabled: false,
@@ -92,6 +93,16 @@ describe('TranslateInputPane', () => {
     render(<TranslateInputPane {...baseProps()} />)
 
     expect(screen.queryByRole('button', { name: 'common.clear' })).not.toBeInTheDocument()
+  })
+
+  it('swaps the copy icon for a check once the text has been copied', () => {
+    const { rerender } = render(<TranslateInputPane {...baseProps()} text="hello" />)
+
+    expect(screen.getByRole('button', { name: 'common.copy' }).querySelector('.lucide-check')).toBeNull()
+
+    rerender(<TranslateInputPane {...baseProps()} text="hello" copied />)
+
+    expect(screen.getByRole('button', { name: 'common.copy' }).querySelector('.lucide-check')).not.toBeNull()
   })
 
   it('shows the drop indicator while a file is dragged over the pane', () => {


### PR DESCRIPTION
### What this PR does

Before this PR:

The Translate page kept a single `copied` state (`useTemporaryValue`) that both `onCopyInput` and `onCopyOutput` set, and only `TranslateOutputPane` consumed it — `TranslateInputPane` never received a `copied` prop at all. Clicking the input pane's copy button therefore left that button unchanged and lit up the *output* pane's button with the "copied" check instead.

After this PR:

Each pane owns its own temporary copied state (`inputCopied` / `outputCopied`), and `TranslateInputPane` renders `copied ? <Check /> : <Copy />` the same way the output pane already did. Copying the source text now acknowledges on the source button, and leaves the output button alone.

Fixes #20112

### Why we need it and why it was done in this way

The `copy` helper coupled "write to clipboard" with "set the feedback flag", which is what made a single shared flag look reasonable in the first place. Rather than threading a target argument through it, the helper was dropped: its three call sites now write to the clipboard directly and set the flag for their own pane. Auto-copy of the translation result keeps driving the output pane's flag, unchanged.

The following tradeoffs were made:

- Two `useTemporaryValue` calls instead of one shared flag. The panes have genuinely independent feedback, so a shared flag cannot express it.
- Removing the `copy` helper leaves three direct `navigator.clipboard.writeText` calls. Each is one line and each needs a different follow-up, so a wrapper would only re-introduce the coupling.

The following alternatives were considered:

- Keeping `copy(value)` and passing the setter in. That is the same coupling with an extra parameter.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The page-level test previously mocked `useTemporaryValue` as `() => [false, vi.fn()]`, so no page test could observe copied feedback at all. That mock is removed in favour of the real hook, and both pane mocks now expose their `copied` prop.

Two regression tests were added, both verified to fail against the old behavior:

- `TranslateInputPane.test.tsx` — the input copy button swaps to the check icon when `copied` is set.
- `TranslatePage.test.tsx` — clicking the input copy button marks the *input* pane copied and leaves the output pane untouched (re-pointing the setter back at `setOutputCopied` turns this red).

Verification: `TranslateInputPane.test.tsx` 8 passed, `TranslatePage.test.tsx` 52 passed, plus `typecheck:web`, `oxlint`, `eslint` and `biome check` clean on the touched files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Translate] Fixed the copy button in the input pane showing its "copied" feedback on the output pane's button.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dowWDMZMH1Mbw9TvuBpfz
