### PR TITLE
fix(ai-sdk): stop replaying function_call item ids to the Responses API

### DIFF
--- a/.changeset/openai-responses-function-call-id.md
+++ b/.changeset/openai-responses-function-call-id.md
@@ -1,0 +1,10 @@
+---
+'@cherrystudio/ai-core': patch
+'@cherrystudio/ai-sdk-provider': patch
+---
+
+Stop replaying `function_call` item ids to the OpenAI Responses API.
+
+- Bump `@ai-sdk/openai` from `3.0.53` to `3.0.109`, which drops `id` from replayed `function_call` input items (upstream fix in `3.0.73`). Cherry always sends `store: false`, so that id names nothing on the server; a relay that synthesizes its own item ids (a UUID rather than `fc_…`) used to poison a topic permanently, because the bad id lived in the persisted history and every later turn replayed it into a `400 invalid_request`. `call_id` alone pairs the call with its `function_call_output`.
+- Rebuild the local `@ai-sdk/openai` patch onto `3.0.109`. Seven hunks carry forward (`forceReasoning` sampling params, image `url` fallback, Ark assistant `type`/`status`, `rawReasoningContent` replay, `response.reasoning_text.delta`, `annotations` leniency); the `gpt-image-2` hunk is dropped now that upstream matches a generic `gpt-image-` prefix.
+- Bump `@ai-sdk/provider-utils` to `4.0.50` via `pnpm.overrides` — `3.0.109` imports `EXPERIMENTAL_EMBEDDING_MODEL_MAX_INPUT_BYTES_PER_CALL`, which `4.0.48` does not export — and `@ai-sdk/azure` to `3.0.116`, whose pinned `@ai-sdk/openai` is `3.0.109`. Without the azure bump its exact pin resolves to an unpatched `3.0.53` carrying both the bug and none of the local hunks.

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   "devDependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.96",
     "@ai-sdk/anthropic": "^3.0.103",
-    "@ai-sdk/azure": "^3.0.54",
+    "@ai-sdk/azure": "^3.0.116",
     "@ai-sdk/bytedance": "1.0.29",
     "@ai-sdk/cerebras": "^2.0.78",
     "@ai-sdk/cohere": "^3.0.30",
@@ -170,7 +170,7 @@
     "@ai-sdk/huggingface": "^1.0.74",
     "@ai-sdk/mistral": "^3.0.30",
     "@ai-sdk/open-responses": "1.0.34",
-    "@ai-sdk/openai": "^3.0.53",
+    "@ai-sdk/openai": "^3.0.109",
     "@ai-sdk/openai-compatible": "2.0.72",
     "@ai-sdk/perplexity": "^3.0.29",
     "@ai-sdk/provider": "^3.0.15",

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ai-sdk/anthropic": "^3.0.71",
     "@ai-sdk/google": "^3.0.113",
