### PR TITLE
fix(word-export): preserve formatted hyperlink text

### DIFF
--- a/src/main/services/ExportService.ts
+++ b/src/main/services/ExportService.ts
@@ -37,45 +37,32 @@ export class ExportService {
 
     const processInlineTokens = (tokens: any[], isHeaderRow: boolean): (TextRun | ExternalHyperlink)[] => {
       const runs: (TextRun | ExternalHyperlink)[] = []
-      let linkText = ''
+      let linkRuns: TextRun[] = []
       let linkUrl = ''
-      let insideLink = false
       let boldStack = 0 // 跟踪嵌套的粗体标记
       let italicStack = 0 // 跟踪嵌套的斜体标记
+
+      const pushRun = (options: Docx.IRunOptions) => {
+        if (linkUrl) {
+          linkRuns.push(new TextRun({ ...options, style: 'Hyperlink', color: '0000FF', underline: { type: 'single' } }))
+        } else {
+          runs.push(new TextRun(options))
+        }
+      }
 
       for (let i = 0; i < tokens.length; i++) {
         const token = tokens[i]
         switch (token.type) {
           case 'link_open':
-            insideLink = true
             linkUrl = token.attrs.find((attr: [string, string]) => attr[0] === 'href')[1]
-            linkText = tokens[i + 1].content
-            i += 1
+            linkRuns = []
             break
           case 'link_close':
-            if (insideLink && linkUrl && linkText) {
-              // Handle any accumulated link text with the ExternalHyperlink
-              runs.push(
-                new ExternalHyperlink({
-                  children: [
-                    new TextRun({
-                      text: linkText,
-                      style: 'Hyperlink',
-                      color: '0000FF',
-                      underline: {
-                        type: 'single'
-                      }
-                    })
-                  ],
-                  link: linkUrl
-                })
-              )
-
-              // Reset link variables
-              linkText = ''
-              linkUrl = ''
-              insideLink = false
+            if (linkRuns.length > 0) {
+              runs.push(new ExternalHyperlink({ children: linkRuns, link: linkUrl }))
             }
+            linkRuns = []
+            linkUrl = ''
             break
           case 'strong_open':
             boldStack++
@@ -90,24 +77,20 @@ export class ExportService {
             italicStack--
             break
           case 'text':
-            runs.push(
-              new TextRun({
-                text: token.content,
-                bold: isHeaderRow || boldStack > 0,
-                italics: italicStack > 0
-              })
-            )
+            pushRun({
+              text: token.content,
+              bold: isHeaderRow || boldStack > 0,
+              italics: italicStack > 0
+            })
             break
           case 'code_inline':
-            runs.push(
-              new TextRun({
-                text: token.content,
-                font: 'Consolas',
-                size: 20,
-                bold: isHeaderRow || boldStack > 0,
-                italics: italicStack > 0
-              })
-            )
+            pushRun({
+              text: token.content,
+              font: 'Consolas',
+              size: 20,
+              bold: isHeaderRow || boldStack > 0,
+              italics: italicStack > 0
+            })
             break
         }
       }

--- a/src/main/services/__tests__/ExportService.test.ts
+++ b/src/main/services/__tests__/ExportService.test.ts
@@ -70,5 +70,43 @@ describe('ExportService.exportToWord', () => {
       expect(documentXml).toContain('Title')
       expect(documentXml).toContain('Body paragraph')
     })
+
+    const textsOf = (xml: string) => [...xml.matchAll(/<w:t[^>]*>([^<]*)<\/w:t>/g)].map((m) => m[1])
+
+    // Catches the link handler taking only the first text token: `[A **B** C](url)` used to
+    // come out as B, C, then a hyperlink holding just "A ".
+    it('exports a link with inline formatting as one hyperlink in source order', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('[A **B** C](https://example.com) tail', 'doc.docx')
+
+      const zip = new AdmZip(tmpFile)
+      const documentXml = zip.readAsText('word/document.xml')
+      const hyperlinks = documentXml.match(/<w:hyperlink[^>]*>[\s\S]*?<\/w:hyperlink>/g) ?? []
+      expect(hyperlinks).toHaveLength(1)
+      const [hyperlink = ''] = hyperlinks
+
+      const linkRuns = hyperlink.match(/<w:r>[\s\S]*?<\/w:r>/g) ?? []
+      expect(linkRuns.map((run) => textsOf(run)[0])).toEqual(['A ', 'B', ' C'])
+      expect(linkRuns.map((run) => run.includes('<w:b/>'))).toEqual([false, true, false])
+      expect(textsOf(documentXml.replace(hyperlink, ''))).toEqual([' tail'])
+
+      const relId = hyperlink.match(/r:id="([^"]+)"/)?.[1]
+      const rels = zip.readAsText('word/_rels/document.xml.rels')
+      expect(rels).toMatch(new RegExp(`Id="${relId}"[^>]*Target="https://example.com"`))
+    })
+
+    it('keeps the text of a link with an empty target as plain text', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('[empty]()', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      expect(documentXml).not.toContain('<w:hyperlink')
+      expect(documentXml).not.toContain('Hyperlink')
+      expect(textsOf(documentXml)).toEqual(['empty'])
+    })
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Word export kept only the first text token inside a hyperlink, moving formatted text outside the link and changing its order. Empty-target links lost their text.

After this PR: Link text stays in source order inside one hyperlink with its inline formatting. Empty-target links remain plain text.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Buffer text runs until the link closes, using the existing docx hyperlink API.

The following alternatives were considered: Joining link text into one string would discard inline formatting.

Links to places where the discussion took place: None. <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

Validation: All 4 ExportService tests pass. Both new regression tests fail against the original implementation. `pnpm lint` and `pnpm test:lint` pass; the latter reports 45 existing ESLint warnings outside the changed files. No user-guide update is required.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Word export losing or reordering formatted hyperlink text and dropping text from links with an empty destination.
```
