### PR TITLE
fix(region-service): do not treat detection failures as China

### DIFF
--- a/src/main/services/RegionService.ts
+++ b/src/main/services/RegionService.ts
@@ -33,6 +33,24 @@ class RegionService {
 
   /** Egress country code (e.g. 'CN', 'US'); defaults to 'CN' on any failure. */
   async getCountry(): Promise<string> {
+    try {
+      return await this.getDetectedCountry()
+    } catch {
+      return DEFAULT_COUNTRY
+    }
+  }
+
+  /** True only when the egress country is successfully detected as China. */
+  async isInChina(): Promise<boolean> {
+    try {
+      const country = await this.getDetectedCountry()
+      return country.toLowerCase() === 'cn'
+    } catch {
+      return false
+    }
+  }
+
+  private async getDetectedCountry(): Promise<string> {
     const proxyKey = application.get('ProxyService').appliedProxyKey
     const cached = application.get('CacheService').get<CachedEgressRegion>(CACHE_KEY)
     if (cached && cached.proxyKey === proxyKey) {
@@ -46,12 +64,6 @@ class RegionService {
     return this.inflight
   }
 
-  /** True when the egress country resolves to China. */
-  async isInChina(): Promise<boolean> {
-    const country = await this.getCountry()
-    return country.toLowerCase() === 'cn'
-  }
-
   private async detectAndCache(proxyKey: string | null): Promise<string> {
     try {
       const country = await this.fetchCountry()
@@ -59,7 +71,7 @@ class RegionService {
       return country
     } catch (error) {
       logger.error('Failed to get IP address information:', error as Error)
-      return DEFAULT_COUNTRY
+      throw error
     }
   }
 

--- a/src/main/services/__tests__/RegionService.test.ts
+++ b/src/main/services/__tests__/RegionService.test.ts
@@ -74,6 +74,19 @@ describe('RegionService', () => {
     await expect(regionService.isInChina()).resolves.toBe(false)
   })
 
+  it.each([
+    ['network failure', () => netFetchMock.mockRejectedValueOnce(new Error('network down'))],
+    [
+      'HTTP failure',
+      () => netFetchMock.mockResolvedValueOnce(fetchResponse({ country_code: 'US' }, { ok: false, status: 500 }))
+    ],
+    ['missing country_code', () => netFetchMock.mockResolvedValueOnce(fetchResponse({}))]
+  ])('does not treat %s as confirmed China', async (_name, arrangeFailure) => {
+    arrangeFailure()
+
+    await expect(regionService.isInChina()).resolves.toBe(false)
+  })
+
   it('does not cache the CN fallback when the request fails', async () => {
     netFetchMock
       .mockRejectedValueOnce(new Error('network down'))


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

## 中文

### 这个 PR 做了什么

修改前，`RegionService.getCountry()` 在区域检测失败时会回退到 `CN`。`isInChina()` 直接使用这个结果，因此网络错误、HTTP 非 OK 响应或缺少 `country_code` 的响应都会被当成“中国”。

修改后，`isInChina()` 只有在区域检测成功且结果为 `CN` 时才返回 `true`。检测失败时返回 `false`。直接调用 `getCountry()` 的代码继续保留现有的 `CN` 回退，避免扩大兼容性影响。

Fixes #20116

### 为什么这样改

多个依赖区域判断的调用方已经按“检测失败时走全球默认路径”处理，例如 `isInChina().catch(() => false)`。当前实现会在调用方看到错误之前把失败转换成 `CN`，使这些 fallback 失效。

这次改动把“成功检测”和“兼容回退”分开处理：共享检测路径保留真实失败；`getCountry()` 在自己的 API 边界回退到 `CN`；`isInChina()` 在无法检测时返回 `false`。

直接修改 `getCountry()` 的回退行为风险更大，因为现有调用方可能依赖它。在每个 consumer 里单独补错误处理也会重复同一套语义，所以这里把判断收敛在 `RegionService`。

### 影响

无破坏性变更。改动只涉及 `RegionService` 和对应测试。缓存和同一代理下的 single-flight 行为不变。

验证：

- `pnpm exec vitest run --project main src/main/services/__tests__/RegionService.test.ts` — 11 passed
- 本地 `pnpm lint` 已确认 oxlint 为 0 warnings / 0 errors；其余检查交给 CI 作为最终 gate

## English

### What this PR does

Before this PR, `RegionService.getCountry()` fell back to `CN` when region detection failed. Because `isInChina()` used that result directly, network errors, non-OK HTTP responses, and responses without `country_code` were treated as confirmed China.

After this PR, `isInChina()` returns `true` only when region detection succeeds and resolves to `CN`. Detection failures return `false`. Direct `getCountry()` callers keep the existing `CN` fallback to avoid a broader compatibility change.

Fixes #20116

### Why this change

Several region-aware callers already expect failed detection to use global routing, for example with `isInChina().catch(() => false)`. The current implementation converts the failure to `CN` before callers can observe it, which defeats that fallback.

This change separates successful detection from the compatibility fallback. The shared detection path preserves real failures; `getCountry()` applies the legacy `CN` fallback at its own API boundary; `isInChina()` returns `false` when detection is unavailable.

Changing `getCountry()` itself would be broader because direct callers may rely on the existing fallback. Handling the same failure independently in every consumer would also duplicate the policy, so the distinction stays inside `RegionService`.

### Impact

No breaking changes. The diff is limited to `RegionService` and its tests. Cache behavior and same-proxy single-flight behavior are unchanged.

Validation:

- `pnpm exec vitest run --project main src/main/services/__tests__/RegionService.test.ts` — 11 passed
- Local `pnpm lint` confirmed 0 oxlint warnings and 0 errors; CI remains the final gate for the remaining checks

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this targeted behavior fix
- [x] Self-review: I have reviewed the exact pushed diff before requesting review from others

### Release note

```release-note
Region-dependent routing now falls back to global endpoints when IP region detection fails instead of treating the failure as mainland China.
区域检测失败时，依赖区域的路由现在会回退到全球默认端点，不再把失败误判为中国大陆。
```