### PR TITLE
fix(provider-settings): bound the model list so virtualization works

### DIFF
--- a/src/renderer/components/VirtualList/DynamicVirtualList.tsx
+++ b/src/renderer/components/VirtualList/DynamicVirtualList.tsx
@@ -380,7 +380,9 @@ function DynamicVirtualList<T>(props: DynamicVirtualListProps<T>) {
             zIndex: isItemActiveSticky ? activeStickyZIndex : isItemSticky ? STICKY_ITEM_Z_INDEX : 0,
             pointerEvents: isCoveredBySticky ? 'none' : 'auto',
             ...(isItemActiveSticky && {
-              backgroundColor: 'var(--background)'
+              // --card, not --background: the latter is translucent in dark mode, so rows
+              // scrolling under a pinned header would show through it.
+              backgroundColor: 'var(--card)'
             }),
             ...(horizontal
               ? {

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -53,7 +53,8 @@ function ProviderSettingSections({
             onOpenApiSetup={() => openApiSetup('api-key')}
             onContinueApiSetup={() => openApiSetup('models')}
           />
-          <div className="flex min-h-0 flex-1 flex-col">
+          {/* Floor keeps the list usable when a tall auth section leaves no room; the strip scrolls instead. */}
+          <div className="flex min-h-[280px] flex-1 flex-col">
             <ModelList
               providerId={providerId}
               modelPullGuideVersion={modelPullGuideVersion}

--- a/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
+++ b/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
@@ -237,7 +237,9 @@ export const modelListClasses = {
     'size-8 rounded-lg border-border-subtle bg-transparent text-muted-foreground shadow-none hover:bg-accent/40 hover:text-foreground',
   emptyState:
     'flex min-h-40 items-center justify-center rounded-2xl border border-border border-dashed bg-muted/30 px-4 text-center text-sm leading-5 text-foreground-tertiary',
-  listScroller: 'min-h-0 min-w-0 w-full flex-1 overflow-x-hidden pt-1',
+  // mt-1, not pt-1: rows scroll through a scroller's top padding, but the pinned
+  // group header sticks below it, so padding here leaks a sliver of the row above.
+  listScroller: 'min-h-0 min-w-0 w-full flex-1 overflow-x-hidden mt-1',
   virtualModelRow: 'border-x border-border-subtle bg-transparent',
   virtualModelRowLast: 'rounded-b-lg border-b border-border-subtle pb-1',
   /**

--- a/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
+++ b/src/renderer/pages/settings/ProviderSettings/primitives/classNames.ts
@@ -34,7 +34,9 @@ export const providerDetailColumnClasses = {
   contentMaxWidth: 'mx-auto w-full max-w-3xl',
   /** Header inner wrapper: same max-width as body content. */
   headerContentMaxWidth: 'mx-auto w-full max-w-3xl',
-  sectionStack: 'mx-auto flex min-h-full w-full min-w-0 max-w-3xl flex-col gap-5'
+  // h-full (not min-h-full): the model list below sizes itself from the remaining
+  // space, which only works if this column has a definite height.
+  sectionStack: 'mx-auto flex h-full w-full min-w-0 max-w-3xl flex-col gap-5'
 } as const
 
 /** Connection-field actions. */


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: the provider settings model list was virtualized in name only. Its scroller sat in a column that took its height from content (`min-h-full` inside the page-level `Scrollbar`), so `useVirtualizer` measured a ~127,000px viewport and rendered every model. With 3,000 models on one provider, opening it produced an 8,582ms blocking task, 2,381 mounted rows and 131,155 DOM nodes — which stayed mounted after leaving Settings, because it is a long-lived tab.

After this PR: the column has a definite height (`h-full`), so the list fills the remaining space and scrolls internally. A `min-h-[280px]` floor keeps the list usable when a tall authentication section (e.g. AWS Bedrock, 589px) leaves no room; in that case the outer strip scrolls instead. Same scenario now: 32ms, no long task, 17 mounted rows, ~3,000 DOM nodes; scrolling the list produces no long tasks (was 2,303ms).

The list now really scrolls internally, which exposed two pre-existing defects in pinned group headers, both fixed here: `DynamicVirtualList` painted sticky rows with `var(--background)`, translucent in dark mode, so rows scrolling underneath showed through (the model selector popover has always looked this way); and the model list scroller kept its top padding inside the scrollport, where rows scroll through it while the header sticks below, leaking a 4px sliver above the header.

Fixes #20093

### Why we need it and why it was done in this way

The following tradeoffs were made: on providers with a tall authentication section the page can now scroll while the model list also scrolls internally, which is the price of keeping the list bounded. The `280px` floor was measured rather than guessed — at the 960x600 minimum window a normal provider has 473px available and uses `142 + 20 + 280 < 473`, so the floor never triggers page scrolling for ordinary providers (a `320px` floor did, by 9px). For the sticky background, `--card` is opaque in both themes, is identical to `--background` in light mode, and is what the repo's other sticky headers (`manageStickyHeader`, history table) already use.

The following alternatives were considered: capping the list with `max-h-[60vh]` on `DynamicVirtualList` alone. It fixes the symptom (verified: 2381 rows to 19, 8582ms to 1197ms) but introduces a nested scroll area on a page that otherwise scrolls as one, and it needs `scrollerStyle` to defeat `flex-1`, which overrides `height` on the main axis. Bounding the existing flex column matches what the `min-h-0 flex-1` classes throughout this subtree already assume.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20093

### Breaking changes

None.

### Special notes for your reviewer

Measured with CDP against a dev instance seeded with 3,000 models on one provider (dev build inflates JS time; DOM node counts are build-independent). Verified at the 960x600 minimum window and at 1400x900, for a normal provider (OpenRouter), a tall-auth provider (AWS Bedrock) and a login-based provider.

The sticky-header change touches `DynamicVirtualList`, so it applies to every list that uses `isSticky` — verified on both current consumers, the settings model list and the model selector popover (whose own header already paints `bg-popover` on top, so only the previously leaking band changes).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Settings] Fix the provider model list freezing the app when a provider has many models, and stop rows showing through pinned group headers.
[设置] 修复服务商模型数量较多时模型列表卡死界面的问题，并修正分组吸顶标题下方透出模型行的显示问题。
```
