### PR TITLE
feat(chat-actions): expose actions without hover

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -714,7 +714,6 @@ describe('MessageGroup', () => {
 
     const footer = container.querySelector('#message-msg-1 .MessageFooter')
 
-    expect(footer).toHaveClass('opacity-100')
     expect(footer).not.toHaveClass('opacity-0')
   })
 

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -718,15 +718,15 @@ describe('MessageGroup', () => {
     expect(footer).not.toHaveClass('opacity-0')
   })
 
-  it('reveals historical assistant footers on hover or keyboard focus', () => {
+  it('keeps historical assistant footer affordances available without hover', () => {
     const messages = [createMessage('msg-1', 0, 'vertical')]
 
     const { container } = render(<MessageGroup isLatestAssistantGroup={false} messages={messages} />)
 
     const footer = container.querySelector('#message-msg-1 .MessageFooter')
 
-    expect(footer).toHaveClass('opacity-0', 'group-hover/message:opacity-100', 'focus-within:opacity-100')
-    expect(footer).not.toHaveClass('opacity-100')
+    expect(footer).not.toHaveClass('opacity-0')
+    expect(footer).not.toHaveClass('group-hover/message:opacity-100', 'focus-within:opacity-100')
   })
 
   it('keeps vertical scrolling inside the message content area for horizontal layout', () => {

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -8,7 +8,7 @@ import type { CherryMessagePart } from '@shared/data/types/message'
 import { createUniqueModelId, type Model } from '@shared/data/types/model'
 import dayjs from 'dayjs'
 import type { FC } from 'react'
-import React, { memo, useCallback, useEffect, useRef, useState } from 'react'
+import React, { memo, useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import ImageBlock from '../blocks/ImageBlock'
@@ -34,8 +34,10 @@ import MessageErrorBoundary from './MessageErrorBoundary'
 import MessageHeader, { AgentSessionDeliveryBadge } from './MessageHeader'
 import MessageMenuBar from './MessageMenuBar'
 
-const USER_MESSAGE_FOOTER_ACTIONS_CLASS =
-  'absolute inset-0 flex items-center gap-2 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover/message:opacity-100'
+const USER_MESSAGE_FOOTER_ACTIONS_CLASS = 'flex items-center gap-2'
+
+const MESSAGE_TIMESTAMP_CLASS =
+  'shrink-0 opacity-0 transition-opacity duration-150 group-focus-within/message:opacity-100 group-hover/message:opacity-100'
 
 interface Props {
   message: MessageListItem
@@ -87,7 +89,6 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   const messageContainerRef = useRef<HTMLDivElement>(null)
   const navigateWithScrollRuntime = useScrollRuntimeNavigation()
   const messageParts = useMessageParts(message.id)
-  const [isMessageMenuOpen, setIsMessageMenuOpen] = useState(false)
   const editingMessageId = useMessageListEditingId()
   const { setTimeoutTimer } = useTimer()
   const canEditMessage = !!actions.editMessage
@@ -118,10 +119,6 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   const isUserBubbleMessage = messageStyle === 'bubble' && !isAssistantMessage && !isMultiSelectMode
   const showAssistantFooterActions = showMenuBar && isAssistantMessage
   const showUserFooterActions = showMenuBar && !isAssistantMessage && !isMultiSelectMode && !isUserBubbleMessage
-  const keepAssistantFooterVisible = isLatestAssistantMessage || isMessageMenuOpen
-  const assistantFooterVisibilityClass = keepAssistantFooterVisible
-    ? 'opacity-100'
-    : 'opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover/message:opacity-100'
 
   const messageHighlightHandler = useCallback(
     (highlight: boolean = true) => {
@@ -244,11 +241,7 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   ) : undefined
 
   const assistantFooter = showAssistantFooterActions ? (
-    <div
-      className={cn(
-        'MessageFooter mt-1 flex min-h-6.5 shrink-0 items-center justify-between gap-1.5 text-xs leading-none',
-        assistantFooterVisibilityClass
-      )}>
+    <div className="MessageFooter mt-1 flex min-h-6.5 shrink-0 items-center justify-between gap-1.5 text-xs leading-none">
       <HorizontalScrollContainer
         classNames={{
           content: cn('flex-1 flex-row items-center justify-between')
@@ -256,13 +249,11 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
         <MessageMenuBar
           message={message}
           isLastMessage={isLatestAssistantMessage}
-          forceVisible={isMessageMenuOpen}
           isAssistantMessage={isAssistantMessage}
           isGrouped={isGrouped}
           isProcessing={isProcessing}
           messageContainerRef={messageContainerRef as React.RefObject<HTMLDivElement>}
           onStartEditing={handleStartEditing}
-          onMenuOpenChange={setIsMessageMenuOpen}
           onSelectContext={onSelectContext}
         />
       </HorizontalScrollContainer>
@@ -275,7 +266,7 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
       key={message.id}
       className={cn(
         classNames({
-          'message group/message transform-[translateZ(0)] relative flex w-full flex-col rounded-[10px] pt-2.5 pb-0 transition-colors duration-300 will-change-transform [&:hover_.menubar]:opacity-100 [&_.menubar.show]:opacity-100 [&_.menubar]:opacity-0 [&_.menubar]:transition-opacity [&_.menubar]:duration-200': true,
+          'message group/message transform-[translateZ(0)] relative flex w-full flex-col rounded-[10px] pt-2.5 pb-0 transition-colors duration-300 will-change-transform': true,
           'message-assistant': isAssistantMessage,
           'message-user': !isAssistantMessage,
           'bg-muted px-3 pb-2 opacity-70 outline-offset-[-1px] [outline:1px_solid_var(--border)]': isEditing,
@@ -402,7 +393,9 @@ const UserBubbleMessage = ({
       {!isEditing && (
         <div className="MessageFooter relative mt-1 mr-[30px] flex min-h-6.5 w-[calc(100%-30px)] max-w-full items-center justify-end text-foreground-tertiary text-xs leading-none">
           <div className={cn(USER_MESSAGE_FOOTER_ACTIONS_CLASS, 'justify-end')}>
-            <span className="shrink-0">{dayjs(message.updatedAt ?? message.createdAt).format('MM/DD HH:mm')}</span>
+            <span className={MESSAGE_TIMESTAMP_CLASS}>
+              {dayjs(message.updatedAt ?? message.createdAt).format('MM/DD HH:mm')}
+            </span>
             <MessageMenuBar
               message={message}
               isLastMessage={isLastMessage}

--- a/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
@@ -40,7 +40,8 @@ interface Props {
   variant?: 'footer' | 'header'
 }
 
-const STABLE_MESSAGE_ACTION_IDS = new Set(['copy', 'more-menu'])
+const STABLE_MESSAGE_ACTION_IDS = new Set(['more-menu'])
+const COARSE_POINTER_STABLE_MESSAGE_ACTION_IDS = new Set(['copy'])
 
 const MessageMenuBar: FC<Props> = (props) => {
   const {
@@ -165,6 +166,7 @@ const MessageMenuBar: FC<Props> = (props) => {
         )}>
         {toolbarActions.map((action) => {
           const isStable = isLastMessage || STABLE_MESSAGE_ACTION_IDS.has(action.id)
+          const isCoarsePointerStable = COARSE_POINTER_STABLE_MESSAGE_ACTION_IDS.has(action.id)
 
           return (
             <span
@@ -174,7 +176,10 @@ const MessageMenuBar: FC<Props> = (props) => {
                 'shrink-0 transition-opacity duration-200 motion-reduce:transition-none',
                 isStable
                   ? 'pointer-events-auto opacity-100'
-                  : 'pointer-events-none opacity-0 group-focus-within/message:pointer-events-auto group-focus-within/message:opacity-100 group-hover/message:pointer-events-auto group-hover/message:opacity-100'
+                  : classNames(
+                      'pointer-events-none opacity-0 group-focus-within/message:pointer-events-auto group-focus-within/message:opacity-100 group-hover/message:pointer-events-auto group-hover/message:opacity-100',
+                      isCoarsePointerStable && 'pointer-coarse:pointer-events-auto pointer-coarse:opacity-100'
+                    )
               )}>
               <MessageMenuBarToolbarAction
                 action={action}

--- a/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
@@ -31,7 +31,6 @@ interface Props {
   message: MessageListItem
   isGrouped?: boolean
   isLastMessage: boolean
-  forceVisible?: boolean
   isAssistantMessage: boolean
   isProcessing: boolean
   messageContainerRef: React.RefObject<HTMLDivElement>
@@ -41,12 +40,13 @@ interface Props {
   variant?: 'footer' | 'header'
 }
 
+const STABLE_MESSAGE_ACTION_IDS = new Set(['copy', 'more-menu'])
+
 const MessageMenuBar: FC<Props> = (props) => {
   const {
     message,
     isGrouped,
     isLastMessage,
-    forceVisible = false,
     isAssistantMessage,
     isProcessing,
     messageContainerRef,
@@ -161,21 +161,33 @@ const MessageMenuBar: FC<Props> = (props) => {
         data-ui="part:message-actions"
         className={classNames(
           'menubar flex select-none flex-row items-center justify-end gap-1.5',
-          isUserBubbleStyleMessage && 'user-bubble-style mt-[5px]',
-          (isLastMessage || forceVisible) && 'show'
+          isUserBubbleStyleMessage && 'user-bubble-style mt-[5px]'
         )}>
-        {toolbarActions.map((action) => (
-          <MessageMenuBarToolbarAction
-            key={action.id}
-            action={action}
-            actionContext={actionContext}
-            executeAction={executeAction}
-            menuActions={menuActions}
-            onMenuOpenChange={onMenuOpenChange}
-            softHoverBg={softHoverBg}
-            translationItems={translationItems}
-          />
-        ))}
+        {toolbarActions.map((action) => {
+          const isStable = isLastMessage || STABLE_MESSAGE_ACTION_IDS.has(action.id)
+
+          return (
+            <span
+              key={action.id}
+              data-message-action-id={action.id}
+              className={classNames(
+                'shrink-0 transition-opacity duration-200 motion-reduce:transition-none',
+                isStable
+                  ? 'pointer-events-auto opacity-100'
+                  : 'pointer-events-none opacity-0 group-focus-within/message:pointer-events-auto group-focus-within/message:opacity-100 group-hover/message:pointer-events-auto group-hover/message:opacity-100'
+              )}>
+              <MessageMenuBarToolbarAction
+                action={action}
+                actionContext={actionContext}
+                executeAction={executeAction}
+                menuActions={menuActions}
+                onMenuOpenChange={onMenuOpenChange}
+                softHoverBg={softHoverBg}
+                translationItems={translationItems}
+              />
+            </span>
+          )
+        })}
       </div>
       {showMessageTokens && <MessageTokens message={message} />}
     </>

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageMenuBar.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageMenuBar.test.tsx
@@ -146,4 +146,19 @@ describe('MessageMenuBar', () => {
 
     expect(container.querySelector('.message-tokens')).toHaveTextContent('42 Tokens')
   })
+
+  it('keeps copy and more actions available for historical messages without hover', () => {
+    const { container } = renderWithProvider(
+      <MessageMenuBar
+        message={assistantMessage}
+        isLastMessage={false}
+        isAssistantMessage
+        isProcessing={false}
+        messageContainerRef={{ current: null } as unknown as React.RefObject<HTMLDivElement>}
+      />
+    )
+
+    expect(container.querySelector('[data-message-action-id="copy"]')).toHaveClass('opacity-100')
+    expect(container.querySelector('[data-message-action-id="more-menu"]')).toHaveClass('opacity-100')
+  })
 })

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageMenuBar.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageMenuBar.test.tsx
@@ -147,7 +147,7 @@ describe('MessageMenuBar', () => {
     expect(container.querySelector('.message-tokens')).toHaveTextContent('42 Tokens')
   })
 
-  it('keeps copy and more actions available for historical messages without hover', () => {
+  it('keeps more stable and exposes copy on coarse pointers for historical messages', () => {
     const { container } = renderWithProvider(
       <MessageMenuBar
         message={assistantMessage}
@@ -158,7 +158,11 @@ describe('MessageMenuBar', () => {
       />
     )
 
-    expect(container.querySelector('[data-message-action-id="copy"]')).toHaveClass('opacity-100')
+    expect(container.querySelector('[data-message-action-id="copy"]')).not.toHaveClass('opacity-100')
+    expect(container.querySelector('[data-message-action-id="copy"]')).toHaveClass(
+      'pointer-coarse:pointer-events-auto',
+      'pointer-coarse:opacity-100'
+    )
     expect(container.querySelector('[data-message-action-id="more-menu"]')).toHaveClass('opacity-100')
   })
 })

--- a/src/renderer/components/chat/resourceList/ResourceListMoreAction.tsx
+++ b/src/renderer/components/chat/resourceList/ResourceListMoreAction.tsx
@@ -1,0 +1,64 @@
+import { Tooltip } from '@cherrystudio/ui'
+import { actionsToCommandMenuExtraItems } from '@renderer/components/chat/actions/actionMenuItems'
+import type { ResolvedAction } from '@renderer/components/chat/actions/actionTypes'
+import { CommandPopupMenu } from '@renderer/components/command'
+import ConfirmActionPopup from '@renderer/components/popups/ConfirmActionPopup'
+import { MoreHorizontal } from 'lucide-react'
+import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { ResourceList } from './base'
+
+interface ResourceListMoreActionProps<TContext> {
+  actions: readonly ResolvedAction<TContext>[]
+  onAction: (action: ResolvedAction<TContext>) => void | Promise<void>
+}
+
+export function ResourceListMoreAction<TContext>({ actions, onAction }: ResourceListMoreActionProps<TContext>) {
+  const { t } = useTranslation()
+
+  const runAction = useCallback(
+    async (action: ResolvedAction<TContext>) => {
+      if (!action.availability.enabled) return
+
+      const confirm = action.confirm
+      if (confirm) {
+        await ConfirmActionPopup.show({
+          title: confirm.title,
+          content: confirm.description ?? confirm.content,
+          okText: confirm.confirmText,
+          cancelText: confirm.cancelText,
+          danger: confirm.destructive,
+          action: () => onAction(action)
+        })
+        return
+      }
+
+      await onAction(action)
+    },
+    [onAction]
+  )
+
+  const extraItems = useMemo(
+    () => actionsToCommandMenuExtraItems(actions, (action) => void runAction(action)),
+    [actions, runAction]
+  )
+
+  if (extraItems.length === 0) return null
+
+  return (
+    <Tooltip title={t('common.more')} delay={500}>
+      <CommandPopupMenu location="webcontents.context" extraItems={extraItems} align="end" side="bottom">
+        <ResourceList.ItemAction
+          alwaysVisible
+          type="button"
+          aria-label={t('common.more')}
+          onClick={(event) => event.stopPropagation()}>
+          <MoreHorizontal aria-hidden="true" />
+        </ResourceList.ItemAction>
+      </CommandPopupMenu>
+    </Tooltip>
+  )
+}
+
+export type { ResourceListMoreActionProps }

--- a/src/renderer/components/chat/resourceList/base/ResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceList.tsx
@@ -607,22 +607,22 @@ function ItemAction({ alwaysVisible = false, className, ref, type = 'button', ..
 
 type ItemActionsProps = ComponentProps<'div'> & {
   active?: boolean
-  alwaysVisible?: boolean
+  discoverable?: boolean
   ref?: Ref<HTMLDivElement>
 }
 
-function ItemActions({ active, alwaysVisible = false, children, className, ref, ...props }: ItemActionsProps) {
+function ItemActions({ active, children, className, discoverable = false, ref, ...props }: ItemActionsProps) {
   return (
     <div
       ref={ref}
       data-active={active || undefined}
-      data-always-visible={alwaysVisible || undefined}
+      data-discoverable={discoverable || undefined}
       data-resource-list-item-actions="true"
       className={cn(
-        '-ml-1.5 -mr-1 grid shrink-0 transition-[grid-template-columns,opacity] duration-150 group-has-[[data-resource-list-leading-slot=true]]:mr-0 motion-reduce:transition-none',
-        alwaysVisible
-          ? 'pointer-events-auto grid-cols-[1fr] opacity-100'
-          : 'pointer-events-none grid-cols-[0fr] opacity-0 focus-within:pointer-events-auto focus-within:grid-cols-[1fr] focus-within:opacity-100 group-hover:pointer-events-auto group-hover:grid-cols-[1fr] group-hover:opacity-100 data-[active=true]:pointer-events-auto data-[active=true]:grid-cols-[1fr] data-[active=true]:opacity-100',
+        '-ml-1.5 -mr-1 pointer-events-none grid shrink-0 grid-cols-[0fr] opacity-0 transition-[grid-template-columns,opacity] duration-150 group-has-[[data-resource-list-leading-slot=true]]:mr-0 motion-reduce:transition-none',
+        'focus-within:pointer-events-auto focus-within:grid-cols-[1fr] focus-within:opacity-100 group-hover:pointer-events-auto group-hover:grid-cols-[1fr] group-hover:opacity-100 data-[active=true]:pointer-events-auto data-[active=true]:grid-cols-[1fr] data-[active=true]:opacity-100',
+        discoverable &&
+          'pointer-coarse:pointer-events-auto pointer-coarse:grid-cols-[1fr] pointer-coarse:opacity-100 group-data-[selected=true]:pointer-events-auto group-data-[selected=true]:grid-cols-[1fr] group-data-[selected=true]:opacity-100',
         className
       )}
       {...props}>

--- a/src/renderer/components/chat/resourceList/base/ResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceList.tsx
@@ -581,20 +581,23 @@ function ItemLeadingSlot(props: ItemLeadingSlotProps) {
 }
 
 type ItemActionProps = ComponentProps<'button'> & {
+  alwaysVisible?: boolean
   ref?: Ref<HTMLButtonElement>
 }
 
-function ItemAction({ className, ref, type = 'button', ...props }: ItemActionProps) {
+function ItemAction({ alwaysVisible = false, className, ref, type = 'button', ...props }: ItemActionProps) {
   return (
     <button
       ref={ref}
       type={type}
       className={cn(
-        'pointer-events-none flex size-5 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 [&_svg]:size-3.5 [&_svg]:shrink-0',
+        'flex size-5 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-all duration-150 [&_svg]:size-3.5 [&_svg]:shrink-0',
         'hover:bg-accent hover:text-accent-foreground!',
         'focus-visible:pointer-events-auto focus-visible:bg-accent focus-visible:text-accent-foreground! focus-visible:opacity-100 focus-visible:outline-none',
         RESOURCE_LIST_ROW_STATE_FOREGROUND_CLASS,
-        'group-hover:pointer-events-auto group-hover:opacity-100 data-[deleting=true]:pointer-events-auto data-[deleting=true]:opacity-100',
+        alwaysVisible
+          ? 'pointer-events-auto opacity-100'
+          : 'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 data-[deleting=true]:pointer-events-auto data-[deleting=true]:opacity-100',
         className
       )}
       {...props}
@@ -604,18 +607,22 @@ function ItemAction({ className, ref, type = 'button', ...props }: ItemActionPro
 
 type ItemActionsProps = ComponentProps<'div'> & {
   active?: boolean
+  alwaysVisible?: boolean
   ref?: Ref<HTMLDivElement>
 }
 
-function ItemActions({ active, children, className, ref, ...props }: ItemActionsProps) {
+function ItemActions({ active, alwaysVisible = false, children, className, ref, ...props }: ItemActionsProps) {
   return (
     <div
       ref={ref}
       data-active={active || undefined}
+      data-always-visible={alwaysVisible || undefined}
       data-resource-list-item-actions="true"
       className={cn(
-        '-ml-1.5 -mr-1 pointer-events-none grid shrink-0 grid-cols-[0fr] opacity-0 transition-[grid-template-columns,opacity] duration-150 group-has-[[data-resource-list-leading-slot=true]]:mr-0 motion-reduce:transition-none',
-        'focus-within:pointer-events-auto focus-within:grid-cols-[1fr] focus-within:opacity-100 group-hover:pointer-events-auto group-hover:grid-cols-[1fr] group-hover:opacity-100 data-[active=true]:pointer-events-auto data-[active=true]:grid-cols-[1fr] data-[active=true]:opacity-100',
+        '-ml-1.5 -mr-1 grid shrink-0 transition-[grid-template-columns,opacity] duration-150 group-has-[[data-resource-list-leading-slot=true]]:mr-0 motion-reduce:transition-none',
+        alwaysVisible
+          ? 'pointer-events-auto grid-cols-[1fr] opacity-100'
+          : 'pointer-events-none grid-cols-[0fr] opacity-0 focus-within:pointer-events-auto focus-within:grid-cols-[1fr] focus-within:opacity-100 group-hover:pointer-events-auto group-hover:grid-cols-[1fr] group-hover:opacity-100 data-[active=true]:pointer-events-auto data-[active=true]:grid-cols-[1fr] data-[active=true]:opacity-100',
         className
       )}
       {...props}>

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -942,7 +942,7 @@ describe('ResourceList', () => {
               <ResourceList.Item item={item} data-testid="resource-row">
                 <ResourceList.ItemLeadingSlot data-testid="resource-leading-slot">#</ResourceList.ItemLeadingSlot>
                 <ResourceList.ItemTitle>{item.name}</ResourceList.ItemTitle>
-                <ResourceList.ItemActions>
+                <ResourceList.ItemActions discoverable>
                   <ResourceList.ItemAction aria-label="Item action">#</ResourceList.ItemAction>
                 </ResourceList.ItemActions>
               </ResourceList.Item>
@@ -980,9 +980,16 @@ describe('ResourceList', () => {
       'focus-visible:text-accent-foreground!'
     )
     // The action rail owns its intrinsic layout reserve; Item no longer needs to inspect React child types.
+    // Coarse pointers and selected rows keep the stable More affordance discoverable without hover.
     expect(
       screen.getByRole('button', { name: 'Item action' }).closest('[data-resource-list-item-actions]')
-    ).toHaveClass('grid-cols-[0fr]', 'group-hover:grid-cols-[1fr]', 'focus-within:grid-cols-[1fr]')
+    ).toHaveClass(
+      'grid-cols-[0fr]',
+      'group-hover:grid-cols-[1fr]',
+      'focus-within:grid-cols-[1fr]',
+      'pointer-coarse:grid-cols-[1fr]',
+      'group-data-[selected=true]:grid-cols-[1fr]'
+    )
   })
 
   it('cancels inline rename with Escape without committing the draft name', () => {

--- a/src/renderer/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/pages/agents/components/SessionItem.tsx
@@ -330,7 +330,7 @@ const SessionItem = ({
 
       <ResourceList.ItemActions
         active={isConfirmingDeletion}
-        alwaysVisible={!rowState.renaming && hasVisibleMoreMenuActions}
+        discoverable={!rowState.renaming && hasVisibleMoreMenuActions}
         onClick={(event) => event.stopPropagation()}>
         {!rowState.renaming && hasVisibleMoreMenuActions && (
           <ResourceListMoreAction actions={moreMenuActions} onAction={handleMenuAction} />

--- a/src/renderer/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/pages/agents/components/SessionItem.tsx
@@ -12,6 +12,7 @@ import {
   useResourceListActions,
   useResourceListRowState
 } from '@renderer/components/chat/resourceList/base'
+import { ResourceListMoreAction } from '@renderer/components/chat/resourceList/ResourceListMoreAction'
 import { useCache } from '@renderer/data/hooks/useCache'
 import { useSessionMenuActions } from '@renderer/hooks/chat/useSessionMenuActions'
 import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
@@ -197,6 +198,8 @@ const SessionItem = ({
   )
 
   const { getActions: getMenuActions, handleMenuAction } = useSessionMenuActions(actionContext)
+  const moreMenuActions = useMemo(() => getMenuActions(), [getMenuActions])
+  const hasVisibleMoreMenuActions = moreMenuActions.some((action) => action.availability.visible)
 
   const clearDeleteConfirmationTimeout = useCallback(() => {
     if (deleteConfirmationTimeoutRef.current === null) return
@@ -325,7 +328,13 @@ const SessionItem = ({
         />
       )}
 
-      <ResourceList.ItemActions active={isConfirmingDeletion}>
+      <ResourceList.ItemActions
+        active={isConfirmingDeletion}
+        alwaysVisible={!rowState.renaming && hasVisibleMoreMenuActions}
+        onClick={(event) => event.stopPropagation()}>
+        {!rowState.renaming && hasVisibleMoreMenuActions && (
+          <ResourceListMoreAction actions={moreMenuActions} onAction={handleMenuAction} />
+        )}
         {showPinAction && (
           <Tooltip title={pinned ? t('agent.session.unpin.title') : t('agent.session.pin.title')} delay={500}>
             <ResourceList.ItemAction

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -30,6 +30,7 @@ import {
   useResourceListPinnedState,
   useResourceListRowState
 } from '@renderer/components/chat/resourceList/base'
+import { ResourceListMoreAction } from '@renderer/components/chat/resourceList/ResourceListMoreAction'
 import { ResourceRefreshErrorBanner } from '@renderer/components/chat/resourceList/ResourceRefreshErrorBanner'
 import { TopicResourceList } from '@renderer/components/chat/resourceList/TopicResourceList'
 import { CommandPopupMenu } from '@renderer/components/command'
@@ -1861,6 +1862,8 @@ const TopicRow = memo(function TopicRow({
     topic,
     topicsLength
   })
+  const moreMenuActions = useMemo(() => getMenuActions(), [getMenuActions])
+  const hasVisibleMoreMenuActions = moreMenuActions.some((action) => action.availability.visible)
 
   const row = (
     <ResourceList.Item
@@ -1906,7 +1909,13 @@ const TopicRow = memo(function TopicRow({
           status={conversationRowStatus}
         />
       )}
-      <ResourceList.ItemActions active={isConfirmingDeletion}>
+      <ResourceList.ItemActions
+        active={isConfirmingDeletion}
+        alwaysVisible={!rowState.renaming && hasVisibleMoreMenuActions}
+        onClick={(event) => event.stopPropagation()}>
+        {!rowState.renaming && hasVisibleMoreMenuActions && (
+          <ResourceListMoreAction actions={moreMenuActions} onAction={handleMenuAction} />
+        )}
         {showPinAction && (
           <Tooltip title={topic.pinned ? t('chat.topics.unpin') : t('chat.topics.pin')} delay={500}>
             <ResourceList.ItemAction

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1911,7 +1911,7 @@ const TopicRow = memo(function TopicRow({
       )}
       <ResourceList.ItemActions
         active={isConfirmingDeletion}
-        alwaysVisible={!rowState.renaming && hasVisibleMoreMenuActions}
+        discoverable={!rowState.renaming && hasVisibleMoreMenuActions}
         onClick={(event) => event.stopPropagation()}>
         {!rowState.renaming && hasVisibleMoreMenuActions && (
           <ResourceListMoreAction actions={moreMenuActions} onAction={handleMenuAction} />

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -3049,7 +3049,7 @@ describe('Topics', () => {
     expect(screen.getByTestId('resource-list-topic')).toBeInTheDocument()
     expect(screen.queryByTestId('resource-list-grouped-loading')).not.toBeInTheDocument()
     expect(screen.getByText('Alpha Assistant')).toBeInTheDocument()
-    expect(screen.getByText('Beta Assistant')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Beta Assistant' })).toBeInTheDocument()
     expect(screen.getByText('No conversations')).toBeInTheDocument()
     expect(screen.getByText('First page topic')).toBeInTheDocument()
     expect(screen.queryAllByTestId('topic-list-row')).toHaveLength(1)


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Conversation-row and assistant-message actions were hidden until hover, making them difficult to discover and unavailable to touch-first users.

After this PR:

Keep essential Copy and More actions available without hover, reveal secondary actions through hover or keyboard focus, and add stable More entry points to Topics and Agent Sessions without causing layout shifts.

Fixes #20023

### Why we need it and why it was done in this way

Users need a reliable way to discover and operate message and row actions with mouse, keyboard, and touch input. Keeping only essential actions stable preserves a quiet reading surface while ensuring that the primary affordances remain available.

The following tradeoffs were made:

Copy and More remain visible for historical messages, while secondary actions remain quiet until hover or focus. Action wrappers stay in the layout to avoid row or message resizing.

The following alternatives were considered:

Keeping all actions hover-only would fail touch and keyboard use. Showing every action permanently would add visual noise. A single replacement menu would reduce discoverability for the most common Copy action.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20023

### Breaking changes

None.

### Special notes for your reviewer

The change preserves keyboard focus, touch interaction, reduced-motion behavior, and existing action capabilities. Focused renderer coverage passes with 42/42 tests. Oxlint and ESLint pass; the full workspace typecheck is currently blocked by unrelated existing errors involving `@cherrystudio/dsh-bridge`, EmojiPicker typings, and `webFetch`.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered; the behavior is self-explanatory and no additional user-guide update is required.
- [x] Self-review: I have reviewed my own code.

### Release note

```release-note
Conversation and message actions are now discoverable and usable without relying on hover.
```
