### PR TITLE
fix(azure-openai): preserve custom gateway URL semantics

### DIFF
--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -746,6 +746,117 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
       expect(config.providerId).toBe('azure')
       expect(settings.baseURL).toMatch(/\/openai$/)
     })
+
+    it('preserves v1 Responses URLs and the configured API version for custom gateways', async () => {
+      vi.mocked(net.fetch).mockResolvedValue(new Response('{}'))
+      const provider = makeProvider({
+        id: 'azure-openai',
+        authType: 'iam-azure',
+        settings: { apiVersion: '2025-04-01-preview' },
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_RESPONSES]: {
+            baseUrl: 'https://proxy.example.com',
+            adapterFamily: 'azure-responses'
+          }
+        }
+      })
+      const model = makeModel({
+        id: 'azure::gpt-5',
+        apiModelId: 'gpt-5',
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES]
+      })
+
+      const config = await providerToAiSdkConfig(provider, model)
+      const settings = config.providerSettings as {
+        baseURL: string
+        fetch: typeof fetch
+        apiVersion?: string
+        useDeploymentBasedUrls?: boolean
+      }
+      await settings.fetch(`${settings.baseURL}/responses`, { method: 'POST' })
+
+      expect(config.providerId).toBe('azure-responses')
+      expect(settings.baseURL).toBe('https://proxy.example.com/openai/v1')
+      expect(settings.apiVersion).toBe('2025-04-01-preview')
+      expect(settings.useDeploymentBasedUrls).toBeUndefined()
+      expect(net.fetch).toHaveBeenCalledWith(
+        'https://proxy.example.com/openai/v1/responses?api-version=2025-04-01-preview',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('uses the default Azure API version for non-deployment custom gateway chat URLs', async () => {
+      vi.mocked(net.fetch).mockResolvedValue(new Response('{}'))
+      const provider = makeProvider({
+        id: 'azure-openai',
+        authType: 'iam-azure',
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+            baseUrl: 'https://proxy.example.com',
+            adapterFamily: 'azure'
+          }
+        }
+      })
+      const model = makeModel({
+        id: 'azure::gpt-4o',
+        apiModelId: 'gpt-4o',
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+      })
+
+      const config = await providerToAiSdkConfig(provider, model)
+      const settings = config.providerSettings as {
+        baseURL: string
+        fetch: typeof fetch
+        apiVersion?: string
+        useDeploymentBasedUrls?: boolean
+      }
+      await settings.fetch(`${settings.baseURL}/chat/completions`, { method: 'POST' })
+
+      expect(config.providerId).toBe('azure')
+      expect(settings.baseURL).toBe('https://proxy.example.com/openai/v1')
+      expect(settings.apiVersion).toBeUndefined()
+      expect(settings.useDeploymentBasedUrls).toBeUndefined()
+      expect(net.fetch).toHaveBeenCalledWith(
+        'https://proxy.example.com/openai/v1/chat/completions?api-version=v1',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('keeps custom gateway chat URLs deployment-based when an API version is configured', async () => {
+      const provider = makeProvider({
+        id: 'azure-openai',
+        authType: 'iam-azure',
+        settings: { apiVersion: '2024-10-21' },
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+            baseUrl: 'https://proxy.example.com',
+            adapterFamily: 'azure'
+          }
+        }
+      })
+      const model = makeModel({
+        id: 'azure::gpt-4o',
+        apiModelId: 'gpt-4o',
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+      })
+
+      const config = await providerToAiSdkConfig(provider, model)
+      const settings = config.providerSettings as {
+        baseURL: string
+        fetch: typeof fetch
+        apiVersion?: string
+        useDeploymentBasedUrls?: boolean
+      }
+
+      expect(config.providerId).toBe('azure')
+      expect(settings.baseURL).toBe('https://proxy.example.com/openai')
+      expect(settings.apiVersion).toBe('2024-10-21')
+      expect(settings.useDeploymentBasedUrls).toBe(true)
+      expect(settings.fetch).toBe(customFetch)
+    })
   })
 
   describe('CherryIn routing (default chat endpoint upgrades to cherryin-chat variant)', () => {

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -736,9 +736,18 @@ function buildCherryinConfig(ctx: BuilderContext): ProviderConfig {
   }
 }
 
-function formatAzureBaseURL(baseURL: string, forAnthropic: boolean): string {
+function formatAzureBaseURL(baseURL: string, forAnthropic: boolean, includeApiVersion = false): string {
   const normalized = baseURL.replace(/\/v1$/, '').replace(/\/openai$/, '')
-  return forAnthropic ? normalized : normalized + '/openai'
+  return forAnthropic ? normalized : `${normalized}/openai${includeApiVersion ? '/v1' : ''}`
+}
+
+function isOfficialAzureOpenAIBaseURL(baseURL: string): boolean {
+  const hostname = new URL(baseURL).hostname
+  return (
+    hostname.endsWith('.openai.azure.com') ||
+    hostname.endsWith('.services.ai.azure.com') ||
+    hostname.endsWith('.cognitiveservices.azure.com')
+  )
 }
 
 function buildAzureConfig(
@@ -762,20 +771,31 @@ function buildAzureConfig(
 
   const apiVersion = ctx.actualProvider.settings?.apiVersion?.trim()
   const isResponsesVariant = ctx.aiSdkProviderId === 'azure-responses'
+  const useDeploymentBasedUrls = Boolean(apiVersion && !isResponsesVariant)
+  const useCustomGatewayV1 = !isOfficialAzureOpenAIBaseURL(ctx.baseConfig.baseURL) && !useDeploymentBasedUrls
 
   const providerSettings: AppProviderSettingsMap['azure'] & {
     apiVersion?: string
     useDeploymentBasedUrls?: boolean
   } = {
     ...ctx.baseConfig,
-    baseURL: formatAzureBaseURL(ctx.baseConfig.baseURL, false),
+    baseURL: formatAzureBaseURL(ctx.baseConfig.baseURL, false, useCustomGatewayV1),
     headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) }
   }
 
   if (apiVersion) {
     providerSettings.apiVersion = apiVersion
-    if (!isResponsesVariant) {
+    if (useDeploymentBasedUrls) {
       providerSettings.useDeploymentBasedUrls = true
+    }
+  }
+
+  if (useCustomGatewayV1) {
+    // The Azure SDK treats non-Azure hosts as complete URLs, so preserve Cherry's v1/version contract here.
+    providerSettings.fetch = (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input)
+      url.searchParams.set('api-version', apiVersion || 'v1')
+      return customFetch(url, init)
     }
   }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Azure custom gateways could lose the `/v1` path and `api-version` query after the AI SDK upgrade.

After this PR: Non-deployment custom gateway requests preserve those URL semantics while official Azure and deployment-based routes remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20149

### Why we need it and why it was done in this way

The following tradeoffs were made: Official-host detection mirrors the current Azure SDK contract so compatibility handling stays limited to custom gateways.

The following alternatives were considered: Patching the dependency or switching adapters would broaden the change and risk altering Azure authentication behavior.

Links to places where the discussion took place: #20149

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Validated with the focused main-process test suite, `pnpm lint`, and `pnpm test:lint`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Azure OpenAI] Restored `/v1` and `api-version` request URLs for custom gateways.
```
