### PR TITLE
fix(region-service): scope in-flight lookup to proxy

### DIFF
--- a/src/main/services/RegionService.ts
+++ b/src/main/services/RegionService.ts
@@ -29,7 +29,7 @@ type CachedEgressRegion = {
  * detections, including those arriving via the system.get_ip_country IPC.
  */
 class RegionService {
-  private inflight: Promise<string> | null = null
+  private inflight: { proxyKey: string | null; promise: Promise<string> } | null = null
 
   /** Egress country code (e.g. 'CN', 'US'); defaults to 'CN' on any failure. */
   async getCountry(): Promise<string> {
@@ -57,11 +57,22 @@ class RegionService {
       return cached.country
     }
 
-    // Dedup concurrent detections — callers share one in-flight request.
-    this.inflight ??= this.detectAndCache(proxyKey).finally(() => {
-      this.inflight = null
+    // Dedup concurrent detections for the active proxy — callers share one in-flight request.
+    if (this.inflight?.proxyKey === proxyKey) {
+      return this.inflight.promise
+    }
+
+    const inflight = {
+      proxyKey,
+      promise: this.detectAndCache(proxyKey)
+    }
+    inflight.promise = inflight.promise.finally(() => {
+      if (this.inflight === inflight) {
+        this.inflight = null
+      }
     })
-    return this.inflight
+    this.inflight = inflight
+    return inflight.promise
   }
 
   private async detectAndCache(proxyKey: string | null): Promise<string> {

--- a/src/main/services/RegionService.ts
+++ b/src/main/services/RegionService.ts
@@ -29,7 +29,7 @@ type CachedEgressRegion = {
  * detections, including those arriving via the system.get_ip_country IPC.
  */
 class RegionService {
-  private inflight: { proxyKey: string | null; promise: Promise<string> } | null = null
+  private inflight = new Map<string | null, { promise: Promise<string> }>()
 
   /** Egress country code (e.g. 'CN', 'US'); defaults to 'CN' on any failure. */
   async getCountry(): Promise<string> {
@@ -58,20 +58,20 @@ class RegionService {
     }
 
     // Dedup concurrent detections for the active proxy — callers share one in-flight request.
-    if (this.inflight?.proxyKey === proxyKey) {
-      return this.inflight.promise
+    const current = this.inflight.get(proxyKey)
+    if (current) {
+      return current.promise
     }
 
     const inflight = {
-      proxyKey,
       promise: this.detectAndCache(proxyKey)
     }
     inflight.promise = inflight.promise.finally(() => {
-      if (this.inflight === inflight) {
-        this.inflight = null
+      if (this.inflight.get(proxyKey) === inflight) {
+        this.inflight.delete(proxyKey)
       }
     })
-    this.inflight = inflight
+    this.inflight.set(proxyKey, inflight)
     return inflight.promise
   }
 

--- a/src/main/services/RegionService.ts
+++ b/src/main/services/RegionService.ts
@@ -78,7 +78,9 @@ class RegionService {
   private async detectAndCache(proxyKey: string | null): Promise<string> {
     try {
       const country = await this.fetchCountry()
-      application.get('CacheService').set<CachedEgressRegion>(CACHE_KEY, { country, proxyKey }, CACHE_TTL)
+      if (application.get('ProxyService').appliedProxyKey === proxyKey) {
+        application.get('CacheService').set<CachedEgressRegion>(CACHE_KEY, { country, proxyKey }, CACHE_TTL)
+      }
       return country
     } catch (error) {
       logger.error('Failed to get IP address information:', error as Error)

--- a/src/main/services/__tests__/RegionService.test.ts
+++ b/src/main/services/__tests__/RegionService.test.ts
@@ -49,6 +49,14 @@ const fetchResponse = (body: unknown, init: { ok?: boolean; status?: number } = 
   json: async () => body
 })
 
+const createDeferred = <T>() => {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {}
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 describe('RegionService', () => {
   beforeEach(() => {
     MockMainCacheServiceUtils.resetMocks()
@@ -151,5 +159,44 @@ describe('RegionService', () => {
 
     await expect(Promise.all([first, second])).resolves.toEqual(['JP', 'JP'])
     expect(netFetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not share an in-flight detection across proxy changes', async () => {
+    const proxyA = createDeferred<ReturnType<typeof fetchResponse>>()
+    const proxyB = createDeferred<ReturnType<typeof fetchResponse>>()
+    netFetchMock.mockReturnValueOnce(proxyA.promise).mockReturnValueOnce(proxyB.promise)
+
+    proxyState.appliedProxyKey = 'proxy-a'
+    const first = regionService.getCountry()
+    proxyState.appliedProxyKey = 'proxy-b'
+    const second = regionService.getCountry()
+
+    proxyA.resolve(fetchResponse({ country_code: 'US' }))
+    proxyB.resolve(fetchResponse({ country_code: 'JP' }))
+    await expect(Promise.all([first, second])).resolves.toEqual(['US', 'JP'])
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let stale completion clear a newer in-flight detection', async () => {
+    const proxyA = createDeferred<ReturnType<typeof fetchResponse>>()
+    const proxyB = createDeferred<ReturnType<typeof fetchResponse>>()
+    netFetchMock
+      .mockReturnValueOnce(proxyA.promise)
+      .mockReturnValueOnce(proxyB.promise)
+      .mockResolvedValueOnce(fetchResponse({ country_code: 'DE' }))
+
+    proxyState.appliedProxyKey = 'proxy-a'
+    const firstA = regionService.getCountry()
+    proxyState.appliedProxyKey = 'proxy-b'
+    const firstB = regionService.getCountry()
+
+    proxyA.resolve(fetchResponse({ country_code: 'US' }))
+    await expect(firstA).resolves.toBe('US')
+
+    const secondB = regionService.getCountry()
+    proxyB.resolve(fetchResponse({ country_code: 'JP' }))
+
+    await expect(Promise.all([firstB, secondB])).resolves.toEqual(['JP', 'JP'])
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/services/__tests__/RegionService.test.ts
+++ b/src/main/services/__tests__/RegionService.test.ts
@@ -199,6 +199,29 @@ describe('RegionService', () => {
     expect(netFetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it('does not let a stale proxy completion overwrite the active proxy cache', async () => {
+    const proxyA = createDeferred<ReturnType<typeof fetchResponse>>()
+    const proxyB = createDeferred<ReturnType<typeof fetchResponse>>()
+    netFetchMock
+      .mockReturnValueOnce(proxyA.promise)
+      .mockReturnValueOnce(proxyB.promise)
+      .mockResolvedValueOnce(fetchResponse({ country_code: 'DE' }))
+
+    proxyState.appliedProxyKey = 'proxy-a'
+    const firstA = regionService.getCountry()
+    proxyState.appliedProxyKey = 'proxy-b'
+    const firstB = regionService.getCountry()
+
+    proxyB.resolve(fetchResponse({ country_code: 'JP' }))
+    await expect(firstB).resolves.toBe('JP')
+
+    proxyA.resolve(fetchResponse({ country_code: 'US' }))
+    await expect(firstA).resolves.toBe('US')
+
+    await expect(regionService.getCountry()).resolves.toBe('JP')
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('does not let stale completion clear a newer in-flight detection', async () => {
     const proxyA = createDeferred<ReturnType<typeof fetchResponse>>()
     const proxyB = createDeferred<ReturnType<typeof fetchResponse>>()

--- a/src/main/services/__tests__/RegionService.test.ts
+++ b/src/main/services/__tests__/RegionService.test.ts
@@ -177,6 +177,28 @@ describe('RegionService', () => {
     expect(netFetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it('reuses a pending lookup when switching from proxy A to B and back to A', async () => {
+    const proxyA = createDeferred<ReturnType<typeof fetchResponse>>()
+    const proxyB = createDeferred<ReturnType<typeof fetchResponse>>()
+    netFetchMock
+      .mockReturnValueOnce(proxyA.promise)
+      .mockReturnValueOnce(proxyB.promise)
+      .mockResolvedValueOnce(fetchResponse({ country_code: 'DE' }))
+
+    proxyState.appliedProxyKey = 'proxy-a'
+    const firstA = regionService.getCountry()
+    proxyState.appliedProxyKey = 'proxy-b'
+    const firstB = regionService.getCountry()
+    proxyState.appliedProxyKey = 'proxy-a'
+    const secondA = regionService.getCountry()
+
+    proxyA.resolve(fetchResponse({ country_code: 'US' }))
+    proxyB.resolve(fetchResponse({ country_code: 'JP' }))
+
+    await expect(Promise.all([firstA, firstB, secondA])).resolves.toEqual(['US', 'JP', 'US'])
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('does not let stale completion clear a newer in-flight detection', async () => {
     const proxyA = createDeferred<ReturnType<typeof fetchResponse>>()
     const proxyB = createDeferred<ReturnType<typeof fetchResponse>>()


### PR DESCRIPTION
## 中文

> ### 分支策略
>
> - 本 PR 目标分支为 `main`。

### 本 PR 做了什么

修改前：

`RegionService` 只保存一个全局进行中的区域检测。代理 A 的请求尚未完成时切换到代理 B，B 可能复用 A 的请求；A 的过期完成还可能清除 B 的新请求状态。

修改后：

按代理 key 跟踪进行中的检测。相同代理共享同一请求，不同代理使用独立请求；`A → B → A` 会复用原先未完成的 A 请求。清理逻辑只删除自己拥有的条目。现有缓存、超时、回退以及 #20117 引入的失败语义保持不变。

Fixes # N/A（无对应上游 issue）

### 为什么需要，以及为什么这样实现

使用按代理 key 索引的 `Map`，让每个代理最多保留一个进行中的检测。条目只在请求待定期间存在。

权衡：快速切换代理时，可能短暂保留多个待定请求；每个请求完成后都会立即清理自己的条目。

考虑过的替代方案：单个 `{ proxyKey, promise }` 条目可以隔离 A 和 B，但无法在 `A → B → A` 时复用原来的 A 请求。

讨论链接：无。

### 破坏性变更

无。

### 审阅者特别说明

确定性的延迟 Promise 测试覆盖跨代理隔离、`A → B → A` 复用、过期完成不清除新请求，以及同代理 single-flight。相关回归用例在修复前失败，修复后通过。

验证结果：RegionService 专项测试 14 项通过；`pnpm lint` 和 `pnpm test:lint` 通过。分支已基于合并 #20117 后的 upstream `main` 重新整理。

### 检查清单

- [x] 分支：本 PR 目标为 `main`
- [x] PR：描述足以帮助后续贡献者理解变更
- [x] 代码：实现保持清晰、简单
- [x] 重构：变更仅限问题所需范围
- [x] 升级：无需迁移或升级处理
- [x] 文档：不需要用户指南更新
- [x] 自审：已检查完整差异和提交历史

### 发布说明

```release-note
修复切换代理时区域检测可能复用错误请求的问题。
```

## English

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`RegionService` kept one global in-flight region lookup. If proxy A had a pending request and the app switched to proxy B, B could reuse A's request. A stale completion could also clear newer in-flight state.

After this PR:

The service tracks in-flight lookups by proxy key. Callers on the same proxy share one request, callers on different proxies use independent requests, and `A → B → A` reuses the original pending A request. Cleanup removes only the entry owned by the completing request. Existing cache, timeout, fallback, and #20117 failure behavior remain unchanged.

Fixes # N/A — no upstream issue

### Why we need it and why it was done in this way

A `Map` keyed by proxy keeps at most one pending lookup per proxy. Entries exist only while their requests are pending.

The following tradeoffs were made:

Rapid proxy switching may briefly keep several requests pending. Each request removes its own entry when it finishes.

The following alternatives were considered:

A single `{ proxyKey, promise }` entry isolates A from B, but it cannot reuse the original A request after an `A → B → A` switch.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

Deterministic deferred-promise tests cover cross-proxy isolation, `A → B → A` reuse, stale completion cleanup, and same-proxy single-flight behavior. The relevant regressions fail before the fix and pass afterward.

Validation passed: 14 focused RegionService tests, `pnpm lint`, and `pnpm test:lint`. The branch is rebased onto upstream `main` after #20117 merged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required
- [x] Self-review: I have reviewed my own code and the complete PR diff before requesting review

### Release note

```release-note
Fix region detection reusing an in-flight request from a different proxy.
```
