### PR TITLE
fix(pi-runtime): resume context-clamped length responses after compaction

### DIFF
--- a/patches/@earendil-works__pi-coding-agent@0.80.3.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.80.3.patch
@@ -1,0 +1,39 @@
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -313,7 +313,7 @@
+             if (event.message.role === "assistant") {
+                 this._lastAssistantMessage = event.message;
+                 const assistantMsg = event.message;
+-                if (assistantMsg.stopReason !== "error") {
++                if (assistantMsg.stopReason !== "error" && assistantMsg.stopReason !== "length") {
+                     this._overflowRecoveryAttempted = false;
+                 }
+                 // Reset retry counter immediately on successful assistant response
+@@ -1449,11 +1449,12 @@
+         if (assistantIsFromBeforeCompaction) {
+             return false;
+         }
+-        // Case 1: Overflow - LLM returned context overflow error, or reported usage exceeded
+-        // the configured window. A successful response over the configured window should compact
+-        // but must not retry: the assistant answer already completed and agent.continue() cannot
+-        // continue from an assistant message.
+-        if (sameModel && isContextOverflow(assistantMessage, contextWindow)) {
++        // Backport earendil-works/pi#7540: recover context-clamped length stops once,
++        // but do not retry a response that reached the model's configured output limit.
++        const desiredMaxOutput = this.model?.maxTokens ?? 0;
++        const recoverableLength = assistantMessage.stopReason === "length" &&
++            desiredMaxOutput > 0 && assistantMessage.usage.output < desiredMaxOutput;
++        if (sameModel && (isContextOverflow(assistantMessage, contextWindow) || recoverableLength)) {
+             const willRetry = assistantMessage.stopReason !== "stop";
+             if (!willRetry) {
+                 return await this._runAutoCompaction("overflow", false);
+@@ -1622,7 +1623,7 @@
+             if (willRetry) {
+                 const messages = this.agent.state.messages;
+                 const lastMsg = messages[messages.length - 1];
+-                if (lastMsg?.role === "assistant" && lastMsg.stopReason === "error") {
++                if (lastMsg?.role === "assistant" && (lastMsg.stopReason === "error" || lastMsg.stopReason === "length")) {
+                     this.agent.state.messages = messages.slice(0, -1);
+                 }
+                 return true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,7 @@ patchedDependencies:
   '@ai-sdk/react@3.0.187': 8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230
   '@deepseek-ai/dsh-llm-pi-ai@0.1.0-rc.7': 9c4deb543997ef0b40cf4a39f177e8edbb42c486c74e756bfdd451b0620c28ed
   '@earendil-works/pi-ai@0.80.6': ba8ed726a49dbae25d6871297718ce26e45a491ec81e2183810cf018c0ec0206
+  '@earendil-works/pi-coding-agent@0.80.3': 1717b3290d2aaa3819537bd040f531534184c38f2e8c0e6d6b52fdb1ed02b564
   '@napi-rs/system-ocr@1.1.0': aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde
   '@openrouter/ai-sdk-provider@2.10.0': fe61d9ff590828fc0fd3f8b3b8b88a4a1b736a99b595a276c8df9e12c9498009
   '@opeoginni/github-copilot-openai-compatible@1.0.0': 4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25
@@ -108,7 +109,7 @@ importers:
         version: 0.80.6(patch_hash=ba8ed726a49dbae25d6871297718ce26e45a491ec81e2183810cf018c0ec0206)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.4))(ws@8.21.0)(zod@4.3.4)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.3
-        version: 0.80.3(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.4))(ws@8.21.0)(zod@4.3.4)
+        version: 0.80.3(patch_hash=1717b3290d2aaa3819537bd040f531534184c38f2e8c0e6d6b52fdb1ed02b564)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.4))(ws@8.21.0)(zod@4.3.4)
       '@firecrawl/anydoc':
         specifier: 0.1.3
         version: 0.1.3
@@ -18607,7 +18608,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.80.3(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.4))(ws@8.21.0)(zod@4.3.4)':
+  '@earendil-works/pi-coding-agent@0.80.3(patch_hash=1717b3290d2aaa3819537bd040f531534184c38f2e8c0e6d6b52fdb1ed02b564)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.4))(ws@8.21.0)(zod@4.3.4)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.80.10(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.4))(ws@8.21.0)(zod@4.3.4)
       '@earendil-works/pi-ai': 0.80.6(patch_hash=ba8ed726a49dbae25d6871297718ce26e45a491ec81e2183810cf018c0ec0206)(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.4))(ws@8.21.0)(zod@4.3.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,6 +99,7 @@ patchedDependencies:
   # rc.7's pi-ai schema drops developer-role compatibility even though its underlying pi-ai model supports it.
   '@deepseek-ai/dsh-llm-pi-ai@0.1.0-rc.7': patches/@deepseek-ai__dsh-llm-pi-ai@0.1.0-rc.7.patch
   '@earendil-works/pi-ai@0.80.6': patches/@earendil-works__pi-ai@0.80.6.patch
+  '@earendil-works/pi-coding-agent@0.80.3': patches/@earendil-works__pi-coding-agent@0.80.3.patch
 
 allowBuilds:
   '@deepseek-ai/dsh-subprocess-local': true

--- a/src/main/ai/runtime/pi/piLengthRecovery.test.ts
+++ b/src/main/ai/runtime/pi/piLengthRecovery.test.ts
@@ -101,7 +101,9 @@ async function createSession(responses: ReturnType<typeof response>[], cancelCom
   const contexts: Context[] = []
   const events: AgentSessionEvent[] = []
   session.subscribe((event) => events.push(event))
-  session.agent.streamFn = (_model, context) => {
+  // pi-agent-core resolves its own @earendil-works/pi-ai copy, so its AssistantMessageEventStream
+  // is a nominally distinct class from ours; the runtime object is the same shape.
+  session.agent.streamFn = ((_model: Model<'openai-completions'>, context: Context) => {
     contexts.push(structuredClone(context))
     const message = responses[contexts.length - 1]
     if (!message) throw new Error('Unexpected extra provider request')
@@ -110,7 +112,7 @@ async function createSession(responses: ReturnType<typeof response>[], cancelCom
     stream.push({ type: 'done', reason: message.stopReason, message })
     stream.end()
     return stream
-  }
+  }) as unknown as typeof session.agent.streamFn
   return { session, contexts, events }
 }
 

--- a/src/main/ai/runtime/pi/piLengthRecovery.test.ts
+++ b/src/main/ai/runtime/pi/piLengthRecovery.test.ts
@@ -1,0 +1,188 @@
+import {
+  type AssistantMessage,
+  type Context,
+  createAssistantMessageEventStream,
+  type Model
+} from '@earendil-works/pi-ai'
+import {
+  type AgentSessionEvent,
+  AuthStorage,
+  createAgentSession,
+  DefaultResourceLoader,
+  ModelRegistry,
+  SessionManager,
+  SettingsManager
+} from '@earendil-works/pi-coding-agent'
+import { describe, expect, it } from 'vitest'
+
+const model: Model<'openai-completions'> = {
+  id: 'length-recovery-test',
+  name: 'Length recovery test',
+  api: 'openai-completions',
+  provider: 'length-recovery-test',
+  baseUrl: 'https://example.invalid/v1',
+  reasoning: false,
+  input: ['text'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 10_000,
+  maxTokens: 1_000
+}
+
+function response(
+  stopReason: 'length' | 'stop',
+  output: number,
+  text: string
+): AssistantMessage & { stopReason: 'length' | 'stop' } {
+  return {
+    role: 'assistant',
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    content: [{ type: 'text', text }],
+    stopReason,
+    usage: {
+      input: 8_000,
+      output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 8_000 + output,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+    },
+    // Keep provider responses newer than compaction boundaries even within the same millisecond.
+    timestamp: Date.now() + 10_000
+  }
+}
+
+async function createSession(responses: ReturnType<typeof response>[], cancelCompaction = false) {
+  const cwd = process.cwd()
+  const settingsManager = SettingsManager.inMemory({
+    compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 1 },
+    retry: { enabled: false }
+  })
+  const resourceLoader = new DefaultResourceLoader({
+    cwd,
+    agentDir: cwd,
+    settingsManager,
+    noExtensions: true,
+    noSkills: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+    extensionFactories: [
+      (pi) => {
+        pi.on('session_before_compact', async (event) => {
+          if (cancelCompaction) return { cancel: true }
+          return {
+            compaction: {
+              summary: 'Synthetic summary',
+              firstKeptEntryId: event.preparation.firstKeptEntryId,
+              tokensBefore: event.preparation.tokensBefore
+            }
+          }
+        })
+      }
+    ]
+  })
+  await resourceLoader.reload()
+  const authStorage = AuthStorage.inMemory()
+  authStorage.setRuntimeApiKey(model.provider, 'synthetic-test-key')
+  const modelRegistry = ModelRegistry.inMemory(authStorage)
+  const { session } = await createAgentSession({
+    cwd,
+    model,
+    authStorage,
+    modelRegistry,
+    settingsManager,
+    resourceLoader,
+    sessionManager: SessionManager.inMemory(cwd),
+    tools: []
+  })
+  await session.bindExtensions({})
+  const contexts: Context[] = []
+  const events: AgentSessionEvent[] = []
+  session.subscribe((event) => events.push(event))
+  session.agent.streamFn = (_model, context) => {
+    contexts.push(structuredClone(context))
+    const message = responses[contexts.length - 1]
+    if (!message) throw new Error('Unexpected extra provider request')
+    const stream = createAssistantMessageEventStream()
+    stream.push({ type: 'start', partial: message })
+    stream.push({ type: 'done', reason: message.stopReason, message })
+    stream.end()
+    return stream
+  }
+  return { session, contexts, events }
+}
+
+describe('Pi context-clamped length recovery SDK contract', () => {
+  it('compacts once and continues without replaying the truncated assistant response', async () => {
+    const { session, contexts, events } = await createSession([
+      response('length', 1, 'truncated response'),
+      response('stop', 10, 'completed response')
+    ])
+    try {
+      await session.prompt('Synthetic context. '.repeat(500))
+
+      expect(contexts).toHaveLength(2)
+      expect(events.filter((event) => event.type === 'compaction_start')).toHaveLength(1)
+      expect(contexts[1].messages).not.toContainEqual(expect.objectContaining({ role: 'assistant' }))
+      expect(session.messages.at(-1)).toEqual(expect.objectContaining({ stopReason: 'stop' }))
+      expect(session.sessionManager.getEntries()).toContainEqual(
+        expect.objectContaining({
+          type: 'message',
+          message: expect.objectContaining({ stopReason: 'length' })
+        })
+      )
+    } finally {
+      session.dispose()
+    }
+  })
+
+  it('does not repeat compact-and-retry when the recovery response is also truncated', async () => {
+    const { session, contexts, events } = await createSession([
+      response('length', 1, 'first truncation'),
+      response('length', 1, 'second truncation')
+    ])
+    try {
+      await session.prompt('Synthetic context. '.repeat(500))
+
+      expect(contexts).toHaveLength(2)
+      expect(events.filter((event) => event.type === 'compaction_start')).toHaveLength(1)
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: 'compaction_end',
+          willRetry: false,
+          errorMessage: expect.stringContaining('one compact-and-retry attempt')
+        })
+      )
+    } finally {
+      session.dispose()
+    }
+  })
+
+  it('does not recover a response that reached the configured output limit', async () => {
+    const { session, contexts, events } = await createSession([response('length', model.maxTokens, 'output capped')])
+    try {
+      await session.prompt('Synthetic context. '.repeat(500))
+
+      expect(contexts).toHaveLength(1)
+      expect(events.filter((event) => event.type === 'compaction_start')).toHaveLength(0)
+    } finally {
+      session.dispose()
+    }
+  })
+
+  it('does not continue when compaction is cancelled', async () => {
+    const { session, contexts, events } = await createSession([response('length', 1, 'truncated response')], true)
+    try {
+      await session.prompt('Synthetic context. '.repeat(500))
+
+      expect(contexts).toHaveLength(1)
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: 'compaction_end', aborted: true, willRetry: false })
+      )
+    } finally {
+      session.dispose()
+    }
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!-- Thanks for sending a pull request! Consider opening it as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md -->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Pi Work could stop after successful compaction when context pressure clamped a response below the model's intended output limit. The user had to send another message to resume. Reporting `length` as an error in #19571 did not restore this recovery path.

