### PR TITLE
fix(agent-channels): reduce message batch latency

### DIFF
--- a/src/main/ai/channels/ChannelMessageHandler.ts
+++ b/src/main/ai/channels/ChannelMessageHandler.ts
@@ -43,7 +43,7 @@ const SESSION_TRACKER_MAX_SIZE = 500
  * succession. Debouncing prevents each fragment from triggering a separate
  * agent round-trip and avoids concurrent stream interleaving.
  */
-const MESSAGE_BATCH_DELAY_MS = 8000
+const MESSAGE_BATCH_DELAY_MS = 1000
 // Cap a sender's debounce extension so another sender in the conversation cannot wait forever.
 const MESSAGE_BATCH_MAX_DELAY_MS = 16000
 
@@ -120,7 +120,7 @@ export class ChannelMessageHandler {
 
   /**
    * Stop channel intake and immediately flush the buffered debounce batches (not waiting out
-   * the 8 s timer) so their agent-turn admissions land before the orchestrator pauses the AI
+   * the 1 s timer) so their agent-turn admissions land before the orchestrator pauses the AI
    * writers. No resume() — dispose your own hold. There is no release compensation: intake
    * dropped while quiesced is not replayable.
    *
@@ -233,7 +233,10 @@ export class ChannelMessageHandler {
         existing.messages.push(message)
         existing.resolvers.push({ resolve, reject })
         clearTimeout(existing.timer)
-        existing.timer = setTimeout(() => this.flushBatch(batchKey), Math.max(0, existing.deadline - Date.now()))
+        existing.timer = setTimeout(
+          () => this.flushBatch(batchKey),
+          Math.min(MESSAGE_BATCH_DELAY_MS, Math.max(0, existing.deadline - Date.now()))
+        )
         logger.debug('Message appended to pending batch', {
           batchKey,
           batchSize: existing.messages.length

--- a/src/main/ai/channels/__tests__/ChannelMessageHandler.pause.test.ts
+++ b/src/main/ai/channels/__tests__/ChannelMessageHandler.pause.test.ts
@@ -190,7 +190,7 @@ describe('ChannelMessageHandler write quiesce', () => {
     simulateStream([{ type: 'text-delta', delta: 'OK' }])
 
     const turn = handler.handleIncoming(adapter, msg('Hi'))
-    // Still buffered — the 8 s debounce has not been advanced.
+    // Still buffered — the 1 s debounce has not been advanced.
     expect(mockStartAgentSessionRun).not.toHaveBeenCalled()
 
     const hold = handler.pause('restore')
@@ -278,7 +278,7 @@ describe('ChannelMessageHandler write quiesce', () => {
     })
 
     const turn = handler.handleIncoming(adapter, msg('Hi'))
-    await vi.advanceTimersByTimeAsync(8500)
+    await vi.advanceTimersByTimeAsync(1000)
     expect(mockStartAgentSessionRun).toHaveBeenCalledTimes(1)
 
     const command = handler.handleCommand(adapter, {
@@ -311,7 +311,7 @@ describe('ChannelMessageHandler write quiesce', () => {
     mockStartAgentSessionRun.mockResolvedValue(undefined)
 
     const turn = handler.handleIncoming(adapter, msg('Hi'))
-    await vi.advanceTimersByTimeAsync(8500)
+    await vi.advanceTimersByTimeAsync(1000)
     const help = handler.handleCommand(adapter, {
       chatId: 'chat-1',
       userId: 'user-1',

--- a/src/main/ai/channels/__tests__/ChannelMessageHandler.test.ts
+++ b/src/main/ai/channels/__tests__/ChannelMessageHandler.test.ts
@@ -162,8 +162,7 @@ function createMockAdapter(overrides: Record<string, unknown> = {}) {
  */
 async function handleIncomingAndFlush(adapter: ReturnType<typeof createMockAdapter>, message: ChannelMessageEvent) {
   const promise = channelMessageHandler.handleIncoming(adapter, { ...message })
-  // Advance past the MESSAGE_BATCH_DELAY_MS debounce (10 000 ms)
-  await vi.advanceTimersByTimeAsync(10500)
+  await vi.advanceTimersByTimeAsync(1000)
   return promise
 }
 
@@ -734,6 +733,87 @@ describe('ChannelMessageHandler', () => {
     expect(agentSessionService.createTx).toHaveBeenCalledTimes(2)
   })
 
+  it('dispatches a single message after exactly one second', async () => {
+    const adapter = createMockAdapter()
+    simulateStream([{ type: 'text-delta', delta: 'reply' }])
+
+    const turn = channelMessageHandler.handleIncoming(adapter, {
+      chatId: 'chat-1',
+      userId: 'user-1',
+      userName: 'User',
+      text: 'hello'
+    })
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(mockStartAgentSessionRun).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await turn
+    expect(mockStartAgentSessionRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispatches a merged batch one second after the latest rapid message', async () => {
+    const adapter = createMockAdapter()
+    simulateStream([{ type: 'text-delta', delta: 'reply' }])
+
+    const first = channelMessageHandler.handleIncoming(adapter, {
+      chatId: 'chat-1',
+      userId: 'user-1',
+      userName: 'User',
+      text: 'first'
+    })
+    await vi.advanceTimersByTimeAsync(500)
+    const second = channelMessageHandler.handleIncoming(adapter, {
+      chatId: 'chat-1',
+      userId: 'user-1',
+      userName: 'User',
+      text: 'second'
+    })
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(mockStartAgentSessionRun).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await Promise.all([first, second])
+    expect(mockStartAgentSessionRun).toHaveBeenCalledTimes(1)
+    expect(mockStartAgentSessionRun.mock.calls[0][0].userParts[0].text).toBe('first\nsecond')
+  })
+
+  it('flushes a sustained message burst at the original sixteen-second deadline', async () => {
+    const adapter = createMockAdapter()
+    simulateStream([{ type: 'text-delta', delta: 'reply' }])
+    const turns = [
+      channelMessageHandler.handleIncoming(adapter, {
+        chatId: 'chat-1',
+        userId: 'user-1',
+        userName: 'User',
+        text: 'message-0'
+      })
+    ]
+
+    for (let index = 1; index <= 17; index++) {
+      await vi.advanceTimersByTimeAsync(900)
+      turns.push(
+        channelMessageHandler.handleIncoming(adapter, {
+          chatId: 'chat-1',
+          userId: 'user-1',
+          userName: 'User',
+          text: `message-${index}`
+        })
+      )
+    }
+
+    await vi.advanceTimersByTimeAsync(699)
+    expect(mockStartAgentSessionRun).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await Promise.all(turns)
+    expect(mockStartAgentSessionRun).toHaveBeenCalledTimes(1)
+    expect(mockStartAgentSessionRun.mock.calls[0][0].userParts[0].text).toBe(
+      Array.from({ length: 18 }, (_, index) => `message-${index}`).join('\n')
+    )
+  })
+
   it('preserves first-arrival order across senders whose debounce timers expire out of order', async () => {
     const adapter = createMockAdapter()
     simulateStream([{ type: 'text-delta', delta: 'A reply' }])
@@ -745,14 +825,14 @@ describe('ChannelMessageHandler', () => {
       userName: 'Alice',
       text: 'A1'
     })
-    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(100)
     const B = channelMessageHandler.handleIncoming(adapter, {
       chatId: 'group-1',
       userId: 'bob',
       userName: 'Bob',
       text: 'B1'
     })
-    await vi.advanceTimersByTimeAsync(6000)
+    await vi.advanceTimersByTimeAsync(100)
     const secondA = channelMessageHandler.handleIncoming(adapter, {
       chatId: 'group-1',
       userId: 'alice',
@@ -760,7 +840,7 @@ describe('ChannelMessageHandler', () => {
       text: 'A2'
     })
 
-    await vi.advanceTimersByTimeAsync(9000)
+    await vi.advanceTimersByTimeAsync(1000)
     await Promise.all([firstA, B, secondA])
 
     expect(mockStartAgentSessionRun.mock.calls.map(([input]) => input.userParts[0].text)).toEqual(['A1\nA2', 'B1'])
@@ -771,38 +851,41 @@ describe('ChannelMessageHandler', () => {
     simulateStream([{ type: 'text-delta', delta: 'A reply' }])
     simulateStream([{ type: 'text-delta', delta: 'B reply' }])
 
-    const firstA = channelMessageHandler.handleIncoming(adapter, {
-      chatId: 'group-1',
-      userId: 'alice',
-      userName: 'Alice',
-      text: 'A1'
-    })
-    await vi.advanceTimersByTimeAsync(1000)
+    const turns = [
+      channelMessageHandler.handleIncoming(adapter, {
+        chatId: 'group-1',
+        userId: 'alice',
+        userName: 'Alice',
+        text: 'A0'
+      })
+    ]
+    await vi.advanceTimersByTimeAsync(100)
     const B = channelMessageHandler.handleIncoming(adapter, {
       chatId: 'group-1',
       userId: 'bob',
       userName: 'Bob',
       text: 'B1'
     })
-    await vi.advanceTimersByTimeAsync(6000)
-    const secondA = channelMessageHandler.handleIncoming(adapter, {
-      chatId: 'group-1',
-      userId: 'alice',
-      userName: 'Alice',
-      text: 'A2'
-    })
-    await vi.advanceTimersByTimeAsync(7000)
-    const thirdA = channelMessageHandler.handleIncoming(adapter, {
-      chatId: 'group-1',
-      userId: 'alice',
-      userName: 'Alice',
-      text: 'A3'
-    })
 
-    await vi.advanceTimersByTimeAsync(2000)
-    await Promise.all([firstA, B, secondA, thirdA])
+    for (let index = 1; index <= 17; index++) {
+      await vi.advanceTimersByTimeAsync(index === 1 ? 800 : 900)
+      turns.push(
+        channelMessageHandler.handleIncoming(adapter, {
+          chatId: 'group-1',
+          userId: 'alice',
+          userName: 'Alice',
+          text: `A${index}`
+        })
+      )
+    }
 
-    expect(mockStartAgentSessionRun.mock.calls.map(([input]) => input.userParts[0].text)).toEqual(['A1\nA2\nA3', 'B1'])
+    await vi.advanceTimersByTimeAsync(700)
+    await Promise.all([...turns, B])
+
+    expect(mockStartAgentSessionRun.mock.calls.map(([input]) => input.userParts[0].text)).toEqual([
+      Array.from({ length: 18 }, (_, index) => `A${index}`).join('\n'),
+      'B1'
+    ])
   })
 
   it('isolates threads in the same chat and preserves their reply context', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Agent channel messages always waited eight seconds before processing. Appending a rapid message reset the timer to the remaining 16-second hard deadline, which could make a short two-message batch wait nearly 16 seconds.

After this PR:

Agent channel messages flush after a one-second debounce. Each rapid message restarts that one-second debounce without extending the original 16-second hard deadline.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20178

### Why we need it and why it was done in this way

The eight-second delay made every supported IM channel feel unresponsive. The append path also used the hard deadline as its normal debounce, making the common two-message case substantially slower than intended.

The following tradeoffs were made:

The existing 16-second hard cap remains unchanged to preserve fairness between senders during sustained bursts. This PR changes only the default timing behavior and does not add a new preference or environment variable.

The following alternatives were considered:

Adding per-channel configuration or an environment variable was considered, but it would add settings and persistence surface for a small timing correction. A one-second default addresses the reported latency with the existing batching model.

Links to places where the discussion took place: #20178

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Fake-timer coverage verifies a single-message one-second delay, debounce restart after a rapid second message, and the original 16-second hard deadline during a sustained burst.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and no upgrade handling is required
- [x] Documentation: A user-guide update was considered and is not required because no user configuration or workflow changed
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent channels now begin processing incoming messages after a one-second batching delay while preserving rapid-message batching. No action required.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible timing change only in channel message batching; core admission, pause/drain, and queue semantics are unchanged.
> 
> **Overview**
> **Agent channel intake** now starts agent turns after a **1 second** debounce instead of **8 seconds**, so IM replies feel much snappier while rapid fragments still merge into one turn.
> 
> When a user sends another message into an **existing** batch, the reset timer is capped at **1 second** (`Math.min(MESSAGE_BATCH_DELAY_MS, …)`) instead of counting down only to the **16 s** hard deadline—fixing the case where two quick messages could wait almost 16 s. The **16 s** `MESSAGE_BATCH_MAX_DELAY_MS` cap for sustained bursts is unchanged.
> 
> Tests were aligned to the new timing and expanded to cover exact 1 s dispatch, debounce restart after a second message, and flush at the 16 s deadline under a long burst.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae377a45a8fecde4bd57ddc5f31eb02b0f5c6d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->