### PR TITLE
fix(translate): preserve keyboard activation of history stars

### DIFF
--- a/src/renderer/pages/translate/components/TranslateHistory.tsx
+++ b/src/renderer/pages/translate/components/TranslateHistory.tsx
@@ -303,6 +303,7 @@ const HistoryRow: FC<{
       tabIndex={0}
       onClick={() => onSelect(item.id)}
       onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
           onSelect(item.id)

--- a/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
@@ -2,6 +2,7 @@ import { toast } from '@renderer/services/toast'
 import type { TranslateHistory as TranslateHistoryItem, TranslateLanguage } from '@shared/data/types/translate'
 import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -344,6 +345,32 @@ describe('TranslateHistory', () => {
       expect(screen.getAllByRole('button', { name: 'translate.history.file.reveal' })).toHaveLength(2)
       expect(screen.queryByRole('button', { name: 'translate.history.file.preview' })).not.toBeInTheDocument()
     })
+  })
+
+  it.each(['{Enter}', ' '])('toggles a row star with %s without opening details', async (key) => {
+    const user = userEvent.setup()
+    renderHistory()
+
+    const row = screen.getByRole('button', { name: /hello/ })
+    const star = within(row).getByRole('button', { name: 'translate.history.star' })
+    star.focus()
+    await user.keyboard(key)
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalledWith('1', { star: true }))
+    expect(screen.queryByRole('button', { name: 'translate.history.back' })).not.toBeInTheDocument()
+    expect(star).toHaveFocus()
+  })
+
+  it.each(['{Enter}', ' '])('opens details with %s when the row itself is focused', async (key) => {
+    const user = userEvent.setup()
+    renderHistory()
+
+    screen.getByRole('button', { name: /hello/ }).focus()
+    await user.keyboard(key)
+
+    expect(screen.getByRole('button', { name: 'translate.history.back' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'translate.history.copy_target' })).toBeInTheDocument()
+    expect(updateMock).not.toHaveBeenCalled()
   })
 
   it('invokes update mutation when clicking row star action', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Pressing Enter or Space on a translation history star opened the history detail instead of toggling the star. The row handled the bubbling keydown and prevented native button activation.

After this PR:
The row handles keyboard activation only when it is the event target. Star buttons retain native keyboard activation, while focusing the row itself still allows Enter or Space to open details.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: None.

### Why we need it and why it was done in this way

The following tradeoffs were made:
Add one event-target guard at the row that owns detail navigation. Keep the existing star click handler and mutation unchanged; text and file histories share the same row.

The following alternatives were considered:
Handling Enter and Space again on the star would duplicate native button behavior and leave the row's event ownership implicit.

Links to places where the discussion took place: None. <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Reproduction: open translation history, focus a row's star with the keyboard, and press Enter or Space. The star should toggle without opening details. Focus the row itself and press either key to open details.

Validation:
- Existing translation history component suite: 27 tests passed. Both added star cases failed before the production fix.
- Real Electron CDP: Enter starred the record, Space unstarred it, focus stayed on the star, and the list remained open. Persisted state matched the UI. Both row keys still opened details. The test record was removed afterward.
- Renderer and ai-core type checks, focused Biome check, and git diff --check passed.
- Full pnpm lint stopped at existing main-process guard/check type errors in DshBridgeServer.ts (49, 252, 277, 278). Subsequent i18n and global format stages were not reached.
- Simplification audit and two independent review workflows found no actionable issues on the unchanged snapshot.

No migration or user-guide update is required for restoring the existing keyboard interaction.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed translation history stars opening details instead of toggling when activated with Enter or Space.
```