### PR TITLE
fix(provider-service): show all providers for v1 upgrades

### DIFF
--- a/src/main/data/migration/v1MigrationOrigin.ts
+++ b/src/main/data/migration/v1MigrationOrigin.ts
@@ -1,0 +1,12 @@
+type MigrationOriginReader = () => boolean
+
+let readMigrationOrigin: MigrationOriginReader = () => false
+
+export function isMigratedFromV1(): boolean {
+  return readMigrationOrigin()
+}
+
+/** Registered by MigrationEngine when its singleton is initialized. */
+export function registerMigrationOriginReader(reader: MigrationOriginReader): void {
+  readMigrationOrigin = reader
+}

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -126,6 +126,7 @@ export class MigrationEngine {
   private migrationDb: MigrationDbService | null = null
   private _paths: MigrationPaths | null = null
   private legacyDataConfirmed = false
+  private migratedFromV1 = false
 
   get paths(): MigrationPaths {
     if (!this._paths) {
@@ -155,6 +156,11 @@ export class MigrationEngine {
   close(): void {
     this.migrationDb?.close()
     this.migrationDb = null
+  }
+
+  /** Whether this profile completed a v1-to-v2 migration, restored during preboot. */
+  isMigratedFromV1(): boolean {
+    return this.migratedFromV1
   }
 
   private getDb(): DbType {
@@ -198,6 +204,7 @@ export class MigrationEngine {
 
     if (status?.value) {
       const statusValue = status.value as MigrationStatusValue
+      this.migratedFromV1 = statusValue.status === 'completed' && statusValue.migratedFromV1 === true
       return statusValue.status !== 'completed'
     }
 
@@ -579,6 +586,7 @@ export class MigrationEngine {
         error: null
       })
     })
+    this.migratedFromV1 = false
   }
 
   /**
@@ -592,6 +600,7 @@ export class MigrationEngine {
       version: '2.0.0',
       error: null
     })
+    this.migratedFromV1 = migratedFromV1
   }
 
   /**
@@ -605,6 +614,7 @@ export class MigrationEngine {
       version: '2.0.0',
       error: error
     })
+    this.migratedFromV1 = false
   }
 
   private upsertMigrationStatus(executor: DbType | DbTransaction, statusValue: MigrationStatusValue): void {

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -44,6 +44,7 @@ import { translateLanguageTable } from '@data/db/schemas/translateLanguage'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import type { DbType } from '@data/db/types'
+import { registerMigrationOriginReader } from '@data/migration/v1MigrationOrigin'
 import { loggerService } from '@logger'
 import { bootConfigService } from '@main/data/bootConfig'
 import { DefaultBootConfig } from '@shared/data/bootConfig/bootConfigSchemas'
@@ -637,3 +638,5 @@ export class MigrationEngine {
 
 // Export singleton instance
 export const migrationEngine = new MigrationEngine()
+
+registerMigrationOriginReader(() => migrationEngine.isMigratedFromV1())

--- a/src/main/data/migration/v2/core/__tests__/MigrationEngine.skip.test.ts
+++ b/src/main/data/migration/v2/core/__tests__/MigrationEngine.skip.test.ts
@@ -85,12 +85,28 @@ describe('MigrationEngine migration status and skipMigration', () => {
     await expect(engine.needsMigration()).resolves.toBe(false)
 
     expect(readStatus()).toMatchObject({ status: 'completed', migratedFromV1: false })
+    expect(engine.isMigratedFromV1()).toBe(false)
   })
 
   it('records a successful migration as migrated from v1', async () => {
     await expect(engine.run({}, '/tmp/cherry-migration-test')).resolves.toMatchObject({ success: true })
 
     expect(readStatus()).toMatchObject({ status: 'completed', migratedFromV1: true })
+    expect(engine.isMigratedFromV1()).toBe(true)
+  })
+
+  it('restores the v1 migration origin from a completed status', async () => {
+    dbh.db
+      .insert(appStateTable)
+      .values({
+        key: MIGRATION_V2_STATUS,
+        value: { status: 'completed', migratedFromV1: true, version: '2.0.0' } satisfies MigrationStatusValue
+      })
+      .run()
+
+    await expect(engine.needsMigration()).resolves.toBe(false)
+
+    expect(engine.isMigratedFromV1()).toBe(true)
   })
 
   it('does not record a failed migration as migrated from v1', async () => {
@@ -109,6 +125,7 @@ describe('MigrationEngine migration status and skipMigration', () => {
     await expect(engine.run({}, '/tmp/cherry-migration-test')).resolves.toMatchObject({ success: false })
 
     expect(readStatus()).toMatchObject({ status: 'failed', migratedFromV1: false })
+    expect(engine.isMigratedFromV1()).toBe(false)
   })
 
   it('clears migrated rows and agent.task schedules, keeps other schedules, and marks completed', async () => {
@@ -120,6 +137,7 @@ describe('MigrationEngine migration status and skipMigration', () => {
     const schedules = dbh.db.select().from(jobScheduleTable).all()
     expect(schedules.map((s) => s.type)).toEqual(['other.job'])
     expect(readStatus()).toMatchObject({ status: 'completed', migratedFromV1: false, error: null })
+    expect(engine.isMigratedFromV1()).toBe(false)
   })
 
   it('restores hardware acceleration to its default and never touches user_data_path', async () => {

--- a/src/main/data/services/ProviderService.ts
+++ b/src/main/data/services/ProviderService.ts
@@ -13,6 +13,7 @@ import type { InsertUserProviderRow, UserProviderRow } from '@data/db/schemas/us
 import { type StoredEndpointConfigOverride, userProviderTable } from '@data/db/schemas/userProvider'
 import { type SqliteErrorHandlers, withSqliteErrors } from '@data/db/sqliteErrors'
 import type { DbType } from '@data/db/types'
+import { migrationEngine } from '@data/migration/v2'
 import { getDataService, registerDataService } from '@data/services/dataServiceRegistry'
 import { pinService } from '@data/services/PinService'
 import type { ProviderDisplayMetadata } from '@data/services/ProviderRegistryService'
@@ -71,7 +72,7 @@ type ProviderIdentity = Pick<UserProviderRow, 'providerId' | 'presetProviderId'>
 
 function isProviderAvailableInCurrentEdition(provider: Pick<Provider, 'availableInEditions'>): boolean {
   const availableInEditions = provider.availableInEditions
-  return !availableInEditions || availableInEditions.includes(getAppEdition())
+  return migrationEngine.isMigratedFromV1() || !availableInEditions || availableInEditions.includes(getAppEdition())
 }
 
 function getAvailableProviderMetadata(row: ProviderIdentity): ProviderDisplayMetadata | null {

--- a/src/main/data/services/ProviderService.ts
+++ b/src/main/data/services/ProviderService.ts
@@ -7,13 +7,13 @@
  */
 
 import { application } from '@application'
-import { appStateTable } from '@data/db/schemas/appState'
 import { providerLogoFileRefTable } from '@data/db/schemas/fileRelations'
 import { userModelTable } from '@data/db/schemas/userModel'
 import type { InsertUserProviderRow, UserProviderRow } from '@data/db/schemas/userProvider'
 import { type StoredEndpointConfigOverride, userProviderTable } from '@data/db/schemas/userProvider'
 import { type SqliteErrorHandlers, withSqliteErrors } from '@data/db/sqliteErrors'
 import type { DbType } from '@data/db/types'
+import { isMigratedFromV1 } from '@data/migration/v1MigrationOrigin'
 import { getDataService, registerDataService } from '@data/services/dataServiceRegistry'
 import { pinService } from '@data/services/PinService'
 import type { ProviderDisplayMetadata } from '@data/services/ProviderRegistryService'
@@ -29,7 +29,6 @@ import { getAppEdition } from '@main/utils/appEdition'
 import { DataApiError, DataApiErrorFactory, ErrorCode } from '@shared/data/api/errors'
 import type { OrderBatchRequest, OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { CreateProviderDto, ListProvidersQuery, UpdateProviderDto } from '@shared/data/api/schemas/providers'
-import type { MigrationStatusValue } from '@shared/data/migration/v2/types'
 import { isManagedCherryProviderId } from '@shared/data/presets/cherryai'
 import type { EndpointType } from '@shared/data/types/model'
 import type {
@@ -49,7 +48,6 @@ import { v4 as uuidv4 } from 'uuid'
 import { isRetiredProvider } from '../retiredProviders'
 
 const logger = loggerService.withContext('DataApi:ProviderService')
-const MIGRATION_V2_STATUS = 'migration_v2_status'
 
 function applyJsonMergePatch(target: unknown, patch: unknown): unknown {
   if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) return patch
@@ -74,7 +72,7 @@ type ProviderIdentity = Pick<UserProviderRow, 'providerId' | 'presetProviderId'>
 
 function isProviderAvailableInCurrentEdition(provider: Pick<Provider, 'availableInEditions'>): boolean {
   const availableInEditions = provider.availableInEditions
-  return providerService.isMigratedFromV1() || !availableInEditions || availableInEditions.includes(getAppEdition())
+  return isMigratedFromV1() || !availableInEditions || availableInEditions.includes(getAppEdition())
 }
 
 function getAvailableProviderMetadata(row: ProviderIdentity): ProviderDisplayMetadata | null {
@@ -331,25 +329,6 @@ function rotationCacheKey(providerId: string): string {
 }
 
 class ProviderService {
-  private migratedFromV1: boolean | undefined
-
-  /** Migration status is immutable after preboot, so the first database read is cached. */
-  isMigratedFromV1(): boolean {
-    if (this.migratedFromV1 === undefined) {
-      const row = application
-        .get('DbService')
-        .getDb()
-        .select({ value: appStateTable.value })
-        .from(appStateTable)
-        .where(eq(appStateTable.key, MIGRATION_V2_STATUS))
-        .get()
-      const status = row?.value as MigrationStatusValue | undefined
-      this.migratedFromV1 = status?.status === 'completed' && status.migratedFromV1 === true
-    }
-
-    return this.migratedFromV1
-  }
-
   private rethrowOrderError(error: unknown): never {
     if (
       error instanceof DataApiError &&

--- a/src/main/data/services/ProviderService.ts
+++ b/src/main/data/services/ProviderService.ts
@@ -7,13 +7,13 @@
  */
 
 import { application } from '@application'
+import { appStateTable } from '@data/db/schemas/appState'
 import { providerLogoFileRefTable } from '@data/db/schemas/fileRelations'
 import { userModelTable } from '@data/db/schemas/userModel'
 import type { InsertUserProviderRow, UserProviderRow } from '@data/db/schemas/userProvider'
 import { type StoredEndpointConfigOverride, userProviderTable } from '@data/db/schemas/userProvider'
 import { type SqliteErrorHandlers, withSqliteErrors } from '@data/db/sqliteErrors'
 import type { DbType } from '@data/db/types'
-import { migrationEngine } from '@data/migration/v2'
 import { getDataService, registerDataService } from '@data/services/dataServiceRegistry'
 import { pinService } from '@data/services/PinService'
 import type { ProviderDisplayMetadata } from '@data/services/ProviderRegistryService'
@@ -29,6 +29,7 @@ import { getAppEdition } from '@main/utils/appEdition'
 import { DataApiError, DataApiErrorFactory, ErrorCode } from '@shared/data/api/errors'
 import type { OrderBatchRequest, OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { CreateProviderDto, ListProvidersQuery, UpdateProviderDto } from '@shared/data/api/schemas/providers'
+import type { MigrationStatusValue } from '@shared/data/migration/v2/types'
 import { isManagedCherryProviderId } from '@shared/data/presets/cherryai'
 import type { EndpointType } from '@shared/data/types/model'
 import type {
@@ -48,6 +49,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { isRetiredProvider } from '../retiredProviders'
 
 const logger = loggerService.withContext('DataApi:ProviderService')
+const MIGRATION_V2_STATUS = 'migration_v2_status'
 
 function applyJsonMergePatch(target: unknown, patch: unknown): unknown {
   if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) return patch
@@ -72,7 +74,7 @@ type ProviderIdentity = Pick<UserProviderRow, 'providerId' | 'presetProviderId'>
 
 function isProviderAvailableInCurrentEdition(provider: Pick<Provider, 'availableInEditions'>): boolean {
   const availableInEditions = provider.availableInEditions
-  return migrationEngine.isMigratedFromV1() || !availableInEditions || availableInEditions.includes(getAppEdition())
+  return providerService.isMigratedFromV1() || !availableInEditions || availableInEditions.includes(getAppEdition())
 }
 
 function getAvailableProviderMetadata(row: ProviderIdentity): ProviderDisplayMetadata | null {
@@ -329,6 +331,25 @@ function rotationCacheKey(providerId: string): string {
 }
 
 class ProviderService {
+  private migratedFromV1: boolean | undefined
+
+  /** Migration status is immutable after preboot, so the first database read is cached. */
+  isMigratedFromV1(): boolean {
+    if (this.migratedFromV1 === undefined) {
+      const row = application
+        .get('DbService')
+        .getDb()
+        .select({ value: appStateTable.value })
+        .from(appStateTable)
+        .where(eq(appStateTable.key, MIGRATION_V2_STATUS))
+        .get()
+      const status = row?.value as MigrationStatusValue | undefined
+      this.migratedFromV1 = status?.status === 'completed' && status.migratedFromV1 === true
+    }
+
+    return this.migratedFromV1
+  }
+
   private rethrowOrderError(error: unknown): never {
     if (
       error instanceof DataApiError &&

--- a/src/main/data/services/__tests__/ModelService.edition.test.ts
+++ b/src/main/data/services/__tests__/ModelService.edition.test.ts
@@ -8,12 +8,17 @@ import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { applicationEdition } = vi.hoisted(() => ({
-  applicationEdition: { current: 'cn' as AppEdition }
+const { applicationEdition, migrationOrigin } = vi.hoisted(() => ({
+  applicationEdition: { current: 'cn' as AppEdition },
+  migrationOrigin: { current: false }
 }))
 
 vi.mock('@main/utils/appEdition', () => ({
   getAppEdition: () => applicationEdition.current
+}))
+
+vi.mock('@data/migration/v2', () => ({
+  migrationEngine: { isMigratedFromV1: () => migrationOrigin.current }
 }))
 
 vi.mock('@cherrystudio/provider-registry/node', () => {
@@ -68,6 +73,7 @@ describe('ModelService edition availability', () => {
 
   beforeEach(() => {
     applicationEdition.current = 'cn'
+    migrationOrigin.current = false
   })
 
   it('excludes persisted models owned by providers unavailable in the current edition', async () => {
@@ -126,5 +132,18 @@ describe('ModelService edition availability', () => {
     const rows = await dbh.db.select().from(userModelTable).where(eq(userModelTable.providerId, 'global-only'))
     expect(rows).toHaveLength(1)
     expect(rows[0].name).toBe('hidden-model')
+  })
+
+  it('keeps every persisted model available for users migrated from v1', async () => {
+    migrationOrigin.current = true
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'global-only',
+      presetProviderId: 'global-only',
+      name: 'Global only',
+      orderKey: 'a0'
+    })
+    await dbh.db.insert(userModelTable).values(modelRow('global-only', 'visible-model', 'a0'))
+
+    expect(modelService.list({}).map((model) => model.id)).toEqual(['global-only::visible-model'])
   })
 })

--- a/src/main/data/services/__tests__/ModelService.edition.test.ts
+++ b/src/main/data/services/__tests__/ModelService.edition.test.ts
@@ -1,6 +1,8 @@
+import { appStateTable } from '@data/db/schemas/appState'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { modelService } from '@data/services/ModelService'
+import { providerService } from '@data/services/ProviderService'
 import { ErrorCode } from '@shared/data/api/errors'
 import { createUniqueModelId } from '@shared/data/types/model'
 import type { AppEdition } from '@shared/types/appEdition'
@@ -8,17 +10,12 @@ import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { applicationEdition, migrationOrigin } = vi.hoisted(() => ({
-  applicationEdition: { current: 'cn' as AppEdition },
-  migrationOrigin: { current: false }
+const { applicationEdition } = vi.hoisted(() => ({
+  applicationEdition: { current: 'cn' as AppEdition }
 }))
 
 vi.mock('@main/utils/appEdition', () => ({
   getAppEdition: () => applicationEdition.current
-}))
-
-vi.mock('@data/migration/v2', () => ({
-  migrationEngine: { isMigratedFromV1: () => migrationOrigin.current }
 }))
 
 vi.mock('@cherrystudio/provider-registry/node', () => {
@@ -73,7 +70,7 @@ describe('ModelService edition availability', () => {
 
   beforeEach(() => {
     applicationEdition.current = 'cn'
-    migrationOrigin.current = false
+    ;(providerService as any).migratedFromV1 = undefined
   })
 
   it('excludes persisted models owned by providers unavailable in the current edition', async () => {
@@ -135,7 +132,10 @@ describe('ModelService edition availability', () => {
   })
 
   it('keeps every persisted model available for users migrated from v1', async () => {
-    migrationOrigin.current = true
+    await dbh.db.insert(appStateTable).values({
+      key: 'migration_v2_status',
+      value: { status: 'completed', migratedFromV1: true, version: '2.0.0' }
+    })
     await dbh.db.insert(userProviderTable).values({
       providerId: 'global-only',
       presetProviderId: 'global-only',

--- a/src/main/data/services/__tests__/ModelService.edition.test.ts
+++ b/src/main/data/services/__tests__/ModelService.edition.test.ts
@@ -1,7 +1,6 @@
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { modelService } from '@data/services/ModelService'
-import { providerService } from '@data/services/ProviderService'
 import { ErrorCode } from '@shared/data/api/errors'
 import { createUniqueModelId } from '@shared/data/types/model'
 import type { AppEdition } from '@shared/types/appEdition'
@@ -9,15 +8,18 @@ import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { applicationEdition } = vi.hoisted(() => ({
-  applicationEdition: { current: 'cn' as AppEdition }
+const { applicationEdition, migrationOrigin } = vi.hoisted(() => ({
+  applicationEdition: { current: 'cn' as AppEdition },
+  migrationOrigin: { current: false }
 }))
 
 vi.mock('@main/utils/appEdition', () => ({
   getAppEdition: () => applicationEdition.current
 }))
 
-const isMigratedFromV1Spy = vi.spyOn(providerService, 'isMigratedFromV1')
+vi.mock('@data/migration/v1MigrationOrigin', () => ({
+  isMigratedFromV1: () => migrationOrigin.current
+}))
 
 vi.mock('@cherrystudio/provider-registry/node', () => {
   class RegistryLoader {
@@ -71,7 +73,7 @@ describe('ModelService edition availability', () => {
 
   beforeEach(() => {
     applicationEdition.current = 'cn'
-    isMigratedFromV1Spy.mockReset().mockReturnValue(false)
+    migrationOrigin.current = false
   })
 
   it('excludes persisted models owned by providers unavailable in the current edition', async () => {
@@ -133,7 +135,7 @@ describe('ModelService edition availability', () => {
   })
 
   it('keeps every persisted model available for users migrated from v1', async () => {
-    isMigratedFromV1Spy.mockReturnValue(true)
+    migrationOrigin.current = true
     await dbh.db.insert(userProviderTable).values({
       providerId: 'global-only',
       presetProviderId: 'global-only',

--- a/src/main/data/services/__tests__/ModelService.edition.test.ts
+++ b/src/main/data/services/__tests__/ModelService.edition.test.ts
@@ -1,4 +1,3 @@
-import { appStateTable } from '@data/db/schemas/appState'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { modelService } from '@data/services/ModelService'
@@ -17,6 +16,8 @@ const { applicationEdition } = vi.hoisted(() => ({
 vi.mock('@main/utils/appEdition', () => ({
   getAppEdition: () => applicationEdition.current
 }))
+
+const isMigratedFromV1Spy = vi.spyOn(providerService, 'isMigratedFromV1')
 
 vi.mock('@cherrystudio/provider-registry/node', () => {
   class RegistryLoader {
@@ -70,7 +71,7 @@ describe('ModelService edition availability', () => {
 
   beforeEach(() => {
     applicationEdition.current = 'cn'
-    ;(providerService as any).migratedFromV1 = undefined
+    isMigratedFromV1Spy.mockReset().mockReturnValue(false)
   })
 
   it('excludes persisted models owned by providers unavailable in the current edition', async () => {
@@ -132,10 +133,7 @@ describe('ModelService edition availability', () => {
   })
 
   it('keeps every persisted model available for users migrated from v1', async () => {
-    await dbh.db.insert(appStateTable).values({
-      key: 'migration_v2_status',
-      value: { status: 'completed', migratedFromV1: true, version: '2.0.0' }
-    })
+    isMigratedFromV1Spy.mockReturnValue(true)
     await dbh.db.insert(userProviderTable).values({
       providerId: 'global-only',
       presetProviderId: 'global-only',

--- a/src/main/data/services/__tests__/ProviderService.edition.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.edition.test.ts
@@ -7,12 +7,17 @@ import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { applicationEdition } = vi.hoisted(() => ({
-  applicationEdition: { current: 'cn' as AppEdition }
+const { applicationEdition, migrationOrigin } = vi.hoisted(() => ({
+  applicationEdition: { current: 'cn' as AppEdition },
+  migrationOrigin: { current: false }
 }))
 
 vi.mock('@main/utils/appEdition', () => ({
   getAppEdition: () => applicationEdition.current
+}))
+
+vi.mock('@data/migration/v2', () => ({
+  migrationEngine: { isMigratedFromV1: () => migrationOrigin.current }
 }))
 
 vi.mock('@cherrystudio/provider-registry/node', () => {
@@ -47,6 +52,7 @@ describe('ProviderService edition availability', () => {
 
   beforeEach(() => {
     applicationEdition.current = 'cn'
+    migrationOrigin.current = false
   })
 
   it('makes a persisted global-only provider unavailable to every runtime read and mutation in China', async () => {
@@ -146,5 +152,17 @@ describe('ProviderService edition availability', () => {
     })
 
     expect(providerService.getByProviderId('global-only').id).toBe('global-only')
+  })
+
+  it('keeps every persisted provider available for users migrated from v1', async () => {
+    migrationOrigin.current = true
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'global-only',
+      presetProviderId: 'global-only',
+      name: 'Global only',
+      orderKey: 'a0'
+    })
+
+    expect(providerService.list({}).map((provider) => provider.id)).toEqual(['global-only'])
   })
 })

--- a/src/main/data/services/__tests__/ProviderService.edition.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.edition.test.ts
@@ -1,4 +1,3 @@
-import { appStateTable } from '@data/db/schemas/appState'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { providerRegistryService } from '@data/services/ProviderRegistryService'
 import { providerService } from '@data/services/ProviderService'
@@ -8,12 +7,17 @@ import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { applicationEdition } = vi.hoisted(() => ({
-  applicationEdition: { current: 'cn' as AppEdition }
+const { applicationEdition, migrationOrigin } = vi.hoisted(() => ({
+  applicationEdition: { current: 'cn' as AppEdition },
+  migrationOrigin: { current: false }
 }))
 
 vi.mock('@main/utils/appEdition', () => ({
   getAppEdition: () => applicationEdition.current
+}))
+
+vi.mock('@data/migration/v1MigrationOrigin', () => ({
+  isMigratedFromV1: () => migrationOrigin.current
 }))
 
 vi.mock('@cherrystudio/provider-registry/node', () => {
@@ -48,7 +52,7 @@ describe('ProviderService edition availability', () => {
 
   beforeEach(() => {
     applicationEdition.current = 'cn'
-    ;(providerService as any).migratedFromV1 = undefined
+    migrationOrigin.current = false
   })
 
   it('makes a persisted global-only provider unavailable to every runtime read and mutation in China', async () => {
@@ -151,10 +155,7 @@ describe('ProviderService edition availability', () => {
   })
 
   it('keeps every persisted provider available for users migrated from v1', async () => {
-    await dbh.db.insert(appStateTable).values({
-      key: 'migration_v2_status',
-      value: { status: 'completed', migratedFromV1: true, version: '2.0.0' }
-    })
+    migrationOrigin.current = true
     await dbh.db.insert(userProviderTable).values({
       providerId: 'global-only',
       presetProviderId: 'global-only',

--- a/src/main/data/services/__tests__/ProviderService.edition.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.edition.test.ts
@@ -1,3 +1,4 @@
+import { appStateTable } from '@data/db/schemas/appState'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { providerRegistryService } from '@data/services/ProviderRegistryService'
 import { providerService } from '@data/services/ProviderService'
@@ -7,17 +8,12 @@ import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { applicationEdition, migrationOrigin } = vi.hoisted(() => ({
-  applicationEdition: { current: 'cn' as AppEdition },
-  migrationOrigin: { current: false }
+const { applicationEdition } = vi.hoisted(() => ({
+  applicationEdition: { current: 'cn' as AppEdition }
 }))
 
 vi.mock('@main/utils/appEdition', () => ({
   getAppEdition: () => applicationEdition.current
-}))
-
-vi.mock('@data/migration/v2', () => ({
-  migrationEngine: { isMigratedFromV1: () => migrationOrigin.current }
 }))
 
 vi.mock('@cherrystudio/provider-registry/node', () => {
@@ -52,7 +48,7 @@ describe('ProviderService edition availability', () => {
 
   beforeEach(() => {
     applicationEdition.current = 'cn'
-    migrationOrigin.current = false
+    ;(providerService as any).migratedFromV1 = undefined
   })
 
   it('makes a persisted global-only provider unavailable to every runtime read and mutation in China', async () => {
@@ -155,7 +151,10 @@ describe('ProviderService edition availability', () => {
   })
 
   it('keeps every persisted provider available for users migrated from v1', async () => {
-    migrationOrigin.current = true
+    await dbh.db.insert(appStateTable).values({
+      key: 'migration_v2_status',
+      value: { status: 'completed', migratedFromV1: true, version: '2.0.0' }
+    })
     await dbh.db.insert(userProviderTable).values({
       providerId: 'global-only',
       presetProviderId: 'global-only',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Profiles successfully migrated from v1 still followed the installed edition's provider availability rules, so a China-edition package hid global-only providers and all models owned by them.

After this PR:

The migration gate restores the persisted v1 migration origin during preboot. Successfully migrated profiles bypass provider edition filtering, making every persisted provider and its models available without changing the package edition or unrelated runtime behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The v1 application exposed the full provider catalog. Users who migrate that profile must retain access to their existing providers and models even when the installed v2 package has edition-specific defaults.

The following tradeoffs were made:

- This PR depends on #20171 for the durable migration-origin marker.
- Only provider edition availability is bypassed. User-selected enabled, search, capability, and agent-context filters keep their existing semantics.

The following alternatives were considered:

- Treating migrated users as the global edition everywhere was rejected because it also changes Cherry Cloud, onboarding, compliance UI, and other unrelated product behavior.
- Reading `migration_v2_status` directly from `ProviderService` was rejected because the migration domain owns that `app_state` key; `MigrationEngine` exposes the restored state instead.

Links to places where the discussion took place: #20171

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This is the upper PR in a stack on #20171. The focused migration and provider/model service tests pass (179 tests), as do `pnpm lint` and `pnpm test:lint`. The existing 45 ESLint warnings are in untouched files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Profiles migrated from v1 now retain access to all providers and models regardless of the installed edition.
```
