### PR TITLE
feat(data-migration): record v1 migration origin

### DIFF
--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -207,7 +207,7 @@ export class MigrationEngine {
     }
 
     logger.info('Fresh install detected (no legacy data found), skipping migration')
-    await this.markCompleted()
+    await this.markCompleted(false)
     return false
   }
 
@@ -346,7 +346,7 @@ export class MigrationEngine {
       this.verifyForeignKeys()
 
       // Mark migration completed
-      await this.markCompleted()
+      await this.markCompleted(true)
 
       logger.info('Migration completed successfully', {
         totalDuration: Date.now() - startTime,
@@ -573,6 +573,7 @@ export class MigrationEngine {
       this.clearMigrationData(tx)
       this.upsertMigrationStatus(tx, {
         status: 'completed',
+        migratedFromV1: false,
         completedAt: Date.now(),
         version: '2.0.0',
         error: null
@@ -583,9 +584,10 @@ export class MigrationEngine {
   /**
    * Mark migration as completed in app_state
    */
-  private async markCompleted(): Promise<void> {
+  private async markCompleted(migratedFromV1: boolean): Promise<void> {
     this.upsertMigrationStatus(this.getDb(), {
       status: 'completed',
+      migratedFromV1,
       completedAt: Date.now(),
       version: '2.0.0',
       error: null
@@ -598,6 +600,7 @@ export class MigrationEngine {
   private async markFailed(error: string): Promise<void> {
     this.upsertMigrationStatus(this.getDb(), {
       status: 'failed',
+      migratedFromV1: false,
       failedAt: Date.now(),
       version: '2.0.0',
       error: error

--- a/src/main/data/migration/v2/core/__tests__/MigrationEngine.skip.test.ts
+++ b/src/main/data/migration/v2/core/__tests__/MigrationEngine.skip.test.ts
@@ -1,5 +1,5 @@
 /**
- * skipMigration() against a real database.
+ * Migration completion status and skipMigration() against a real database.
  *
  * Migration is not one big transaction, so a failed run leaves committed
  * migrator data behind. Skipping must clear everything migration wrote (shared
@@ -25,6 +25,10 @@ vi.mock('@main/data/bootConfig', () => ({
   }
 }))
 
+vi.mock('../MigrationContext', () => ({
+  createMigrationContext: vi.fn().mockResolvedValue({})
+}))
+
 const MIGRATION_V2_STATUS = 'migration_v2_status'
 
 const failedStatus: MigrationStatusValue = {
@@ -34,14 +38,16 @@ const failedStatus: MigrationStatusValue = {
   error: 'ChatMigrator execute failed'
 }
 
-describe('MigrationEngine.skipMigration', () => {
+describe('MigrationEngine migration status and skipMigration', () => {
   const dbh = setupTestDatabase()
   let engine: MigrationEngine
 
   beforeEach(() => {
     vi.clearAllMocks()
     engine = new MigrationEngine()
+    ;(engine as any)._paths = { migrationDexieExportDir: '/tmp/cherry-migration-test' }
     ;(engine as any).migrationDb = { getDb: () => dbh.db, close: vi.fn() }
+    vi.spyOn(engine as any, 'cleanupTempFiles').mockResolvedValue(undefined)
   })
 
   /** Rows a partially-failed run would leave behind: business data + schedules. */
@@ -73,6 +79,38 @@ describe('MigrationEngine.skipMigration', () => {
     return row?.value as MigrationStatusValue | undefined
   }
 
+  it('records a fresh install as not migrated from v1', async () => {
+    vi.spyOn(engine as any, 'hasLegacyData').mockReturnValue(false)
+
+    await expect(engine.needsMigration()).resolves.toBe(false)
+
+    expect(readStatus()).toMatchObject({ status: 'completed', migratedFromV1: false })
+  })
+
+  it('records a successful migration as migrated from v1', async () => {
+    await expect(engine.run({}, '/tmp/cherry-migration-test')).resolves.toMatchObject({ success: true })
+
+    expect(readStatus()).toMatchObject({ status: 'completed', migratedFromV1: true })
+  })
+
+  it('does not record a failed migration as migrated from v1', async () => {
+    engine.registerMigrators([
+      {
+        id: 'failing',
+        name: 'failing',
+        order: 1,
+        reset: vi.fn(),
+        setProgressCallback: vi.fn(),
+        prepare: vi.fn().mockResolvedValue({ success: true, itemCount: 1 }),
+        execute: vi.fn().mockResolvedValue({ success: false, processedCount: 0, error: 'failed' })
+      } as any
+    ])
+
+    await expect(engine.run({}, '/tmp/cherry-migration-test')).resolves.toMatchObject({ success: false })
+
+    expect(readStatus()).toMatchObject({ status: 'failed', migratedFromV1: false })
+  })
+
   it('clears migrated rows and agent.task schedules, keeps other schedules, and marks completed', async () => {
     seedMigratedData()
 
@@ -81,7 +119,7 @@ describe('MigrationEngine.skipMigration', () => {
     expect(dbh.db.select().from(preferenceTable).all()).toHaveLength(0)
     const schedules = dbh.db.select().from(jobScheduleTable).all()
     expect(schedules.map((s) => s.type)).toEqual(['other.job'])
-    expect(readStatus()).toMatchObject({ status: 'completed', error: null })
+    expect(readStatus()).toMatchObject({ status: 'completed', migratedFromV1: false, error: null })
   })
 
   it('restores hardware acceleration to its default and never touches user_data_path', async () => {

--- a/src/shared/data/migration/v2/types.ts
+++ b/src/shared/data/migration/v2/types.ts
@@ -121,6 +121,8 @@ export interface MigrationResult {
 // Migration status stored in app_state table
 export interface MigrationStatusValue {
   status: 'completed' | 'failed' | 'in_progress'
+  /** True only when a v1-to-v2 migration completed successfully. Missing on historical records. */
+  migratedFromV1?: boolean
   completedAt?: number
   failedAt?: number
   version: string


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The `migration_v2_status` database record used the same completed value for successful v1 migrations, fresh installs, and skipped migrations, so callers could not identify migrated users from SQLite.

After this PR:

The existing status JSON records `migratedFromV1: true` only after a successful v1-to-v2 migration and `false` for fresh installs, skipped migrations, and failed migrations. Historical records remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Migration origin needs to be queryable from the database without inferring it from business data or filesystem history. The marker is stored inside the existing `app_state` JSON value, so no schema migration or additional table is required.

The following tradeoffs were made:

- Historical completed records without the field remain unknown rather than being backfilled from weaker evidence.
- The optional type preserves compatibility with those historical records.

The following alternatives were considered:

- A separate `app_state` key or database column was rejected because the existing migration status already owns this state.
- Backfilling from `version.log` was excluded because historical users are outside this change's scope.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Focused migration tests cover successful migration, fresh installation, skipped migration, and failed migration. `pnpm lint` passed; its 45 pre-existing renderer warnings are unrelated to this change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
