### PR TITLE
fix(dev-profile): isolate preboot paths under one root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,10 @@ CSLOGGER_MAIN_LEVEL=info
 CSLOGGER_RENDERER_LEVEL=info
 #CSLOGGER_MAIN_SHOW_MODULES=
 #CSLOGGER_RENDERER_SHOW_MODULES=
+# Set an absolute root to isolate Cherry home, userData, and logs in development.
+#CS_DEV_PROFILE_ROOT=
 # Set a unique suffix when running multiple dev instances, e.g. DevQuito.
+# Ignored when CS_DEV_PROFILE_ROOT is set.
 #CS_DEV_USER_DATA_SUFFIX=
 # Override the Cherry Cloud origin used for login and model requests in a custom build.
 #MAIN_VITE_CHERRY_CLOUD_API_ORIGIN=https://cloud.example.com

--- a/docs/contrib/development.md
+++ b/docs/contrib/development.md
@@ -87,6 +87,12 @@ This keeps Cherry home, BootConfig, legacy config discovery, Electron
 filesystem root, and packaged builds ignore it. When set, it takes precedence
 over `CS_DEV_USER_DATA_SUFFIX`.
 
+| Data | Isolated location |
+|------|-------------------|
+| Cherry home and BootConfig | `{profileRoot}/.cherrystudio` |
+| Electron `userData` | `{profileRoot}/userData` |
+| Application logs | `{profileRoot}/logs` |
+
 For lightweight isolation of multiple development instances, give each
 instance a unique userData suffix. You can set it in `.env`:
 

--- a/docs/contrib/development.md
+++ b/docs/contrib/development.md
@@ -75,8 +75,20 @@ pnpm dev
 
 By default, development runs append `Dev` to Electron's default `userData`
 directory, keeping local dev data separate from packaged app data. To run
