### PR TITLE
fix(smooth-stream): flush buffered text on completion

### DIFF
--- a/src/renderer/hooks/__tests__/useSmoothStream.test.ts
+++ b/src/renderer/hooks/__tests__/useSmoothStream.test.ts
@@ -121,9 +121,9 @@ describe('useSmoothStream', () => {
     expect(lastText(onUpdate).length).toBe(600)
   })
 
-  // After streamDone the tail must beat the old fixed 5/frame: frame 1 is
-  // MIN_STEP, then a 999 tail reveals ceil(999*16/(2*1000))=8 (> 5).
-  it('drains a huge tail faster than the gentle step once streamDone', () => {
+  // Once the source is done, every queued grapheme is already final. Keeping
+  // it buffered would expose a completed state whose copyable text is partial.
+  it('flushes the queued tail on the first frame after streamDone', () => {
     const onUpdate = vi.fn()
     const { result, rerender } = renderHook(
       ({ done }: { done: boolean }) => useSmoothStream({ onUpdate, streamDone: done, minDelay: 0 }),
@@ -132,12 +132,8 @@ describe('useSmoothStream', () => {
 
     act(() => result.current.addChunk('a'.repeat(1000)))
     rerender({ done: true })
-    act(() => tick(16)) // frame 1: MIN_STEP → 1
-    const afterFirst = lastText(onUpdate).length
-    act(() => tick(16)) // frame 2: tail step
-    expect(lastText(onUpdate).length - afterFirst).toBeGreaterThan(5)
+    act(() => tick(16))
 
-    act(() => tick(16, 5000))
     expect(onUpdate).toHaveBeenLastCalledWith('a'.repeat(1000))
   })
 

--- a/src/renderer/hooks/useSmoothStream.ts
+++ b/src/renderer/hooks/useSmoothStream.ts
@@ -77,17 +77,6 @@ const MAX_BACKLOG = 400
 /** rAF doesn't fire in background tabs; on return `dt` would be huge and
  *  drain the whole queue. Clamp so a hidden→visible tab resumes smoothly. */
 const MAX_FRAME_DT_MS = 100
-
-/**
- * After the upstream stream ends there are no more arrivals, so `rate_est`
- * decays to ~0. The tail then plays out at `max(POST_STREAM_STEP per frame,
- * fast enough to finish within POST_STREAM_DRAIN_SEC)`: a short tail keeps
- * the gentle typewriter; a multi-thousand-char tail finishes in a couple of
- * seconds instead of crawling at MIN_STEP.
- */
-const POST_STREAM_STEP = 5
-const POST_STREAM_DRAIN_SEC = 2.0
-
 const MIN_STEP = 1
 
 export const useSmoothStream = ({
@@ -241,6 +230,14 @@ export const useSmoothStream = ({
       return
     }
 
+    if (streamDone) {
+      displayedTextRef.current += queue.join('')
+      chunkQueueRef.current = []
+      onUpdateRef.current(displayedTextRef.current)
+      animationFrameRef.current = null
+      return
+    }
+
     const now = performance.now()
     const last = lastFrameTimeRef.current
 
@@ -273,47 +270,40 @@ export const useSmoothStream = ({
     const dt = Math.min(elapsed, MAX_FRAME_DT_MS)
 
     let count: number
-    if (streamDone) {
-      // No more arrivals: gentle typewriter for short tails, but fast enough
-      // that a huge tail still finishes within POST_STREAM_DRAIN_SEC.
-      const perFrameToFinish = Math.ceil((queue.length * dt) / (POST_STREAM_DRAIN_SEC * 1000))
-      count = Math.max(POST_STREAM_STEP, perFrameToFinish)
+    // Sustained rate: total / max(elapsed, floor). Never 0 mid-stall
+    // (total>0, elapsed monotonic), so the cushion below truly spans it.
+    const elapsedMs = now - firstChunkTRef.current
+    const ratePerSec = (totalCharsRef.current / Math.max(elapsedMs, SUSTAINED_MIN_MS)) * 1000
+
+    // Slow release: the armed cushion decays toward 0 (→ FLOOR) so a
+    // stream that stops stalling returns to low latency.
+    stallEstRef.current *= Math.exp(-(dt / 1000) / STALL_RELEASE_SEC)
+    const targetSec = Math.min(TARGET_DELAY_CAP_SEC, Math.max(TARGET_DELAY_FLOOR_SEC, stallEstRef.current))
+
+    // Play at the inbound rate, pulled toward the adaptive cushion:
+    // below target → slower (let the next burst refill), above → faster.
+    const target = ratePerSec * targetSec
+    const adjustedRate = ratePerSec + (queue.length - target) / RELAX_SEC
+
+    if (adjustedRate > 0) {
+      // Fractional credit: a sub-1-grapheme-per-frame budget accumulates,
+      // so a genuinely slow stream plays at its true rate instead of the
+      // old MIN_STEP (≈60/s at 60fps) floor that dumped slow input then
+      // stalled. MIN_STEP is no longer a speed floor.
+      creditRef.current += (adjustedRate * dt) / 1000
+      count = Math.floor(creditRef.current)
+      creditRef.current -= count
     } else {
-      // Sustained rate: total / max(elapsed, floor). Never 0 mid-stall
-      // (total>0, elapsed monotonic), so the cushion below truly spans it.
-      const elapsedMs = now - firstChunkTRef.current
-      const ratePerSec = (totalCharsRef.current / Math.max(elapsedMs, SUSTAINED_MIN_MS)) * 1000
-
-      // Slow release: the armed cushion decays toward 0 (→ FLOOR) so a
-      // stream that stops stalling returns to low latency.
-      stallEstRef.current *= Math.exp(-(dt / 1000) / STALL_RELEASE_SEC)
-      const targetSec = Math.min(TARGET_DELAY_CAP_SEC, Math.max(TARGET_DELAY_FLOOR_SEC, stallEstRef.current))
-
-      // Play at the inbound rate, pulled toward the adaptive cushion:
-      // below target → slower (let the next burst refill), above → faster.
-      const target = ratePerSec * targetSec
-      const adjustedRate = ratePerSec + (queue.length - target) / RELAX_SEC
-
-      if (adjustedRate > 0) {
-        // Fractional credit: a sub-1-grapheme-per-frame budget accumulates,
-        // so a genuinely slow stream plays at its true rate instead of the
-        // old MIN_STEP (≈60/s at 60fps) floor that dumped slow input then
-        // stalled. MIN_STEP is no longer a speed floor.
-        creditRef.current += (adjustedRate * dt) / 1000
-        count = Math.floor(creditRef.current)
-        creditRef.current -= count
-      } else {
-        // adjustedRate ≤ 0 only when the queue is deep below the cushion —
-        // a stall draining past equilibrium. Dribble MIN_STEP so the buffer
-        // keeps flowing instead of freezing with content unshown.
-        // Slow-steady streams keep adjustedRate > 0 and never reach here.
-        count = MIN_STEP
-        creditRef.current = 0
-      }
-      if (queue.length - count > MAX_BACKLOG) {
-        // Hard latency ceiling vs the live model.
-        count = queue.length - MAX_BACKLOG
-      }
+      // adjustedRate ≤ 0 only when the queue is deep below the cushion —
+      // a stall draining past equilibrium. Dribble MIN_STEP so the buffer
+      // keeps flowing instead of freezing with content unshown.
+      // Slow-steady streams keep adjustedRate > 0 and never reach here.
+      count = MIN_STEP
+      creditRef.current = 0
+    }
+    if (queue.length - count > MAX_BACKLOG) {
+      // Hard latency ceiling vs the live model.
+      count = queue.length - MAX_BACKLOG
     }
 
     count = Math.min(count, queue.length)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`useSmoothStream` continued pacing its queued tail after the source stream had completed. Translation controls could report completion while the displayed, copyable, and exportable output was still a prefix of the final text.

After this PR:

The hook keeps its existing adaptive pacing while content is streaming, then flushes every queued grapheme together on the first animation frame after completion. Completion-sensitive consumers therefore observe the full result without maintaining a second output state.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20109

### Why we need it and why it was done in this way

The following tradeoffs were made:

The final buffered tail no longer keeps the typewriter pacing after completion. Live-stream pacing remains unchanged; once the source is done, preserving copy/export correctness takes precedence over continuing a cosmetic delay.

The following alternatives were considered:

Adding a separate draining state, disabling copy during the drain, or making copy read the raw accumulation would add state and leave the unnecessary post-completion delay in place. Flushing the existing queue keeps the completion contract local to `useSmoothStream`.

Links to places where the discussion took place: #20109

### Breaking changes

None.

### Special notes for your reviewer

- RED: the previous implementation failed the completion contract by exposing only 1 of 1,000 queued graphemes on the first frame after `streamDone`.
- GREEN: the focused `useSmoothStream` suite passes 14/14, including a 1,000-grapheme completion flush.
- `pnpm lint` and `pnpm test:lint` pass.
- Existing live-stream pacing and the 400-grapheme backlog ceiling remain covered by focused tests.

Interaction result:

An authenticated completion stream could not be produced in the isolated development profile: its configured translation provider did not enter a running state or return output. No misleading empty-state screenshot is attached. The completion timing contract is instead covered by the focused hook test, which verifies that a 1,000-grapheme queued tail is fully visible on the first animation frame after `streamDone`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Streaming] Show the complete buffered response as soon as generation finishes.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized hook behavior change at stream end only; streaming pacing is untouched and covered by existing tests.
> 
> **Overview**
> **`useSmoothStream` no longer typewriter-drains the queue after the source finishes.** When `streamDone` is true and buffered graphemes remain, the render loop appends the entire queue in one animation frame, clears it, emits `onUpdate`, and stops—instead of using the removed `POST_STREAM_STEP` / `POST_STREAM_DRAIN_SEC` paced tail drain.
> 
> **Live streaming behavior is unchanged:** adaptive rate matching, backlog cap, and first-frame `MIN_STEP` rules still apply only while the stream is active.
> 
> The hook test now expects a 1,000-grapheme backlog to be fully visible after a single frame once completion is signaled, fixing cases where UI could show “done” while copy/export still held a partial prefix (e.g. #20109).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09dd5e68c565261253461f820cba89bdd6e5901c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->