### PR TITLE
fix(agent-tasks): refresh task run history on job state changes

### DIFF
--- a/docs/references/job-and-scheduler/handler-authoring.md
+++ b/docs/references/job-and-scheduler/handler-authoring.md
@@ -91,6 +91,15 @@ Anti-pattern: `while (true)` (cannot be cancelled), `await sleep(N)` without sig
 
 Generic metadata is not a substitute for a domain relationship. A stable reference to an entity owned by another domain must be maintained through lifecycle APIs owned by that entity's service, with database constraints when the relationship topology permits. When constraints would create circular foreign keys, follow the application-level [soft-reference pattern](../data/database-patterns.md#circular-foreign-key-references) instead. For example, the non-circular `agent.task` sticky-session relationship uses the constrained `agent_session.taskScheduleId` relation maintained by `AgentSessionService`, not a session id in schedule metadata.
 
+## Enqueue observer (`onEnqueued`)
+
+`onEnqueued?(snapshot: Readonly<JobSnapshot>): void` is a synchronous observer
+called for a newly committed job before dispatch or delayed arming. It can
+publish business read-model changes while a job is still queued. `enqueueTx`
+defers it to the post-commit microtask and re-reads the persisted snapshot;
+rolled-back inserts and idempotency hits do not call it. Exceptions are logged
+and do not prevent dispatch. Keep the observer synchronous and short.
+
 ## Settled event (`onSettled`)
 
 `onSettled?(event: JobSettledEvent<TPayload>)` fires once when a job reaches a terminal state (errors are caught + logged, never propagated). The event is a projection of the persisted terminal snapshot — no `jobService.getById` reverse lookup needed:

