### PR TITLE
fix(agent-runtime): align gateway timeout budgets

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -948,6 +948,7 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
       ANTHROPIC_BASE_URL: 'http://127.0.0.1:24444',
       ANTHROPIC_API_KEY: 'gateway-key',
       ANTHROPIC_AUTH_TOKEN: 'gateway-key',
+      API_TIMEOUT_MS: '1800000',
       ANTHROPIC_MODEL: 'openai:gpt-main-api',
       ANTHROPIC_DEFAULT_OPUS_MODEL: 'openai:gpt-main-api',
       ANTHROPIC_DEFAULT_SONNET_MODEL: 'openai:gpt-plan-api',
@@ -956,7 +957,23 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     expect(request?.settings.env?.ANTHROPIC_CUSTOM_HEADERS).toBe(
       'x-cherry-agent-session-id: session-1\nx-cherry-internal-usage-token: internal-token'
     )
+    expect(request?.options.env?.API_TIMEOUT_MS).toBe('1800000')
     expect(request?.usageCapture).toEqual({ owner: 'provider-calls' })
+  })
+
+  it('preserves an explicit API timeout for local API gateway routes', async () => {
+    mocks.getAgent.mockReturnValue({ id: 'agent-1', model: 'openai::gpt-main' })
+    mocks.getProviderByProviderId.mockReturnValue({
+      id: 'openai',
+      endpointConfigs: { 'openai-chat-completions': { baseUrl: 'https://openai.example.com' } }
+    })
+    mocks.getModelByKey.mockReturnValue({ id: 'gpt-main', apiModelId: 'gpt-main-api' })
+    mocks.getLastRuntimeResumeToken.mockReturnValue(null)
+    mocks.buildSessionSettings.mockResolvedValue({ env: { API_TIMEOUT_MS: '3600000' } })
+
+    const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(request?.options.env?.API_TIMEOUT_MS).toBe('3600000')
   })
 
   // The gateway is never started implicitly (#18521); the caller turns this into the prompt that

--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -949,6 +949,8 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
       ANTHROPIC_API_KEY: 'gateway-key',
       ANTHROPIC_AUTH_TOKEN: 'gateway-key',
       API_TIMEOUT_MS: '1800000',
+      API_FORCE_IDLE_TIMEOUT: '0',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: '1800000',
       ANTHROPIC_MODEL: 'openai:gpt-main-api',
       ANTHROPIC_DEFAULT_OPUS_MODEL: 'openai:gpt-main-api',
       ANTHROPIC_DEFAULT_SONNET_MODEL: 'openai:gpt-plan-api',
@@ -961,7 +963,7 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     expect(request?.usageCapture).toEqual({ owner: 'provider-calls' })
   })
 
-  it('preserves an explicit API timeout for local API gateway routes', async () => {
+  it('preserves explicit timeout controls for local API gateway routes', async () => {
     mocks.getAgent.mockReturnValue({ id: 'agent-1', model: 'openai::gpt-main' })
     mocks.getProviderByProviderId.mockReturnValue({
       id: 'openai',
@@ -969,11 +971,23 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     })
     mocks.getModelByKey.mockReturnValue({ id: 'gpt-main', apiModelId: 'gpt-main-api' })
     mocks.getLastRuntimeResumeToken.mockReturnValue(null)
-    mocks.buildSessionSettings.mockResolvedValue({ env: { API_TIMEOUT_MS: '3600000' } })
+    mocks.buildSessionSettings.mockResolvedValue({
+      env: {
+        API_TIMEOUT_MS: '3600000',
+        API_FORCE_IDLE_TIMEOUT: '1',
+        CLAUDE_STREAM_IDLE_TIMEOUT_MS: '900000',
+        CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '600000'
+      }
+    })
 
     const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
 
-    expect(request?.options.env?.API_TIMEOUT_MS).toBe('3600000')
+    expect(request?.options.env).toMatchObject({
+      API_TIMEOUT_MS: '3600000',
+      API_FORCE_IDLE_TIMEOUT: '1',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: '900000',
+      CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '600000'
+    })
   })
 
   // The gateway is never started implicitly (#18521); the caller turns this into the prompt that

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -11,7 +11,7 @@ import { modelService } from '@data/services/ModelService'
 import { projectRuntimeReasoning, providerRegistryService } from '@data/services/ProviderRegistryService'
 import { providerService } from '@data/services/ProviderService'
 import { loggerService } from '@logger'
-import { CHERRY_FAST_MODE_HEADER, CHERRY_INTERNAL_REQUEST_TOKEN_HEADER } from '@main/ai/constants'
+import { CHERRY_FAST_MODE_HEADER, CHERRY_INTERNAL_REQUEST_TOKEN_HEADER, DEFAULT_TIMEOUT } from '@main/ai/constants'
 import {
   type AgentNotificationContext,
   resolveAgentNotificationContext,
@@ -911,6 +911,9 @@ function mergeRuntimeSettings(
   const env = mergeAgentLoopbackProxyBypass(
     {
       ...settings.env,
+      ...(route.branch === 'gateway' && settings.env?.API_TIMEOUT_MS === undefined
+        ? { API_TIMEOUT_MS: String(DEFAULT_TIMEOUT) }
+        : {}),
       ANTHROPIC_MODEL: route.modelIds.primary,
       ANTHROPIC_DEFAULT_OPUS_MODEL: route.modelIds.opus,
       ANTHROPIC_DEFAULT_SONNET_MODEL: route.modelIds.sonnet,

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -911,8 +911,12 @@ function mergeRuntimeSettings(
   const env = mergeAgentLoopbackProxyBypass(
     {
       ...settings.env,
-      ...(route.branch === 'gateway' && settings.env?.API_TIMEOUT_MS === undefined
-        ? { API_TIMEOUT_MS: String(DEFAULT_TIMEOUT) }
+      ...(route.branch === 'gateway'
+        ? {
+            API_TIMEOUT_MS: settings.env?.API_TIMEOUT_MS ?? String(DEFAULT_TIMEOUT),
+            API_FORCE_IDLE_TIMEOUT: settings.env?.API_FORCE_IDLE_TIMEOUT ?? '0',
+            CLAUDE_STREAM_IDLE_TIMEOUT_MS: settings.env?.CLAUDE_STREAM_IDLE_TIMEOUT_MS ?? String(DEFAULT_TIMEOUT)
+          }
         : {}),
       ANTHROPIC_MODEL: route.modelIds.primary,
       ANTHROPIC_DEFAULT_OPUS_MODEL: route.modelIds.opus,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Claude Code gateway requests inherited independent five-minute SDK idle watchdogs, which could terminate slow local or gateway-backed model responses before Cherry's own gateway timeout.

After this PR: Gateway routes default the API and stream idle budgets to thirty minutes and disable the redundant SDK body-idle timeout while preserving explicit user overrides; Cherry's twenty-minute upstream idle timeout remains the protective boundary.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Related to #19923

### Why we need it and why it was done in this way

The following tradeoffs were made: A silent gateway request may remain active until Cherry's twenty-minute upstream idle timeout instead of failing after five minutes.

The following alternatives were considered: Changing all Claude Code routes globally was rejected because the evidence and timeout mismatch are specific to Cherry's gateway path; changing only the byte watchdog was insufficient because the event and body-idle timers are independent.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19923

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Diagnostics for #19923 show the SDK timing out about five minutes after a successful gateway response. Verified with the focused main-process test (64 tests), `pnpm lint`, and `pnpm test:lint`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Claude Code agent sessions using local or gateway-backed models disconnecting after about five minutes of silent generation.
```
