### PR TITLE
fix(mini-apps): search localized display names

### DIFF
--- a/src/renderer/pages/miniApps/MiniAppsPage.tsx
+++ b/src/renderer/pages/miniApps/MiniAppsPage.tsx
@@ -78,7 +78,10 @@ const MiniAppsPage: FC = () => {
 
   const filteredApps = search
     ? miniApps.filter(
-        (app) => app.name.toLowerCase().includes(search.toLowerCase()) || app.url.includes(search.toLowerCase())
+        (app) =>
+          app.name.toLowerCase().includes(search.toLowerCase()) ||
+          (app.nameKey && t(app.nameKey).toLowerCase().includes(search.toLowerCase())) ||
+          app.url.includes(search.toLowerCase())
       )
     : miniApps
   const filteredBuiltins = search

--- a/src/renderer/pages/miniApps/__tests__/MiniAppsPage.test.tsx
+++ b/src/renderer/pages/miniApps/__tests__/MiniAppsPage.test.tsx
@@ -226,7 +226,10 @@ vi.mock('../InstallMiniAppPanel', () => ({
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', resolvedLanguage: 'en' } })
+  useTranslation: () => ({
+    t: (key: string) => (key === 'mini_apps.yuanbao' ? '腾讯元宝' : key),
+    i18n: { language: 'zh-CN', resolvedLanguage: 'zh-CN' }
+  })
 }))
 
 describe('MiniAppsPage', () => {
@@ -262,6 +265,23 @@ describe('MiniAppsPage', () => {
 
     expect(screen.getByText('ChatGPT')).toBeInTheDocument()
     expect(screen.queryByText('Gemini')).not.toBeInTheDocument()
+  })
+
+  it('finds a translated tile by its displayed name, original name, and URL', async () => {
+    const user = userEvent.setup()
+    mocks.apps.push(
+      stubApp({ appId: 'yuanbao', name: 'Yuanbao', nameKey: 'mini_apps.yuanbao', url: 'https://yuanbao.tencent.com' })
+    )
+    render(<MiniAppsPage />)
+
+    const search = screen.getByPlaceholderText('common.search')
+    expect(screen.getByRole('button', { name: '腾讯元宝' })).toBeInTheDocument()
+    for (const query of ['腾讯元宝', '元宝', 'YUANBAO', 'tencent.com']) {
+      await user.clear(search)
+      await user.type(search, query)
+      expect(screen.getByRole('button', { name: '腾讯元宝' })).toBeInTheDocument()
+      expect(screen.queryByText('Gemini')).not.toBeInTheDocument()
+    }
   })
 
   it('edits the latest app data after a non-visual configuration update', async () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Mini Apps displayed translated names such as 腾讯元宝, but searching those names returned no results. Searching the original English names still worked.

After this PR: Search also matches the current translation of `nameKey`, while preserving original-name and URL matching.

Fixes: None.

### Why we need it and why it was done in this way

Users should be able to search for the name shown on a tile.

The following tradeoffs were made: Reuse the existing translation function in the page filter; no stored data or shared contracts change.

The following alternatives were considered: Maintaining a separate alias list would duplicate translations and was unnecessary.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

- Added a regression covering the displayed Chinese name, a Chinese substring, the uppercase original name, URL matching, and exclusion of unrelated tiles. It failed before the fix.
- Focused MiniAppsPage suite: 12/12 passed.
- Renderer typecheck, targeted ESLint/Oxlint/Biome, and diff checks passed.
- Real Electron/CDP validation after a cold renderer reload: 腾讯元宝/Yuanbao, 文心一言/Wenxin, and 秘塔AI搜索/Metaso each passed two rounds. Search was cleared afterward.
- Full repository lint and test suites were not run. No user-guide update is required for this search fix.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Mini Apps search failing to find apps by their translated display names.
```
