### PR TITLE
fix(pdf-preview): normalize page input after submission

### DIFF
--- a/src/renderer/components/FilePreview/plugins/pdf/PdfFilePreviewToolbar.tsx
+++ b/src/renderer/components/FilePreview/plugins/pdf/PdfFilePreviewToolbar.tsx
@@ -50,7 +50,6 @@ export function PdfFilePreviewToolbar({
     const pageNumber = Number(pageValue)
     if (Number.isInteger(pageNumber) && pageNumber > 0) {
       onJumpToPage(pageNumber)
-      return
     }
     setPageValue(hasPages ? String(currentPage) : '')
   }

--- a/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/pdf/__tests__/PdfFilePreview.test.tsx
@@ -359,6 +359,24 @@ describe('PdfFilePreview', () => {
     expect(mocks.pdfViewerPageNumbers).toContain(3)
   })
 
+  it.each(['{Enter}', '{Tab}'])('normalizes an out-of-range page at the last page on %s', async (commitKey) => {
+    const user = userEvent.setup()
+    renderPreview()
+    const pageInput = screen.getByRole('textbox', { name: 'file_preview.pdf.page_number' })
+    await waitFor(() => expect(pageInput).toBeEnabled())
+
+    await user.clear(pageInput)
+    await user.type(pageInput, '3{Enter}')
+    await waitFor(() => expect(pageInput).toHaveValue('3'))
+    expect(screen.getByRole('button', { name: 'common.next' })).toBeDisabled()
+
+    await user.clear(pageInput)
+    await user.type(pageInput, `999${commitKey}`)
+
+    expect(pageInput).toHaveValue('3')
+    expect(screen.getByRole('button', { name: 'common.next' })).toBeDisabled()
+  })
+
   it('shows the PDF outline and navigates to its destinations', async () => {
     const user = userEvent.setup()
     const destination = [{ num: 4, gen: 0 }, { name: 'XYZ' }, 0, 0, null]


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
A PDF already on its last page could keep showing an out-of-range draft such as `999 / 10` after submission, although the viewer correctly stayed on page 10.

<img width="1694" height="992" alt="PixPin_2026-09-07_10-49-30" src="https://github.com/user-attachments/assets/0b631d47-b92b-4c90-9655-c53d0d7cc3ec" />

After this PR:
Submitting the page field restores the actual page number even when navigation leaves the current page unchanged. Regression tests cover Enter and blur submission in the existing PDF preview component suite.

<img width="1694" height="992" alt="PixPin_2026-09-07_10-50-09" src="https://github.com/user-attachments/assets/eddeb7c9-b24e-4cc2-bc53-eb0da50b0e77" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: None.

### Why we need it and why it was done in this way

The following tradeoffs were made:
Remove the early return from the toolbar commit handler so it always resets the draft. Keep page-range clamping in the parent viewer and retain the existing synchronization for page changes.

The following alternatives were considered:
Clamping again in the toolbar would duplicate the viewer's responsibility and is unnecessary.

Links to places where the discussion took place: None. <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Reproduction: open a 10-page PDF, navigate to page 10, enter `999`, then press Enter or move focus away. The field should show `10 / 10`.

Validation:
- Existing PDF preview component suite: 14 passed. The two added cases failed before the production fix and passed afterward.
- Real Electron CDP: last-page overflow via Enter and Tab, valid navigation to page 2, and invalid `0` on blur passed.
- Renderer and ai-core type checks passed; focused Biome check and `git diff --check` passed.
- Full `pnpm lint` was blocked by existing `guard/check` type errors in `src/main/ai/runtime/dsh/DshBridgeServer.ts` (lines 49, 252, 277, 278). Subsequent global i18n/format stages were not reached.
- Two rounds of local static review found no actionable issues.

No migration or user-guide update is required; this restores the existing page-input behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed PDF page input retaining an out-of-range number when submitting from the last page.
```