After this PR:

The pinned coding-agent makes one compact-and-retry attempt for a length-stopped response whose output is below the model's intended output cap. A second truncated response does not reset the recovery guard. The rebuilt context excludes a retained trailing truncated assistant response so continuation can proceed. Genuine full-output-cap responses and cancelled compactions are not automatically continued.

Fixes #20160

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Backport the three relevant `AgentSession` changes from [earendil-works/pi#7540](https://github.com/earendil-works/pi/pull/7540) using the existing pnpm patched-dependency mechanism.
- Keep the dependency pinned at 0.80.3 and inline the small recovery predicate to avoid requiring another Pi export/API change.
- Add synthetic tests against the real SDK session rather than replacing the session with a mock.

The following alternatives were considered:

- A broader SDK upgrade also changes other integration contracts and is not required for this fix.
- Unconditional auto-continuation would hide genuine output-cap stops or risk retry loops.
- The later [post-tool compaction change, pi#8782](https://github.com/earendil-works/pi/pull/8782), is useful prevention work but changes loop-hook timing and is kept out of this PR.

Links to places where the discussion took place: #20160; related but distinct fixes #19457 and #19571; upstream pi#7540 linked above.

### Breaking changes

None. No dependency version changes, new settings, schema changes or migration changes.

### Special notes for your reviewer

Validation (Node 24.15.0, pnpm 11.8.0, Vitest 3.2.7):

- The same new real-SDK test file against unpatched coding-agent 0.80.3: 3 failed / 1 passed, reproducing the missing recovery.
- Against an independent copy of that SDK with this exact patch: 4 / 4 passed. The isolated Vitest config skips application-native setup, not the Pi SDK or its session loop.
- TypeScript 5.9.3 strict type-check of the new test, Biome format, targeted `simple-import-sort`, `git diff --check`, and `git apply --check` against the unpatched SDK: passed.
- `pnpm install --frozen-lockfile --lockfile-only --ignore-scripts --offline`: passed.
- Full application lint/build/test suite was not completed: the full dependency download timed out. This PR does not claim full CI or a new long-running live-model task has passed. Maintainer-approved CI should run the normal repository checks.

All reproduction data is synthetic. No private conversation content, task files, application logs, local paths, endpoint addresses or credentials are included. The example API key and `example.invalid` URL in the tests are inert fixtures; the custom stream handles requests in memory.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

Documentation note: this restores automatic recovery with no new user action or setting, so a separate user-guide update is not required. No unrelated refactoring is included.

### Release note

```release-note
[Work] Resume Pi tasks after context-clamped length responses with one bounded compact-and-retry attempt.
```
