### PR TITLE
perf(message-renderer): isolate content from topic status updates

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -274,7 +274,6 @@ interface RenderGroupedEntryOptions {
   settleActiveTools?: boolean
   settleStreamingReasoning?: boolean
   toolDisplay?: 'content' | 'disclosure'
-  onRemoveTranslation?: () => void
 }
 
 const EMPTY_CITATION_PROJECTIONS: ReadonlyMap<CherryMessagePart, ResolvedCitationMarkers> = new Map()
@@ -584,6 +583,34 @@ const ErrorPartView = React.memo(function ErrorPartView({
   return <ErrorBlock partId={partId} error={error} message={message} cachedDiagnosis={cachedDiagnosis} />
 })
 
+const TranslationPartView = React.memo(function TranslationPartView({
+  content,
+  id,
+  isStreaming,
+  messageId
+}: {
+  content: string
+  id: string
+  isStreaming: boolean
+  messageId: string
+}) {
+  const { removeMessageTranslation, notifySuccess } = useMessageListActions()
+  const { t } = useTranslation()
+  const handleRemoveTranslation = React.useCallback(async () => {
+    await removeMessageTranslation?.(messageId)
+    notifySuccess?.(t('translate.closed'))
+  }, [messageId, notifySuccess, removeMessageTranslation, t])
+
+  return (
+    <TranslationBlock
+      id={id}
+      content={content}
+      isStreaming={isStreaming}
+      onDelete={removeMessageTranslation ? handleRemoveTranslation : undefined}
+    />
+  )
+})
+
 /**
  * Render a single part directly from CherryMessagePart — no MessageBlock conversion.
  *
@@ -642,12 +669,12 @@ function renderPart(
     case 'data-translation': {
       const translationData = (part as { data: { content: string } }).data
       return (
-        <TranslationBlock
+        <TranslationPartView
           key={partId}
           id={partId}
           content={translationData.content}
           isStreaming={isStreaming}
-          onDelete={options?.onRemoveTranslation}
+          messageId={message.id}
         />
       )
     }
@@ -1429,6 +1456,11 @@ interface MessagePartsRendererContentProps extends Props {
   priorCitationParts: readonly CherryMessagePart[]
 }
 
+const ActiveTurnStatusView = ({ fallback }: { fallback: React.ReactNode }) => {
+  const activeTurnStatus = useMessageListActiveTurnStatus()
+  return activeTurnStatus ? activeTurnStatus(fallback) : fallback
+}
+
 const MessagePartsRendererContent = React.memo(function MessagePartsRendererContent({
   collapseCompletedToolHistory,
   hoistAttachments,
@@ -1438,19 +1470,6 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
   messageParts,
   priorCitationParts
 }: MessagePartsRendererContentProps) {
-  // Inline ephemeral status for the live turn (e.g. agent api-retry). Only the active-turn message
-  // renders it; the node itself renders nothing when there is no such state.
-  const activeTurnStatus = useMessageListActiveTurnStatus()
-  const { removeMessageTranslation, notifySuccess } = useMessageListActions()
-  const { t } = useTranslation()
-  const canRemoveTranslation = !!removeMessageTranslation
-  const removeTranslationRef = React.useRef({ removeMessageTranslation, notifySuccess, t })
-  removeTranslationRef.current = { removeMessageTranslation, notifySuccess, t }
-  const handleRemoveTranslation = React.useCallback(async () => {
-    const { removeMessageTranslation, notifySuccess, t } = removeTranslationRef.current
-    await removeMessageTranslation?.(message.id)
-    notifySuccess?.(t('translate.closed'))
-  }, [message.id])
   const [expandedTextPartIds, setExpandedTextPartIds] = React.useState<ReadonlySet<string>>(() => new Set())
   const [unsettledTextPlayoutPartIds, setUnsettledTextPlayoutPartIds] = React.useState<ReadonlySet<string>>(
     () => new Set()
@@ -1551,16 +1570,13 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
       readOnlyFilePreviews,
       hiddenComposerTokens: displayProjection.hiddenImageTokens,
       onTextPlayoutSettledChange: handleTextPlayoutSettledChange,
-      onTextPartExpandedChange: handleTextPartExpandedChange,
-      onRemoveTranslation: canRemoveTranslation ? handleRemoveTranslation : undefined
+      onTextPartExpandedChange: handleTextPartExpandedChange
     }),
     [
-      canRemoveTranslation,
       expandedTextPartIds,
       citationProjectionByPart,
       handleTextPartExpandedChange,
       handleTextPlayoutSettledChange,
-      handleRemoveTranslation,
       messageCitations,
       readOnlyFilePreviews,
       displayProjection.hiddenImageTokens
@@ -1584,7 +1600,9 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
       // The status renderer replaces the placeholder while active (e.g. an api-retry line) and falls
       // back to it otherwise.
       return (
-        <AnimatePresence mode="sync">{activeTurnStatus ? activeTurnStatus(placeholder) : placeholder}</AnimatePresence>
+        <AnimatePresence mode="sync">
+          <ActiveTurnStatusView fallback={placeholder} />
+        </AnimatePresence>
       )
     }
     if (message.role === 'assistant' && message.status === 'paused') {
@@ -1604,7 +1622,7 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
         message={message}
         renderOptions={renderOptions}
       />
-      {isActiveTurnProcessing && activeTurnStatus?.(null)}
+      {isActiveTurnProcessing && <ActiveTurnStatusView fallback={null} />}
       {unsettledTextPlayoutPartIds.size === 0 && sessionTargets.length > 0 && (
         <AnimatedBlockWrapper key={`session-results-${message.id}`} enableAnimation={false} animation="fade">
           <SessionResultCards targets={sessionTargets} />

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { KeyedMessageActivityStore, useMessageActivityState } from '../../hooks/useMessageActivityState'
+import { KeyedMessageActivityStore } from '../../hooks/useMessageActivityState'
 import { MessageListProvider } from '../../MessageListProvider'
 import { defaultMessageRenderConfig, type MessageListItem, type MessageListProviderValue } from '../../types'
 import { withMessagePartDiagnosis } from '../../utils/messageDiagnosis'
@@ -544,56 +544,6 @@ describe('MessagePartsRenderer', () => {
   })
 
   describe('leaf rendering', () => {
-    it('does not rerender completed message content when the topic stream status changes', () => {
-      const completedMessage = msg({ id: 'msg-completed' })
-      const messages = [completedMessage]
-      const partsByMessageId = {
-        [completedMessage.id]: [{ type: 'text', text: 'Completed' }] as CherryMessagePart[]
-      }
-      let updateCommits = 0
-
-      function TopicActivityProvider({ children }: { children: React.ReactNode }) {
-        const activity = useMessageActivityState('t')
-        const value: MessageListProviderValue = {
-          state: {
-            topic: { id: 't', name: 'Topic' } as MessageListProviderValue['state']['topic'],
-            messages,
-            partsByMessageId,
-            messageNavigation: 'none',
-            estimateSize: 400,
-            overscan: 0,
-            loadOlderDelayMs: 0,
-            loadingResetDelayMs: 0,
-            renderConfig: defaultMessageRenderConfig,
-            messageActivityStore: activity.store,
-            getMessageActivityState: activity.getMessageActivityState
-          },
-          actions: {},
-          meta: { selectionLayer: false }
-        }
-
-        return <MessageListProvider value={value}>{children}</MessageListProvider>
-      }
-
-      render(
-        <TopicActivityProvider>
-          <React.Profiler
-            id={completedMessage.id}
-            onRender={(_, phase) => {
-              if (phase === 'update') updateCommits++
-            }}>
-            <MessagePartsRenderer message={completedMessage} />
-          </React.Profiler>
-        </TopicActivityProvider>
-      )
-
-      act(() => {
-        topicStreamStore.setStatus('streaming')
-      })
-
-      expect(updateCommits).toBe(0)
-    })
-
     it('does not rerender unrelated message content when another message becomes active', () => {
       const firstMessage = msg({ id: 'msg-1' })
       const secondMessage = msg({ id: 'msg-2' })

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { KeyedMessageActivityStore } from '../../hooks/useMessageActivityState'
+import { KeyedMessageActivityStore, useMessageActivityState } from '../../hooks/useMessageActivityState'
 import { MessageListProvider } from '../../MessageListProvider'
 import { defaultMessageRenderConfig, type MessageListItem, type MessageListProviderValue } from '../../types'
 import { withMessagePartDiagnosis } from '../../utils/messageDiagnosis'
@@ -544,6 +544,56 @@ describe('MessagePartsRenderer', () => {
   })
 
   describe('leaf rendering', () => {
+    it('does not rerender completed message content when the topic stream status changes', () => {
+      const completedMessage = msg({ id: 'msg-completed' })
+      const messages = [completedMessage]
+      const partsByMessageId = {
+        [completedMessage.id]: [{ type: 'text', text: 'Completed' }] as CherryMessagePart[]
+      }
+      let updateCommits = 0
+
+      function TopicActivityProvider({ children }: { children: React.ReactNode }) {
+        const activity = useMessageActivityState('t')
+        const value: MessageListProviderValue = {
+          state: {
+            topic: { id: 't', name: 'Topic' } as MessageListProviderValue['state']['topic'],
+            messages,
+            partsByMessageId,
+            messageNavigation: 'none',
+            estimateSize: 400,
+            overscan: 0,
+            loadOlderDelayMs: 0,
+            loadingResetDelayMs: 0,
+            renderConfig: defaultMessageRenderConfig,
+            messageActivityStore: activity.store,
+            getMessageActivityState: activity.getMessageActivityState
+          },
+          actions: {},
+          meta: { selectionLayer: false }
+        }
+
+        return <MessageListProvider value={value}>{children}</MessageListProvider>
+      }
+
+      render(
+        <TopicActivityProvider>
+          <React.Profiler
+            id={completedMessage.id}
+            onRender={(_, phase) => {
+              if (phase === 'update') updateCommits++
+            }}>
+            <MessagePartsRenderer message={completedMessage} />
+          </React.Profiler>
+        </TopicActivityProvider>
+      )
+
+      act(() => {
+        topicStreamStore.setStatus('streaming')
+      })
+
+      expect(updateCommits).toBe(0)
+    })
+
     it('does not rerender unrelated message content when another message becomes active', () => {
       const firstMessage = msg({ id: 'msg-1' })
       const secondMessage = msg({ id: 'msg-2' })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Topic stream status updates could re-render `MessagePartsRendererContent` for completed messages. The content component consumed broad message-list contexts directly, so `React.memo` could not protect the expensive message projection subtree from context invalidation.

After this PR:

Active-turn status and translation actions are read by small leaf components that render only where those capabilities are needed. `MessagePartsRendererContent` is now context-free and its existing memo boundary can skip completed messages whose own parts and activity did not change.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20145

### Why we need it and why it was done in this way

The previous keyed activity-store work isolated the outer renderer, but context reads inside the memoized content component still bypassed that boundary. Keeping the same activity store and moving only the remaining context reads closes the deep render fan-out without adding subscriptions or changing message projection logic.

The following tradeoffs were made:

- Active-turn status and translation leaves still react to their relevant contexts, but those updates are bounded to the small UI that needs them.
- The content memo boundary remains prop-driven; render configuration continues to reach it as the existing scalar prop.

The following alternatives were considered:

- Splitting the full message-list provider into more contexts would expand the shared API for two localized consumers.
- Passing broad context values through props would still invalidate every content memo when those values changed.

Links to places where the discussion took place: #20145, #19875

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- No screenshot is included because this is a render-isolation performance change with no visual output change; the review follow-up only removes a test.
- Current head `41b3b6ffc0bb77c8566093aa62bd687534875b5e` removes the whole-component React Profiler update-count test because it encoded an implementation detail. Existing component tests continue to cover active-turn status replacement and translation removal as user-observable behavior.
- Current-head validation: `MessagePartsRenderer.test.tsx` (83 tests), `CI=1 pnpm lint`, `CI=1 pnpm test:lint`, and `git diff --check` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