--- a/src/main/ai/agents/__tests__/agentTaskJobHandler.test.ts
+++ b/src/main/ai/agents/__tests__/agentTaskJobHandler.test.ts
@@ -16,7 +16,8 @@ vi.mock('@data/services/JobService', () => ({
 
 vi.mock('@data/services/AgentTaskService', () => ({
   agentTaskService: {
-    notifyReadModelChange: vi.fn()
+    notifyReadModelChange: vi.fn(),
+    notifyRunLogChange: vi.fn()
   }
 }))
 
@@ -95,6 +96,7 @@ describe('AgentTaskJobHandler', () => {
     vi.mocked(jobService.listRecentTerminalByScheduleId).mockReset()
     vi.mocked(jobService.getById).mockReset()
     vi.mocked(agentTaskService.notifyReadModelChange).mockReset()
+    vi.mocked(agentTaskService.notifyRunLogChange).mockReset()
     vi.mocked(runAgentTask).mockReset()
   })
 
@@ -142,12 +144,13 @@ describe('AgentTaskJobHandler', () => {
       vi.mocked(jobService.getById).mockReturnValueOnce(makeTerminal('completed', 'j1'))
       vi.mocked(runAgentTask).mockImplementationOnce(async () => {
         expect(agentTaskService.notifyReadModelChange).toHaveBeenCalledWith(['s1'])
+        expect(agentTaskService.notifyRunLogChange).toHaveBeenCalledWith('s1', 'j1', 'membership')
         return { result: 'ok' }
       })
 
       await agentTaskJobHandler.execute({ jobId: 'j1' } as JobContext<AgentTaskInput>)
 
-      expect.assertions(1)
+      expect.assertions(2)
     })
 
     it('does not publish for an ad-hoc job with no schedule', async () => {
@@ -156,6 +159,7 @@ describe('AgentTaskJobHandler', () => {
       await agentTaskJobHandler.execute({ jobId: 'j1' } as JobContext<AgentTaskInput>)
 
       expect(agentTaskService.notifyReadModelChange).not.toHaveBeenCalled()
+      expect(agentTaskService.notifyRunLogChange).not.toHaveBeenCalled()
     })
   })
 
@@ -209,6 +213,10 @@ describe('AgentTaskJobHandler', () => {
       await agentTaskJobHandler.onSettled?.(makeSettled({ status: 'cancelled' }))
 
       expect(vi.mocked(agentTaskService.notifyReadModelChange).mock.calls).toEqual([[['s1']], [['s1']]])
+      expect(vi.mocked(agentTaskService.notifyRunLogChange).mock.calls).toEqual([
+        ['s1', 'job-1', 'projection'],
+        ['s1', 'job-1', 'projection']
+      ])
     })
 
     it('does not act when the failed job has no scheduleId (ad-hoc enqueue)', async () => {
@@ -216,6 +224,7 @@ describe('AgentTaskJobHandler', () => {
 
       expect(jobService.listRecentTerminalByScheduleId).not.toHaveBeenCalled()
       expect(pauseSpy).not.toHaveBeenCalled()
+      expect(agentTaskService.notifyRunLogChange).not.toHaveBeenCalled()
     })
 
     it('swallows pauseJobScheduleById errors so onSettled cannot throw', async () => {

--- a/src/main/ai/agents/__tests__/agentTaskJobHandler.test.ts
+++ b/src/main/ai/agents/__tests__/agentTaskJobHandler.test.ts
@@ -16,8 +16,7 @@ vi.mock('@data/services/JobService', () => ({
 
 vi.mock('@data/services/AgentTaskService', () => ({
   agentTaskService: {
-    notifyReadModelChange: vi.fn(),
-    notifyRunLogChange: vi.fn()
+    notifyRunChange: vi.fn()
   }
 }))
 
@@ -95,8 +94,7 @@ describe('AgentTaskJobHandler', () => {
     pauseSpy.mockResolvedValue(true)
     vi.mocked(jobService.listRecentTerminalByScheduleId).mockReset()
     vi.mocked(jobService.getById).mockReset()
-    vi.mocked(agentTaskService.notifyReadModelChange).mockReset()
-    vi.mocked(agentTaskService.notifyRunLogChange).mockReset()
+    vi.mocked(agentTaskService.notifyRunChange).mockReset()
     vi.mocked(runAgentTask).mockReset()
   })
 
@@ -126,6 +124,20 @@ describe('AgentTaskJobHandler', () => {
     })
   })
 
+  describe('onEnqueued', () => {
+    it('announces log membership while a scheduled job is still pending', () => {
+      agentTaskJobHandler.onEnqueued?.({ ...makeTerminal('completed', 'j1'), status: 'pending', startedAt: null })
+
+      expect(vi.mocked(agentTaskService.notifyRunChange).mock.calls).toEqual([['s1', 'j1', 'membership']])
+    })
+
+    it('does not announce task logs for an ad-hoc job', () => {
+      agentTaskJobHandler.onEnqueued?.({ ...makeTerminal('completed', 'j1'), status: 'pending', scheduleId: null })
+
+      expect(agentTaskService.notifyRunChange).not.toHaveBeenCalled()
+    })
+  })
+
   describe('execute', () => {
     it('delegates to runAgentTask with the JobContext', async () => {
       vi.mocked(runAgentTask).mockResolvedValueOnce({ result: 'ok' })
@@ -143,14 +155,13 @@ describe('AgentTaskJobHandler', () => {
     it('publishes the run-state change before running so open task lists leave the previous state', async () => {
       vi.mocked(jobService.getById).mockReturnValueOnce(makeTerminal('completed', 'j1'))
       vi.mocked(runAgentTask).mockImplementationOnce(async () => {
-        expect(agentTaskService.notifyReadModelChange).toHaveBeenCalledWith(['s1'])
-        expect(agentTaskService.notifyRunLogChange).toHaveBeenCalledWith('s1', 'j1', 'membership')
+        expect(vi.mocked(agentTaskService.notifyRunChange).mock.calls).toEqual([['s1', 'j1', 'projection']])
         return { result: 'ok' }
       })
 
       await agentTaskJobHandler.execute({ jobId: 'j1' } as JobContext<AgentTaskInput>)
 
-      expect.assertions(2)
+      expect.assertions(1)
     })
 
     it('does not publish for an ad-hoc job with no schedule', async () => {
@@ -158,8 +169,7 @@ describe('AgentTaskJobHandler', () => {
 
       await agentTaskJobHandler.execute({ jobId: 'j1' } as JobContext<AgentTaskInput>)
 
-      expect(agentTaskService.notifyReadModelChange).not.toHaveBeenCalled()
-      expect(agentTaskService.notifyRunLogChange).not.toHaveBeenCalled()
+      expect(agentTaskService.notifyRunChange).not.toHaveBeenCalled()
     })
   })
 
@@ -208,15 +218,11 @@ describe('AgentTaskJobHandler', () => {
       expect(pauseSpy).not.toHaveBeenCalled()
     })
 
-    it('publishes the run-state change on every terminal status, not just failures', async () => {
-      await agentTaskJobHandler.onSettled?.(makeSettled({ status: 'completed' }))
-      await agentTaskJobHandler.onSettled?.(makeSettled({ status: 'cancelled' }))
+    it.each(['completed', 'failed', 'cancelled'] as const)('publishes one run-state change on %s', async (status) => {
+      vi.mocked(jobService.listRecentTerminalByScheduleId).mockReturnValueOnce([])
+      await agentTaskJobHandler.onSettled?.(makeSettled({ status }))
 
-      expect(vi.mocked(agentTaskService.notifyReadModelChange).mock.calls).toEqual([[['s1']], [['s1']]])
-      expect(vi.mocked(agentTaskService.notifyRunLogChange).mock.calls).toEqual([
-        ['s1', 'job-1', 'projection'],
-        ['s1', 'job-1', 'projection']
-      ])
+      expect(vi.mocked(agentTaskService.notifyRunChange).mock.calls).toEqual([['s1', 'job-1', 'projection']])
     })
 
     it('does not act when the failed job has no scheduleId (ad-hoc enqueue)', async () => {
@@ -224,7 +230,7 @@ describe('AgentTaskJobHandler', () => {
 
       expect(jobService.listRecentTerminalByScheduleId).not.toHaveBeenCalled()
       expect(pauseSpy).not.toHaveBeenCalled()
-      expect(agentTaskService.notifyRunLogChange).not.toHaveBeenCalled()
+      expect(agentTaskService.notifyRunChange).not.toHaveBeenCalled()
     })
 
     it('swallows pauseJobScheduleById errors so onSettled cannot throw', async () => {

--- a/src/main/ai/agents/agentTaskJobHandler.ts
+++ b/src/main/ai/agents/agentTaskJobHandler.ts
@@ -52,21 +52,25 @@ export const agentTaskJobHandler: JobHandler<AgentTaskInput> = {
    */
   defaultRetryPolicy: { maxAttempts: 1, backoff: 'none', baseDelayMs: 0, maxDelayMs: 0 },
 
+  onEnqueued(snapshot) {
+    if (snapshot.scheduleId) {
+      agentTaskService.notifyRunChange(snapshot.scheduleId, snapshot.id, 'membership')
+    }
+  },
+
   async execute(ctx) {
     // The row is already `running` here; publish so open task lists leave the
     // previous run's state. JobContext carries no scheduleId — resolve the row.
     const scheduleId = jobService.getById(ctx.jobId)?.scheduleId
     if (scheduleId) {
-      agentTaskService.notifyReadModelChange([scheduleId])
-      agentTaskService.notifyRunLogChange(scheduleId, ctx.jobId, 'membership')
+      agentTaskService.notifyRunChange(scheduleId, ctx.jobId, 'projection')
     }
     return await runAgentTask(ctx)
   },
 
   async onSettled(event) {
     if (event.scheduleId) {
-      agentTaskService.notifyReadModelChange([event.scheduleId])
-      agentTaskService.notifyRunLogChange(event.scheduleId, event.jobId, 'projection')
+      agentTaskService.notifyRunChange(event.scheduleId, event.jobId, 'projection')
     }
     if (event.status !== 'failed' || !event.scheduleId) return
 

--- a/src/main/ai/agents/agentTaskJobHandler.ts
+++ b/src/main/ai/agents/agentTaskJobHandler.ts
@@ -56,12 +56,18 @@ export const agentTaskJobHandler: JobHandler<AgentTaskInput> = {
     // The row is already `running` here; publish so open task lists leave the
     // previous run's state. JobContext carries no scheduleId — resolve the row.
     const scheduleId = jobService.getById(ctx.jobId)?.scheduleId
-    if (scheduleId) agentTaskService.notifyReadModelChange([scheduleId])
+    if (scheduleId) {
+      agentTaskService.notifyReadModelChange([scheduleId])
+      agentTaskService.notifyRunLogChange(scheduleId, ctx.jobId, 'membership')
+    }
     return await runAgentTask(ctx)
   },
 
   async onSettled(event) {
-    if (event.scheduleId) agentTaskService.notifyReadModelChange([event.scheduleId])
+    if (event.scheduleId) {
+      agentTaskService.notifyReadModelChange([event.scheduleId])
+      agentTaskService.notifyRunLogChange(event.scheduleId, event.jobId, 'projection')
+    }
     if (event.status !== 'failed' || !event.scheduleId) return
 
     const recent = jobService.listRecentTerminalByScheduleId(event.scheduleId, RECENT_TERMINAL_WINDOW)

--- a/src/main/core/job/JobManager.ts
+++ b/src/main/core/job/JobManager.ts
@@ -962,6 +962,7 @@ export class JobManager extends BaseService {
     const snapshot = jobService.create(insertRow)
     this.publishState(snapshot)
     const handle = this.handleFor(snapshot)
+    this.notifyEnqueued(handler, snapshot)
 
     if (snapshot.status === 'pending') {
       void this.dispatch(queueName)
@@ -1039,6 +1040,7 @@ export class JobManager extends BaseService {
           return
         }
         this.publishState(persisted)
+        this.notifyEnqueued(handler, persisted)
         logger.info('Job enqueued (tx)', {
           id: persisted.id,
           type,
@@ -2371,6 +2373,14 @@ export class JobManager extends BaseService {
 
   private isTerminal(status: JobSnapshot['status']): boolean {
     return status === 'completed' || status === 'failed' || status === 'cancelled'
+  }
+
+  private notifyEnqueued(handler: JobHandler, snapshot: JobSnapshot): void {
+    try {
+      handler.onEnqueued?.(snapshot)
+    } catch (err) {
+      logger.warn('handler.onEnqueued threw — ignoring', { jobId: snapshot.id, type: snapshot.type, err })
+    }
   }
 
   /** Push a job snapshot to the cross-window shared cache (renderer hooks read this). */

--- a/src/main/core/job/__tests__/JobManager.integration.test.ts
+++ b/src/main/core/job/__tests__/JobManager.integration.test.ts
@@ -31,6 +31,7 @@ import { JobManager } from '@main/core/job/JobManager'
 import type { JobHandle, JobHandler, JobSettledEvent } from '@main/core/job/types'
 import { BaseService } from '@main/core/lifecycle/BaseService'
 import { SchedulerService } from '@main/core/scheduler/SchedulerService'
+import type { JobSnapshot } from '@shared/data/api/schemas/jobs'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainCacheServiceExport } from '@test-mocks/main/CacheService'
 import { MockMainDbServiceExport } from '@test-mocks/main/DbService'
@@ -1047,6 +1048,126 @@ describe('JobManager integration', () => {
 
       await drainAllQueues(jobManager)
       await teardownManager(scheduler, jobManager)
+    })
+  })
+
+  describe('onEnqueued', () => {
+    it('exposes a timer-fired pending row while its queue is full', async () => {
+      const observed: JobSnapshot[] = []
+      const release = Promise.withResolvers<void>()
+      const entered = Promise.withResolvers<void>()
+      const handler: JobHandler = {
+        recovery: 'abandon',
+        defaultConcurrency: 1,
+        onEnqueued(snapshot) {
+          observed.push(jobService.getById(snapshot.id)!)
+        },
+        async execute() {
+          entered.resolve()
+          await release.promise
+        }
+      }
+      const { scheduler, jobManager } = await bootstrapManager({
+        handlers: [['enqueue.observe', handler]],
+        keepFakeTimers: true
+      })
+      try {
+        const first = jobManager.enqueue('enqueue.observe' as never, {} as never)
+        await entered.promise
+        const schedule = jobManager.registerJobSchedule({
+          type: 'enqueue.observe' as never,
+          trigger: { kind: 'once', at: Date.now() + 1000 },
+          jobInputTemplate: {} as never,
+          catchUpPolicy: { kind: 'skip-missed' }
+        })
+        await vi.advanceTimersByTimeAsync(1000)
+
+        expect(observed).toHaveLength(2)
+        expect(observed[0]).toMatchObject({ id: first.id, status: 'pending' })
+        expect(observed[1]).toMatchObject({ scheduleId: schedule.id, status: 'pending', startedAt: null })
+        expect(jobService.getById(observed[1].id)?.status).toBe('pending')
+      } finally {
+        release.resolve()
+        await drainAllQueues(jobManager)
+        await teardownManager(scheduler, jobManager)
+        vi.useRealTimers()
+      }
+    })
+
+    it('notifies only committed new rows, never rolled-back or idempotently reused rows', async () => {
+      const observed: JobSnapshot[] = []
+      const { scheduler, jobManager } = await bootstrapManager({
+        handlers: [
+          [
+            'enqueue.tx',
+            {
+              recovery: 'abandon',
+              onEnqueued(snapshot) {
+                observed.push(jobService.getById(snapshot.id)!)
+              },
+              async execute() {}
+            }
+          ]
+        ]
+      })
+      jobManager.pause()
+      try {
+        const dbSvc = application.get('DbService')
+        const handle = dbSvc.withWriteTx((tx) => {
+          const created = jobManager.enqueueTx(tx, 'enqueue.tx' as never, {} as never, { idempotencyKey: 'one' })
+          expect(observed).toEqual([])
+          return created
+        })
+        await Promise.resolve()
+        expect(observed).toHaveLength(1)
+        expect(observed[0]).toMatchObject({ id: handle.id, status: 'pending' })
+
+        expect(() =>
+          dbSvc.withWriteTx((tx) => {
+            jobManager.enqueueTx(tx, 'enqueue.tx' as never, {} as never)
+            throw new Error('rollback')
+          })
+        ).toThrow('rollback')
+        const reused = jobManager.enqueue('enqueue.tx' as never, {} as never, { idempotencyKey: 'one' })
+        const reusedTx = dbSvc.withWriteTx((tx) =>
+          jobManager.enqueueTx(tx, 'enqueue.tx' as never, {} as never, { idempotencyKey: 'one' })
+        )
+        await Promise.resolve()
+        expect(reused.id).toBe(handle.id)
+        expect(reusedTx.id).toBe(handle.id)
+        expect(observed).toHaveLength(1)
+      } finally {
+        await teardownManager(scheduler, jobManager)
+      }
+    })
+
+    it('still dispatches committed jobs when the enqueue observer throws', async () => {
+      const { scheduler, jobManager } = await bootstrapManager({
+        handlers: [
+          [
+            'enqueue.throws',
+            {
+              recovery: 'abandon',
+              onEnqueued() {
+                throw new Error('observer failed')
+              },
+              async execute() {
+                return 'done'
+              }
+            }
+          ]
+        ]
+      })
+      try {
+        const direct = jobManager.enqueue('enqueue.throws' as never, {} as never)
+        const transactional = application
+          .get('DbService')
+          .withWriteTx((tx) => jobManager.enqueueTx(tx, 'enqueue.throws' as never, {} as never))
+        expect(await direct.finished).toMatchObject({ status: 'completed', output: 'done' })
+        expect(await transactional.finished).toMatchObject({ status: 'completed', output: 'done' })
+      } finally {
+        await teardownManager(scheduler, jobManager)
+      }
     })
   })
 

--- a/src/main/core/job/types.ts
+++ b/src/main/core/job/types.ts
@@ -90,6 +90,12 @@ export interface JobHandler<TPayload = unknown> {
   cancelTimeoutMs?: number
   /** Execute one job attempt. Throw to fail; reject with AbortError to cancel. */
   execute(ctx: JobContext<TPayload>): Promise<unknown>
+  /**
+   * Optional synchronous observer of a newly committed row, before dispatch.
+   * enqueueTx defers this until after commit; rollback and idempotency hits skip it.
+   * Errors are caught and logged without preventing dispatch.
+   */
+  onEnqueued?(snapshot: Readonly<JobSnapshot>): void
   /** Optional. Called when a schedule fire was missed. */
   onMissed?(event: JobMissEvent): void | Promise<void>
   /**

--- a/src/main/data/services/AgentTaskService.ts
+++ b/src/main/data/services/AgentTaskService.ts
@@ -144,6 +144,13 @@ export class AgentTaskService {
     ])
   }
 
+  /** Publish one run-log row change: `membership` when the row first becomes visible, `projection` when it settles. */
+  notifyRunLogChange(taskId: string, jobId: string, kind: 'membership' | 'projection'): void {
+    notifyDataApiDataChange([
+      { endpoint: '/agents/:agentId/tasks/:taskId/logs', kind, routeParams: { taskId }, entityIds: [jobId] }
+    ])
+  }
+
   listWorkspaceReferencesTx(tx: DbOrTx, workspaceId: string): AgentWorkspaceReferenceItem[] {
     return findWorkspaceScheduleReferences(
       jobScheduleService.listAllTx(tx, { type: AGENT_TASK_TYPE }),

--- a/src/main/data/services/AgentTaskService.ts
+++ b/src/main/data/services/AgentTaskService.ts
@@ -28,7 +28,7 @@ import {
   type AgentWorkspaceReferenceItem
 } from '@shared/data/api/schemas/agentWorkspaces'
 import type { JobScheduleSnapshot, JobSnapshot } from '@shared/data/api/schemas/jobs'
-import type { ListOptions } from '@shared/data/api/types'
+import type { DataApiDataChangeEffect, ListOptions } from '@shared/data/api/types'
 
 const AGENT_TASK_TYPE = 'agent.task' as const
 
@@ -131,22 +131,27 @@ function deriveStatus(snapshot: JobScheduleSnapshot): 'active' | 'paused' | 'com
   return 'active'
 }
 
+function taskReadModelEffects(entityIds: string[]): DataApiDataChangeEffect[] {
+  return [
+    { endpoint: '/agent-tasks', kind: 'projection', entityIds },
+    { endpoint: '/agents/:agentId/tasks', kind: 'projection', entityIds },
+    { endpoint: '/agent-tasks/:taskId', entityIds },
+    { endpoint: '/agents/:agentId/tasks/:taskId', entityIds }
+  ]
+}
+
 export class AgentTaskService {
   /** Publish every DataApi projection backed by the composed task read model. */
   notifyReadModelChange(taskIds: readonly string[]): void {
     const entityIds = [...new Set(taskIds)]
     if (entityIds.length === 0) return
-    notifyDataApiDataChange([
-      { endpoint: '/agent-tasks', kind: 'projection', entityIds },
-      { endpoint: '/agents/:agentId/tasks', kind: 'projection', entityIds },
-      { endpoint: '/agent-tasks/:taskId', entityIds },
-      { endpoint: '/agents/:agentId/tasks/:taskId', entityIds }
-    ])
+    notifyDataApiDataChange(taskReadModelEffects(entityIds))
   }
 
-  /** Publish one run-log row change: `membership` when the row first becomes visible, `projection` when it settles. */
-  notifyRunLogChange(taskId: string, jobId: string, kind: 'membership' | 'projection'): void {
+  /** Publish task and run-log projections together: membership on enqueue, projection on state changes. */
+  notifyRunChange(taskId: string, jobId: string, kind: 'membership' | 'projection'): void {
     notifyDataApiDataChange([
+      ...taskReadModelEffects([taskId]),
       { endpoint: '/agents/:agentId/tasks/:taskId/logs', kind, routeParams: { taskId }, entityIds: [jobId] }
     ])
   }

--- a/src/main/data/services/__tests__/AgentTaskService.test.ts
+++ b/src/main/data/services/__tests__/AgentTaskService.test.ts
@@ -133,18 +133,27 @@ describe('AgentTaskService (read side)', () => {
     ])
   })
 
-  it('publishes a run-log change scoped to its task and carrying the job id', () => {
-    agentTaskService.notifyRunLogChange(TASK_ID, 'job-1', 'projection')
+  it.each(['membership', 'projection'] as const)(
+    'publishes task and run-log effects in one %s notification',
+    (kind) => {
+      agentTaskService.notifyRunChange(TASK_ID, 'job-1', kind)
 
-    expect(notifyDataApiDataChangeMock).toHaveBeenCalledWith([
-      {
-        endpoint: '/agents/:agentId/tasks/:taskId/logs',
-        kind: 'projection',
-        routeParams: { taskId: TASK_ID },
-        entityIds: ['job-1']
-      }
-    ])
-  })
+      expect(notifyDataApiDataChangeMock).toHaveBeenCalledTimes(1)
+
+      expect(notifyDataApiDataChangeMock).toHaveBeenCalledWith([
+        { endpoint: '/agent-tasks', kind: 'projection', entityIds: [TASK_ID] },
+        { endpoint: '/agents/:agentId/tasks', kind: 'projection', entityIds: [TASK_ID] },
+        { endpoint: '/agent-tasks/:taskId', entityIds: [TASK_ID] },
+        { endpoint: '/agents/:agentId/tasks/:taskId', entityIds: [TASK_ID] },
+        {
+          endpoint: '/agents/:agentId/tasks/:taskId/logs',
+          kind,
+          routeParams: { taskId: TASK_ID },
+          entityIds: ['job-1']
+        }
+      ])
+    }
+  )
 
   describe('getTask', () => {
     it('returns a task by id without requiring the owning agent id', () => {

--- a/src/main/data/services/__tests__/AgentTaskService.test.ts
+++ b/src/main/data/services/__tests__/AgentTaskService.test.ts
@@ -133,6 +133,19 @@ describe('AgentTaskService (read side)', () => {
     ])
   })
 
+  it('publishes a run-log change scoped to its task and carrying the job id', () => {
+    agentTaskService.notifyRunLogChange(TASK_ID, 'job-1', 'projection')
+
+    expect(notifyDataApiDataChangeMock).toHaveBeenCalledWith([
+      {
+        endpoint: '/agents/:agentId/tasks/:taskId/logs',
+        kind: 'projection',
+        routeParams: { taskId: TASK_ID },
+        entityIds: ['job-1']
+      }
+    ])
+  })
+
   describe('getTask', () => {
     it('returns a task by id without requiring the owning agent id', () => {
       vi.mocked(jobScheduleService.getById).mockReturnValueOnce(makeSnapshot())

--- a/src/renderer/hooks/agent/__tests__/useTasks.test.ts
+++ b/src/renderer/hooks/agent/__tests__/useTasks.test.ts
@@ -14,6 +14,7 @@ import {
   useRunTask,
   useSetTaskEnabled,
   useTask,
+  useTaskLogs,
   useTasks,
   useUpdateTask
 } from '../useTasks'
@@ -130,6 +131,28 @@ describe('useTask', () => {
     renderHook(() => useTask('t-1'))
 
     MockUseDataApiUtils.emitDataChange([{ endpoint: '/agent-tasks/:taskId', entityIds: ['t-1'] }])
+
+    expect(refetch).toHaveBeenCalled()
+  })
+})
+
+describe('useTaskLogs', () => {
+  it('refetches the run history when a run of the viewed task changes state', () => {
+    const refetch = vi.fn()
+    MockUseDataApiUtils.mockQueryResult('/agents/:agentId/tasks/:taskId/logs', {
+      data: { items: [], total: 0, page: 1 } as any,
+      refetch
+    })
+    renderHook(() => useTaskLogs('agent-1', 't-1'))
+
+    MockUseDataApiUtils.emitDataChange([
+      {
+        endpoint: '/agents/:agentId/tasks/:taskId/logs',
+        kind: 'projection',
+        routeParams: { taskId: 't-1' },
+        entityIds: ['job-1']
+      }
+    ])
 
     expect(refetch).toHaveBeenCalled()
   })

--- a/src/renderer/hooks/agent/useTasks.ts
+++ b/src/renderer/hooks/agent/useTasks.ts
@@ -212,11 +212,14 @@ export const useDeleteTask = () => {
 }
 
 export const useTaskLogs = (agentId: string | null, taskId: string | null) => {
-  const { data, error, isLoading } = useQuery('/agents/:agentId/tasks/:taskId/logs', {
+  const { data, error, isLoading, refetch } = useQuery('/agents/:agentId/tasks/:taskId/logs', {
     params: { agentId: agentId!, taskId: taskId! },
     query: { limit: 50 },
     enabled: !!(agentId && taskId),
     swrOptions: { keepPreviousData: false }
+  })
+  useDataChange('/agents/:agentId/tasks/:taskId/logs', () => refetch(), {
+    routeParams: taskId ? { taskId } : undefined
   })
   return {
     logs: data?.items ?? [],


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The run-history panel of a scheduled agent task refreshed only once, right after a manual run was enqueued. Runs that started, completed, failed or were cancelled afterwards, and every timer-fired run, left the panel showing stale rows until it was closed and reopened.

After this PR:

The run history refreshes automatically whenever a run of the viewed task changes state, for manual and scheduled runs alike.

Fixes # N/A

### Why we need it and why it was done in this way

Each run transition publishes the task projections and the task-scoped logs effect in one DataApi notification. Task effects carry schedule ids; the logs effect carries the job id and `routeParams: { taskId }`. `useTaskLogs` subscribes to changes for the viewed task.

The JobManager now calls an optional synchronous `onEnqueued` observer after a new row commits and before dispatch. The agent handler publishes log membership there, including timer-fired jobs waiting behind the per-agent concurrency limit. Execution and settlement publish projection changes. Transactional enqueue observes the persisted row in its post-commit microtask; rollback and idempotency hits emit no enqueue event, and observer errors cannot prevent dispatch.

The following tradeoffs were made:

- A small generic enqueue observer is added to the JobHandler contract so scheduling infrastructure stays independent of agent-specific DataApi endpoints.
- The observer is synchronous and intended for short post-commit notifications.

The following alternatives were considered:

- Publishing task and log effects separately: rejected because a consumer observing both would receive duplicate convergence callbacks.
- Publishing log membership only when execution starts: rejected because queued timer-fired jobs would remain invisible.
- Renderer polling: unnecessary because the existing push channel handles convergence.

Links to places where the discussion took place: [batched notification review](https://github.com/CherryHQ/cherry-studio/pull/20154#discussion_r3948080184), [queued run review](https://github.com/CherryHQ/cherry-studio/pull/20154#discussion_r3948080189).

### Breaking changes

None.

### Special notes for your reviewer

- Regression tests cover timer-fired enqueue with a saturated queue, post-commit visibility, rollback, idempotency, observer failure isolation, one combined notification, and queued/running/terminal handler wiring.
- Validation: 100 targeted tests passed across JobManager integration, AgentTaskService, agentTaskJobHandler, useTasks, and scoped agent queries. `pnpm lint`, `pnpm test:lint`, and `pnpm docs:check` passed (45 existing ESLint warnings, no errors). The enqueue regressions were reproduced on the original implementation before applying the fix.
- No interactive Electron run was performed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the scheduled task run history not refreshing when a run is queued, starts, finishes, fails or is cancelled.
```