-multiple development instances at the same time, give each instance a unique
-suffix. You can set it in `.env`:
+an entirely isolated development profile, set an absolute profile root in
+`.env`:
+
+```bash
+CS_DEV_PROFILE_ROOT=/absolute/path/to/cherry-profile
+```
+
+This keeps Cherry home, BootConfig, legacy config discovery, Electron
+`userData`, and logs under that root. The root cannot be relative or the
+filesystem root, and packaged builds ignore it. When set, it takes precedence
+over `CS_DEV_USER_DATA_SUFFIX`.
+
+For lightweight isolation of multiple development instances, give each
+instance a unique userData suffix. You can set it in `.env`:
 
 ```bash
 CS_DEV_USER_DATA_SUFFIX=DevQuito

--- a/docs/references/data/README.md
+++ b/docs/references/data/README.md
@@ -257,7 +257,7 @@ See [App State Overview](./app-state-overview.md) for full rules and the key reg
                          │
          ┌───────────────▼─────────────┐
          │ BootConfigService                       │
-         │ (sync load, ~/.cherrystudio/            │
+         │ (sync load, {cherryHome}/               │
          │  boot-config.json — also used directly  │
          │  in early boot before lifecycle)        │
          └─────────────────────────────────────────┘

--- a/docs/references/data/boot-config-overview.md
+++ b/docs/references/data/boot-config-overview.md
@@ -101,7 +101,7 @@ Keys follow the same naming convention as preferences: `namespace.key_name`
 │  │ BootConfigService                    │                       │
 │  │ - Sync load on import                │                       │
 │  │ - In-memory config map               │◄──── boot-config.json │
-│  │ - Debounced save                     │      (~/.cherrystudio/)│
+│  │ - Debounced save                     │      ({cherryHome}/)   │
 │  └──────────────────────────────────────┘                       │
 └─────────────────────────────────────────────────────────────────┘
 
@@ -118,7 +118,7 @@ Keys follow the same naming convention as preferences: `namespace.key_name`
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-BootConfig also carries data migrated from v1's `~/.cherrystudio/config/config.json` file (see `BootConfigMigrator`'s file source). The `app.user_data_path` key holds the custom user data directory mapping that the v1 file stored under `appDataPath`; preboot reads it before the path registry is frozen. User-initiated directory changes are first written to `temp.user_data_relocation`, then the next launch executes them during preboot (`src/main/services/userDataRelocation/`), copying or switching the Electron `userData` directory and committing `app.user_data_path`.
+BootConfig also carries data migrated from v1's `{cherryHome}/config/config.json` file (see `BootConfigMigrator`'s file source). The `app.user_data_path` key holds the custom user data directory mapping that the v1 file stored under `appDataPath`; preboot reads it before the path registry is frozen. User-initiated directory changes are first written to `temp.user_data_relocation`, then the next launch executes them during preboot (`src/main/services/userDataRelocation/`), copying or switching the Electron `userData` directory and committing `app.user_data_path`.
 
 ## Access Convention
 
@@ -175,10 +175,11 @@ Utility functions in `src/shared/data/preference/preferenceUtils.ts`:
 
 ## File Storage
 
-- **Path:** `~/.cherrystudio/boot-config.json` (intentionally outside `userData`)
+- **Path:** `{cherryHome}/boot-config.json` (intentionally outside `userData`)
+- **Cherry home:** `~/.cherrystudio` by default; `{profileRoot}/.cherrystudio` for unpackaged runs with `CS_DEV_PROFILE_ROOT`
 - **Format:** Flat JSON object, pretty-printed (2-space indent)
 
-> **Why outside `userData`?** Boot config must be readable *before* the app data directory is determined. Storing it under `userData` would create a chicken-and-egg problem: the file that decides where data lives cannot itself live inside that data. Placing it under `~/.cherrystudio/` keeps it stable across changes to `appDataPath` and ensures it is always available at process start, before `initAppDataDir()` runs.
+> **Why outside `userData`?** Boot config must be readable *before* the app data directory is determined. Storing it under `userData` would create a chicken-and-egg problem: the file that decides where data lives cannot itself live inside that data. Placing it under `{cherryHome}` keeps it stable across changes to `appDataPath` and ensures it is always available at process start, before `initAppDataDir()` runs.
 
 ```json
 {

--- a/docs/references/data/boot-config-schema-guide.md
+++ b/docs/references/data/boot-config-schema-guide.md
@@ -145,7 +145,7 @@ The `v2-refactor-temp/tools/data-classify/` directory contains the code generati
 | ElectronStore | `ElectronStoreReader.get(key)` | Direct key lookup |
 | Dexie settings | Key-value table | Direct key lookup |
 | localStorage | `localStorage.getItem(key)` | Direct key lookup |
-| Legacy home config file | `LegacyHomeConfigReader` | `~/.cherrystudio/config/config.json` (`appDataPath` field only) |
+| Legacy home config file | `LegacyHomeConfigReader` | `{cherryHome}/config/config.json` (`appDataPath` field only) |
 
 > **Config-file source mappings are manually maintained.** The `data-classify` toolchain's `classification.json` doesn't model config-file sources yet. In two places, a small hand-maintained list complements the classification-driven pipeline:
 >
@@ -189,11 +189,11 @@ cd v2-refactor-temp/tools/data-classify && npm run generate
 | Legacy Source | Legacy Key | Target Key |
 |---------------|-----------|------------|
 | Redux (`settings`) | `disableHardwareAcceleration` | `app.disable_hardware_acceleration` |
-| Config file (`~/.cherrystudio/config/config.json`) | `appDataPath` | `app.user_data_path` |
+| Config file (`{cherryHome}/config/config.json`) | `appDataPath` | `app.user_data_path` |
 
 #### AppImage / Windows Portable Executable Path
 
-The v1 `~/.cherrystudio/config/config.json` stores `appDataPath` as an array of `{ executablePath, dataPath }` entries keyed by executable path. AppImage Linux builds and Windows portable builds use a normalized executable key that differs from `app.getPath('exe')`:
+The v1 `{cherryHome}/config/config.json` stores `appDataPath` as an array of `{ executablePath, dataPath }` entries keyed by executable path. `{cherryHome}` defaults to `~/.cherrystudio`; unpackaged runs with `CS_DEV_PROFILE_ROOT` use `{profileRoot}/.cherrystudio`. AppImage Linux builds and Windows portable builds use a normalized executable key that differs from `app.getPath('exe')`:
 
 - AppImage: `path.dirname(process.env.APPIMAGE) + '/cherry-studio.appimage'`
 - Windows portable: `process.env.PORTABLE_EXECUTABLE_DIR + '/cherry-studio-portable.exe'`

--- a/docs/references/data/v2-migration-guide.md
+++ b/docs/references/data/v2-migration-guide.md
@@ -80,9 +80,9 @@ src/main/data/migration/v2/
 ## Core Contracts
 
 - `core/MigrationEngine.ts` coordinates all migrators in order, surfaces progress to the UI, and uses `app_state.key = 'migration_v2_status'` as the only durable migration marker. It clears new-schema tables before running and aborts on validation or global foreign-key failure.
-- `core/MigrationPaths.ts` defines `MigrationPaths` (a frozen object of pre-computed paths) and `resolveMigrationPaths()` which detects v1 legacy userData directories from `~/.cherrystudio/config/config.json`. Called once at the migration gate entry, before engine initialization. All migration code uses these paths instead of `app.getPath()` — see the **Path safety** convention below.
+- `core/MigrationPaths.ts` defines `MigrationPaths` (a frozen object of pre-computed paths) and `resolveMigrationPaths()` which detects v1 legacy userData directories from `{cherryHome}/config/config.json`. `{cherryHome}` defaults to `~/.cherrystudio`; unpackaged runs with `CS_DEV_PROFILE_ROOT` use `{profileRoot}/.cherrystudio`. Called once at the migration gate entry, before engine initialization. All migration code uses these paths instead of `app.getPath()` — see the **Path safety** convention below.
 - `core/MigrationContext.ts` builds the shared context passed to every migrator:
-  - `sources`: `ElectronStoreReader` (electron-store), `ReduxStateReader` (per-category Redux Persist export files), `DexieFileReader` (JSON exports), `LegacyHomeConfigReader` (v1 `~/.cherrystudio/config/config.json` for the config-file migration path used by `BootConfigMigrator`)
+  - `sources`: `ElectronStoreReader` (electron-store), `ReduxStateReader` (per-category Redux Persist export files), `DexieFileReader` (JSON exports), `LegacyHomeConfigReader` (v1 `{cherryHome}/config/config.json` for the config-file migration path used by `BootConfigMigrator`)
   - `db`: current SQLite connection
   - `paths`: `MigrationPaths` — pre-computed filesystem paths; migrators that need file paths use `ctx.paths` instead of `app.getPath()`
   - `sharedData`: `Map` for passing cross-cutting info between migrators
@@ -129,7 +129,7 @@ src/main/data/migration/v2/
 - `utils/ReduxStateReader.ts`: safe on-demand accessor for categorized Redux Persist export files with dot-path lookup.
 - `utils/DexieFileReader.ts`: reads exported Dexie JSON tables; can stream large tables.
 - `utils/JsonStreamReader.ts`: streaming reader with batching, counting, and sampling helpers for very large arrays.
-- `utils/LegacyHomeConfigReader.ts`: synchronously reads the v1 `~/.cherrystudio/config/config.json` file and normalizes its `appDataPath` field (both the legacy string shape and the current `{ executablePath, dataPath }[]` shape) into a `Record<executablePath, dataPath> | null`. Used exclusively by `BootConfigMigrator`'s `'configfile'` source.
+- `utils/LegacyHomeConfigReader.ts`: synchronously reads the v1 `{cherryHome}/config/config.json` file and normalizes its `appDataPath` field (both the legacy string shape and the current `{ executablePath, dataPath }[]` shape) into a `Record<executablePath, dataPath> | null`. Used exclusively by `BootConfigMigrator`'s `'configfile'` source.
 
 ## Window & IPC Integration
 

--- a/docs/references/diagnostics/README.md
+++ b/docs/references/diagnostics/README.md
@@ -37,7 +37,7 @@ CS_DIAGNOSTICS=1 "./Cherry Studio-<version>-<arch>.AppImage"
 
 ### Output
 
-Both dev and packaged runs write to the platform **app logs directory** exposed as `application.getPath('app.logs')` (dev diverts its logs like it does userData, using the same suffix — `Dev` by default, replaced by `CS_DEV_USER_DATA_SUFFIX` when set — so on macOS packaged runs use `~/Library/Logs/CherryStudio/` and dev runs use `~/Library/Logs/CherryStudioDev/`): signals stream into `app.<date>.log`, and the CPU profile lands beside it as `boot-whenReady.cpuprofile`.
+Both dev and packaged runs write to the **app logs directory** exposed as `application.getPath('app.logs')`. With `CS_DEV_PROFILE_ROOT`, unpackaged runs use `{profileRoot}/logs`; otherwise development diverts the platform location with the same suffix as `userData` (`Dev` by default, replaced by `CS_DEV_USER_DATA_SUFFIX`). For example, macOS packaged runs use `~/Library/Logs/CherryStudio/` and default development runs use `~/Library/Logs/CherryStudioDev/`. Signals stream into `app.<date>.log`, and the CPU profile lands beside it as `boot-whenReady.cpuprofile`.
 
 ## Signals
 

--- a/src/main/core/paths/README.md
+++ b/src/main/core/paths/README.md
@@ -22,7 +22,7 @@ application.getPath('invalid.key')
 
 | File | Role |
 |------|------|
-| `constants.ts` | Earliest path constants (`CHERRY_HOME`, `BOOT_CONFIG_PATH`, `LOGS_DIR`) — used before the registry exists; imported directly by the pre-registry bootstrappers (`LoggerService`, `BootConfigService`) |
+| `constants.ts` | Earliest path constants (`CHERRY_HOME`, `BOOT_CONFIG_PATH`, `LOGS_DIR`) and dev-profile isolation — used before the registry exists; imported directly by the pre-registry bootstrappers (`LoggerService`, `BootConfigService`) |
 | `pathRegistry.ts` | `buildPathRegistry()` + `shouldAutoEnsure` + `PathKey` / `PathMap` types. Imported directly by `Application.ts`. ESLint-enforced key format |
 
 **No barrel.** The module's public access point is `application.getPath()`, not an `index.ts` — its two files are independent building blocks imported directly by their specific consumers (per [Naming §6.4](../../../../docs/references/architecture/naming-conventions.md): a directory that merely aggregates independent sub-modules gets no barrel).
@@ -148,6 +148,7 @@ No object literals besides the registry itself — the ESLint rule validates eve
   user's home instead of aborting startup
 - Calling `application.getPath()` before `initPathRegistry()` throws
 - `LoggerService` and `BootConfigService` bypass the registry — they read from `paths/constants.ts` directly (they run before the registry exists)
+- Unpackaged runs can set `CS_DEV_PROFILE_ROOT` to keep Cherry home, BootConfig, legacy config discovery, Electron `userData`, and logs below one absolute non-root directory
 
 ## Testing
 

--- a/src/main/core/paths/README.md
+++ b/src/main/core/paths/README.md
@@ -31,7 +31,7 @@ application.getPath('invalid.key')
 
 | Namespace | Ownership | Examples |
 |-----------|-----------|----------|
-| `cherry.*` | Generic infra under `~/.cherrystudio` | `cherry.home`, `cherry.bin` |
+| `cherry.*` | Generic infra under `{cherryHome}` (`~/.cherrystudio` by default) | `cherry.home`, `cherry.bin` |
 | `sys.*` | OS-managed directories | `sys.home`, `sys.temp`, `sys.downloads` |
 | `app.*` | Electron app: install dir, userData, database, logs, temp root | `app.userdata`, `app.database.file` |
 | `feature.*` | Cherry-owned feature data (grouped by feature) | `feature.files.data`, `feature.mcp.oauth` |
@@ -87,7 +87,7 @@ Type-checked via `satisfies` — typos and stale references fail at compile time
 
 | Key | Physical location | Note |
 |-----|-------------------|------|
-| `feature.mcp.oauth` | `~/.cherrystudio/config/mcp/oauth` | Under `config/`, not `mcp/` |
+| `feature.mcp.oauth` | `{cherryHome}/config/mcp/oauth` | Under `config/`, not `mcp/` |
 | `feature.agents.skills.install.temp` | `{app.temp}/skill-install` | Sibling `feature.agents.skills` lives at `{userData}/Data/Skills` |
 | `feature.pdf_translation.babeldoc` | `{userData}/Runtime/models/babeldoc` | Grouped with the other downloaded model caches, not under a `pdf_translation/` dir |
 

--- a/src/main/core/paths/__tests__/constants.test.ts
+++ b/src/main/core/paths/__tests__/constants.test.ts
@@ -98,7 +98,13 @@ describe('LOGS_DIR dev diversion', () => {
       path.join(DEV_PROFILE_ROOT, 'userData'),
       path.join(DEV_PROFILE_ROOT, 'logs')
     ])
-    expect(isolatedPaths.every((value) => value.startsWith(DEV_PROFILE_ROOT))).toBe(true)
+    const normalizedProfileRoot = path.normalize(DEV_PROFILE_ROOT)
+    expect(
+      isolatedPaths.every((value) => {
+        const relative = path.relative(normalizedProfileRoot, value)
+        return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative)
+      })
+    ).toBe(true)
     expect(isolatedPaths.every((value) => !value.startsWith(os.homedir()))).toBe(true)
     expect(setAppLogsPath).toHaveBeenCalledWith(path.join(DEV_PROFILE_ROOT, 'logs'))
   })

