### PR TITLE
fix(context-management): restore follow-current-model option

### DIFF
--- a/src/renderer/components/DefaultModelSelector.tsx
+++ b/src/renderer/components/DefaultModelSelector.tsx
@@ -18,6 +18,7 @@ export interface ModelSelectorTriggerProps extends Omit<ComponentProps<typeof Bu
 export interface DefaultModelSelectorProps extends ModelSelectorTriggerProps {
   filter: ModelSelectorFilter
   isModelDisabled?: ModelSelectorFilter
+  noneOptionLabel?: string
   onSelect: (model: Model | undefined) => void
 }
 
@@ -69,6 +70,7 @@ export const DefaultModelSelector: FC<DefaultModelSelectorProps> = ({
   compact,
   filter,
   isModelDisabled,
+  noneOptionLabel,
   onSelect
 }) => (
   <ModelSelector
@@ -77,6 +79,7 @@ export const DefaultModelSelector: FC<DefaultModelSelectorProps> = ({
     onSelect={onSelect}
     filter={filter}
     isModelDisabled={isModelDisabled}
+    noneOptionLabel={noneOptionLabel}
     trigger={
       <ModelSelectorTriggerButton model={model} providers={providers} placeholder={placeholder} compact={compact} />
     }

--- a/src/renderer/pages/settings/GeneralSettings/ContextManagementSettings.tsx
+++ b/src/renderer/pages/settings/GeneralSettings/ContextManagementSettings.tsx
@@ -190,6 +190,7 @@ export const ContextManagementSettings = () => {
                     filter={chatModelFilter}
                     onSelect={handleSelectCompressModel}
                     placeholder={t('settings.models.context_management.compress_model_follow')}
+                    noneOptionLabel={t('settings.models.context_management.compress_model_follow')}
                   />
                 </div>
               </SettingRow>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Selecting a specific context compression model removed the ability to return to "Follow current model" from the global settings selector.

After this PR: The selector includes "Follow current model". Selecting it clears the explicit compression model preference and restores the existing current-request-model fallback, subject to assistant overrides.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20146

### Why we need it and why it was done in this way

The following tradeoffs were made: Add an optional `noneOptionLabel` passthrough to `DefaultModelSelector`, reusing the existing clearing action and translation. Other callers remain unchanged.

The following alternatives were considered: A page-specific reset control or a synthetic model entry would duplicate behavior already supported by `ModelSelector`.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20146 <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None. No migration or user action is required.

### Special notes for your reviewer

<!-- optional -->

Static review completed. Biome formatting and ESLint checks passed through the commit hooks. Automated tests and Electron UI validation were not run during this submission workflow.

Suggested manual verification: select a specific compression model, switch back to "Follow current model", reopen settings, and confirm that the choice persists. With no assistant override, compression should use the current request model.

No separate user-guide update is required for restoring this existing behavior. Refactoring is N/A.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed the context compression model selector so users can switch back to "Follow current model" after choosing a specific model.
```
