### PR TITLE
fix(paintings): skip image generation when the signal is already aborted

### DIFF
--- a/src/renderer/pages/paintings/model/__tests__/generatePainting.test.ts
+++ b/src/renderer/pages/paintings/model/__tests__/generatePainting.test.ts
@@ -77,14 +77,26 @@ describe('generatePainting', () => {
     expect(payload).not.toHaveProperty('size')
   })
 
+  // The pipeline awaits model-support prefetch, provider checks and input-image reads before
+  // reaching generatePainting. An abort during those must not fire the billable request.
+  it('never requests ai.image.generate when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(generatePainting(makeOptions({}, controller.signal))).rejects.toMatchObject({ name: 'AbortError' })
+    expect(ipcRequestMock).not.toHaveBeenCalled()
+  })
+
   // A provider failure now crosses IpcApi as an IpcError (name 'IpcError'), which no longer
   // satisfies runPainting's `name === 'AbortError'` silent-cancel check — generatePainting's
   // `.catch` re-derives a real AbortError only when the user aborted, else re-throws the original.
   it('re-throws a real AbortError when the request rejects after the user aborted', async () => {
     const controller = new AbortController()
-    controller.abort()
     ipcRequestMock.mockImplementation(async (route: string) => {
-      if (route === 'ai.image.generate') throw new Error('cancelled by main')
+      if (route === 'ai.image.generate') {
+        controller.abort()
+        throw new Error('cancelled by main')
+      }
       return undefined
     })
 

--- a/src/renderer/pages/paintings/model/generatePainting.ts
+++ b/src/renderer/pages/paintings/model/generatePainting.ts
@@ -39,6 +39,11 @@ export interface GeneratePaintingOptions {
 
 export function generatePainting(opts: GeneratePaintingOptions): Promise<FileMetadata[]> {
   return runPainting(async () => {
+    // The caller awaits model-support prefetch, provider checks and input-image reads
+    // before reaching here; an abort during those never fires the listener below.
+    if (opts.signal.aborted) {
+      throw new DOMException('Image generation aborted', 'AbortError')
+    }
     const requestId = crypto.randomUUID()
     const onAbort = () => void ipcApi.request('ai.image.abort', { requestId })
     opts.signal.addEventListener('abort', onAbort, { once: true })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Clicking **Stop** while the painting pipeline is still awaiting the model-support prefetch, the provider-enabled check, or the input-image reads did not cancel the generation. `generatePainting` only attached an `abort` listener to a signal that was already aborted, which never fires, so `ai.image.generate` was still sent to main and the provider ran the billable request to completion. The result was only discarded afterwards.

After this PR:

`generatePainting` checks `signal.aborted` before minting a request id or sending the IPC. A pre-aborted signal rejects with the same `AbortError` the file already uses, so `runPainting` still treats it as a silent cancel and no request leaves the renderer. The existing listener keeps handling aborts that arrive while a request is in flight.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

An abort during the pre-generation awaits silently costs the user a paid image call. `addEventListener('abort')` on an already-aborted signal is a no-op, so the listener alone cannot cover that window.

The following tradeoffs were made:

The check lives in `generatePainting` rather than in each awaiting caller. It is the single choke point right before the IPC with no `await` between the check and the send, so one guard covers the prefetch, the provider check, and the image reads without touching them.

The following alternatives were considered:

- `signal.throwIfAborted()`: shorter, but it throws `signal.reason`, so a future caller passing a custom reason would break `runPainting`'s `name === 'AbortError'` silent-cancel check. The explicit `DOMException` matches the two existing throws in the file.
- Checking the signal inside `canonicalGenerate` and `paintingPipeline` after each await: covers the same windows with three checks instead of one and would need repeating for any new await.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The new test aborts before calling `generatePainting` and asserts that `ipcApi.request` is never called. It fails on `main` and passes with the guard.
- The existing "re-throws a real AbortError when the request rejects after the user aborted" test used to abort before the call. With the guard that path no longer reaches the `.catch` branch it documents, so it now aborts from inside the mocked request instead.
- Verified locally with `npx vitest run src/renderer/pages/paintings/model/__tests__/generatePainting.test.ts` (6 passed), `oxlint --deny-warnings`, `biome check`, and `tsgo --noEmit -p tsconfig.web.json --composite false` on the touched files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Paintings: stopping a generation before the request is sent no longer fires a billable image request.
```