--- a/src/main/core/paths/__tests__/constants.test.ts
+++ b/src/main/core/paths/__tests__/constants.test.ts
@@ -1,3 +1,4 @@
+import os from 'node:os'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -15,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const DEFAULT_LOGS = '/default/Logs/CherryStudio'
 const DEFAULT_USER_DATA = '/default/userData/CherryStudio'
+const DEV_PROFILE_ROOT = '/private/tmp/cherry-profile'
 const REAL_PLATFORM = process.platform
 
 function stubPlatform(platform: NodeJS.Platform) {
@@ -71,12 +73,34 @@ afterEach(() => {
 })
 
 describe('LOGS_DIR dev diversion', () => {
-  it('packaged: leaves the platform default untouched', async () => {
+  it('packaged: ignores even an unsafe dev profile root and leaves platform defaults untouched', async () => {
     stubPlatform('darwin')
+    vi.stubEnv('CS_DEV_PROFILE_ROOT', 'relative/profile')
     const { setAppLogsPath } = stubElectron({ isPackaged: true })
-    const { LOGS_DIR } = await loadConstants()
+    const { CHERRY_HOME, LOGS_DIR } = await loadConstants()
     expect(setAppLogsPath).not.toHaveBeenCalled()
+    expect(CHERRY_HOME).toBe(path.join(os.homedir(), '.cherrystudio'))
     expect(LOGS_DIR).toBe(DEFAULT_LOGS)
+  })
+
+  it('dev profile root keeps Cherry home, BootConfig, userData, and logs outside the real home', async () => {
+    stubPlatform('darwin')
+    vi.stubEnv('CS_DEV_PROFILE_ROOT', `  ${DEV_PROFILE_ROOT}  `)
+    vi.stubEnv('CS_DEV_USER_DATA_SUFFIX', 'IgnoredWhenRootIsSet')
+    const { setAppLogsPath } = stubElectron()
+
+    const { BOOT_CONFIG_PATH, CHERRY_HOME, LOGS_DIR, resolveDevUserDataPath } = await loadConstants()
+
+    const isolatedPaths = [CHERRY_HOME, BOOT_CONFIG_PATH, resolveDevUserDataPath(), LOGS_DIR]
+    expect(isolatedPaths).toEqual([
+      path.join(DEV_PROFILE_ROOT, '.cherrystudio'),
+      path.join(DEV_PROFILE_ROOT, '.cherrystudio', 'boot-config.json'),
+      path.join(DEV_PROFILE_ROOT, 'userData'),
+      path.join(DEV_PROFILE_ROOT, 'logs')
+    ])
+    expect(isolatedPaths.every((value) => value.startsWith(DEV_PROFILE_ROOT))).toBe(true)
+    expect(isolatedPaths.every((value) => !value.startsWith(os.homedir()))).toBe(true)
+    expect(setAppLogsPath).toHaveBeenCalledWith(path.join(DEV_PROFILE_ROOT, 'logs'))
   })
 
   it('dev macOS: suffixes the name-derived logs directory', async () => {
@@ -168,5 +192,25 @@ describe('CS_DEV_USER_DATA_SUFFIX validation', () => {
     stubElectron()
     const { LOGS_DIR } = await loadConstants()
     expect(LOGS_DIR).toBe(`${DEFAULT_LOGS}Dev2`)
+  })
+})
+
+describe('CS_DEV_PROFILE_ROOT validation', () => {
+  it.each([['relative/profile'], ['/']])('aborts startup for unsafe root %j', async (value) => {
+    stubPlatform('darwin')
+    vi.stubEnv('CS_DEV_PROFILE_ROOT', value)
+    stubElectron()
+    await expect(loadConstants()).rejects.toThrow(/CS_DEV_PROFILE_ROOT/)
+  })
+
+  it('blank values preserve the existing suffix behavior', async () => {
+    stubPlatform('darwin')
+    vi.stubEnv('CS_DEV_PROFILE_ROOT', '   ')
+    vi.stubEnv('CS_DEV_USER_DATA_SUFFIX', 'DevQuito')
+    stubElectron()
+    const { CHERRY_HOME, LOGS_DIR, resolveDevUserDataPath } = await loadConstants()
+    expect(CHERRY_HOME).toBe(path.join(os.homedir(), '.cherrystudio'))
+    expect(resolveDevUserDataPath()).toBe(`${DEFAULT_USER_DATA}DevQuito`)
+    expect(LOGS_DIR).toBe(`${DEFAULT_LOGS}DevQuito`)
   })
 })

--- a/src/main/core/paths/constants.ts
+++ b/src/main/core/paths/constants.ts
@@ -19,7 +19,24 @@ import path from 'node:path'
 import { app } from 'electron'
 
 export const CHERRY_HOME_DIRNAME = '.cherrystudio'
-export const CHERRY_HOME = path.join(os.homedir(), CHERRY_HOME_DIRNAME)
+
+function resolveDevProfileRoot(): string | undefined {
+  if (app.isPackaged) return undefined
+
+  const configured = process.env.CS_DEV_PROFILE_ROOT?.trim()
+  if (!configured) return undefined
+
+  const normalized = path.normalize(configured)
+  if (!path.isAbsolute(normalized) || normalized === path.parse(normalized).root) {
+    throw new Error('CS_DEV_PROFILE_ROOT must be an absolute directory other than the filesystem root.')
+  }
+  return normalized
+}
+
+export const DEV_PROFILE_ROOT = resolveDevProfileRoot()
+export const CHERRY_HOME = DEV_PROFILE_ROOT
+  ? path.join(DEV_PROFILE_ROOT, CHERRY_HOME_DIRNAME)
+  : path.join(os.homedir(), CHERRY_HOME_DIRNAME)
 export const BOOT_CONFIG_PATH = path.join(CHERRY_HOME, 'boot-config.json')
 
 const DEFAULT_DEV_USER_DATA_SUFFIX = 'Dev'
@@ -62,6 +79,7 @@ function resolveDevUserDataSuffix(): string {
  * derive from one definition.
  */
 export function resolveDevUserDataPath(): string {
+  if (DEV_PROFILE_ROOT) return path.join(DEV_PROFILE_ROOT, 'userData')
   return app.getPath('userData') + resolveDevUserDataSuffix()
 }
 
@@ -72,9 +90,11 @@ export function resolveDevUserDataPath(): string {
 // its logs with a packaged install's.
 if (!app.isPackaged) {
   app.setAppLogsPath(
-    process.platform === 'darwin'
-      ? app.getPath('logs') + resolveDevUserDataSuffix()
-      : path.join(resolveDevUserDataPath(), 'logs')
+    DEV_PROFILE_ROOT
+      ? path.join(DEV_PROFILE_ROOT, 'logs')
+      : process.platform === 'darwin'
+        ? app.getPath('logs') + resolveDevUserDataSuffix()
+        : path.join(resolveDevUserDataPath(), 'logs')
   )
 }
 

--- a/src/main/core/paths/pathRegistry.ts
+++ b/src/main/core/paths/pathRegistry.ts
@@ -59,7 +59,7 @@ export function buildPathRegistry() {
   const appRootResources = path.join(app.getAppPath(), 'resources')
 
   return Object.freeze({
-    // -- A. cherry.* — ~/.cherrystudio infrastructure --
+    // -- A. cherry.* — CHERRY_HOME infrastructure --
     'cherry.home': CHERRY_HOME,
     'cherry.bin': path.join(CHERRY_HOME, 'bin'),
     'cherry.config': path.join(CHERRY_HOME, 'config'),

--- a/src/main/core/preboot/README.md
+++ b/src/main/core/preboot/README.md
@@ -85,14 +85,16 @@ without good reason.
 Throughout `core/preboot/`, the word **userData** refers exclusively to
 Electron's `app.getPath('userData')` directory — the OS-level directory
 tree where Chromium and Electron persist their state alongside the
-application's own files.
+application's own files. With `CS_DEV_PROFILE_ROOT`, this directory is
+`{profileRoot}/userData` instead of the platform default plus a suffix.
 
 It does **not** mean "user data" in the colloquial sense (用户数据). The
 Electron userData directory contains a mix of user content
 (`Data/cherrystudio.sqlite`, `Data/Files`, `Data/KnowledgeBase`, …) AND
 Chromium runtime state (`Network/`, `Partitions/`, `IndexedDB`,
 `Local Storage`, …) AND, on Windows and Linux, application logs
-(`logs/` — macOS keeps them in `~/Library/Logs` instead).
+(`logs/` — macOS normally keeps them in `~/Library/Logs`; profile-root mode
+uses `{profileRoot}/logs` on every platform).
 
 ## Layout
 
@@ -100,10 +102,10 @@ Chromium runtime state (`Network/`, `Partitions/`, `IndexedDB`,
 preboot/
 ├── singleInstance.ts    claims Electron's single-instance lock and exits
 │                        second instances. Runs after userData resolution so
-│                        dev instances with different userData suffixes use
-│                        isolated locks.
-├── userDataLocation.ts  resolves userData (dev suffix or BootConfig) and
-│                        exports the shared isUsableDataDir(p) validator
+│                        dev instances with different profile roots or
+│                        userData suffixes use isolated locks.
+├── userDataLocation.ts  resolves userData (dev profile root, suffix, or
+│                        BootConfig) and exports the shared isUsableDataDir(p) validator
 │                        used by v1→v2 migration
 ├── chromiumFlags.ts     Chromium startup flags that must run before
 │                        app.whenReady()

--- a/src/main/core/preboot/README.md
+++ b/src/main/core/preboot/README.md
@@ -135,13 +135,23 @@ preboot/
 The directory is intentionally flat. New domains add a sibling file rather
 than a subdirectory.
 
-### Development userData suffix
+### Development profile isolation
 
 Unpackaged development runs never read the BootConfig userData mapping
 (`app.user_data_path`).
 Instead, `userDataLocation.ts` appends a suffix to Electron's default
 userData directory before the path registry and single-instance lock are
 initialized. The default suffix is `Dev`.
+
+Set `CS_DEV_PROFILE_ROOT` to an absolute directory when the entire writable
+development profile must be isolated. Cherry home, BootConfig, legacy config
+discovery, Electron `userData`, and logs are placed below that root. Relative
+paths and the filesystem root abort startup. Packaged builds ignore the
+variable. When set, it takes precedence over `CS_DEV_USER_DATA_SUFFIX`.
+
+```bash
+CS_DEV_PROFILE_ROOT=/absolute/path/to/cherry-profile pnpm dev
+```
 
 Set `CS_DEV_USER_DATA_SUFFIX` to run multiple development instances with
 isolated app data and locks. Use `.env` for a persistent local default:

--- a/src/main/core/preboot/__tests__/userDataLocation.test.ts
+++ b/src/main/core/preboot/__tests__/userDataLocation.test.ts
@@ -115,6 +115,7 @@ function stubBootConfig(store: BootConfigStore = {}) {
 function stubFs(opts: FsStubOptions = {}) {
   const existsSync = vi.fn(opts.existsSyncImpl ?? (() => true))
   const accessSync = vi.fn(opts.accessSyncImpl ?? (() => undefined))
+  const mkdirSync = vi.fn()
   // isUsableDataDir() gates on statSync().isDirectory(); default to a directory.
   const statSync = vi.fn(opts.statSyncImpl ?? (() => ({ isDirectory: () => true, isFile: () => false })))
   cpSyncMock.mockImplementation(opts.cpSyncImpl ?? (() => undefined))
@@ -133,10 +134,11 @@ function stubFs(opts: FsStubOptions = {}) {
       },
       readFileSync: vi.fn(),
       writeFileSync: vi.fn(),
-      mkdirSync: vi.fn()
+      mkdirSync
     }
     return { ...fsMock, default: fsMock }
   })
+  return { mkdirSync }
 }
 
 async function loadModule() {
@@ -306,6 +308,22 @@ describe('resolveUserDataLocation', () => {
       resolveUserDataLocation()
       expect(setPathMock).toHaveBeenCalledWith('userData', '/mock/userDataDevQuito')
       expect(setPathMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('app.isPackaged=false: creates and selects the configured dev profile userData', async () => {
+      vi.stubEnv('CS_DEV_PROFILE_ROOT', '/private/tmp/cherry-profile')
+      stubConstants({ isLinux: false, isWin: false, isPortable: false })
+      stubElectron({ isPackaged: false, userData: '/mock/userData' })
+      stubBootConfig({ 'app.user_data_path': { '/mock/exe': '/real/user/data' } })
+      const { mkdirSync } = stubFs()
+
+      const { resolveUserDataLocation } = await loadModule()
+      resolveUserDataLocation()
+
+      expect(mkdirSync).toHaveBeenCalledWith('/private/tmp/cherry-profile/userData', { recursive: true })
+      expect(setPathMock).toHaveBeenCalledWith('userData', '/private/tmp/cherry-profile/userData')
+      expect(setPathMock).toHaveBeenCalledTimes(1)
+      expect(bootConfigGetMock).not.toHaveBeenCalled()
     })
 
     it('app.isPackaged=false: blank configured dev suffix falls back to Dev', async () => {

--- a/src/main/core/preboot/__tests__/v2MigrationGate.test.ts
+++ b/src/main/core/preboot/__tests__/v2MigrationGate.test.ts
@@ -121,6 +121,7 @@ function stubElectron() {
 function stubApplication() {
   vi.doMock('@application', () => ({
     application: {
+      getPath: vi.fn((key: string) => (key === 'cherry.home' ? '/mock/cherry-home' : undefined)),
       quit: appQuitMock,
       relaunch: appRelaunchMock
     }
@@ -663,6 +664,7 @@ describe('runV2MigrationGate', () => {
 
       expect(result).toBe('handled')
       expect(showErrorBoxMock).toHaveBeenCalledTimes(1)
+      expect(showErrorBoxMock.mock.calls[0][1]).toContain('/mock/cherry-home')
       expect(appQuitMock).toHaveBeenCalledTimes(1)
       expect(initializeMock).not.toHaveBeenCalled()
     })

--- a/src/main/core/preboot/userDataLocation.ts
+++ b/src/main/core/preboot/userDataLocation.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { loggerService } from '@logger'
-import { resolveDevUserDataPath } from '@main/core/paths/constants'
+import { DEV_PROFILE_ROOT, resolveDevUserDataPath } from '@main/core/paths/constants'
 import { isLinux, isPortable, isWin } from '@main/core/platform'
 import { bootConfigService } from '@main/data/bootConfig'
 import { app } from 'electron'
@@ -49,8 +49,9 @@ export function canonicalizeUserDataPath(userDataPath: string): string {
 export function resolveUserDataLocation(): void {
   if (!app.isPackaged) {
     const devPath = resolveDevUserDataPath()
+    if (DEV_PROFILE_ROOT) fs.mkdirSync(devPath, { recursive: true })
     app.setPath('userData', devPath)
-    logger.info('userData set with dev suffix', { devPath })
+    logger.info(DEV_PROFILE_ROOT ? 'userData set from dev profile root' : 'userData set with dev suffix', { devPath })
     return
   }
 

--- a/src/main/core/preboot/userDataLocation.ts
+++ b/src/main/core/preboot/userDataLocation.ts
@@ -12,7 +12,8 @@ const logger = loggerService.withContext('Preboot')
 /**
  * "userData" in this module means Electron's complete OS-level userData
  * directory, including user content, Chromium state, and — on Windows and
- * Linux — application logs (macOS keeps logs in ~/Library/Logs instead).
+ * Linux — application logs. macOS normally keeps logs in ~/Library/Logs;
+ * dev profile-root mode keeps them under the configured root on every OS.
  */
 
 export function getNormalizedExecutablePath(): string {

--- a/src/main/core/preboot/v2MigrationGate.ts
+++ b/src/main/core/preboot/v2MigrationGate.ts
@@ -60,7 +60,7 @@ async function quitWithDataLocationError(cause: unknown): Promise<V2MigrationGat
   dialog.showErrorBox(
     'Data Location Error - Application Cannot Start',
     `Could not save the application data directory:\n\n  ${(cause as Error).message}\n\n` +
-      `Check that there is free disk space and that ~/.cherrystudio is writable, then try again. The application will now exit.`
+      `Check that there is free disk space and that ${application.getPath('cherry.home')} is writable, then try again. The application will now exit.`
   )
   application.quit()
   return 'handled'

--- a/src/main/data/bootConfig/BootConfigService.ts
+++ b/src/main/data/bootConfig/BootConfigService.ts
@@ -46,7 +46,7 @@ export class BootConfigService {
   private loadError: BootConfigLoadError | null = null
 
   constructor() {
-    // Stored under ~/.cherrystudio/ rather than userData so that:
+    // Stored under CHERRY_HOME rather than userData so that:
     // 1. It survives a custom appDataPath setting (boot config decides where userData is, not the other way around).
     // 2. It can be read before initAppDataDir() rewrites the userData path.
     // BOOT_CONFIG_PATH is sourced from @main/core/paths/constants — a zero-dependency

--- a/src/main/data/migration/v2/README.md
+++ b/src/main/data/migration/v2/README.md
@@ -24,7 +24,7 @@ src/main/data/migration/v2/
 > **⚠️ WARNING: Not using predefined paths may cause user data loss.**
 >
 > v1 users may have configured a custom userData directory via
-> `~/.cherrystudio/config/config.json`. If migration code calls
+> `{cherryHome}/config/config.json` (`~/.cherrystudio` by default). If migration code calls
 > `app.getPath('userData')` or `new Store()` directly, on the first v2
 > launch it will read from the Electron default path instead of the
 > user's actual data directory — causing migration to be silently

--- a/src/main/data/migration/v2/core/MigrationPaths.ts
+++ b/src/main/data/migration/v2/core/MigrationPaths.ts
@@ -40,7 +40,7 @@ export interface MigrationPaths {
 
   /** Resolved v1 userData directory (accounts for legacy config.json custom path). */
   readonly userData: string
-  /** ~/.cherrystudio — cherry home directory. */
+  /** Cherry home directory (`~/.cherrystudio` by default). */
   readonly cherryHome: string
 
   // ── Derived from userData (pre-computed, consumers use directly) ──

--- a/src/main/data/migration/v2/core/MigrationPaths.ts
+++ b/src/main/data/migration/v2/core/MigrationPaths.ts
@@ -6,7 +6,7 @@
  *
  * WARNING: Bypassing MigrationPaths and calling `app.getPath('userData')`
  * directly will cause data loss for v1 users who configured a custom
- * userData directory via `~/.cherrystudio/config/config.json`. On the
+ * userData directory via `{cherryHome}/config/config.json`. On the
  * first v2 launch, `app.getPath('userData')` returns the Electron default
  * — not the user's actual data directory — because `resolveUserDataLocation()`
  * has not yet migrated the legacy config into boot-config.json.
@@ -128,7 +128,7 @@ export interface MigrationPathsResult {
  *   1. Start with the current `app.getPath('userData')` (set by
  *      `resolveUserDataLocation()` in preboot — may be the Electron
  *      default if boot-config.json had no entry).
- *   2. Read `~/.cherrystudio/config/config.json` for a legacy `appDataPath`.
+ *   2. Read `{cherryHome}/config/config.json` for a legacy `appDataPath`.
  *   3. If a valid custom path is found and differs from current:
  *      - Call `app.setPath('userData', ...)` so Chromium-level storage
  *        (IndexedDB, localStorage) initializes at the correct location

--- a/src/main/data/migration/v2/core/MigrationPaths.ts
+++ b/src/main/data/migration/v2/core/MigrationPaths.ts
@@ -16,7 +16,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { loggerService } from '@logger'
-import { CHERRY_HOME } from '@main/core/paths/constants'
+import { CHERRY_HOME, DEV_PROFILE_ROOT } from '@main/core/paths/constants'
 import { getNormalizedExecutablePath, isUsableDataDir } from '@main/core/preboot/userDataLocation'
 import { bootConfigService } from '@main/data/bootConfig'
 import { app } from 'electron'
@@ -162,14 +162,16 @@ export function resolveMigrationPaths(): MigrationPathsResult {
   let dataLocation: string | undefined
 
   const exe = getNormalizedExecutablePath()
-  const bootConfigEntry = bootConfigService.get('app.user_data_path')?.[exe]
+  const bootConfigEntry = DEV_PROFILE_ROOT ? undefined : bootConfigService.get('app.user_data_path')?.[exe]
 
   // ── Front gate P: split the boot-config short-circuit ──
   //
   // resolveUserDataLocation() (preboot) has already run: if a boot-config
   // entry existed and was VALID, it setPath'd userData to it; if it existed
   // but was INVALID, it silently fell through to the Electron default.
-  if (bootConfigEntry) {
+  if (DEV_PROFILE_ROOT) {
+    logger.info('Dev profile root active, skipping legacy userData redirects', { currentUserData })
+  } else if (bootConfigEntry) {
     if (isUsableDataDir(bootConfigEntry)) {
       // Valid → current userData already IS the target. Skip legacy probing.
       logger.info('Boot-config userData entry present and valid, skipping legacy detection', { exe })

--- a/src/main/data/migration/v2/core/__tests__/MigrationPaths.test.ts
+++ b/src/main/data/migration/v2/core/__tests__/MigrationPaths.test.ts
@@ -37,7 +37,8 @@ const h = vi.hoisted(() => ({
   normalizedExe: vi.fn((): string => '/current/exe'),
   bootGet: vi.fn((): unknown => undefined),
   bootSet: vi.fn(),
-  bootPersist: vi.fn()
+  bootPersist: vi.fn(),
+  devProfileRoot: undefined as string | undefined
 }))
 
 vi.mock('node:fs', async () => {
@@ -70,6 +71,9 @@ vi.mock('@main/core/paths/constants', () => ({
   CHERRY_HOME: '/mock/home/.cherrystudio',
   CHERRY_HOME_DIRNAME: '.cherrystudio',
   BOOT_CONFIG_PATH: '/mock/home/.cherrystudio/boot-config.json',
+  get DEV_PROFILE_ROOT() {
+    return h.devProfileRoot
+  },
   LOGS_DIR: '/mock/logs',
   resolveDevUserDataPath: () => '/mock/userDataDev'
 }))
@@ -357,9 +361,35 @@ beforeEach(() => {
   h.getVersion.mockReturnValue('2.0.0')
   h.normalizedExe.mockReturnValue('/current/exe')
   h.bootGet.mockReturnValue(undefined)
+  h.devProfileRoot = undefined
 })
 
 describe('resolveMigrationPaths — legacy custom userData recovery', () => {
+  it('keeps a dev profile migration isolated from legacy paths outside the profile root', () => {
+    const profileUserData = '/mock/profile/userData'
+    const externalUserData = '/external/legacy-data'
+    h.devProfileRoot = '/mock/profile'
+    h.getPath.mockImplementation((key: string) => (key === 'userData' ? profileUserData : '/mock/unknown'))
+    applyFs({
+      dirs: [profileUserData, externalUserData],
+      contents: {
+        [CONFIG_FILE]: JSON.stringify({ appDataPath: externalUserData }),
+        [marker(profileUserData, 'version.log')]: GOOD_VERSION_LOG,
+        [marker(externalUserData, 'version.log')]: GOOD_VERSION_LOG
+      }
+    })
+
+    const result = resolveMigrationPaths()
+
+    expect(result.paths.userData).toBe(profileUserData)
+    expect(result.userDataChanged).toBe(false)
+    expect(result.legacyDataConfirmed).toBe(true)
+    expect(h.bootGet).not.toHaveBeenCalled()
+    expect(h.setPath).not.toHaveBeenCalled()
+    expect(h.bootSet).not.toHaveBeenCalled()
+    expect(h.bootPersist).not.toHaveBeenCalled()
+  })
+
   it('places v2-managed data under Data while retaining explicit v1 source paths', () => {
     applyFs({ dirs: [DEFAULT_USER_DATA] })
 

--- a/src/main/data/migration/v2/migrators/BootConfigMigrator.ts
+++ b/src/main/data/migration/v2/migrators/BootConfigMigrator.ts
@@ -2,8 +2,8 @@
  * Boot config migrator - migrates boot configuration from legacy storage to BootConfigService
  *
  * Reads from ElectronStore, Redux, Dexie settings, localStorage, and the legacy
- * home config file (~/.cherrystudio/config/config.json) sources, then writes
- * values to bootConfigService (~/.cherrystudio/boot-config.json).
+ * home config file ({cherryHome}/config/config.json) sources, then writes
+ * values to bootConfigService ({cherryHome}/boot-config.json).
  */
 
 import { loggerService } from '@logger'
@@ -301,7 +301,7 @@ export class BootConfigMigrator extends BaseMigrator {
     // prepare(), matching the reader's `null` return semantics.
     const configFileMappings: ReadonlyArray<{ originalKey: string; targetKey: BootConfigKey }> = [
       {
-        // `appDataPath` field at the top level of ~/.cherrystudio/config/config.json
+        // `appDataPath` field at the top level of {cherryHome}/config/config.json
         // (legacy string or array of { executablePath, dataPath })
         originalKey: 'appDataPath',
         targetKey: 'app.user_data_path'

--- a/src/main/data/migration/v2/migrators/README-BootConfigMigrator.md
+++ b/src/main/data/migration/v2/migrators/README-BootConfigMigrator.md
@@ -2,7 +2,7 @@
 
 The `BootConfigMigrator` migrates early-boot configuration from legacy storage into `bootConfigService` — the synchronous, file-based config used by code that runs before the lifecycle system takes over (e.g. Chromium flags, custom userData directory).
 
-Unlike other migrators, it writes to a **file-based store** (`~/.cherrystudio/boot-config.json`) rather than a SQLite table. See [Boot Config Overview](../../../../../../docs/references/data/boot-config-overview.md) for why this system exists.
+Unlike other migrators, it writes to a **file-based store** (`{cherryHome}/boot-config.json`) rather than a SQLite table. `{cherryHome}` defaults to `~/.cherrystudio`; unpackaged runs with `CS_DEV_PROFILE_ROOT` use `{profileRoot}/.cherrystudio`. See [Boot Config Overview](../../../../../../docs/references/data/boot-config-overview.md) for why this system exists.
 
 ## Data Sources
 
@@ -14,11 +14,11 @@ Boot config pulls from **five** source kinds. Four are classification-driven (vi
 | `electronStore` | `ctx.sources.electronStore` (electron-store) | `{userData}/config.json` | (none currently — classification empty) |
 | `dexie-settings` | `DexieSettingsReader` | Dexie `settings` table export | (none currently — classification empty) |
 | `localStorage` | `LocalStorageReader` | localStorage export JSON | (none currently — classification empty) |
-| `configfile` | `LegacyHomeConfigReader` | `~/.cherrystudio/config/config.json` (v1 home config file) | `appDataPath` → `app.user_data_path` |
+| `configfile` | `LegacyHomeConfigReader` | `{cherryHome}/config/config.json` (v1 home config file) | `appDataPath` → `app.user_data_path` |
 
 ### The `configfile` source
 
-The `configfile` source exists because v1 stored the user-customized userData directory in `~/.cherrystudio/config/config.json` rather than in any of the four classification-driven stores. That file is outside the app's `userData` directory (intentionally — it needs to be readable before the userData path is decided), so none of the other readers can reach it.
+The `configfile` source exists because v1 stored the user-customized userData directory in `{cherryHome}/config/config.json` rather than in any of the four classification-driven stores. That file is outside the app's `userData` directory (intentionally — it needs to be readable before the userData path is decided), so none of the other readers can reach it.
 
 `LegacyHomeConfigReader` reads the v1 file and normalizes two historical data shapes:
 
@@ -39,7 +39,7 @@ Returns `null` (not `{}`) when no data is present (missing file / parse error / 
 
 | Source (file / field) | Target Key | Type | Default |
 |---|---|---|---|
-| `~/.cherrystudio/config/config.json` → `appDataPath` | `app.user_data_path` | `Record<string, string>` | *(null — see below)* |
+| `{cherryHome}/config/config.json` → `appDataPath` | `app.user_data_path` | `Record<string, string>` | *(null — see below)* |
 
 **Why `defaultValue: null` for config-file entries**: the other sources fall back to `DefaultBootConfig[targetKey]` when the source has no value, so missing keys get sensible defaults. For config-file data like `app.user_data_path`, "no v1 file" must mean "nothing to migrate" — writing the schema default `{}` would be a spurious migration. Setting `defaultValue: null` on these entries routes them through the shared null-skip guard in `prepare()`, skipping the item entirely when the reader returns `null`.
 

--- a/src/main/data/migration/v2/utils/LegacyHomeConfigReader.ts
+++ b/src/main/data/migration/v2/utils/LegacyHomeConfigReader.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import { app } from 'electron'
 
 /**
- * Reader for the legacy v1 home config file (typically ~/.cherrystudio/config/config.json).
+ * Reader for the legacy v1 config at `{cherryHome}/config/config.json`.
  *
  * The file path is injected via the constructor rather than computed internally,
  * so callers control where the config file is located.


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Development could suffix Electron `userData` and logs, but Cherry home, BootConfig, and legacy config discovery still used the real home directory. Migration could also follow a legacy `appDataPath` outside an explicitly isolated development profile, then reopen the next launch from an empty profile directory.

After this PR:

Unpackaged runs can set `CS_DEV_PROFILE_ROOT` to keep Cherry home, BootConfig, legacy config discovery, Electron `userData`, logs, and v1 migration paths below one isolated root. Profile-root migration ignores BootConfig and legacy userData redirects while still migrating v1 data already present inside `{profileRoot}/userData`. Unset and packaged behavior is unchanged.

Fixes #

None

### Why we need it and why it was done in this way

The following tradeoffs were made:

The explicit root takes precedence over `CS_DEV_USER_DATA_SUFFIX`, rejects relative paths and filesystem roots, and pre-creates `userData` before calling Electron's `app.setPath`. Migration reuses that already-resolved path instead of interpreting legacy relocation mappings, so the isolation boundary survives both migration and relaunch.

The following alternatives were considered:

Extending the existing suffix behavior was considered, but it cannot place all preboot state below one caller-controlled directory. Allowing legacy redirects only when they appear to be below the profile root was also unnecessary: the profile's own v1 data is already discovered through its resolved `userData`.

Links to places where the discussion took place: None

### Breaking changes

None. The new environment variable is opt-in and ignored by packaged builds.

### Special notes for your reviewer

This is dev-only and has no UI change. `CS_DEV_USER_DATA_SUFFIX` behavior remains unchanged when the new root is unset or blank.

Validation on current head `fbcd56a6224720f7a52734411eb9fd4ca8f2a3d6`:

- The migration isolation regression failed before the fix by redirecting `/mock/profile/userData` to `/external/legacy-data`.
- Migration path suite: 31/31 passed.
- Related preboot, path constants, userData location, and migration gate suites: 109/109 passed.
- `pnpm lint` passed.
- `pnpm test:lint` passed.
- GitHub commit signature is Verified and DCO sign-off is present.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update is not required for this dev-only behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```