-    "@ai-sdk/openai": "^3.0.53",
+    "@ai-sdk/openai": "^3.0.109",
     "@ai-sdk/openai-compatible": "^2.0.72"
   },
   "dependencies": {

--- a/packages/aiCore/package.json
+++ b/packages/aiCore/package.json
@@ -32,12 +32,12 @@
   "homepage": "https://github.com/CherryHQ/cherry-studio#readme",
   "peerDependencies": {
     "@ai-sdk/google": "^3.0.113",
-    "@ai-sdk/openai": "^3.0.53",
+    "@ai-sdk/openai": "^3.0.109",
     "ai": "^6.0.116"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.103",
-    "@ai-sdk/azure": "^3.0.54",
+    "@ai-sdk/azure": "^3.0.116",
     "@ai-sdk/deepseek": "^2.0.57",
     "@ai-sdk/openai-compatible": "^2.0.72",
     "@ai-sdk/provider": "^3.0.15",

--- a/patches/@ai-sdk__openai@3.0.109.patch
+++ b/patches/@ai-sdk__openai@3.0.109.patch
@@ -1,17 +1,17 @@
 diff --git a/dist/index.js b/dist/index.js
-index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..9489a0c2b109af4865e2c76ac80fb7b9af5b4c95 100644
+index 48ea06e..c6c8dde 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -737,7 +737,7 @@ var OpenAIChatLanguageModel = class {
-       // messages:
-       messages
-     };
+@@ -1012,7 +1012,7 @@ var OpenAIChatLanguageModel = class {
+         details: "promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead"
+       });
+     }
 -    if (isReasoningModel) {
 +    if (modelCapabilities.isReasoningModel) {
        if (openaiOptions.reasoningEffort !== "none" || !modelCapabilities.supportsNonReasoningParameters) {
          if (baseArgs.temperature != null) {
            baseArgs.temperature = void 0;
-@@ -1725,7 +1725,8 @@ var openaiImageResponseSchema = (0, import_provider_utils12.lazySchema)(
+@@ -2025,7 +2025,8 @@ var openaiImageResponseSchema = (0, import_provider_utils12.lazySchema)(
        created: import_v48.z.number().nullish(),
        data: import_v48.z.array(
          import_v48.z.object({
@@ -21,24 +21,7 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..9489a0c2b109af4865e2c76ac80fb7b9
            revised_prompt: import_v48.z.string().nullish()
          })
        ),
-@@ -1753,13 +1754,15 @@ var modelMaxImagesPerCall = {
-   "gpt-image-1": 10,
-   "gpt-image-1-mini": 10,
-   "gpt-image-1.5": 10,
-+  "gpt-image-2": 10,
-   "chatgpt-image-latest": 10
- };
- var defaultResponseFormatPrefixes = [
-   "chatgpt-image-",
-   "gpt-image-1-mini",
-   "gpt-image-1.5",
--  "gpt-image-1"
-+  "gpt-image-1",
-+  "gpt-image-2"
- ];
- function hasDefaultResponseFormat(modelId) {
-   return defaultResponseFormatPrefixes.some(
-@@ -1843,7 +1846,11 @@ var OpenAIImageModel = class {
+@@ -2213,7 +2214,11 @@ var OpenAIImageModel = class {
          fetch: this.config.fetch
        });
        return {
@@ -51,20 +34,20 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..9489a0c2b109af4865e2c76ac80fb7b9
          warnings,
          usage: response2.usage != null ? {
            inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
-@@ -1899,7 +1906,11 @@ var OpenAIImageModel = class {
+@@ -2280,7 +2285,11 @@ var OpenAIImageModel = class {
        fetch: this.config.fetch
      });
      return {
 -      images: response.data.map((item) => item.b64_json),
 +      images: response.data.flatMap((item) => {
-+        if (typeof item.b64_json === "string") return [item.b64_json];
-+        if (typeof item.url === "string") return [item.url];
-+        return [];
-+      }),
++          if (typeof item.b64_json === "string") return [item.b64_json];
++          if (typeof item.url === "string") return [item.url];
++          return [];
++        }),
        warnings,
        usage: response.usage != null ? {
          inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
-@@ -2756,9 +2767,11 @@ async function convertToOpenAIResponsesInput({
+@@ -3443,9 +3452,11 @@ async function convertToOpenAIResponsesInput({
                  break;
                }
                input.push({
@@ -76,11 +59,11 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..9489a0c2b109af4865e2c76ac80fb7b9
                  ...phase != null && { phase }
                });
                break;
-@@ -3002,6 +3015,12 @@ async function convertToOpenAIResponsesInput({
+@@ -3724,6 +3735,12 @@ async function convertToOpenAIResponsesInput({
                      encrypted_content: encryptedContent,
                      summary: summaryParts
                    });
-+                } else if ((providerOptions == null ? void 0 : providerOptions.rawReasoningContent) && part.text.length > 0) {
++                } else if ((providerOptions2 == null ? void 0 : providerOptions2.rawReasoningContent) && part.text.length > 0) {
 +                  input.push({
 +                    type: "reasoning",
 +                    summary: [],
@@ -89,30 +72,30 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..9489a0c2b109af4865e2c76ac80fb7b9
                  } else {
                    warnings.push({
                      type: "other",
-@@ -3249,7 +3268,8 @@ async function convertToOpenAIResponsesInput({
+@@ -4020,7 +4037,8 @@ ${text}`,
  }
- var openaiResponsesReasoningProviderOptionsSchema = import_v420.z.object({
-   itemId: import_v420.z.string().nullish(),
--  reasoningEncryptedContent: import_v420.z.string().nullish()
-+  reasoningEncryptedContent: import_v420.z.string().nullish(),
-+  rawReasoningContent: import_v420.z.boolean().nullish()
+ var openaiResponsesReasoningProviderOptionsSchema = import_v421.z.object({
+   itemId: import_v421.z.string().nullish(),
+-  reasoningEncryptedContent: import_v421.z.string().nullish()
++  reasoningEncryptedContent: import_v421.z.string().nullish(),
++  rawReasoningContent: import_v421.z.boolean().nullish()
  });
  
  // src/responses/map-openai-responses-finish-reason.ts
-@@ -3778,6 +3798,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils26.lazySchema)(
-         summary_index: import_v421.z.number(),
-         delta: import_v421.z.string()
+@@ -4658,6 +4676,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils28.lazySchema)(
+         summary_index: import_v422.z.number(),
+         delta: import_v422.z.string()
        }),
-+      import_v421.z.object({
-+        type: import_v421.z.literal("response.reasoning_text.delta"),
-+        item_id: import_v421.z.string(),
-+        delta: import_v421.z.string()
++      import_v422.z.object({
++        type: import_v422.z.literal("response.reasoning_text.delta"),
++        item_id: import_v422.z.string(),
++        delta: import_v422.z.string()
 +      }),
-       import_v421.z.object({
-         type: import_v421.z.literal("response.reasoning_summary_part.done"),
-         item_id: import_v421.z.string(),
-@@ -3878,7 +3903,7 @@ var openaiResponsesResponseSchema = (0, import_provider_utils26.lazySchema)(
-                       index: import_v421.z.number()
+       import_v422.z.object({
+         type: import_v422.z.literal("response.reasoning_summary_part.done"),
+         item_id: import_v422.z.string(),
+@@ -4752,7 +4775,7 @@ var openaiResponsesResponseSchema = (0, import_provider_utils28.lazySchema)(
+                       index: import_v422.z.number()
                      })
                    ])
 -                )
@@ -120,16 +103,16 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..9489a0c2b109af4865e2c76ac80fb7b9
                })
              )
            }),
-@@ -4812,7 +4837,7 @@ var OpenAIResponsesLanguageModel = class {
-         }
-       }
-     };
+@@ -5960,7 +5983,7 @@ var OpenAIResponsesLanguageModel = class {
+         details: "promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead"
+       });
+     }
 -    if (isReasoningModel) {
 +    if (modelCapabilities.isReasoningModel) {
        if (!((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) === "none" && modelCapabilities.supportsNonReasoningParameters)) {
          if (baseArgs.temperature != null) {
            baseArgs.temperature = void 0;
-@@ -6105,6 +6130,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -7411,6 +7434,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -148,19 +131,19 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..9489a0c2b109af4865e2c76ac80fb7b9
                if (store) {
                  controller.enqueue({
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..4536cc06d7026fa76b9af104fc652335c1deac09 100644
+index 2648382..cb43aa5 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -728,7 +728,7 @@ var OpenAIChatLanguageModel = class {
-       // messages:
-       messages
-     };
+@@ -1008,7 +1008,7 @@ var OpenAIChatLanguageModel = class {
+         details: "promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead"
+       });
+     }
 -    if (isReasoningModel) {
 +    if (modelCapabilities.isReasoningModel) {
        if (openaiOptions.reasoningEffort !== "none" || !modelCapabilities.supportsNonReasoningParameters) {
          if (baseArgs.temperature != null) {
            baseArgs.temperature = void 0;
-@@ -1740,7 +1740,8 @@ var openaiImageResponseSchema = lazySchema7(
+@@ -2056,7 +2056,8 @@ var openaiImageResponseSchema = lazySchema7(
        created: z8.number().nullish(),
        data: z8.array(
          z8.object({
@@ -170,24 +153,7 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..4536cc06d7026fa76b9af104fc652335
            revised_prompt: z8.string().nullish()
          })
        ),
-@@ -1768,13 +1769,15 @@ var modelMaxImagesPerCall = {
-   "gpt-image-1": 10,
-   "gpt-image-1-mini": 10,
-   "gpt-image-1.5": 10,
-+  "gpt-image-2": 10,
-   "chatgpt-image-latest": 10
- };
- var defaultResponseFormatPrefixes = [
-   "chatgpt-image-",
-   "gpt-image-1-mini",
-   "gpt-image-1.5",
--  "gpt-image-1"
-+  "gpt-image-1",
-+  "gpt-image-2"
- ];
- function hasDefaultResponseFormat(modelId) {
-   return defaultResponseFormatPrefixes.some(
-@@ -1858,7 +1861,11 @@ var OpenAIImageModel = class {
+@@ -2247,7 +2248,11 @@ var OpenAIImageModel = class {
          fetch: this.config.fetch
        });
        return {
@@ -200,20 +166,20 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..4536cc06d7026fa76b9af104fc652335
          warnings,
          usage: response2.usage != null ? {
            inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
-@@ -1914,7 +1921,11 @@ var OpenAIImageModel = class {
+@@ -2314,7 +2319,11 @@ var OpenAIImageModel = class {
        fetch: this.config.fetch
      });
      return {
 -      images: response.data.map((item) => item.b64_json),
 +      images: response.data.flatMap((item) => {
-+        if (typeof item.b64_json === "string") return [item.b64_json];
-+        if (typeof item.url === "string") return [item.url];
-+        return [];
-+      }),
++          if (typeof item.b64_json === "string") return [item.b64_json];
++          if (typeof item.url === "string") return [item.url];
++          return [];
++        }),
        warnings,
        usage: response.usage != null ? {
          inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
-@@ -2833,9 +2844,11 @@ async function convertToOpenAIResponsesInput({
+@@ -3541,9 +3550,11 @@ async function convertToOpenAIResponsesInput({
                  break;
                }
                input.push({
@@ -225,11 +191,11 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..4536cc06d7026fa76b9af104fc652335
                  ...phase != null && { phase }
                });
                break;
-@@ -3079,6 +3092,12 @@ async function convertToOpenAIResponsesInput({
+@@ -3822,6 +3833,12 @@ async function convertToOpenAIResponsesInput({
                      encrypted_content: encryptedContent,
                      summary: summaryParts
                    });
-+                } else if ((providerOptions == null ? void 0 : providerOptions.rawReasoningContent) && part.text.length > 0) {
++                } else if ((providerOptions2 == null ? void 0 : providerOptions2.rawReasoningContent) && part.text.length > 0) {
 +                  input.push({
 +                    type: "reasoning",
 +                    summary: [],
@@ -238,30 +204,30 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..4536cc06d7026fa76b9af104fc652335
                  } else {
                    warnings.push({
                      type: "other",
-@@ -3326,7 +3345,8 @@ async function convertToOpenAIResponsesInput({
+@@ -4118,7 +4135,8 @@ ${text}`,
  }
- var openaiResponsesReasoningProviderOptionsSchema = z20.object({
-   itemId: z20.string().nullish(),
--  reasoningEncryptedContent: z20.string().nullish()
-+  reasoningEncryptedContent: z20.string().nullish(),
-+  rawReasoningContent: z20.boolean().nullish()
+ var openaiResponsesReasoningProviderOptionsSchema = z21.object({
+   itemId: z21.string().nullish(),
+-  reasoningEncryptedContent: z21.string().nullish()
++  reasoningEncryptedContent: z21.string().nullish(),
++  rawReasoningContent: z21.boolean().nullish()
  });
  
  // src/responses/map-openai-responses-finish-reason.ts
-@@ -3855,6 +3875,11 @@ var openaiResponsesChunkSchema = lazySchema19(
-         summary_index: z21.number(),
-         delta: z21.string()
+@@ -4759,6 +4777,11 @@ var openaiResponsesChunkSchema = lazySchema20(
+         summary_index: z22.number(),
+         delta: z22.string()
        }),
-+      z21.object({
-+        type: z21.literal("response.reasoning_text.delta"),
-+        item_id: z21.string(),
-+        delta: z21.string()
++      z22.object({
++        type: z22.literal("response.reasoning_text.delta"),
++        item_id: z22.string(),
++        delta: z22.string()
 +      }),
-       z21.object({
-         type: z21.literal("response.reasoning_summary_part.done"),
-         item_id: z21.string(),
-@@ -3955,7 +3980,7 @@ var openaiResponsesResponseSchema = lazySchema19(
-                       index: z21.number()
+       z22.object({
+         type: z22.literal("response.reasoning_summary_part.done"),
+         item_id: z22.string(),
+@@ -4853,7 +4876,7 @@ var openaiResponsesResponseSchema = lazySchema20(
+                       index: z22.number()
                      })
                    ])
 -                )
@@ -269,16 +235,16 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..4536cc06d7026fa76b9af104fc652335
                })
              )
            }),
-@@ -4891,7 +4916,7 @@ var OpenAIResponsesLanguageModel = class {
-         }
-       }
-     };
+@@ -6066,7 +6089,7 @@ var OpenAIResponsesLanguageModel = class {
+         details: "promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead"
+       });
+     }
 -    if (isReasoningModel) {
 +    if (modelCapabilities.isReasoningModel) {
        if (!((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) === "none" && modelCapabilities.supportsNonReasoningParameters)) {
          if (baseArgs.temperature != null) {
            baseArgs.temperature = void 0;
-@@ -6184,6 +6209,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -7517,6 +7540,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -297,19 +263,19 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..4536cc06d7026fa76b9af104fc652335
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..b05a907baa10ed0323d6b5abc48e613025a06a07 100644
+index e5b1f96..ab28d81 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
-@@ -764,7 +764,7 @@ var OpenAIChatLanguageModel = class {
-       // messages:
-       messages
-     };
+@@ -1047,7 +1047,7 @@ var OpenAIChatLanguageModel = class {
+         details: "promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead"
+       });
+     }
 -    if (isReasoningModel) {
 +    if (modelCapabilities.isReasoningModel) {
        if (openaiOptions.reasoningEffort !== "none" || !modelCapabilities.supportsNonReasoningParameters) {
          if (baseArgs.temperature != null) {
            baseArgs.temperature = void 0;
-@@ -1752,7 +1752,8 @@ var openaiImageResponseSchema = (0, import_provider_utils12.lazySchema)(
+@@ -2060,7 +2060,8 @@ var openaiImageResponseSchema = (0, import_provider_utils12.lazySchema)(
        created: import_v48.z.number().nullish(),
        data: import_v48.z.array(
          import_v48.z.object({
@@ -319,24 +285,7 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..b05a907baa10ed0323d6b5abc48e6130
            revised_prompt: import_v48.z.string().nullish()
          })
        ),
-@@ -1780,13 +1781,15 @@ var modelMaxImagesPerCall = {
-   "gpt-image-1": 10,
-   "gpt-image-1-mini": 10,
-   "gpt-image-1.5": 10,
-+  "gpt-image-2": 10,
-   "chatgpt-image-latest": 10
- };
- var defaultResponseFormatPrefixes = [
-   "chatgpt-image-",
-   "gpt-image-1-mini",
-   "gpt-image-1.5",
--  "gpt-image-1"
-+  "gpt-image-1",
-+  "gpt-image-2"
- ];
- function hasDefaultResponseFormat(modelId) {
-   return defaultResponseFormatPrefixes.some(
-@@ -1870,7 +1873,11 @@ var OpenAIImageModel = class {
+@@ -2248,7 +2249,11 @@ var OpenAIImageModel = class {
          fetch: this.config.fetch
        });
        return {
@@ -349,20 +298,20 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..b05a907baa10ed0323d6b5abc48e6130
          warnings,
          usage: response2.usage != null ? {
            inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
-@@ -1926,7 +1933,11 @@ var OpenAIImageModel = class {
+@@ -2315,7 +2320,11 @@ var OpenAIImageModel = class {
        fetch: this.config.fetch
      });
      return {
 -      images: response.data.map((item) => item.b64_json),
 +      images: response.data.flatMap((item) => {
-+        if (typeof item.b64_json === "string") return [item.b64_json];
-+        if (typeof item.url === "string") return [item.url];
-+        return [];
-+      }),
++          if (typeof item.b64_json === "string") return [item.b64_json];
++          if (typeof item.url === "string") return [item.url];
++          return [];
++        }),
        warnings,
        usage: response.usage != null ? {
          inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
-@@ -2698,9 +2709,11 @@ async function convertToOpenAIResponsesInput({
+@@ -3387,9 +3396,11 @@ async function convertToOpenAIResponsesInput({
                  break;
                }
                input.push({
@@ -374,11 +323,11 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..b05a907baa10ed0323d6b5abc48e6130
                  ...phase != null && { phase }
                });
                break;
-@@ -2944,6 +2957,12 @@ async function convertToOpenAIResponsesInput({
+@@ -3668,6 +3679,12 @@ async function convertToOpenAIResponsesInput({
                      encrypted_content: encryptedContent,
                      summary: summaryParts
                    });
-+                } else if ((providerOptions == null ? void 0 : providerOptions.rawReasoningContent) && part.text.length > 0) {
++                } else if ((providerOptions2 == null ? void 0 : providerOptions2.rawReasoningContent) && part.text.length > 0) {
 +                  input.push({
 +                    type: "reasoning",
 +                    summary: [],
@@ -387,30 +336,30 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..b05a907baa10ed0323d6b5abc48e6130
                  } else {
                    warnings.push({
                      type: "other",
-@@ -3191,7 +3210,8 @@ async function convertToOpenAIResponsesInput({
+@@ -3964,7 +3981,8 @@ ${text}`,
  }
- var openaiResponsesReasoningProviderOptionsSchema = import_v416.z.object({
-   itemId: import_v416.z.string().nullish(),
--  reasoningEncryptedContent: import_v416.z.string().nullish()
-+  reasoningEncryptedContent: import_v416.z.string().nullish(),
-+  rawReasoningContent: import_v416.z.boolean().nullish()
+ var openaiResponsesReasoningProviderOptionsSchema = import_v417.z.object({
+   itemId: import_v417.z.string().nullish(),
+-  reasoningEncryptedContent: import_v417.z.string().nullish()
++  reasoningEncryptedContent: import_v417.z.string().nullish(),
++  rawReasoningContent: import_v417.z.boolean().nullish()
  });
  
  // src/responses/map-openai-responses-finish-reason.ts
-@@ -3720,6 +3740,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils24.lazySchema)(
-         summary_index: import_v417.z.number(),
-         delta: import_v417.z.string()
+@@ -4602,6 +4620,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils26.lazySchema)(
+         summary_index: import_v418.z.number(),
+         delta: import_v418.z.string()
        }),
-+      import_v417.z.object({
-+        type: import_v417.z.literal("response.reasoning_text.delta"),
-+        item_id: import_v417.z.string(),
-+        delta: import_v417.z.string()
++      import_v418.z.object({
++        type: import_v418.z.literal("response.reasoning_text.delta"),
++        item_id: import_v418.z.string(),
++        delta: import_v418.z.string()
 +      }),
-       import_v417.z.object({
-         type: import_v417.z.literal("response.reasoning_summary_part.done"),
-         item_id: import_v417.z.string(),
-@@ -3820,7 +3845,7 @@ var openaiResponsesResponseSchema = (0, import_provider_utils24.lazySchema)(
-                       index: import_v417.z.number()
+       import_v418.z.object({
+         type: import_v418.z.literal("response.reasoning_summary_part.done"),
+         item_id: import_v418.z.string(),
+@@ -4696,7 +4719,7 @@ var openaiResponsesResponseSchema = (0, import_provider_utils26.lazySchema)(
+                       index: import_v418.z.number()
                      })
                    ])
 -                )
@@ -418,16 +367,16 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..b05a907baa10ed0323d6b5abc48e6130
                })
              )
            }),
-@@ -5073,7 +5098,7 @@ var OpenAIResponsesLanguageModel = class {
-         }
-       }
-     };
+@@ -6228,7 +6251,7 @@ var OpenAIResponsesLanguageModel = class {
+         details: "promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead"
+       });
+     }
 -    if (isReasoningModel) {
 +    if (modelCapabilities.isReasoningModel) {
        if (!((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) === "none" && modelCapabilities.supportsNonReasoningParameters)) {
          if (baseArgs.temperature != null) {
            baseArgs.temperature = void 0;
-@@ -6366,6 +6391,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -7679,6 +7702,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -446,19 +395,19 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..b05a907baa10ed0323d6b5abc48e6130
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index db50beda01459008c836cd5648e024340fe31e90..412e91203d5a79b44cf5570a66d831fe9cd7493b 100644
+index 714e237..a14b186 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
-@@ -720,7 +720,7 @@ var OpenAIChatLanguageModel = class {
-       // messages:
-       messages
-     };
+@@ -1000,7 +1000,7 @@ var OpenAIChatLanguageModel = class {
+         details: "promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead"
+       });
+     }
 -    if (isReasoningModel) {
 +    if (modelCapabilities.isReasoningModel) {
        if (openaiOptions.reasoningEffort !== "none" || !modelCapabilities.supportsNonReasoningParameters) {
          if (baseArgs.temperature != null) {
            baseArgs.temperature = void 0;
-@@ -1732,7 +1732,8 @@ var openaiImageResponseSchema = lazySchema7(
+@@ -2048,7 +2048,8 @@ var openaiImageResponseSchema = lazySchema7(
        created: z8.number().nullish(),
        data: z8.array(
          z8.object({
@@ -468,24 +417,7 @@ index db50beda01459008c836cd5648e024340fe31e90..412e91203d5a79b44cf5570a66d831fe
            revised_prompt: z8.string().nullish()
          })
        ),
-@@ -1760,13 +1761,15 @@ var modelMaxImagesPerCall = {
-   "gpt-image-1": 10,
-   "gpt-image-1-mini": 10,
-   "gpt-image-1.5": 10,
-+  "gpt-image-2": 10,
-   "chatgpt-image-latest": 10
- };
- var defaultResponseFormatPrefixes = [
-   "chatgpt-image-",
-   "gpt-image-1-mini",
-   "gpt-image-1.5",
--  "gpt-image-1"
-+  "gpt-image-1",
-+  "gpt-image-2"
- ];
- function hasDefaultResponseFormat(modelId) {
-   return defaultResponseFormatPrefixes.some(
-@@ -1850,7 +1853,11 @@ var OpenAIImageModel = class {
+@@ -2239,7 +2240,11 @@ var OpenAIImageModel = class {
          fetch: this.config.fetch
        });
        return {
@@ -498,20 +430,20 @@ index db50beda01459008c836cd5648e024340fe31e90..412e91203d5a79b44cf5570a66d831fe
          warnings,
          usage: response2.usage != null ? {
            inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
-@@ -1906,7 +1913,11 @@ var OpenAIImageModel = class {
+@@ -2306,7 +2311,11 @@ var OpenAIImageModel = class {
        fetch: this.config.fetch
      });
      return {
 -      images: response.data.map((item) => item.b64_json),
 +      images: response.data.flatMap((item) => {
-+        if (typeof item.b64_json === "string") return [item.b64_json];
-+        if (typeof item.url === "string") return [item.url];
-+        return [];
-+      }),
++          if (typeof item.b64_json === "string") return [item.b64_json];
++          if (typeof item.url === "string") return [item.url];
++          return [];
++        }),
        warnings,
        usage: response.usage != null ? {
          inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
-@@ -2724,9 +2735,11 @@ async function convertToOpenAIResponsesInput({
+@@ -3432,9 +3441,11 @@ async function convertToOpenAIResponsesInput({
                  break;
                }
                input.push({
@@ -523,11 +455,11 @@ index db50beda01459008c836cd5648e024340fe31e90..412e91203d5a79b44cf5570a66d831fe
                  ...phase != null && { phase }
                });
                break;
-@@ -2970,6 +2983,12 @@ async function convertToOpenAIResponsesInput({
+@@ -3713,6 +3724,12 @@ async function convertToOpenAIResponsesInput({
                      encrypted_content: encryptedContent,
                      summary: summaryParts
                    });
-+                } else if ((providerOptions == null ? void 0 : providerOptions.rawReasoningContent) && part.text.length > 0) {
++                } else if ((providerOptions2 == null ? void 0 : providerOptions2.rawReasoningContent) && part.text.length > 0) {
 +                  input.push({
 +                    type: "reasoning",
 +                    summary: [],
@@ -536,30 +468,30 @@ index db50beda01459008c836cd5648e024340fe31e90..412e91203d5a79b44cf5570a66d831fe
                  } else {
                    warnings.push({
                      type: "other",
-@@ -3217,7 +3236,8 @@ async function convertToOpenAIResponsesInput({
+@@ -4009,7 +4026,8 @@ ${text}`,
  }
- var openaiResponsesReasoningProviderOptionsSchema = z16.object({
-   itemId: z16.string().nullish(),
--  reasoningEncryptedContent: z16.string().nullish()
-+  reasoningEncryptedContent: z16.string().nullish(),
-+  rawReasoningContent: z16.boolean().nullish()
+ var openaiResponsesReasoningProviderOptionsSchema = z17.object({
+   itemId: z17.string().nullish(),
+-  reasoningEncryptedContent: z17.string().nullish()
++  reasoningEncryptedContent: z17.string().nullish(),
++  rawReasoningContent: z17.boolean().nullish()
  });
  
  // src/responses/map-openai-responses-finish-reason.ts
-@@ -3746,6 +3766,11 @@ var openaiResponsesChunkSchema = lazySchema15(
-         summary_index: z17.number(),
-         delta: z17.string()
+@@ -4650,6 +4668,11 @@ var openaiResponsesChunkSchema = lazySchema16(
+         summary_index: z18.number(),
+         delta: z18.string()
        }),
-+      z17.object({
-+        type: z17.literal("response.reasoning_text.delta"),
-+        item_id: z17.string(),
-+        delta: z17.string()
++      z18.object({
++        type: z18.literal("response.reasoning_text.delta"),
++        item_id: z18.string(),
++        delta: z18.string()
 +      }),
-       z17.object({
-         type: z17.literal("response.reasoning_summary_part.done"),
-         item_id: z17.string(),
-@@ -3846,7 +3871,7 @@ var openaiResponsesResponseSchema = lazySchema15(
-                       index: z17.number()
+       z18.object({
+         type: z18.literal("response.reasoning_summary_part.done"),
+         item_id: z18.string(),
+@@ -4744,7 +4767,7 @@ var openaiResponsesResponseSchema = lazySchema16(
+                       index: z18.number()
                      })
                    ])
 -                )
@@ -567,16 +499,16 @@ index db50beda01459008c836cd5648e024340fe31e90..412e91203d5a79b44cf5570a66d831fe
                })
              )
            }),
-@@ -5129,7 +5154,7 @@ var OpenAIResponsesLanguageModel = class {
-         }
-       }
-     };
+@@ -6309,7 +6332,7 @@ var OpenAIResponsesLanguageModel = class {
+         details: "promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead"
+       });
+     }
 -    if (isReasoningModel) {
 +    if (modelCapabilities.isReasoningModel) {
        if (!((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) === "none" && modelCapabilities.supportsNonReasoningParameters)) {
          if (baseArgs.temperature != null) {
            baseArgs.temperature = void 0;
-@@ -6422,6 +6447,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -7760,6 +7783,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -595,10 +527,10 @@ index db50beda01459008c836cd5648e024340fe31e90..412e91203d5a79b44cf5570a66d831fe
                if (store) {
                  controller.enqueue({
 diff --git a/src/chat/openai-chat-language-model.ts b/src/chat/openai-chat-language-model.ts
-index 96077d47c9e104143430d261e040b9ae89340940..31417bad69cc06d5213be0b17b3ef08aa6d77671 100644
+index e5bda94..f31c9ff 100644
 --- a/src/chat/openai-chat-language-model.ts
 +++ b/src/chat/openai-chat-language-model.ts
-@@ -180,7 +180,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
+@@ -211,7 +211,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
  
      // remove unsupported settings for reasoning models
      // see https://platform.openai.com/docs/guides/reasoning#limitations
@@ -608,7 +540,7 @@ index 96077d47c9e104143430d261e040b9ae89340940..31417bad69cc06d5213be0b17b3ef08a
        //  https://platform.openai.com/docs/guides/latest-model#gpt-5-1-parameter-compatibility
        if (
 diff --git a/src/image/openai-image-api.ts b/src/image/openai-image-api.ts
-index de779ca46aa2102cc5bef4a733ef6b6807260731..14b724785e15ab95f4cd2ff4d35d35c2ca7605c7 100644
+index de779ca..14b7247 100644
 --- a/src/image/openai-image-api.ts
 +++ b/src/image/openai-image-api.ts
 @@ -9,7 +9,8 @@ export const openaiImageResponseSchema = lazySchema(() =>
@@ -622,23 +554,23 @@ index de779ca46aa2102cc5bef4a733ef6b6807260731..14b724785e15ab95f4cd2ff4d35d35c2
          }),
        ),
 diff --git a/src/image/openai-image-model.ts b/src/image/openai-image-model.ts
-index d456d6398aefb5f78650780867bba92427b1d542..baaade4152183264b1af2b1ac2907bbb7adb4edd 100644
+index 41b81b2..f0858ff 100644
 --- a/src/image/openai-image-model.ts
 +++ b/src/image/openai-image-model.ts
-@@ -116,7 +116,11 @@ export class OpenAIImageModel implements ImageModelV3 {
+@@ -132,7 +132,11 @@ export class OpenAIImageModel implements ImageModelV3 {
        });
  
        return {
 -        images: response.data.map(item => item.b64_json),
 +        images: response.data.flatMap(item => {
-+          if (typeof item.b64_json === 'string') return [item.b64_json];
-+          if (typeof item.url === 'string') return [item.url];
-+          return [];
-+        }),
++        if (typeof item.b64_json === 'string') return [item.b64_json];
++        if (typeof item.url === 'string') return [item.url];
++        return [];
++      }),
          warnings,
          usage:
            response.usage != null
-@@ -178,7 +182,11 @@ export class OpenAIImageModel implements ImageModelV3 {
+@@ -207,7 +211,11 @@ export class OpenAIImageModel implements ImageModelV3 {
      });
  
      return {
@@ -652,10 +584,10 @@ index d456d6398aefb5f78650780867bba92427b1d542..baaade4152183264b1af2b1ac2907bbb
        usage:
          response.usage != null
 diff --git a/src/responses/convert-to-openai-responses-input.ts b/src/responses/convert-to-openai-responses-input.ts
-index ad42deeedaf1a9c3fdb578aadb0e295a5499ec39..56ed9e241cbdeb327878345b3852159d774aecbb 100644
+index 5c27d8f..c5f0bbf 100644
 --- a/src/responses/convert-to-openai-responses-input.ts
 +++ b/src/responses/convert-to-openai-responses-input.ts
-@@ -191,9 +191,14 @@ export async function convertToOpenAIResponsesInput({
+@@ -514,9 +514,14 @@ export async function convertToOpenAIResponsesInput({
                }
  
                input.push({
@@ -670,7 +602,7 @@ index ad42deeedaf1a9c3fdb578aadb0e295a5499ec39..56ed9e241cbdeb327878345b3852159d
                  ...(phase != null && { phase }),
                });
  
-@@ -538,6 +543,17 @@ export async function convertToOpenAIResponsesInput({
+@@ -955,6 +960,17 @@ export async function convertToOpenAIResponsesInput({
                      encrypted_content: encryptedContent,
                      summary: summaryParts,
                    });
@@ -688,7 +620,7 @@ index ad42deeedaf1a9c3fdb578aadb0e295a5499ec39..56ed9e241cbdeb327878345b3852159d
                  } else {
                    warnings.push({
                      type: 'other',
-@@ -848,6 +864,7 @@ export async function convertToOpenAIResponsesInput({
+@@ -1335,6 +1351,7 @@ export async function convertToOpenAIResponsesInput({
  const openaiResponsesReasoningProviderOptionsSchema = z.object({
    itemId: z.string().nullish(),
    reasoningEncryptedContent: z.string().nullish(),
@@ -697,10 +629,10 @@ index ad42deeedaf1a9c3fdb578aadb0e295a5499ec39..56ed9e241cbdeb327878345b3852159d
  
  export type OpenAIResponsesReasoningProviderOptions = z.infer<
 diff --git a/src/responses/openai-responses-api.ts b/src/responses/openai-responses-api.ts
-index 53a3f242d81d0b52d9126b0f4580a30778373606..b478c2cd2af3112592255d010f67b61187cb4f2b 100644
+index aef872b..b34fcfd 100644
 --- a/src/responses/openai-responses-api.ts
 +++ b/src/responses/openai-responses-api.ts
-@@ -985,6 +985,11 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
+@@ -1206,6 +1206,11 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
          summary_index: z.number(),
          delta: z.string(),
        }),
@@ -712,7 +644,7 @@ index 53a3f242d81d0b52d9126b0f4580a30778373606..b478c2cd2af3112592255d010f67b611
        z.object({
          type: z.literal('response.reasoning_summary_part.done'),
          item_id: z.string(),
-@@ -1111,7 +1116,7 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
+@@ -1327,7 +1332,7 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
                          index: z.number(),
                        }),
                      ]),
@@ -722,10 +654,10 @@ index 53a3f242d81d0b52d9126b0f4580a30778373606..b478c2cd2af3112592255d010f67b611
                ),
              }),
 diff --git a/src/responses/openai-responses-language-model.ts b/src/responses/openai-responses-language-model.ts
-index fe9616c8119e0d81750b4b367115aa1e58c9bc3d..ee29c4bf14104ceb2e5ce1dafe816828b14018cb 100644
+index 485880b..e25dd4f 100644
 --- a/src/responses/openai-responses-language-model.ts
 +++ b/src/responses/openai-responses-language-model.ts
-@@ -358,7 +358,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
+@@ -436,7 +436,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
  
      // remove unsupported settings for reasoning models
      // see https://platform.openai.com/docs/guides/reasoning#limitations
@@ -734,7 +666,7 @@ index fe9616c8119e0d81750b4b367115aa1e58c9bc3d..ee29c4bf14104ceb2e5ce1dafe816828
        // when reasoning effort is none, gpt-5.1 models allow temperature, topP, logprobs
        //  https://platform.openai.com/docs/guides/latest-model#gpt-5-1-parameter-compatibility
        if (
-@@ -1969,6 +1969,17 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
+@@ -2243,6 +2243,17 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                    } satisfies ResponsesReasoningProviderMetadata,
                  },
                });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ overrides:
   '@napi-rs/system-ocr-darwin-arm64': 1.0.2
   '@napi-rs/system-ocr-darwin-x64': 1.0.2
   '@ai-sdk/provider': 3.0.15
-  '@ai-sdk/provider-utils': 4.0.48
+  '@ai-sdk/provider-utils': 4.0.50
   '@ai-sdk/anthropic': 3.0.103
   ai: 6.0.185
 
@@ -65,7 +65,7 @@ patchedDependencies:
   '@ai-sdk/google@3.0.113': 8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874
   '@ai-sdk/open-responses@1.0.34': 7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648
   '@ai-sdk/openai-compatible@2.0.72': e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480
-  '@ai-sdk/openai@3.0.53': 9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c
+  '@ai-sdk/openai@3.0.109': 350f48bc773a9ecb47ff0d16ecce61ccc0a38be7e93e49c45489270ffada9a06
   '@ai-sdk/react@3.0.187': 8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230
   '@deepseek-ai/dsh-llm-pi-ai@0.1.0-rc.7': 9c4deb543997ef0b40cf4a39f177e8edbb42c486c74e756bfdd451b0620c28ed
   '@earendil-works/pi-ai@0.80.6': ba8ed726a49dbae25d6871297718ce26e45a491ec81e2183810cf018c0ec0206
@@ -225,8 +225,8 @@ importers:
         specifier: 3.0.103
         version: 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)
       '@ai-sdk/azure':
-        specifier: ^3.0.54
-        version: 3.0.54(zod@4.3.4)
+        specifier: ^3.0.116
+        version: 3.0.116(zod@4.3.4)
       '@ai-sdk/bytedance':
         specifier: 1.0.29
         version: 1.0.29(zod@4.3.4)
@@ -261,8 +261,8 @@ importers:
         specifier: 1.0.34
         version: 1.0.34(patch_hash=7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648)(zod@4.3.4)
       '@ai-sdk/openai':
-        specifier: ^3.0.53
-        version: 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)
+        specifier: ^3.0.109
+        version: 3.0.109(patch_hash=350f48bc773a9ecb47ff0d16ecce61ccc0a38be7e93e49c45489270ffada9a06)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.72
         version: 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
@@ -273,8 +273,8 @@ importers:
         specifier: 3.0.15
         version: 3.0.15
       '@ai-sdk/provider-utils':
-        specifier: 4.0.48
-        version: 4.0.48(zod@4.3.4)
+        specifier: 4.0.50
+        version: 4.0.50(zod@4.3.4)
       '@ai-sdk/react':
         specifier: ^3.0.147
         version: 3.0.187(patch_hash=8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230)(react@19.2.3)(zod@4.3.4)
@@ -724,7 +724,7 @@ importers:
         version: 6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4)
       ai-retry:
         specifier: ^1.11.0
-        version: 1.11.1(@ai-sdk/provider-utils@4.0.48(zod@4.3.4))(@ai-sdk/provider@3.0.15)(@opentelemetry/api@1.9.0)(ai@6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4))(zod@4.3.4)
+        version: 1.11.1(@ai-sdk/provider-utils@4.0.50(zod@4.3.4))(@ai-sdk/provider@3.0.15)(@opentelemetry/api@1.9.0)(ai@6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4))(zod@4.3.4)
       ansi-to-react:
         specifier: ^6.2.6
         version: 6.2.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1441,8 +1441,8 @@ importers:
         specifier: ^3.0.113
         version: 3.0.113(patch_hash=8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874)(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^3.0.53
-        version: 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.4.3)
+        specifier: ^3.0.109
+        version: 3.0.109(patch_hash=350f48bc773a9ecb47ff0d16ecce61ccc0a38be7e93e49c45489270ffada9a06)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.72
         version: 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.4.3)
@@ -1450,8 +1450,8 @@ importers:
         specifier: 3.0.15
         version: 3.0.15
       '@ai-sdk/provider-utils':
-        specifier: 4.0.48
-        version: 4.0.48(zod@4.4.3)
+        specifier: 4.0.50
+        version: 4.0.50(zod@4.4.3)
     devDependencies:
       tsdown:
         specifier: ^0.20.3
@@ -1469,8 +1469,8 @@ importers:
         specifier: 3.0.103
         version: 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)
       '@ai-sdk/azure':
-        specifier: ^3.0.54
-        version: 3.0.54(zod@4.3.4)
+        specifier: ^3.0.116
+        version: 3.0.116(zod@4.3.4)
       '@ai-sdk/deepseek':
         specifier: ^2.0.57
         version: 2.0.57(zod@4.3.4)
@@ -1478,8 +1478,8 @@ importers:
         specifier: ^3.0.113
         version: 3.0.113(patch_hash=8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874)(zod@4.3.4)
       '@ai-sdk/openai':
-        specifier: ^3.0.53
-        version: 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)
+        specifier: ^3.0.109
+        version: 3.0.109(patch_hash=350f48bc773a9ecb47ff0d16ecce61ccc0a38be7e93e49c45489270ffada9a06)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.72
         version: 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
@@ -1487,8 +1487,8 @@ importers:
         specifier: 3.0.15
         version: 3.0.15
       '@ai-sdk/provider-utils':
-        specifier: 4.0.48
-        version: 4.0.48(zod@4.3.4)
+        specifier: 4.0.50
+        version: 4.0.50(zod@4.3.4)
       '@ai-sdk/xai':
         specifier: ^3.0.126
         version: 3.0.126(zod@4.3.4)
@@ -1844,8 +1844,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@ai-sdk/provider-utils':
-        specifier: 4.0.48
-        version: 4.0.48(zod@4.3.6)
+        specifier: 4.0.50
+        version: 4.0.50(zod@4.3.6)
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -2123,8 +2123,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/azure@3.0.54':
-    resolution: {integrity: sha512-lnW7V+Kl3OKKvNXHaZSf/D35vo4bchfMm7WzxILZMPJ5N7W6i1oDeSXVurSKlR685Kvpi8ZA76LBJKSbzff3yw==}
+  '@ai-sdk/azure@3.0.116':
+    resolution: {integrity: sha512-ea7W5BBaTeJdJLzvv440sS+S04/6m74LKYWnnIl2WqZfuKh1T6a7anvKEMgMsWqQOuXYEJeAxKORzoB3UstfsA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2149,6 +2149,12 @@ packages:
 
   '@ai-sdk/deepseek@2.0.57':
     resolution: {integrity: sha512-dGSieE6Q9JLSuSYajEgYZYL4o1vKEEXOgM8eNQGT+9HdoCYBNqLybVdjJB+iu127s0jKLCxK0Nq53ufN+mofEg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/deepseek@2.0.62':
+    resolution: {integrity: sha512-9gtHuDMxd/OIwb0x2M5vLQfhRTIKc3kfOq+QCXZBZSb4P0XR9cJanu3FTkH2zbgJvyUWpOwDq2rDGogQ5/Pn1w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2212,8 +2218,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.53':
-    resolution: {integrity: sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==}
+  '@ai-sdk/openai@3.0.109':
+    resolution: {integrity: sha512-5mxPiRS83KaOtu04fz79dhZ9J5u/aUb7ekNcdiNUPioziORFnjcw7dJSfKS/yj8sj+IfSnp8eDZfTSBRBgvXAQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2224,8 +2230,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.48':
-    resolution: {integrity: sha512-l3LqNFx3hgIqaCNHKbZgWPhKMw8xxOjsNhElzeawWe1Gsjozu2EA4NJUMoKi7sUsNQjn1cw0DPs/zR519oHRXQ==}
+  '@ai-sdk/provider-utils@4.0.50':
+    resolution: {integrity: sha512-YAcB+7M1JhAYsHorTrWyldCyZihjCKr/QRXH2vFrara/+lwqNE7q5KzoucKLZ7ktFiUonhnhFhRoiymsq/2K2Q==}
     engines: {node: '>=18.17'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -9145,7 +9151,7 @@ packages:
     resolution: {integrity: sha512-J/nffw5v1cISfNAvZQSW4v6p1BMsSqvsP0PpwjUsnumRRVLfW3N5wls9ASIhaZAx1faMdvhMi9qh2oUTxCMc2A==}
     peerDependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48
+      '@ai-sdk/provider-utils': 4.0.50
       '@opentelemetry/api': ^1.9.0
       ai: 6.0.185
       zod: ^4.0.0
@@ -16013,7 +16019,7 @@ snapshots:
     dependencies:
       '@ai-sdk/anthropic': 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       '@smithy/eventstream-codec': 4.2.14
       '@smithy/util-utf8': 4.2.2
       aws4fetch: 1.0.20
@@ -16022,45 +16028,52 @@ snapshots:
   '@ai-sdk/anthropic@3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/anthropic@3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/azure@3.0.54(zod@4.3.4)':
+  '@ai-sdk/azure@3.0.116(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai': 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)
+      '@ai-sdk/deepseek': 2.0.62(zod@4.3.4)
+      '@ai-sdk/openai': 3.0.109(patch_hash=350f48bc773a9ecb47ff0d16ecce61ccc0a38be7e93e49c45489270ffada9a06)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/bytedance@1.0.29(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/cerebras@2.0.78(zod@4.3.4)':
     dependencies:
       '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/cohere@3.0.30(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/deepseek@2.0.57(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
+      zod: 4.3.4
+
+  '@ai-sdk/deepseek@2.0.62(zod@4.3.4)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/devtools@0.0.17':
@@ -16072,14 +16085,14 @@ snapshots:
   '@ai-sdk/gateway@3.0.104(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       '@vercel/oidc': 3.2.0
       zod: 4.3.4
 
   '@ai-sdk/gateway@3.0.116(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       '@vercel/oidc': 3.2.0
       zod: 4.3.4
 
@@ -16089,7 +16102,7 @@ snapshots:
       '@ai-sdk/google': 3.0.113(patch_hash=8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874)(zod@4.3.4)
       '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       google-auth-library: 10.6.2
       zod: 4.3.4
     transitivePeerDependencies:
@@ -16098,71 +16111,71 @@ snapshots:
   '@ai-sdk/google@3.0.113(patch_hash=8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/google@3.0.113(patch_hash=8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/groq@3.0.35(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/huggingface@1.0.74(zod@4.3.4)':
     dependencies:
       '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/mistral@3.0.30(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/open-responses@1.0.34(patch_hash=7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/openai-compatible@2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/openai-compatible@2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)':
+  '@ai-sdk/openai@3.0.109(patch_hash=350f48bc773a9ecb47ff0d16ecce61ccc0a38be7e93e49c45489270ffada9a06)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai@3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.109(patch_hash=350f48bc773a9ecb47ff0d16ecce61ccc0a38be7e93e49c45489270ffada9a06)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/perplexity@3.0.29(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/provider-utils@4.0.48(zod@4.3.4)':
+  '@ai-sdk/provider-utils@4.0.50(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
       '@standard-schema/spec': 1.1.0
@@ -16170,7 +16183,7 @@ snapshots:
       undici: 6.28.0
       zod: 4.3.4
 
-  '@ai-sdk/provider-utils@4.0.48(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.50(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
       '@standard-schema/spec': 1.1.0
@@ -16178,7 +16191,7 @@ snapshots:
       undici: 6.28.0
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.48(zod@4.4.3)':
+  '@ai-sdk/provider-utils@4.0.50(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
       '@standard-schema/spec': 1.1.0
@@ -16192,7 +16205,7 @@ snapshots:
 
   '@ai-sdk/react@3.0.187(patch_hash=8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230)(react@19.2.3)(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       ai: 6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4)
       react: 19.2.3
       swr: 2.3.8(react@19.2.3)
@@ -16211,14 +16224,14 @@ snapshots:
     dependencies:
       '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/xai@3.0.126(zod@4.3.4)':
     dependencies:
       '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@aiany/sqlite-vec-darwin-arm64@0.1.10-alpha.4.aiany.2':
@@ -20326,7 +20339,7 @@ snapshots:
     dependencies:
       '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
     transitivePeerDependencies:
       - zod
 
@@ -24077,10 +24090,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai-retry@1.11.1(@ai-sdk/provider-utils@4.0.48(zod@4.3.4))(@ai-sdk/provider@3.0.15)(@opentelemetry/api@1.9.0)(ai@6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4))(zod@4.3.4):
+  ai-retry@1.11.1(@ai-sdk/provider-utils@4.0.50(zod@4.3.4))(@ai-sdk/provider@3.0.15)(@opentelemetry/api@1.9.0)(ai@6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4))(zod@4.3.4):
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       ai: 6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4)
       zod: 4.3.4
     optionalDependencies:
@@ -24090,7 +24103,7 @@ snapshots:
     dependencies:
       '@ai-sdk/gateway': 3.0.116(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.4
 
@@ -28901,7 +28914,7 @@ snapshots:
   ollama-ai-provider-v2@3.3.1(patch_hash=d2b640ac5475c802eee5f983bcad08fb4e5cec7615c57aac188850c3f531743b)(ai@6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4))(zod@4.3.4):
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       ai: 6.0.185(patch_hash=61fc175c652267f39ec01df738fc61d1639faa19b980441005f7e9cd645d1711)(zod@4.3.4)
       zod: 4.3.4
 
@@ -31779,7 +31792,7 @@ snapshots:
   voyage-ai-provider@3.0.0(zod@4.3.4):
     dependencies:
       '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.48(zod@4.3.4)
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
     optionalDependencies:
       zod: 4.3.4
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,9 +58,9 @@ overrides:
   '@napi-rs/system-ocr-darwin-arm64': '1.0.2'
   '@napi-rs/system-ocr-darwin-x64': '1.0.2'
   # Keep exactly one @ai-sdk/provider + provider-utils so `instanceof APICallError` holds
-  # across every provider package; 3.0.15 / 4.0.48 is what the current provider set declares.
+  # across every provider package; 3.0.15 / 4.0.50 is what the current provider set declares.
   '@ai-sdk/provider': '3.0.15'
-  '@ai-sdk/provider-utils': '4.0.48'
+  '@ai-sdk/provider-utils': '4.0.50'
   # Pin to the version our patch (patches/@ai-sdk__anthropic.patch) targets so every
   # instance — including the copies pulled transitively by @ai-sdk/amazon-bedrock and
   # @ai-sdk/google-vertex — resolves to the single patched build. 3.0.103 includes
@@ -79,7 +79,7 @@ patchedDependencies:
   'file-stream-rotator@0.6.1': patches/file-stream-rotator-npm-0.6.1-eab45fb13d.patch
   'ollama-ai-provider-v2@3.3.1': patches/ollama-ai-provider-v2@3.3.1.patch
   '@opeoginni/github-copilot-openai-compatible@1.0.0': patches/@opeoginni__github-copilot-openai-compatible@1.0.0.patch
-  '@ai-sdk/openai@3.0.53': patches/@ai-sdk__openai@3.0.53.patch
+  '@ai-sdk/openai@3.0.109': patches/@ai-sdk__openai@3.0.109.patch
   '@ai-sdk/google@3.0.113': patches/@ai-sdk__google@3.0.113.patch
   '@ai-sdk/anthropic': patches/@ai-sdk__anthropic.patch
   '@tiptap/extension-drag-handle@3.26.1': patches/@tiptap__extension-drag-handle@3.26.1.patch
@@ -235,3 +235,5 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/xai@3.0.126'
   - '@ai-sdk/provider-utils@4.0.48'
   - '@cherrystudio/analytics-client@1.3.1'
+  - '@ai-sdk/openai@3.0.109'
+  - '@ai-sdk/azure@3.0.116'

--- a/src/main/ai/provider/__tests__/openaiResponsesAnnotationsPatch.test.ts
+++ b/src/main/ai/provider/__tests__/openaiResponsesAnnotationsPatch.test.ts
@@ -1,7 +1,7 @@
 import { createOpenAI } from '@ai-sdk/openai'
 import { describe, expect, it } from 'vitest'
 
-// Guards patches/@ai-sdk__openai@3.0.53.patch. The upstream non-streaming Responses schema
+// Guards patches/@ai-sdk__openai@3.0.109.patch. The upstream non-streaming Responses schema
 // requires `annotations` on every output_text part, but third-party Responses implementations
 // (Volcano Ark's Agent plan, #19337) omit it entirely — a valid HTTP 200 that, unpatched, fails
 // schema validation (AI_TypeValidationError) and breaks every non-streaming call. The patch

--- a/src/main/ai/provider/__tests__/openaiResponsesAssistantStatusPatch.test.ts
+++ b/src/main/ai/provider/__tests__/openaiResponsesAssistantStatusPatch.test.ts
@@ -2,7 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { describe, expect, it } from 'vitest'
 
 /**
- * Guards the assistant-item hunk in patches/@ai-sdk__openai@3.0.53.patch.
+ * Guards the assistant-item hunk in patches/@ai-sdk__openai@3.0.109.patch.
  * Volcengine Ark rejects an assistant input item that omits `type` or `status`
  * (400 MissingParameter, reported one field at a time, #18253) — the adapter
  * infers both from the role. Only the assistant item needs them: Ark validates

--- a/src/main/ai/provider/__tests__/openaiResponsesFunctionCallId.test.ts
+++ b/src/main/ai/provider/__tests__/openaiResponsesFunctionCallId.test.ts
@@ -1,0 +1,71 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A replayed tool call must not carry the item id it was received with. `id` names an
+ * object the server stored; we always send `store: false`, so nothing is stored and the
+ * id is meaningless. Relays that synthesize their own item ids (UUIDs rather than `fc_…`)
+ * used to poison a topic permanently: the bad id lived in the persisted history and every
+ * later turn replayed it, so strict channels answered 400 until the topic was abandoned.
+ * `call_id` alone pairs the call with its output. Fixed upstream in @ai-sdk/openai 3.0.73.
+ */
+describe('@ai-sdk/openai replayed tool calls', () => {
+  it('pairs by call_id and drops the received item id', async () => {
+    let body: any
+    const model = createOpenAI({
+      apiKey: 'sk-test',
+      baseURL: 'https://example.com/v1',
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        body = JSON.parse(init?.body as string)
+        return new Response(
+          JSON.stringify({
+            id: 'resp_1',
+            created_at: 0,
+            model: 'm',
+            status: 'completed',
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 }
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+    }).responses('gpt-5.6')
+
+    await model.doGenerate({
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'weather?' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_abc',
+              toolName: 'search',
+              input: { query: 'weather' },
+              // what a relay handed us on the previous turn
+              providerOptions: { openai: { itemId: 'bda7112f-9c3e-4a1d-8f52-1e0d6b7a4c99' } }
+            }
+          ]
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_abc',
+              toolName: 'search',
+              output: { type: 'text', value: 'sunny' }
+            }
+          ]
+        }
+      ],
+      tools: [{ type: 'function', name: 'search', inputSchema: { type: 'object', properties: {} } }],
+      providerOptions: { openai: { store: false } }
+    })
+
+    const call = body.input.find((item: any) => item.type === 'function_call')
+    expect(call).toMatchObject({ call_id: 'call_abc', name: 'search' })
+    expect(call).not.toHaveProperty('id')
+    expect(body.input.find((item: any) => item.type === 'function_call_output')).toMatchObject({ call_id: 'call_abc' })
+  })
+})

--- a/src/main/ai/provider/__tests__/openaiResponsesReasoningPatch.test.ts
+++ b/src/main/ai/provider/__tests__/openaiResponsesReasoningPatch.test.ts
@@ -6,7 +6,7 @@ const prompt: LanguageModelV3CallOptions['prompt'] = [
   { role: 'user', content: [{ type: 'text', text: 'Think before answering.' }] }
 ]
 
-// Guards patches/@ai-sdk__openai@3.0.53.patch. DeepSeek's Responses API emits
+// Guards patches/@ai-sdk__openai@3.0.109.patch. DeepSeek's Responses API emits
 // response.reasoning_text.delta rather than OpenAI's reasoning summary delta event.
 // Without the patch, the SDK accepts the event as an unknown chunk and silently
 // drops the reasoning text before it reaches Cherry Studio's stream pipeline.

--- a/src/main/ai/provider/__tests__/openaiResponsesSamplingParamsPatch.test.ts
+++ b/src/main/ai/provider/__tests__/openaiResponsesSamplingParamsPatch.test.ts
@@ -2,7 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { describe, expect, it } from 'vitest'
 
 /**
- * Guards the sampling-parameter hunk in patches/@ai-sdk__openai@3.0.53.patch.
+ * Guards the sampling-parameter hunk in patches/@ai-sdk__openai@3.0.109.patch.
  * `forceReasoning` exists to make the adapter emit `reasoning` for models its
  * own id allowlist does not recognize — Cherry sets it for every Responses
  * request. Upstream also let it drive "OpenAI reasoning models reject


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: every replayed tool call sent `function_call.id` — the item id we received on the previous turn — back to the Responses API. `id` names an object the server stored, but we always send `store: false`, so it names nothing. A relay that synthesizes its own item ids (a UUID rather than `fc_…`) therefore poisoned a topic permanently: the bad id was written into the persisted history and every later turn replayed it, so strict channels answered `400 invalid_request` and switching models did not help, because the id was still in the history.

After this PR: `@ai-sdk/openai` is upgraded 3.0.53 → 3.0.109, which drops `id` from replayed `function_call` items (upstream fix in 3.0.73). `call_id` alone pairs the call with its `function_call_output`, so any item id the upstream returns is now inert.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The fix is a version bump rather than a local patch hunk, so we inherit upstream's shape instead of forking it. The existing patch had to be rebuilt onto 3.0.109: seven hunks carried forward (`forceReasoning` sampling params, image `url` fallback, Ark assistant `type`/`status`, `rawReasoningContent` replay, `response.reasoning_text.delta`, `annotations` nullish), and the `gpt-image-2` hunk was dropped because upstream now matches a generic `gpt-image-` prefix.
- Two dependencies had to move with it. `@ai-sdk/provider-utils` 4.0.48 → 4.0.50, because 3.0.109 imports `EXPERIMENTAL_EMBEDDING_MODEL_MAX_INPUT_BYTES_PER_CALL` and the override pins every instance to one copy. `@ai-sdk/azure` 3.0.54 → 3.0.116, because azure pins `@ai-sdk/openai` exactly; leaving it would have resolved Azure to an unpatched 3.0.53 that still carries the bug and none of our hunks.
- 3.0.109 is recent enough that pnpm added it and azure@3.0.116 to `minimumReleaseAgeExclude`. 3.0.106 also contains the fix if a more settled version is preferred.

The following alternatives were considered:

- Patching `id` out of 3.0.53 locally — same one-line effect, but it forks a file upstream had already fixed and keeps us 56 patch releases behind.
- Fixing it gateway-side by stripping `id` from forwarded input. That only blocks the item-id shapes we have already seen; dropping `id` on the client makes us immune to whatever a relay synthesizes next.

Links to places where the discussion took place: N/A

### Breaking changes

None. Topics that already contain a poisoned item id are repaired by this change, because the id is no longer sent.

### Special notes for your reviewer

The patch was rebuilt by scripting the seven hunks onto a pristine 3.0.109 with a match-count assertion per hunk, then diffing — `pnpm patch`'s version picker is a raw-mode TTY prompt and cannot be driven non-interactively. Each hunk was then re-verified by grep against the installed package, and Azure was confirmed to resolve to the same patched instance. `src/main/ai/provider/__tests__/openaiResponsesFunctionCallId.test.ts` reproduces the original 400: it feeds a history tool call carrying a UUID `itemId` and asserts the outgoing `function_call` has no `id` and still pairs by `call_id`. The four existing patch-guard tests only had their patch filename references updated.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Chat] Fixed a topic permanently failing with a 400 error after a tool call when the provider or relay returns a non-standard item id.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
