### PR TITLE
fix(s3-backup): normalize Qiniu bucket endpoints

### DIFF
--- a/src/main/services/S3Storage.ts
+++ b/src/main/services/S3Storage.ts
@@ -15,7 +15,7 @@ const logger = loggerService.withContext('S3Storage')
 const S3_SOCKET_IDLE_TIMEOUT_MS = 5 * 60_000
 
 // 需要使用 Virtual Host-Style 的服务商域名后缀白名单
-const VIRTUAL_HOST_SUFFIXES = ['aliyuncs.com', 'myqcloud.com', 'volces.com']
+const VIRTUAL_HOST_SUFFIXES = ['aliyuncs.com', 'myqcloud.com', 'qiniucs.com', 'volces.com']
 
 interface S3UploadOptions {
   signal?: AbortSignal
@@ -31,18 +31,25 @@ export default class S3Storage {
 
   constructor(config: S3Config) {
     const { endpoint, region, accessKeyId, secretAccessKey, bucket, root } = config
+    let resolvedEndpoint = endpoint || undefined
 
     const usePathStyle = (() => {
       if (!endpoint) return false
 
       try {
-        const { hostname } = new URL(endpoint)
+        const endpointUrl = new URL(endpoint)
+        const { hostname } = endpointUrl
 
         if (hostname === 'localhost' || net.isIP(hostname) !== 0) {
           return true
         }
 
         const isInWhiteList = VIRTUAL_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))
+        const bucketPrefix = `${bucket.toLowerCase()}.`
+        if (isInWhiteList && hostname.startsWith(bucketPrefix)) {
+          endpointUrl.hostname = hostname.slice(bucketPrefix.length)
+          resolvedEndpoint = endpointUrl.toString()
+        }
         return !isInWhiteList
       } catch (e) {
         logger.warn(`[S3Storage] Failed to parse endpoint, fallback to Path-Style: ${endpoint}`, e as Error)
@@ -52,7 +59,7 @@ export default class S3Storage {
 
     this.client = new S3Client({
       region,
-      endpoint: endpoint || undefined,
+      endpoint: resolvedEndpoint,
       credentials: {
         accessKeyId: accessKeyId,
         secretAccessKey: secretAccessKey

--- a/src/main/services/__tests__/S3Storage.test.ts
+++ b/src/main/services/__tests__/S3Storage.test.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3'
+import { DeleteObjectCommand, ListObjectsV2Command, type S3Client } from '@aws-sdk/client-s3'
 import type { S3Config } from '@shared/types/backup'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -17,6 +17,85 @@ const config: S3Config = {
 }
 
 describe('S3Storage', () => {
+  it.each(['https://s3.cn-east-1.qiniucs.com', 'https://backups.s3.cn-east-1.qiniucs.com'])(
+    'addresses a Qiniu bucket exactly once with endpoint %s',
+    async (endpoint) => {
+      const storage = new S3Storage({
+        ...config,
+        endpoint
+      })
+      const client = Reflect.get(storage, 'client') as S3Client
+      const handle =
+        vi.fn<
+          (
+            request: unknown
+          ) => Promise<{ response: { statusCode: number; headers: Record<string, string>; body: string } }>
+        >()
+      handle.mockResolvedValue({ response: { statusCode: 200, headers: {}, body: '' } })
+      Object.assign(client.config.requestHandler, { handle })
+
+      await storage.checkConnection()
+
+      expect(handle).toHaveBeenCalledOnce()
+      expect(handle.mock.calls[0][0]).toMatchObject({
+        hostname: 'backups.s3.cn-east-1.qiniucs.com',
+        path: '/'
+      })
+    }
+  )
+
+  it('keeps Qiniu list and delete requests scoped to the configured root', async () => {
+    const storage = new S3Storage({
+      ...config,
+      endpoint: 'https://backups.s3.cn-east-1.qiniucs.com'
+    })
+    const client = Reflect.get(storage, 'client') as S3Client
+    const requests: Array<{ hostname: string; method: string; path: string; query?: Record<string, string> }> = []
+    const listResponse = Buffer.from(`
+      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Name>backups</Name>
+        <Prefix>cherry-studio/test/</Prefix>
+        <KeyCount>1</KeyCount>
+        <MaxKeys>1000</MaxKeys>
+        <IsTruncated>false</IsTruncated>
+        <Contents>
+          <Key>cherry-studio/test/backup.zip</Key>
+          <LastModified>2026-09-07T00:00:00.000Z</LastModified>
+          <Size>1</Size>
+        </Contents>
+      </ListBucketResult>
+    `)
+    const handle = vi.fn(async (request: (typeof requests)[number]) => {
+      requests.push(request)
+      return {
+        response: {
+          statusCode: 200,
+          headers: { 'content-type': 'application/xml' },
+          body: request.method === 'GET' ? listResponse : Buffer.from('')
+        }
+      }
+    })
+    Object.assign(client.config.requestHandler, { handle })
+
+    const files = await storage.listFiles()
+    await storage.deleteFile(files[0].key)
+
+    expect(files).toEqual([{ key: 'backup.zip', lastModified: '2026-09-07T00:00:00.000Z', size: 1 }])
+    expect(requests).toMatchObject([
+      {
+        hostname: 'backups.s3.cn-east-1.qiniucs.com',
+        method: 'GET',
+        path: '/',
+        query: { prefix: 'cherry-studio/test/' }
+      },
+      {
+        hostname: 'backups.s3.cn-east-1.qiniucs.com',
+        method: 'DELETE',
+        path: '/cherry-studio/test/backup.zip'
+      }
+    ])
+  })
+
   it('lists object keys relative to the configured root', async () => {
     const storage = new S3Storage(config)
     const send = vi.fn().mockResolvedValue({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Qiniu S3 endpoints were forced to path-style addressing. When the configured endpoint already included the bucket name, SDK requests addressed the bucket twice, for example `backups.s3.cn-east-1.qiniucs.com/backups/`. Uploads therefore created an extra bucket-named prefix, while listing, restore, deletion, and retention cleanup looked under a different prefix.

After this PR: Qiniu endpoints use the provider's supported virtual-host addressing. Bucket-prefixed endpoints are normalized before the SDK resolves them, so both the regional endpoint and the bucket-prefixed endpoint address the bucket exactly once.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20158

### Why we need it and why it was done in this way

The following tradeoffs were made: endpoint normalization is limited to providers already known to require virtual-host addressing. Localhost, IP endpoints, and other S3-compatible providers keep their existing path-style behavior.

The following alternatives were considered: adding only `qiniucs.com` to the virtual-host allowlist would turn an existing bucket-prefixed endpoint into `backups.backups.s3...`; keeping path-style would preserve the duplicate `/backups/` path. Normalizing a matching bucket prefix before SDK resolution handles both supported Qiniu endpoint forms.

Links to places where the discussion took place: #20158 and Qiniu's S3 endpoint documentation: https://developer.qiniu.com/kodo/4088/s3-access-domainname

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Request-level tests exercise the real AWS SDK endpoint resolver. They verify both `s3.cn-east-1.qiniucs.com` and `backups.s3.cn-east-1.qiniucs.com`, plus the complete rooted list-to-delete flow used by backup management and retention cleanup.

Validation:

- `pnpm exec vitest run --project main src/main/services/__tests__/S3Storage.test.ts src/main/services/__tests__/LegacyBackupManager.test.ts` (91 passed)
- `pnpm lint`
- `pnpm test:lint`
- No screenshot: this changes S3 request addressing and has no visual UI output.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Qiniu Cloud S3 backup, restore, management, and retention cleanup when using regional or bucket-prefixed endpoints.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes S3 request addressing for Qiniu (and bucket-prefixed virtual-host endpoints on the allowlist), which affects where backups are stored and listed; scope is limited to known provider suffixes.
> 
> **Overview**
> Fixes Qiniu Cloud S3 backup when endpoints are regional or already include the bucket name in the hostname.
> 
> **`S3Storage`** now treats `qiniucs.com` like other virtual-host providers (Aliyun, Tencent, Volcengine). If the configured endpoint hostname already starts with `{bucket}.`, that prefix is stripped before the AWS SDK builds requests, so the bucket is not addressed twice in the host and path.
> 
> New tests assert resolved request hostnames for both Qiniu endpoint forms and that list/delete stay scoped to the configured `root` prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2362de01182775cfa06ac835cf59146b56bae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->