### PR TITLE
feat(composer): reference Notes from @ mentions

### DIFF
--- a/src/main/ipc/handlers/__tests__/file.test.ts
+++ b/src/main/ipc/handlers/__tests__/file.test.ts
@@ -14,6 +14,7 @@ const {
   readChunkByPathMock,
   safeOpenMock,
   showPathInFolderMock,
+  validateNotesDirectoryMock,
   writeIfUnchangedByPathMock
 } = vi.hoisted(() => ({
   appGetMock: vi.fn(),
@@ -24,6 +25,7 @@ const {
   readChunkByPathMock: vi.fn(),
   safeOpenMock: vi.fn(),
   showPathInFolderMock: vi.fn(),
+  validateNotesDirectoryMock: vi.fn(),
   writeIfUnchangedByPathMock: vi.fn()
 }))
 vi.mock('@application', () => ({ application: { get: appGetMock } }))
@@ -63,6 +65,7 @@ vi.mock('@main/services/file', async () => {
     readChunkByPath: readChunkByPathMock,
     safeOpen: safeOpenMock,
     showInFolder: showPathInFolderMock,
+    validateNotesDirectory: validateNotesDirectoryMock,
     writeIfUnchangedByPath: writeIfUnchangedByPathMock
   }
 })
@@ -448,6 +451,15 @@ describe('fileHandlers', () => {
     expect(showPathInFolderMock).toHaveBeenCalledWith('/tmp/report.md')
     expect(fileManager.open).not.toHaveBeenCalled()
     expect(fileManager.showInFolder).not.toHaveBeenCalled()
+  })
+
+  it('validates Notes directories through the typed file route', async () => {
+    validateNotesDirectoryMock.mockReturnValueOnce(true)
+
+    await expect(fileHandlers['file.validate_notes_directory']('/tmp/notes' as AbsoluteFilePath, ctx)).resolves.toBe(
+      true
+    )
+    expect(validateNotesDirectoryMock).toHaveBeenCalledWith('/tmp/notes')
   })
 
   it('dispatches range reads for entry and path handles through file.read', async () => {

--- a/src/main/ipc/handlers/file.ts
+++ b/src/main/ipc/handlers/file.ts
@@ -8,6 +8,7 @@ import {
   readChunkByPath,
   safeOpen,
   showInFolder as showPathInFolder,
+  validateNotesDirectory,
   writeIfUnchangedByPath
 } from '@main/services/file'
 import { DirectoryTreeStoppedError, StaleVersionError } from '@main/services/file'
@@ -153,6 +154,7 @@ export const fileHandlers: IpcHandlersFor<typeof fileRequestSchemas> = {
     const fileManager = application.get('FileManager')
     return dispatchHandle(handle as FileHandle, (entryId) => fileManager.showInFolder(entryId), showPathInFolder)
   },
+  'file.validate_notes_directory': async (path) => validateNotesDirectory(path),
   'file.tree.create': async ({ rootPath, options }, { senderId }) => {
     try {
       return await application.get('DirectoryTreeManager').create(requireSenderWebContents(senderId), rootPath, options)

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -16,9 +16,12 @@
  * `safeOpen` handoff in `openPath`. */
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { isWin } from '@main/core/platform'
 import { t } from '@main/i18n'
-import { assertOutsideManagedStorageMutation, safeOpen } from '@main/services/file'
+import {
+  assertOutsideManagedStorageMutation,
+  safeOpen,
+  validateNotesDirectory as validateNotesDirectoryPath
+} from '@main/services/file'
 import { getFileType } from '@main/utils/file'
 import {
   checkName,
@@ -708,66 +711,7 @@ class FileStorage {
   }
 
   public validateNotesDirectory = async (_: Electron.IpcMainInvokeEvent, dirPath: string): Promise<boolean> => {
-    try {
-      if (!dirPath || typeof dirPath !== 'string') {
-        return false
-      }
-
-      // Normalize path
-      const normalizedPath = path.resolve(dirPath)
-
-      // Check if directory exists
-      if (!fs.existsSync(normalizedPath)) {
-        return false
-      }
-
-      // Check if it's actually a directory
-      const stats = fs.statSync(normalizedPath)
-      if (!stats.isDirectory()) {
-        return false
-      }
-
-      // Get app paths to prevent selection of restricted directories
-      const appDataPath = path.resolve(application.getPath('sys.appdata'))
-      const filesDir = path.resolve(application.getPath('feature.files.data'))
-      const currentNotesDir = path.resolve(application.getPath('feature.notes.data'))
-
-      // Prevent selecting app data directories
-      if (
-        normalizedPath.startsWith(filesDir) ||
-        normalizedPath.startsWith(appDataPath) ||
-        normalizedPath === currentNotesDir
-      ) {
-        logger.warn(`Invalid directory selection: ${normalizedPath} (app data directory)`)
-        return false
-      }
-
-      // Prevent selecting system root directories
-      const isSystemRoot = isWin
-        ? /^[a-zA-Z]:[\\/]?$/.test(normalizedPath)
-        : normalizedPath === '/' ||
-          normalizedPath === '/usr' ||
-          normalizedPath === '/etc' ||
-          normalizedPath === '/System'
-
-      if (isSystemRoot) {
-        logger.warn(`Invalid directory selection: ${normalizedPath} (system root directory)`)
-        return false
-      }
-
-      // Check write permissions
-      try {
-        fs.accessSync(normalizedPath, fs.constants.W_OK)
-      } catch (error) {
-        logger.warn(`Directory not writable: ${normalizedPath}`)
-        return false
-      }
-
-      return true
-    } catch (error) {
-      logger.error('Failed to validate notes directory:', error as Error)
-      return false
-    }
+    return validateNotesDirectoryPath(dirPath)
   }
 
   public save = async (

--- a/src/main/services/file/index.ts
+++ b/src/main/services/file/index.ts
@@ -88,6 +88,7 @@ export { readByPath, readChunkByPath, writeIfUnchangedByPath } from './utils/con
 // IPC batch-metadata handler.
 export { assertOutsideManagedStorageMutation } from './utils/managedStorageGuard'
 export { getMetadataByPath } from './utils/metadata'
+export { validateNotesDirectory } from './utils/notesDirectory'
 
 // Directory listing primitives. Consumed by legacy IPC directory routes
 // (pending IpcApi migration).

--- a/src/main/services/file/utils/__tests__/notesDirectory.test.ts
+++ b/src/main/services/file/utils/__tests__/notesDirectory.test.ts
@@ -1,0 +1,60 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loggerMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn()
+}))
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory()
+})
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => loggerMocks
+  }
+}))
+
+const { application } = await import('@application')
+const { validateNotesDirectory } = await import('../notesDirectory')
+
+describe('validateNotesDirectory', () => {
+  let root: string
+  let appDataPath: string
+  let filesPath: string
+  let notesPath: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'cherry-notes-directory-'))
+    appDataPath = path.join(root, 'AppData')
+    filesPath = path.join(root, 'Files')
+    notesPath = path.join(root, 'Notes')
+    await Promise.all([mkdir(appDataPath), mkdir(filesPath), mkdir(notesPath), mkdir(path.join(root, 'CustomNotes'))])
+    vi.spyOn(application, 'getPath').mockImplementation((key: string) => {
+      if (key === 'sys.appdata') return appDataPath
+      if (key === 'feature.files.data') return filesPath
+      if (key === 'feature.notes.data') return notesPath
+      throw new Error(`Unexpected application.getPath(${key})`)
+    })
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('accepts a writable directory outside application-managed paths', () => {
+    expect(validateNotesDirectory(path.join(root, 'CustomNotes'))).toBe(true)
+  })
+
+  it('rejects application data, FileManager data, and the default Notes directory', () => {
+    expect(validateNotesDirectory(appDataPath)).toBe(false)
+    expect(validateNotesDirectory(filesPath)).toBe(false)
+    expect(validateNotesDirectory(notesPath)).toBe(false)
+  })
+})

--- a/src/main/services/file/utils/notesDirectory.ts
+++ b/src/main/services/file/utils/notesDirectory.ts
@@ -1,0 +1,53 @@
+import * as fs from 'node:fs'
+import path from 'node:path'
+
+import { application } from '@application'
+import { loggerService } from '@logger'
+import { isWin } from '@main/core/platform'
+
+const logger = loggerService.withContext('NotesDirectory')
+
+export function validateNotesDirectory(dirPath: string): boolean {
+  try {
+    if (!dirPath || typeof dirPath !== 'string') return false
+
+    const normalizedPath = path.resolve(dirPath)
+    if (!fs.existsSync(normalizedPath) || !fs.statSync(normalizedPath).isDirectory()) return false
+
+    const appDataPath = path.resolve(application.getPath('sys.appdata'))
+    const filesDir = path.resolve(application.getPath('feature.files.data'))
+    const currentNotesDir = path.resolve(application.getPath('feature.notes.data'))
+    if (
+      normalizedPath.startsWith(filesDir) ||
+      normalizedPath.startsWith(appDataPath) ||
+      normalizedPath === currentNotesDir
+    ) {
+      logger.warn(`Invalid directory selection: ${normalizedPath} (app data directory)`)
+      return false
+    }
+
+    const isSystemRoot =
+      (isWin && /^[a-zA-Z]:[\\/]?$/.test(normalizedPath)) ||
+      (!isWin &&
+        (normalizedPath === '/' ||
+          normalizedPath === '/usr' ||
+          normalizedPath === '/etc' ||
+          normalizedPath === '/System'))
+    if (isSystemRoot) {
+      logger.warn(`Invalid directory selection: ${normalizedPath} (system root directory)`)
+      return false
+    }
+
+    try {
+      fs.accessSync(normalizedPath, fs.constants.W_OK)
+    } catch {
+      logger.warn(`Directory not writable: ${normalizedPath}`)
+      return false
+    }
+
+    return true
+  } catch (error) {
+    logger.error('Failed to validate notes directory:', error as Error)
+    return false
+  }
+}

--- a/src/renderer/components/composer/tools/definitions/__tests__/noteReferenceTool.test.tsx
+++ b/src/renderer/components/composer/tools/definitions/__tests__/noteReferenceTool.test.tsx
@@ -57,7 +57,8 @@ vi.mock('@renderer/services/NotesService', () => ({
   resolveNotesPath: (...args: unknown[]) => mocks.resolveNotesPath(...args)
 }))
 
-import { NoteReferenceComposerRuntime, noteToComposerAttachment } from '../noteReferenceTool'
+import { noteToComposerAttachment } from '../noteReference'
+import { NoteReferenceComposerRuntime } from '../noteReferenceTool'
 
 const t = ((key: string) => key) as any
 

--- a/src/renderer/components/composer/tools/definitions/noteReference.ts
+++ b/src/renderer/components/composer/tools/definitions/noteReference.ts
@@ -1,0 +1,26 @@
+import { FILE_TYPE } from '@renderer/types/file'
+import type { NotesTreeNode } from '@renderer/types/note'
+import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
+import { createComposerFileTokenSourceId } from '@renderer/utils/message/composerFileTokenSource'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
+import type { DirectoryTreeOptions } from '@shared/utils/file'
+
+export const NOTES_TREE_OPTIONS: DirectoryTreeOptions = {
+  extensions: ['.md'],
+  respectGitignore: false,
+  includeHidden: false
+}
+
+export function noteToComposerAttachment(note: Pick<NotesTreeNode, 'externalPath' | 'name'>): ComposerAttachment {
+  const fileName = note.externalPath.split(/[\\/]/).at(-1) || `${note.name}.md`
+
+  return {
+    fileTokenSourceId: createComposerFileTokenSourceId(),
+    path: AbsoluteFilePathSchema.parse(note.externalPath),
+    name: fileName,
+    origin_name: fileName,
+    ext: '.md',
+    size: 0,
+    type: FILE_TYPE.TEXT
+  }
+}

--- a/src/renderer/components/composer/tools/definitions/noteReferenceTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/noteReferenceTool.tsx
@@ -8,37 +8,14 @@ import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import { openRoute } from '@renderer/services/mainWindowNavigation'
 import { projectNotesTree, resolveNotesPath } from '@renderer/services/NotesService'
 import { flattenTreeToFiles } from '@renderer/services/NotesTreeService'
-import { FILE_TYPE } from '@renderer/types/file'
-import type { NotesTreeNode } from '@renderer/types/note'
-import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
-import { createComposerFileTokenSourceId } from '@renderer/utils/message/composerFileTokenSource'
-import { AbsoluteFilePathSchema } from '@shared/types/file'
 import { NotebookPen, Settings2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { NOTES_TREE_OPTIONS,noteToComposerAttachment } from './noteReference'
+
 export const NOTE_REFERENCE_LAUNCHER_ID = 'note-reference'
 
-const NOTES_TREE_OPTIONS = {
-  extensions: ['.md'],
-  respectGitignore: false,
-  includeHidden: false
-}
-
 type NoteReferenceToolContext = ToolRenderContext<readonly ['files'], readonly ['setFiles']>
-
-export function noteToComposerAttachment(note: NotesTreeNode): ComposerAttachment {
-  const fileName = note.externalPath.split(/[\\/]/).at(-1) || `${note.name}.md`
-
-  return {
-    fileTokenSourceId: createComposerFileTokenSourceId(),
-    path: AbsoluteFilePathSchema.parse(note.externalPath),
-    name: fileName,
-    origin_name: fileName,
-    ext: '.md',
-    size: 0,
-    type: FILE_TYPE.TEXT
-  }
-}
 
 export const NoteReferenceComposerRuntime = ({ context }: { context: NoteReferenceToolContext }) => {
   const { actions, launcher, state, t } = context

--- a/src/renderer/components/composer/tools/definitions/noteReferenceTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/noteReferenceTool.tsx
@@ -11,7 +11,7 @@ import { flattenTreeToFiles } from '@renderer/services/NotesTreeService'
 import { NotebookPen, Settings2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { NOTES_TREE_OPTIONS,noteToComposerAttachment } from './noteReference'
+import { NOTES_TREE_OPTIONS, noteToComposerAttachment } from './noteReference'
 
 export const NOTE_REFERENCE_LAUNCHER_ID = 'note-reference'
 

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -80,6 +80,7 @@ import { ChatConversationControls, type ChatConversationControlsProps } from './
 import { type ChatComposerDraftCache, readChatDraftCache, writeChatDraftCache } from './chat/chatDraftCache'
 import { createEditableMessageDraft, getEditableKnowledgeBases } from './chat/messageEditingDraft'
 import { useChatMentionedModels } from './chat/useChatMentionedModels'
+import { useNoteReferenceMentionItems } from './chat/useNoteReferenceMentionItems'
 import {
   chatComposerTokenId,
   fileToComposerToken,
@@ -1248,9 +1249,22 @@ const ChatComposerInner = ({
     [reconcileTokens]
   )
 
+  const { getItems: getNoteReferenceItems, resetItems: resetNoteReferenceItems } = useNoteReferenceMentionItems({
+    files,
+    setFiles
+  })
+  const additionalReferenceItems = useMemo(
+    () => ({
+      getItems: getNoteReferenceItems,
+      onExit: resetNoteReferenceItems,
+      title: t('chat.input.note_reference.title')
+    }),
+    [getNoteReferenceItems, resetNoteReferenceItems, t]
+  )
   const { sources: entityReferenceSources, hasPendingReference } = useEntityReferenceMentionSource({
     entityType: 'topic',
-    excludeId: topicId
+    excludeId: topicId,
+    additionalItems: additionalReferenceItems
   })
 
   const onPause = useCallback(() => {

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -1249,17 +1249,13 @@ const ChatComposerInner = ({
     [reconcileTokens]
   )
 
-  const { getItems: getNoteReferenceItems, resetItems: resetNoteReferenceItems } = useNoteReferenceMentionItems({
-    files,
-    setFiles
-  })
+  const { getItems: getNoteReferenceItems } = useNoteReferenceMentionItems({ files, setFiles })
   const additionalReferenceItems = useMemo(
     () => ({
       getItems: getNoteReferenceItems,
-      onExit: resetNoteReferenceItems,
       title: t('chat.input.note_reference.title')
     }),
-    [getNoteReferenceItems, resetNoteReferenceItems, t]
+    [getNoteReferenceItems, t]
   )
   const { sources: entityReferenceSources, hasPendingReference } = useEntityReferenceMentionSource({
     entityType: 'topic',

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -40,7 +40,6 @@ const mocks = vi.hoisted(() => ({
   getDraft: vi.fn(),
   getNoteReferenceItems: vi.fn(async (): Promise<ComposerSuggestionItem[]> => []),
   reconcileTokens: vi.fn(),
-  resetNoteReferenceItems: vi.fn(),
   commandHandlers: new Map<string, () => void>(),
   commandOptions: new Map<string, { enabled?: boolean }>(),
   eventListeners: new Map<string, (payload: unknown) => void>(),
@@ -208,8 +207,7 @@ vi.mock('@renderer/components/composer/ComposerSurface', () => {
 
 vi.mock('../chat/useNoteReferenceMentionItems', () => ({
   useNoteReferenceMentionItems: () => ({
-    getItems: mocks.getNoteReferenceItems,
-    resetItems: mocks.resetNoteReferenceItems
+    getItems: mocks.getNoteReferenceItems
   })
 }))
 
@@ -725,7 +723,6 @@ describe('ChatComposer', () => {
     mocks.getDraft.mockReturnValue({ text: 'original draft', tokens: [] })
     mocks.getNoteReferenceItems.mockReset()
     mocks.getNoteReferenceItems.mockResolvedValue([])
-    mocks.resetNoteReferenceItems.mockReset()
     mocks.reconcileTokens.mockReset()
     mocks.reconcileTokens.mockImplementation((draftTokens: readonly ComposerSerializedToken[]) => {
       const knowledgeTokenIds = new Set(
@@ -863,9 +860,6 @@ describe('ChatComposer', () => {
     expect(source?.title).toBe('chat.input.reference_panel.title')
     await expect(source?.items({ query: 'daily', editor: {} as never })).resolves.toEqual([noteItem])
     expect(mocks.getNoteReferenceItems).toHaveBeenCalledWith({ query: 'daily', editor: {} })
-
-    source?.onExit?.({} as never)
-    expect(mocks.resetNoteReferenceItems).toHaveBeenCalled()
   })
 
   it('renders context usage after the speed control next to the send action', () => {

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -8,6 +8,7 @@ import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { IpcChannel } from '@shared/IpcChannel'
 import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
+import { MockDataApiUtils } from '@test-mocks/renderer/DataApiService'
 import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -16,6 +17,7 @@ import type * as ReactI18nextModule from 'react-i18next'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerSurfaceProps } from '../../ComposerSurface'
+import type { ComposerSuggestionItem } from '../../quickPanel'
 import type { ComposerSerializedToken } from '../../tokens'
 import type { ComposerToolFooterAction } from '../../toolLauncher'
 import ChatComposer, { ChatHomeComposer, ChatPlacementComposer } from '../ChatComposer'
@@ -36,7 +38,9 @@ const mocks = vi.hoisted(() => ({
   replaceDraft: vi.fn(),
   toggleExpanded: vi.fn(),
   getDraft: vi.fn(),
+  getNoteReferenceItems: vi.fn(async (): Promise<ComposerSuggestionItem[]> => []),
   reconcileTokens: vi.fn(),
+  resetNoteReferenceItems: vi.fn(),
   commandHandlers: new Map<string, () => void>(),
   commandOptions: new Map<string, { enabled?: boolean }>(),
   eventListeners: new Map<string, (payload: unknown) => void>(),
@@ -201,6 +205,13 @@ vi.mock('@renderer/components/composer/ComposerSurface', () => {
     default: MockComposerSurface
   }
 })
+
+vi.mock('../chat/useNoteReferenceMentionItems', () => ({
+  useNoteReferenceMentionItems: () => ({
+    getItems: mocks.getNoteReferenceItems,
+    resetItems: mocks.resetNoteReferenceItems
+  })
+}))
 
 vi.mock('@renderer/services/EventService', () => ({
   EVENT_NAMES: {
@@ -712,6 +723,9 @@ describe('ChatComposer', () => {
     mocks.toggleExpanded.mockReset()
     mocks.getDraft.mockReset()
     mocks.getDraft.mockReturnValue({ text: 'original draft', tokens: [] })
+    mocks.getNoteReferenceItems.mockReset()
+    mocks.getNoteReferenceItems.mockResolvedValue([])
+    mocks.resetNoteReferenceItems.mockReset()
     mocks.reconcileTokens.mockReset()
     mocks.reconcileTokens.mockImplementation((draftTokens: readonly ComposerSerializedToken[]) => {
       const knowledgeTokenIds = new Set(
@@ -790,6 +804,7 @@ describe('ChatComposer', () => {
       return () => mocks.ipcListeners.delete(channel)
     })
     MockUseCacheUtils.resetMocks()
+    MockDataApiUtils.resetMocks()
     Object.defineProperty(window, 'electron', {
       configurable: true,
       value: {
@@ -831,6 +846,26 @@ describe('ChatComposer', () => {
       within(screen.getByTestId('composer-send-accessory')).queryByRole('button', { name: 'tool menu' })
     ).not.toBeInTheDocument()
     expect(mocks.surfaceProps?.narrowMode).toBe(false)
+  })
+
+  it('includes Notes results in the chat @ reference source', async () => {
+    const noteItem: ComposerSuggestionItem = {
+      id: 'note-reference:/notes/Daily.md',
+      label: 'Daily',
+      command: vi.fn()
+    }
+    mocks.getNoteReferenceItems.mockResolvedValue([noteItem])
+    MockDataApiUtils.setCustomResponse('/search/entities', 'GET', { groups: [] })
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    const source = mocks.surfaceProps?.suggestionSources?.find((candidate) => candidate.char === '@')
+    expect(source?.title).toBe('chat.input.reference_panel.title')
+    await expect(source?.items({ query: 'daily', editor: {} as never })).resolves.toEqual([noteItem])
+    expect(mocks.getNoteReferenceItems).toHaveBeenCalledWith({ query: 'daily', editor: {} })
+
+    source?.onExit?.({} as never)
+    expect(mocks.resetNoteReferenceItems).toHaveBeenCalled()
   })
 
   it('renders context usage after the speed control next to the send action', () => {

--- a/src/renderer/components/composer/variants/chat/__tests__/useNoteReferenceMentionItems.test.tsx
+++ b/src/renderer/components/composer/variants/chat/__tests__/useNoteReferenceMentionItems.test.tsx
@@ -4,16 +4,17 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import type { Editor } from '@tiptap/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ComposerSuggestionItem } from '../../../quickPanel'
 import { useNoteReferenceMentionItems } from '../useNoteReferenceMentionItems'
 
 const mocks = vi.hoisted(() => ({
   directoryTreeCalls: [] as Array<{ path: string | undefined; options: unknown }>,
   directoryTreeError: null as Error | null,
   directoryTreeLoading: false,
-  directoryTreeRoot: null as object | null,
+  directoryTreeRoot: true,
   directoryTreeVersion: 0,
-  ipcApiRequest: vi.fn(),
   projectNotesTree: vi.fn(),
+  resolveNotesPath: vi.fn(),
   notesPath: '/configured-notes'
 }))
 
@@ -21,7 +22,7 @@ vi.mock('@renderer/hooks/useDirectoryTree', () => ({
   useDirectoryTree: (path: string | undefined, options: unknown) => {
     mocks.directoryTreeCalls.push({ path, options })
     return {
-      root: path ? mocks.directoryTreeRoot : null,
+      root: path && mocks.directoryTreeRoot ? { path } : null,
       isLoading: mocks.directoryTreeLoading,
       error: mocks.directoryTreeError,
       version: mocks.directoryTreeVersion
@@ -33,14 +34,9 @@ vi.mock('@renderer/hooks/useNotesSettings', () => ({
   useNotesSettings: () => ({ notesPath: mocks.notesPath })
 }))
 
-vi.mock('@renderer/ipc', () => ({
-  ipcApi: {
-    request: (...args: unknown[]) => mocks.ipcApiRequest(...args)
-  }
-}))
-
 vi.mock('@renderer/services/NotesService', () => ({
-  projectNotesTree: (...args: unknown[]) => mocks.projectNotesTree(...args)
+  projectNotesTree: (...args: unknown[]) => mocks.projectNotesTree(...args),
+  resolveNotesPath: (...args: unknown[]) => mocks.resolveNotesPath(...args)
 }))
 
 const createEditor = () => {
@@ -58,14 +54,14 @@ describe('useNoteReferenceMentionItems', () => {
     mocks.directoryTreeCalls = []
     mocks.directoryTreeError = null
     mocks.directoryTreeLoading = false
-    mocks.directoryTreeRoot = {}
+    mocks.directoryTreeRoot = true
     mocks.directoryTreeVersion = 0
     mocks.notesPath = '/configured-notes'
-    mocks.ipcApiRequest.mockResolvedValue({ notesPath: '/default-notes' })
     mocks.projectNotesTree.mockReturnValue([])
+    mocks.resolveNotesPath.mockImplementation(async (path: string) => ({ path, isFallback: false }))
   })
 
-  it('activates the canonical tree only after a Notes @ mention is requested', async () => {
+  it('waits for the original Notes @ request and returns real deep-note results', async () => {
     const deepPath = `/configured-notes/${Array.from({ length: 11 }, (_, index) => `level-${index + 1}`).join('/')}/Launch plan.md`
     const deepNote: NotesTreeNode = {
       id: deepPath,
@@ -76,23 +72,31 @@ describe('useNoteReferenceMentionItems', () => {
       createdAt: '',
       updatedAt: ''
     }
+    mocks.directoryTreeLoading = true
     mocks.projectNotesTree.mockReturnValue([deepNote])
     const setFiles = vi.fn()
-    const { result } = renderHook(() => useNoteReferenceMentionItems({ files: [], setFiles }))
+    const { result, rerender } = renderHook(() => useNoteReferenceMentionItems({ files: [], setFiles }))
 
     expect(mocks.directoryTreeCalls.some(({ path }) => path === '/configured-notes')).toBe(false)
 
-    await act(async () => {
-      const items = await result.current.getItems({ query: 'launch', editor: createEditor().editor })
-      expect(items[0]).toMatchObject({ id: 'note-reference:mention-loading', disabled: true })
+    let itemsPromise!: Promise<ComposerSuggestionItem[]>
+    act(() => {
+      itemsPromise = result.current.getItems({ query: 'launch', editor: createEditor().editor })
     })
 
+    await waitFor(() => expect(mocks.resolveNotesPath).toHaveBeenCalledWith('/configured-notes'))
     await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/configured-notes')).toBe(true))
-    const items = await result.current.getItems({ query: 'launch', editor: createEditor().editor })
 
-    expect(mocks.ipcApiRequest).not.toHaveBeenCalled()
+    act(() => {
+      mocks.directoryTreeLoading = false
+      rerender()
+    })
+
+    const items = await itemsPromise
+
     expect(items).toHaveLength(1)
     expect(items[0]).toMatchObject({
+      id: `note-reference:${deepPath}`,
       label: 'Launch plan',
       description: `/level-1/level-2/level-3/level-4/level-5/level-6/level-7/level-8/level-9/level-10/level-11/Launch plan`
     })
@@ -116,11 +120,12 @@ describe('useNoteReferenceMentionItems', () => {
     const { editor, insertComposerToken, run } = createEditor()
     const { result } = renderHook(() => useNoteReferenceMentionItems({ files, setFiles }))
 
-    await act(async () => {
-      await result.current.getItems({ query: 'daily', editor })
+    let itemsPromise!: Promise<ComposerSuggestionItem[]>
+    act(() => {
+      itemsPromise = result.current.getItems({ query: 'daily', editor })
     })
     await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/configured-notes')).toBe(true))
-    const [item] = await result.current.getItems({ query: 'daily', editor })
+    const [item] = await itemsPromise
 
     act(() => item.command({ editor, range: { from: 1, to: 7 }, item, query: 'daily' }))
 
@@ -143,15 +148,30 @@ describe('useNoteReferenceMentionItems', () => {
     ])
   })
 
-  it('loads the default Notes directory through IpcApi only after a mention is requested', async () => {
-    mocks.notesPath = ''
+  it('uses the validated configured-path fallback before loading Notes after @ is requested', async () => {
+    const defaultNote: NotesTreeNode = {
+      id: '/default-notes/Welcome.md',
+      name: 'Welcome',
+      type: 'file',
+      treePath: '/Welcome',
+      externalPath: '/default-notes/Welcome.md',
+      createdAt: '',
+      updatedAt: ''
+    }
+    mocks.notesPath = '/invalid-notes'
+    mocks.projectNotesTree.mockReturnValue([defaultNote])
+    mocks.resolveNotesPath.mockResolvedValue({ path: '/default-notes', isFallback: true })
     const { result } = renderHook(() => useNoteReferenceMentionItems({ files: [], setFiles: vi.fn() }))
 
-    await act(async () => {
-      await result.current.getItems({ query: '', editor: createEditor().editor })
+    let itemsPromise!: Promise<ComposerSuggestionItem[]>
+    act(() => {
+      itemsPromise = result.current.getItems({ query: 'welcome', editor: createEditor().editor })
     })
-
-    await waitFor(() => expect(mocks.ipcApiRequest).toHaveBeenCalledWith('app.get_info'))
     await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/default-notes')).toBe(true))
+    const [item] = await itemsPromise
+
+    expect(mocks.resolveNotesPath).toHaveBeenCalledWith('/invalid-notes')
+    expect(mocks.directoryTreeCalls.some(({ path }) => path === '/default-notes')).toBe(true)
+    expect(item).toMatchObject({ id: 'note-reference:/default-notes/Welcome.md', label: 'Welcome' })
   })
 })

--- a/src/renderer/components/composer/variants/chat/__tests__/useNoteReferenceMentionItems.test.tsx
+++ b/src/renderer/components/composer/variants/chat/__tests__/useNoteReferenceMentionItems.test.tsx
@@ -1,14 +1,32 @@
+import type { NotesTreeNode } from '@renderer/types/note'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import type { Editor } from '@tiptap/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNoteReferenceMentionItems } from '../useNoteReferenceMentionItems'
 
 const mocks = vi.hoisted(() => ({
-  listDirectory: vi.fn(),
+  directoryTreeCalls: [] as Array<{ path: string | undefined; options: unknown }>,
+  directoryTreeError: null as Error | null,
+  directoryTreeLoading: false,
+  directoryTreeRoot: null as object | null,
+  directoryTreeVersion: 0,
+  projectNotesTree: vi.fn(),
   resolveNotesPath: vi.fn(),
   notesPath: '/configured-notes'
+}))
+
+vi.mock('@renderer/hooks/useDirectoryTree', () => ({
+  useDirectoryTree: (path: string | undefined, options: unknown) => {
+    mocks.directoryTreeCalls.push({ path, options })
+    return {
+      root: mocks.directoryTreeRoot,
+      isLoading: mocks.directoryTreeLoading,
+      error: mocks.directoryTreeError,
+      version: mocks.directoryTreeVersion
+    }
+  }
 }))
 
 vi.mock('@renderer/hooks/useNotesSettings', () => ({
@@ -16,6 +34,7 @@ vi.mock('@renderer/hooks/useNotesSettings', () => ({
 }))
 
 vi.mock('@renderer/services/NotesService', () => ({
+  projectNotesTree: (...args: unknown[]) => mocks.projectNotesTree(...args),
   resolveNotesPath: (...args: unknown[]) => mocks.resolveNotesPath(...args)
 }))
 
@@ -31,50 +50,61 @@ const createEditor = () => {
 describe('useNoteReferenceMentionItems', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.directoryTreeCalls = []
+    mocks.directoryTreeError = null
+    mocks.directoryTreeLoading = false
+    mocks.directoryTreeRoot = {}
+    mocks.directoryTreeVersion = 0
     mocks.notesPath = '/configured-notes'
     mocks.resolveNotesPath.mockResolvedValue({ path: '/notes', isFallback: true })
-    Object.defineProperty(window, 'api', {
-      configurable: true,
-      value: {
-        file: {
-          listDirectory: mocks.listDirectory
-        }
-      }
-    })
+    mocks.projectNotesTree.mockReturnValue([])
   })
 
-  it('searches the resolved Notes directory and exposes matching Markdown notes', async () => {
-    mocks.listDirectory.mockResolvedValue(['/notes/projects/Launch plan.md', '/notes/assets/launch.png'])
+  it('searches deep Markdown notes from the canonical directory tree', async () => {
+    const deepPath = `/notes/${Array.from({ length: 11 }, (_, index) => `level-${index + 1}`).join('/')}/Launch plan.md`
+    const deepNote: NotesTreeNode = {
+      id: deepPath,
+      name: 'Launch plan',
+      type: 'file',
+      treePath: `/${deepPath.slice('/notes/'.length, -'.md'.length)}`,
+      externalPath: deepPath,
+      createdAt: '',
+      updatedAt: ''
+    }
+    mocks.projectNotesTree.mockReturnValue([deepNote])
     const setFiles = vi.fn()
     const { result } = renderHook(() => useNoteReferenceMentionItems({ files: [], setFiles }))
 
+    await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/notes')).toBe(true))
     const items = await result.current.getItems({ query: 'launch', editor: createEditor().editor })
 
     expect(mocks.resolveNotesPath).toHaveBeenCalledWith('/configured-notes')
-    expect(mocks.listDirectory).toHaveBeenCalledWith(
-      '/notes',
-      expect.objectContaining({
-        recursive: true,
-        includeFiles: true,
-        includeDirectories: false,
-        searchPattern: '.'
-      })
-    )
     expect(items).toHaveLength(1)
     expect(items[0]).toMatchObject({
       label: 'Launch plan',
-      description: '/projects/Launch plan'
+      description: `/level-1/level-2/level-3/level-4/level-5/level-6/level-7/level-8/level-9/level-10/level-11/Launch plan`
     })
   })
 
   it('inserts a selected note through the existing file token and attachment flow', async () => {
-    mocks.listDirectory.mockResolvedValue(['/notes/Daily.md'])
+    const note: NotesTreeNode = {
+      id: '/notes/Daily.md',
+      name: 'Daily',
+      type: 'file',
+      treePath: '/Daily',
+      externalPath: '/notes/Daily.md',
+      createdAt: '',
+      updatedAt: ''
+    }
+    mocks.projectNotesTree.mockReturnValue([note])
     let files: ComposerAttachment[] = []
     const setFiles = vi.fn((updater: React.SetStateAction<ComposerAttachment[]>) => {
       files = typeof updater === 'function' ? updater(files) : updater
     })
     const { editor, insertComposerToken, run } = createEditor()
     const { result } = renderHook(() => useNoteReferenceMentionItems({ files, setFiles }))
+
+    await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/notes')).toBe(true))
     const [item] = await result.current.getItems({ query: 'daily', editor })
 
     act(() => item.command({ editor, range: { from: 1, to: 7 }, item, query: 'daily' }))

--- a/src/renderer/components/composer/variants/chat/__tests__/useNoteReferenceMentionItems.test.tsx
+++ b/src/renderer/components/composer/variants/chat/__tests__/useNoteReferenceMentionItems.test.tsx
@@ -12,8 +12,8 @@ const mocks = vi.hoisted(() => ({
   directoryTreeLoading: false,
   directoryTreeRoot: null as object | null,
   directoryTreeVersion: 0,
+  ipcApiRequest: vi.fn(),
   projectNotesTree: vi.fn(),
-  resolveNotesPath: vi.fn(),
   notesPath: '/configured-notes'
 }))
 
@@ -21,7 +21,7 @@ vi.mock('@renderer/hooks/useDirectoryTree', () => ({
   useDirectoryTree: (path: string | undefined, options: unknown) => {
     mocks.directoryTreeCalls.push({ path, options })
     return {
-      root: mocks.directoryTreeRoot,
+      root: path ? mocks.directoryTreeRoot : null,
       isLoading: mocks.directoryTreeLoading,
       error: mocks.directoryTreeError,
       version: mocks.directoryTreeVersion
@@ -33,9 +33,14 @@ vi.mock('@renderer/hooks/useNotesSettings', () => ({
   useNotesSettings: () => ({ notesPath: mocks.notesPath })
 }))
 
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    request: (...args: unknown[]) => mocks.ipcApiRequest(...args)
+  }
+}))
+
 vi.mock('@renderer/services/NotesService', () => ({
-  projectNotesTree: (...args: unknown[]) => mocks.projectNotesTree(...args),
-  resolveNotesPath: (...args: unknown[]) => mocks.resolveNotesPath(...args)
+  projectNotesTree: (...args: unknown[]) => mocks.projectNotesTree(...args)
 }))
 
 const createEditor = () => {
@@ -56,17 +61,17 @@ describe('useNoteReferenceMentionItems', () => {
     mocks.directoryTreeRoot = {}
     mocks.directoryTreeVersion = 0
     mocks.notesPath = '/configured-notes'
-    mocks.resolveNotesPath.mockResolvedValue({ path: '/notes', isFallback: true })
+    mocks.ipcApiRequest.mockResolvedValue({ notesPath: '/default-notes' })
     mocks.projectNotesTree.mockReturnValue([])
   })
 
-  it('searches deep Markdown notes from the canonical directory tree', async () => {
-    const deepPath = `/notes/${Array.from({ length: 11 }, (_, index) => `level-${index + 1}`).join('/')}/Launch plan.md`
+  it('activates the canonical tree only after a Notes @ mention is requested', async () => {
+    const deepPath = `/configured-notes/${Array.from({ length: 11 }, (_, index) => `level-${index + 1}`).join('/')}/Launch plan.md`
     const deepNote: NotesTreeNode = {
       id: deepPath,
       name: 'Launch plan',
       type: 'file',
-      treePath: `/${deepPath.slice('/notes/'.length, -'.md'.length)}`,
+      treePath: `/${deepPath.slice('/configured-notes/'.length, -'.md'.length)}`,
       externalPath: deepPath,
       createdAt: '',
       updatedAt: ''
@@ -75,10 +80,17 @@ describe('useNoteReferenceMentionItems', () => {
     const setFiles = vi.fn()
     const { result } = renderHook(() => useNoteReferenceMentionItems({ files: [], setFiles }))
 
-    await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/notes')).toBe(true))
+    expect(mocks.directoryTreeCalls.some(({ path }) => path === '/configured-notes')).toBe(false)
+
+    await act(async () => {
+      const items = await result.current.getItems({ query: 'launch', editor: createEditor().editor })
+      expect(items[0]).toMatchObject({ id: 'note-reference:mention-loading', disabled: true })
+    })
+
+    await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/configured-notes')).toBe(true))
     const items = await result.current.getItems({ query: 'launch', editor: createEditor().editor })
 
-    expect(mocks.resolveNotesPath).toHaveBeenCalledWith('/configured-notes')
+    expect(mocks.ipcApiRequest).not.toHaveBeenCalled()
     expect(items).toHaveLength(1)
     expect(items[0]).toMatchObject({
       label: 'Launch plan',
@@ -88,11 +100,11 @@ describe('useNoteReferenceMentionItems', () => {
 
   it('inserts a selected note through the existing file token and attachment flow', async () => {
     const note: NotesTreeNode = {
-      id: '/notes/Daily.md',
+      id: '/configured-notes/Daily.md',
       name: 'Daily',
       type: 'file',
       treePath: '/Daily',
-      externalPath: '/notes/Daily.md',
+      externalPath: '/configured-notes/Daily.md',
       createdAt: '',
       updatedAt: ''
     }
@@ -104,7 +116,10 @@ describe('useNoteReferenceMentionItems', () => {
     const { editor, insertComposerToken, run } = createEditor()
     const { result } = renderHook(() => useNoteReferenceMentionItems({ files, setFiles }))
 
-    await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/notes')).toBe(true))
+    await act(async () => {
+      await result.current.getItems({ query: 'daily', editor })
+    })
+    await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/configured-notes')).toBe(true))
     const [item] = await result.current.getItems({ query: 'daily', editor })
 
     act(() => item.command({ editor, range: { from: 1, to: 7 }, item, query: 'daily' }))
@@ -113,18 +128,30 @@ describe('useNoteReferenceMentionItems', () => {
       expect.objectContaining({
         kind: 'file',
         label: 'Daily.md',
-        payload: expect.objectContaining({ path: '/notes/Daily.md', type: 'text' })
+        payload: expect.objectContaining({ path: '/configured-notes/Daily.md', type: 'text' })
       })
     )
     expect(run).toHaveBeenCalled()
     expect(files).toEqual([
       expect.objectContaining({
-        path: '/notes/Daily.md',
+        path: '/configured-notes/Daily.md',
         name: 'Daily.md',
         origin_name: 'Daily.md',
         ext: '.md',
         type: 'text'
       })
     ])
+  })
+
+  it('loads the default Notes directory through IpcApi only after a mention is requested', async () => {
+    mocks.notesPath = ''
+    const { result } = renderHook(() => useNoteReferenceMentionItems({ files: [], setFiles: vi.fn() }))
+
+    await act(async () => {
+      await result.current.getItems({ query: '', editor: createEditor().editor })
+    })
+
+    await waitFor(() => expect(mocks.ipcApiRequest).toHaveBeenCalledWith('app.get_info'))
+    await waitFor(() => expect(mocks.directoryTreeCalls.some(({ path }) => path === '/default-notes')).toBe(true))
   })
 })

--- a/src/renderer/components/composer/variants/chat/__tests__/useNoteReferenceMentionItems.test.tsx
+++ b/src/renderer/components/composer/variants/chat/__tests__/useNoteReferenceMentionItems.test.tsx
@@ -1,0 +1,100 @@
+import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
+import { act, renderHook } from '@testing-library/react'
+import type { Editor } from '@tiptap/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useNoteReferenceMentionItems } from '../useNoteReferenceMentionItems'
+
+const mocks = vi.hoisted(() => ({
+  listDirectory: vi.fn(),
+  resolveNotesPath: vi.fn(),
+  notesPath: '/configured-notes'
+}))
+
+vi.mock('@renderer/hooks/useNotesSettings', () => ({
+  useNotesSettings: () => ({ notesPath: mocks.notesPath })
+}))
+
+vi.mock('@renderer/services/NotesService', () => ({
+  resolveNotesPath: (...args: unknown[]) => mocks.resolveNotesPath(...args)
+}))
+
+const createEditor = () => {
+  const run = vi.fn()
+  const insertContent = vi.fn(() => ({ run }))
+  const insertComposerToken = vi.fn(() => ({ insertContent, run }))
+  const focus = vi.fn(() => ({ insertComposerToken }))
+  const editor = { chain: vi.fn(() => ({ focus })) } as unknown as Editor
+  return { editor, insertComposerToken, run }
+}
+
+describe('useNoteReferenceMentionItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.notesPath = '/configured-notes'
+    mocks.resolveNotesPath.mockResolvedValue({ path: '/notes', isFallback: true })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        file: {
+          listDirectory: mocks.listDirectory
+        }
+      }
+    })
+  })
+
+  it('searches the resolved Notes directory and exposes matching Markdown notes', async () => {
+    mocks.listDirectory.mockResolvedValue(['/notes/projects/Launch plan.md', '/notes/assets/launch.png'])
+    const setFiles = vi.fn()
+    const { result } = renderHook(() => useNoteReferenceMentionItems({ files: [], setFiles }))
+
+    const items = await result.current.getItems({ query: 'launch', editor: createEditor().editor })
+
+    expect(mocks.resolveNotesPath).toHaveBeenCalledWith('/configured-notes')
+    expect(mocks.listDirectory).toHaveBeenCalledWith(
+      '/notes',
+      expect.objectContaining({
+        recursive: true,
+        includeFiles: true,
+        includeDirectories: false,
+        searchPattern: '.'
+      })
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      label: 'Launch plan',
+      description: '/projects/Launch plan'
+    })
+  })
+
+  it('inserts a selected note through the existing file token and attachment flow', async () => {
+    mocks.listDirectory.mockResolvedValue(['/notes/Daily.md'])
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: React.SetStateAction<ComposerAttachment[]>) => {
+      files = typeof updater === 'function' ? updater(files) : updater
+    })
+    const { editor, insertComposerToken, run } = createEditor()
+    const { result } = renderHook(() => useNoteReferenceMentionItems({ files, setFiles }))
+    const [item] = await result.current.getItems({ query: 'daily', editor })
+
+    act(() => item.command({ editor, range: { from: 1, to: 7 }, item, query: 'daily' }))
+
+    expect(insertComposerToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'file',
+        label: 'Daily.md',
+        payload: expect.objectContaining({ path: '/notes/Daily.md', type: 'text' })
+      })
+    )
+    expect(run).toHaveBeenCalled()
+    expect(files).toEqual([
+      expect.objectContaining({
+        path: '/notes/Daily.md',
+        name: 'Daily.md',
+        origin_name: 'Daily.md',
+        ext: '.md',
+        type: 'text'
+      })
+    ])
+  })
+})

--- a/src/renderer/components/composer/variants/chat/useNoteReferenceMentionItems.tsx
+++ b/src/renderer/components/composer/variants/chat/useNoteReferenceMentionItems.tsx
@@ -1,15 +1,15 @@
+import { useDirectoryTree } from '@renderer/hooks/useDirectoryTree'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
-import { resolveNotesPath } from '@renderer/services/NotesService'
-import { FILE_TYPE } from '@renderer/types/file'
+import { projectNotesTree, resolveNotesPath } from '@renderer/services/NotesService'
+import { flattenTreeToFiles } from '@renderer/services/NotesTreeService'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
-import { createComposerFileTokenSourceId } from '@renderer/utils/message/composerFileTokenSource'
-import { AbsoluteFilePathSchema } from '@shared/types/file'
 import type { Editor } from '@tiptap/core'
 import { NotebookPen } from 'lucide-react'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ComposerSuggestionItem } from '../../quickPanel'
+import { NOTES_TREE_OPTIONS,noteToComposerAttachment } from '../../tools/definitions/noteReference'
 import { fileToComposerToken } from '../shared/composerTokens'
 
 const NOTE_MENTION_RESULT_LIMIT = 50
@@ -21,26 +21,9 @@ interface NoteReferenceMentionOptions {
 
 interface NoteReferenceMentionItems {
   getItems: (options: { query: string; editor: Editor }) => Promise<ComposerSuggestionItem[]>
-  resetItems: () => void
 }
 
 const normalizePath = (value: string) => value.replace(/\\/g, '/')
-const stripMarkdownExtension = (value: string) => value.replace(/\.md$/i, '')
-
-const createNoteAttachment = (filePath: string): ComposerAttachment => {
-  const normalizedPath = normalizePath(filePath)
-  const fileName = normalizedPath.split('/').at(-1) || 'note.md'
-
-  return {
-    fileTokenSourceId: createComposerFileTokenSourceId(),
-    path: AbsoluteFilePathSchema.parse(normalizedPath),
-    name: fileName,
-    origin_name: fileName,
-    ext: '.md',
-    size: 0,
-    type: FILE_TYPE.TEXT
-  }
-}
 
 export function useNoteReferenceMentionItems({
   files,
@@ -48,85 +31,40 @@ export function useNoteReferenceMentionItems({
 }: NoteReferenceMentionOptions): NoteReferenceMentionItems {
   const { t } = useTranslation()
   const { notesPath } = useNotesSettings()
+  const [resolvedNotesPath, setResolvedNotesPath] = useState<string>()
+  const [pathError, setPathError] = useState<Error | null>(null)
   const stateRef = useRef({ files, notesPath, setFiles, t })
-  const notePathsPromiseRef = useRef<
-    { configuredPath: string; promise: Promise<{ rootPath: string; paths: string[] }> } | undefined
-  >(undefined)
   stateRef.current = { files, notesPath, setFiles, t }
 
-  const resetItems = useCallback(() => {
-    notePathsPromiseRef.current = undefined
-  }, [])
+  useEffect(() => {
+    let cancelled = false
+    setResolvedNotesPath(undefined)
+    setPathError(null)
 
-  useEffect(() => resetItems, [resetItems])
+    void resolveNotesPath(notesPath)
+      .then(({ path }) => {
+        if (!cancelled) setResolvedNotesPath(path)
+      })
+      .catch((error) => {
+        if (!cancelled) setPathError(error instanceof Error ? error : new Error(String(error)))
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [notesPath])
+
+  const { root, isLoading, error, version } = useDirectoryTree(resolvedNotesPath, NOTES_TREE_OPTIONS)
+  const noteFiles = useMemo(() => {
+    void version
+    if (!root || !resolvedNotesPath) return []
+    return flattenTreeToFiles(projectNotesTree(root, resolvedNotesPath))
+  }, [resolvedNotesPath, root, version])
 
   const getItems = useCallback(
     async ({ query }: { query: string; editor: Editor }): Promise<ComposerSuggestionItem[]> => {
-      const { files, notesPath, t } = stateRef.current
-      let pendingNotes = notePathsPromiseRef.current
-
-      if (!pendingNotes || pendingNotes.configuredPath !== notesPath) {
-        pendingNotes = {
-          configuredPath: notesPath,
-          promise: resolveNotesPath(notesPath).then(async ({ path: rootPath }) => ({
-            rootPath,
-            paths: await window.api.file.listDirectory(rootPath, {
-              recursive: true,
-              includeHidden: false,
-              includeFiles: true,
-              includeDirectories: false,
-              searchPattern: '.'
-            })
-          }))
-        }
-        notePathsPromiseRef.current = pendingNotes
-      }
-
-      try {
-        const { rootPath, paths } = await pendingNotes.promise
-        const normalizedRootPath = normalizePath(rootPath).replace(/\/$/, '')
-        const normalizedQuery = query.trim().toLowerCase()
-
-        return paths
-          .filter((path) => path.toLowerCase().endsWith('.md'))
-          .map((path) => {
-            const normalizedPath = normalizePath(path)
-            const relativePath = normalizedPath.startsWith(`${normalizedRootPath}/`)
-              ? normalizedPath.slice(normalizedRootPath.length + 1)
-              : normalizedPath.split('/').at(-1) || normalizedPath
-            const description = `/${stripMarkdownExtension(relativePath)}`
-            const label = stripMarkdownExtension(relativePath.split('/').at(-1) || relativePath)
-            return { label, description, normalizedPath }
-          })
-          .filter(({ label, description }) =>
-            normalizedQuery ? `${label} ${description}`.toLowerCase().includes(normalizedQuery) : true
-          )
-          .slice(0, NOTE_MENTION_RESULT_LIMIT)
-          .map(({ label, description, normalizedPath }): ComposerSuggestionItem => {
-            const isSelected = files.some((file) => normalizePath(file.path ?? '') === normalizedPath)
-
-            return {
-              id: `note-reference:${normalizedPath}`,
-              label,
-              description,
-              filterText: `${label} ${description}`,
-              icon: <NotebookPen size={16} />,
-              disabled: isSelected,
-              command: ({ editor }) => {
-                const currentFiles = stateRef.current.files
-                if (currentFiles.some((file) => normalizePath(file.path ?? '') === normalizedPath)) return
-
-                const attachment = createNoteAttachment(normalizedPath)
-                editor.chain().focus().insertComposerToken(fileToComposerToken(attachment)).insertContent(' ').run()
-                stateRef.current.setFiles((previousFiles) =>
-                  previousFiles.some((file) => normalizePath(file.path ?? '') === normalizedPath)
-                    ? previousFiles
-                    : [...previousFiles, attachment]
-                )
-              }
-            }
-          })
-      } catch {
+      const { files, t } = stateRef.current
+      if (pathError || error) {
         return [
           {
             id: 'note-reference:mention-error',
@@ -137,9 +75,52 @@ export function useNoteReferenceMentionItems({
           }
         ]
       }
+
+      if (isLoading || !resolvedNotesPath) {
+        return [
+          {
+            id: 'note-reference:mention-loading',
+            label: t('chat.input.note_reference.loading'),
+            icon: <NotebookPen size={16} />,
+            disabled: true,
+            command: () => undefined
+          }
+        ]
+      }
+
+      const normalizedQuery = query.trim().toLowerCase()
+
+      return noteFiles
+        .filter((note) => (normalizedQuery ? `${note.name} ${note.treePath}`.toLowerCase().includes(normalizedQuery) : true))
+        .slice(0, NOTE_MENTION_RESULT_LIMIT)
+        .map((note): ComposerSuggestionItem => {
+          const normalizedPath = normalizePath(note.externalPath)
+          const isSelected = files.some((file) => normalizePath(file.path ?? '') === normalizedPath)
+
+          return {
+            id: `note-reference:${normalizedPath}`,
+            label: note.name,
+            description: note.treePath,
+            filterText: `${note.name} ${note.treePath}`,
+            icon: <NotebookPen size={16} />,
+            disabled: isSelected,
+            command: ({ editor }) => {
+              const currentFiles = stateRef.current.files
+              if (currentFiles.some((file) => normalizePath(file.path ?? '') === normalizedPath)) return
+
+              const attachment = noteToComposerAttachment(note)
+              editor.chain().focus().insertComposerToken(fileToComposerToken(attachment)).insertContent(' ').run()
+              stateRef.current.setFiles((previousFiles) =>
+                previousFiles.some((file) => normalizePath(file.path ?? '') === normalizedPath)
+                  ? previousFiles
+                  : [...previousFiles, attachment]
+              )
+            }
+          }
+        })
     },
-    []
+    [error, isLoading, noteFiles, pathError, resolvedNotesPath]
   )
 
-  return { getItems, resetItems }
+  return { getItems }
 }

--- a/src/renderer/components/composer/variants/chat/useNoteReferenceMentionItems.tsx
+++ b/src/renderer/components/composer/variants/chat/useNoteReferenceMentionItems.tsx
@@ -1,10 +1,11 @@
 import { useDirectoryTree } from '@renderer/hooks/useDirectoryTree'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
-import { ipcApi } from '@renderer/ipc'
-import { projectNotesTree } from '@renderer/services/NotesService'
+import { projectNotesTree, resolveNotesPath } from '@renderer/services/NotesService'
 import { flattenTreeToFiles } from '@renderer/services/NotesTreeService'
+import type { NotesTreeNode } from '@renderer/types/note'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import type { Editor } from '@tiptap/core'
+import type { TFunction } from 'i18next'
 import { NotebookPen } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -24,7 +25,52 @@ interface NoteReferenceMentionItems {
   getItems: (options: { query: string; editor: Editor }) => Promise<ComposerSuggestionItem[]>
 }
 
+interface NotesPathResolution {
+  requestPath: string
+  path?: string
+  error?: Error
+}
+
+interface PendingNotesLoad {
+  requestPath: string
+  promise: Promise<void>
+  resolve: () => void
+}
+
+interface LatestMentionState {
+  files: ComposerAttachment[]
+  isLoadTerminal: boolean
+  noteFiles: NotesTreeNode[]
+  notesPath: string
+  pathError: Error | null
+  requestedNotesPath: string | null
+  setFiles: React.Dispatch<React.SetStateAction<ComposerAttachment[]>>
+  t: TFunction
+  treeError: Error | null
+}
+
 const normalizePath = (value: string) => value.replace(/\\/g, '/')
+
+function createPendingNotesLoad(requestPath: string): PendingNotesLoad {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return { requestPath, promise, resolve }
+}
+
+function loadFailedItem(t: TFunction): ComposerSuggestionItem[] {
+  return [
+    {
+      id: 'note-reference:mention-error',
+      label: t('chat.input.note_reference.load_failed'),
+      icon: <NotebookPen size={16} />,
+      disabled: true,
+      command: () => undefined
+    }
+  ]
+}
 
 export function useNoteReferenceMentionItems({
   files,
@@ -32,84 +78,119 @@ export function useNoteReferenceMentionItems({
 }: NoteReferenceMentionOptions): NoteReferenceMentionItems {
   const { t } = useTranslation()
   const { notesPath } = useNotesSettings()
-  const [dataRequested, setDataRequested] = useState(false)
-  const [defaultNotesPath, setDefaultNotesPath] = useState<string>()
-  const [pathError, setPathError] = useState<Error | null>(null)
-  const stateRef = useRef({ files, notesPath, setFiles, t })
-  stateRef.current = { files, notesPath, setFiles, t }
+  const configuredNotesPath = notesPath || ''
+  const [requestedNotesPath, setRequestedNotesPath] = useState<string | null>(null)
+  const [resolution, setResolution] = useState<NotesPathResolution | null>(null)
+  const pendingLoadRef = useRef<PendingNotesLoad | null>(null)
+  const mountedRef = useRef(true)
+  const stateRef = useRef<LatestMentionState | null>(null)
 
   useEffect(() => {
-    if (!dataRequested) return
+    mountedRef.current = true
 
-    setPathError(null)
-    if (notesPath) return
+    return () => {
+      mountedRef.current = false
+      pendingLoadRef.current?.resolve()
+      pendingLoadRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (requestedNotesPath === null) return
 
     let cancelled = false
+    setResolution(null)
 
-    void ipcApi
-      .request('app.get_info')
-      .then((appInfo) => {
-        if (!cancelled) setDefaultNotesPath(appInfo.notesPath)
+    void resolveNotesPath(requestedNotesPath)
+      .then((resolved) => {
+        if (!cancelled) setResolution({ requestPath: requestedNotesPath, path: resolved.path })
       })
       .catch((error) => {
-        if (!cancelled) setPathError(error instanceof Error ? error : new Error(String(error)))
+        if (!cancelled) {
+          setResolution({
+            requestPath: requestedNotesPath,
+            error: error instanceof Error ? error : new Error(String(error))
+          })
+        }
       })
 
     return () => {
       cancelled = true
     }
-  }, [dataRequested, notesPath])
+  }, [requestedNotesPath])
 
-  const activeNotesPath = notesPath || defaultNotesPath
-  const { root, isLoading, error, version } = useDirectoryTree(
-    dataRequested ? activeNotesPath : undefined,
-    NOTES_TREE_OPTIONS
+  const resolvedNotesPath =
+    resolution?.requestPath === requestedNotesPath && !resolution.error ? resolution.path : undefined
+  const pathError = resolution?.requestPath === requestedNotesPath ? (resolution.error ?? null) : null
+  const { root, isLoading, error, version } = useDirectoryTree(resolvedNotesPath, NOTES_TREE_OPTIONS)
+  const treeMatchesResolvedPath = Boolean(
+    root && resolvedNotesPath && normalizePath(root.path) === normalizePath(resolvedNotesPath)
   )
+  const treeError = resolvedNotesPath ? error : null
+  const isLoadTerminal = Boolean(pathError || treeError || (resolvedNotesPath && treeMatchesResolvedPath && !isLoading))
   const noteFiles = useMemo(() => {
     void version
-    if (!root || !activeNotesPath) return []
-    return flattenTreeToFiles(projectNotesTree(root, activeNotesPath))
-  }, [activeNotesPath, root, version])
+    if (!root || !resolvedNotesPath || !treeMatchesResolvedPath) return []
+    return flattenTreeToFiles(projectNotesTree(root, resolvedNotesPath))
+  }, [resolvedNotesPath, root, treeMatchesResolvedPath, version])
+
+  stateRef.current = {
+    files,
+    isLoadTerminal,
+    noteFiles,
+    notesPath: configuredNotesPath,
+    pathError,
+    requestedNotesPath,
+    setFiles,
+    t,
+    treeError
+  }
+
+  useEffect(() => {
+    const pending = pendingLoadRef.current
+    if (!pending || pending.requestPath !== requestedNotesPath || !isLoadTerminal) return
+
+    pending.resolve()
+    pendingLoadRef.current = null
+  }, [isLoadTerminal, requestedNotesPath])
+
+  const waitForCurrentNotes = useCallback(async (): Promise<LatestMentionState | null> => {
+    while (mountedRef.current) {
+      const current = stateRef.current
+      if (!current) return null
+
+      const requestPath = current.notesPath
+      if (current.requestedNotesPath === requestPath && current.isLoadTerminal) return current
+
+      let pending = pendingLoadRef.current
+      if (!pending || pending.requestPath !== requestPath) {
+        pending?.resolve()
+        pending = createPendingNotesLoad(requestPath)
+        pendingLoadRef.current = pending
+        setRequestedNotesPath(requestPath)
+      }
+
+      await pending.promise
+    }
+
+    return null
+  }, [])
 
   const getItems = useCallback(
     async ({ query }: { query: string; editor: Editor }): Promise<ComposerSuggestionItem[]> => {
-      const { files, t } = stateRef.current
-      if (!dataRequested) setDataRequested(true)
-
-      if (pathError || error) {
-        return [
-          {
-            id: 'note-reference:mention-error',
-            label: t('chat.input.note_reference.load_failed'),
-            icon: <NotebookPen size={16} />,
-            disabled: true,
-            command: () => undefined
-          }
-        ]
-      }
-
-      if (!dataRequested || isLoading || !activeNotesPath) {
-        return [
-          {
-            id: 'note-reference:mention-loading',
-            label: t('chat.input.note_reference.loading'),
-            icon: <NotebookPen size={16} />,
-            disabled: true,
-            command: () => undefined
-          }
-        ]
-      }
+      const current = await waitForCurrentNotes()
+      if (!current || current.pathError || current.treeError) return loadFailedItem(current?.t ?? t)
 
       const normalizedQuery = query.trim().toLowerCase()
 
-      return noteFiles
+      return current.noteFiles
         .filter((note) =>
           normalizedQuery ? `${note.name} ${note.treePath}`.toLowerCase().includes(normalizedQuery) : true
         )
         .slice(0, NOTE_MENTION_RESULT_LIMIT)
         .map((note): ComposerSuggestionItem => {
           const normalizedPath = normalizePath(note.externalPath)
-          const isSelected = files.some((file) => normalizePath(file.path ?? '') === normalizedPath)
+          const isSelected = current.files.some((file) => normalizePath(file.path ?? '') === normalizedPath)
 
           return {
             id: `note-reference:${normalizedPath}`,
@@ -119,12 +200,12 @@ export function useNoteReferenceMentionItems({
             icon: <NotebookPen size={16} />,
             disabled: isSelected,
             command: ({ editor }) => {
-              const currentFiles = stateRef.current.files
+              const currentFiles = stateRef.current?.files ?? []
               if (currentFiles.some((file) => normalizePath(file.path ?? '') === normalizedPath)) return
 
               const attachment = noteToComposerAttachment(note)
               editor.chain().focus().insertComposerToken(fileToComposerToken(attachment)).insertContent(' ').run()
-              stateRef.current.setFiles((previousFiles) =>
+              stateRef.current?.setFiles((previousFiles) =>
                 previousFiles.some((file) => normalizePath(file.path ?? '') === normalizedPath)
                   ? previousFiles
                   : [...previousFiles, attachment]
@@ -133,7 +214,7 @@ export function useNoteReferenceMentionItems({
           }
         })
     },
-    [activeNotesPath, dataRequested, error, isLoading, noteFiles, pathError]
+    [t, waitForCurrentNotes]
   )
 
   return { getItems }

--- a/src/renderer/components/composer/variants/chat/useNoteReferenceMentionItems.tsx
+++ b/src/renderer/components/composer/variants/chat/useNoteReferenceMentionItems.tsx
@@ -1,0 +1,145 @@
+import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
+import { resolveNotesPath } from '@renderer/services/NotesService'
+import { FILE_TYPE } from '@renderer/types/file'
+import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
+import { createComposerFileTokenSourceId } from '@renderer/utils/message/composerFileTokenSource'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
+import type { Editor } from '@tiptap/core'
+import { NotebookPen } from 'lucide-react'
+import { useCallback, useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { ComposerSuggestionItem } from '../../quickPanel'
+import { fileToComposerToken } from '../shared/composerTokens'
+
+const NOTE_MENTION_RESULT_LIMIT = 50
+
+interface NoteReferenceMentionOptions {
+  files: ComposerAttachment[]
+  setFiles: React.Dispatch<React.SetStateAction<ComposerAttachment[]>>
+}
+
+interface NoteReferenceMentionItems {
+  getItems: (options: { query: string; editor: Editor }) => Promise<ComposerSuggestionItem[]>
+  resetItems: () => void
+}
+
+const normalizePath = (value: string) => value.replace(/\\/g, '/')
+const stripMarkdownExtension = (value: string) => value.replace(/\.md$/i, '')
+
+const createNoteAttachment = (filePath: string): ComposerAttachment => {
+  const normalizedPath = normalizePath(filePath)
+  const fileName = normalizedPath.split('/').at(-1) || 'note.md'
+
+  return {
+    fileTokenSourceId: createComposerFileTokenSourceId(),
+    path: AbsoluteFilePathSchema.parse(normalizedPath),
+    name: fileName,
+    origin_name: fileName,
+    ext: '.md',
+    size: 0,
+    type: FILE_TYPE.TEXT
+  }
+}
+
+export function useNoteReferenceMentionItems({
+  files,
+  setFiles
+}: NoteReferenceMentionOptions): NoteReferenceMentionItems {
+  const { t } = useTranslation()
+  const { notesPath } = useNotesSettings()
+  const stateRef = useRef({ files, notesPath, setFiles, t })
+  const notePathsPromiseRef = useRef<
+    { configuredPath: string; promise: Promise<{ rootPath: string; paths: string[] }> } | undefined
+  >(undefined)
+  stateRef.current = { files, notesPath, setFiles, t }
+
+  const resetItems = useCallback(() => {
+    notePathsPromiseRef.current = undefined
+  }, [])
+
+  useEffect(() => resetItems, [resetItems])
+
+  const getItems = useCallback(
+    async ({ query }: { query: string; editor: Editor }): Promise<ComposerSuggestionItem[]> => {
+      const { files, notesPath, t } = stateRef.current
+      let pendingNotes = notePathsPromiseRef.current
+
+      if (!pendingNotes || pendingNotes.configuredPath !== notesPath) {
+        pendingNotes = {
+          configuredPath: notesPath,
+          promise: resolveNotesPath(notesPath).then(async ({ path: rootPath }) => ({
+            rootPath,
+            paths: await window.api.file.listDirectory(rootPath, {
+              recursive: true,
+              includeHidden: false,
+              includeFiles: true,
+              includeDirectories: false,
+              searchPattern: '.'
+            })
+          }))
+        }
+        notePathsPromiseRef.current = pendingNotes
+      }
+
+      try {
+        const { rootPath, paths } = await pendingNotes.promise
+        const normalizedRootPath = normalizePath(rootPath).replace(/\/$/, '')
+        const normalizedQuery = query.trim().toLowerCase()
+
+        return paths
+          .filter((path) => path.toLowerCase().endsWith('.md'))
+          .map((path) => {
+            const normalizedPath = normalizePath(path)
+            const relativePath = normalizedPath.startsWith(`${normalizedRootPath}/`)
+              ? normalizedPath.slice(normalizedRootPath.length + 1)
+              : normalizedPath.split('/').at(-1) || normalizedPath
+            const description = `/${stripMarkdownExtension(relativePath)}`
+            const label = stripMarkdownExtension(relativePath.split('/').at(-1) || relativePath)
+            return { label, description, normalizedPath }
+          })
+          .filter(({ label, description }) =>
+            normalizedQuery ? `${label} ${description}`.toLowerCase().includes(normalizedQuery) : true
+          )
+          .slice(0, NOTE_MENTION_RESULT_LIMIT)
+          .map(({ label, description, normalizedPath }): ComposerSuggestionItem => {
+            const isSelected = files.some((file) => normalizePath(file.path ?? '') === normalizedPath)
+
+            return {
+              id: `note-reference:${normalizedPath}`,
+              label,
+              description,
+              filterText: `${label} ${description}`,
+              icon: <NotebookPen size={16} />,
+              disabled: isSelected,
+              command: ({ editor }) => {
+                const currentFiles = stateRef.current.files
+                if (currentFiles.some((file) => normalizePath(file.path ?? '') === normalizedPath)) return
+
+                const attachment = createNoteAttachment(normalizedPath)
+                editor.chain().focus().insertComposerToken(fileToComposerToken(attachment)).insertContent(' ').run()
+                stateRef.current.setFiles((previousFiles) =>
+                  previousFiles.some((file) => normalizePath(file.path ?? '') === normalizedPath)
+                    ? previousFiles
+                    : [...previousFiles, attachment]
+                )
+              }
+            }
+          })
+      } catch {
+        return [
+          {
+            id: 'note-reference:mention-error',
+            label: t('chat.input.note_reference.load_failed'),
+            icon: <NotebookPen size={16} />,
+            disabled: true,
+            command: () => undefined
+          }
+        ]
+      }
+    },
+    []
+  )
+
+  return { getItems, resetItems }
+}

--- a/src/renderer/components/composer/variants/chat/useNoteReferenceMentionItems.tsx
+++ b/src/renderer/components/composer/variants/chat/useNoteReferenceMentionItems.tsx
@@ -1,6 +1,7 @@
 import { useDirectoryTree } from '@renderer/hooks/useDirectoryTree'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
-import { projectNotesTree, resolveNotesPath } from '@renderer/services/NotesService'
+import { ipcApi } from '@renderer/ipc'
+import { projectNotesTree } from '@renderer/services/NotesService'
 import { flattenTreeToFiles } from '@renderer/services/NotesTreeService'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import type { Editor } from '@tiptap/core'
@@ -9,7 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ComposerSuggestionItem } from '../../quickPanel'
-import { NOTES_TREE_OPTIONS,noteToComposerAttachment } from '../../tools/definitions/noteReference'
+import { NOTES_TREE_OPTIONS, noteToComposerAttachment } from '../../tools/definitions/noteReference'
 import { fileToComposerToken } from '../shared/composerTokens'
 
 const NOTE_MENTION_RESULT_LIMIT = 50
@@ -31,19 +32,24 @@ export function useNoteReferenceMentionItems({
 }: NoteReferenceMentionOptions): NoteReferenceMentionItems {
   const { t } = useTranslation()
   const { notesPath } = useNotesSettings()
-  const [resolvedNotesPath, setResolvedNotesPath] = useState<string>()
+  const [dataRequested, setDataRequested] = useState(false)
+  const [defaultNotesPath, setDefaultNotesPath] = useState<string>()
   const [pathError, setPathError] = useState<Error | null>(null)
   const stateRef = useRef({ files, notesPath, setFiles, t })
   stateRef.current = { files, notesPath, setFiles, t }
 
   useEffect(() => {
-    let cancelled = false
-    setResolvedNotesPath(undefined)
-    setPathError(null)
+    if (!dataRequested) return
 
-    void resolveNotesPath(notesPath)
-      .then(({ path }) => {
-        if (!cancelled) setResolvedNotesPath(path)
+    setPathError(null)
+    if (notesPath) return
+
+    let cancelled = false
+
+    void ipcApi
+      .request('app.get_info')
+      .then((appInfo) => {
+        if (!cancelled) setDefaultNotesPath(appInfo.notesPath)
       })
       .catch((error) => {
         if (!cancelled) setPathError(error instanceof Error ? error : new Error(String(error)))
@@ -52,18 +58,24 @@ export function useNoteReferenceMentionItems({
     return () => {
       cancelled = true
     }
-  }, [notesPath])
+  }, [dataRequested, notesPath])
 
-  const { root, isLoading, error, version } = useDirectoryTree(resolvedNotesPath, NOTES_TREE_OPTIONS)
+  const activeNotesPath = notesPath || defaultNotesPath
+  const { root, isLoading, error, version } = useDirectoryTree(
+    dataRequested ? activeNotesPath : undefined,
+    NOTES_TREE_OPTIONS
+  )
   const noteFiles = useMemo(() => {
     void version
-    if (!root || !resolvedNotesPath) return []
-    return flattenTreeToFiles(projectNotesTree(root, resolvedNotesPath))
-  }, [resolvedNotesPath, root, version])
+    if (!root || !activeNotesPath) return []
+    return flattenTreeToFiles(projectNotesTree(root, activeNotesPath))
+  }, [activeNotesPath, root, version])
 
   const getItems = useCallback(
     async ({ query }: { query: string; editor: Editor }): Promise<ComposerSuggestionItem[]> => {
       const { files, t } = stateRef.current
+      if (!dataRequested) setDataRequested(true)
+
       if (pathError || error) {
         return [
           {
@@ -76,7 +88,7 @@ export function useNoteReferenceMentionItems({
         ]
       }
 
-      if (isLoading || !resolvedNotesPath) {
+      if (!dataRequested || isLoading || !activeNotesPath) {
         return [
           {
             id: 'note-reference:mention-loading',
@@ -91,7 +103,9 @@ export function useNoteReferenceMentionItems({
       const normalizedQuery = query.trim().toLowerCase()
 
       return noteFiles
-        .filter((note) => (normalizedQuery ? `${note.name} ${note.treePath}`.toLowerCase().includes(normalizedQuery) : true))
+        .filter((note) =>
+          normalizedQuery ? `${note.name} ${note.treePath}`.toLowerCase().includes(normalizedQuery) : true
+        )
         .slice(0, NOTE_MENTION_RESULT_LIMIT)
         .map((note): ComposerSuggestionItem => {
           const normalizedPath = normalizePath(note.externalPath)
@@ -119,7 +133,7 @@ export function useNoteReferenceMentionItems({
           }
         })
     },
-    [error, isLoading, noteFiles, pathError, resolvedNotesPath]
+    [activeNotesPath, dataRequested, error, isLoading, noteFiles, pathError]
   )
 
   return { getItems }

--- a/src/renderer/components/composer/variants/shared/__tests__/useEntityReferenceMentionSource.test.tsx
+++ b/src/renderer/components/composer/variants/shared/__tests__/useEntityReferenceMentionSource.test.tsx
@@ -1,0 +1,39 @@
+import { dataApiService } from '@data/DataApiService'
+import { renderHook } from '@testing-library/react'
+import type { Editor } from '@tiptap/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useEntityReferenceMentionSource } from '../useEntityReferenceMentionSource'
+
+vi.mock('@data/DataApiService', () => ({
+  dataApiService: { get: vi.fn() }
+}))
+
+describe('useEntityReferenceMentionSource', () => {
+  beforeEach(() => {
+    vi.mocked(dataApiService.get).mockReset()
+  })
+
+  it('keeps Note results available when conversation search fails', async () => {
+    vi.mocked(dataApiService.get).mockRejectedValueOnce(new Error('topic search unavailable'))
+    const noteItems = [
+      {
+        id: 'note-reference:/notes/Launch.md',
+        label: 'Launch',
+        command: vi.fn()
+      }
+    ]
+    const getNoteItems = vi.fn().mockResolvedValue(noteItems)
+    const { result } = renderHook(() =>
+      useEntityReferenceMentionSource({
+        entityType: 'topic',
+        additionalItems: { getItems: getNoteItems, title: 'Notes' }
+      })
+    )
+
+    const items = await result.current.sources[0].items({ query: 'launch', editor: {} as Editor })
+
+    expect(items).toEqual(noteItems)
+    expect(getNoteItems).toHaveBeenCalledWith({ query: 'launch', editor: expect.anything() })
+  })
+})

--- a/src/renderer/components/composer/variants/shared/useEntityReferenceMentionSource.tsx
+++ b/src/renderer/components/composer/variants/shared/useEntityReferenceMentionSource.tsx
@@ -251,10 +251,26 @@ export function useEntityReferenceMentionSource({
   // panel (agent `@`), the raw item list stays empty so the host's empty handling wins.
   const getItemsWithEmptyState = useCallback(
     async (args: { query: string; editor: Editor }): Promise<ComposerSuggestionItem[]> => {
-      const [items, extraItems] = await Promise.all([
-        getItems(args),
-        additionalItems ? additionalItems.getItems(args) : []
-      ])
+      if (!additionalItems) {
+        const items = await getItems(args)
+        if (items.length > 0) return items
+        return [
+          {
+            id: 'entity-reference:no-results',
+            label: getEntityNoResultsLabel(entityType, t),
+            description: getEntityNoResultsDescription(entityType, t),
+            icon: entityType === 'topic' ? <MessageSquare size={16} /> : <MousePointerClick size={16} />,
+            disabled: true,
+            command: () => undefined
+          }
+        ]
+      }
+
+      const [itemsResult, extraItemsResult] = await Promise.allSettled([getItems(args), additionalItems.getItems(args)])
+      if (itemsResult.status === 'rejected' && extraItemsResult.status === 'rejected') throw itemsResult.reason
+
+      const items = itemsResult.status === 'fulfilled' ? itemsResult.value : []
+      const extraItems = extraItemsResult.status === 'fulfilled' ? extraItemsResult.value : []
 
       if (additionalItems && !args.query.trim() && items.length > 0 && extraItems.length > 0) {
         return [
@@ -270,8 +286,7 @@ export function useEntityReferenceMentionSource({
       return [
         {
           id: 'entity-reference:no-results',
-          label: additionalItems ? t('common.no_results') : getEntityNoResultsLabel(entityType, t),
-          description: additionalItems ? undefined : getEntityNoResultsDescription(entityType, t),
+          label: t('common.no_results'),
           icon: entityType === 'topic' ? <MessageSquare size={16} /> : <MousePointerClick size={16} />,
           disabled: true,
           command: () => undefined

--- a/src/renderer/components/composer/variants/shared/useEntityReferenceMentionSource.tsx
+++ b/src/renderer/components/composer/variants/shared/useEntityReferenceMentionSource.tsx
@@ -2,6 +2,7 @@ import { dataApiService } from '@data/DataApiService'
 import { toast } from '@renderer/services/toast'
 import type { Editor } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import type { TFunction } from 'i18next'
 import { MessageSquare, MousePointerClick } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -12,6 +13,7 @@ import type { ComposerSuggestionItem, ComposerSuggestionSource } from '../../qui
 import { fetchEntityReferencePromptText } from './entityReferenceContext'
 
 const REFERENCE_RESULT_LIMIT = 50
+const EMPTY_QUERY_GROUP_LIMIT = 5
 // List endpoints page pinned-first in manual order, so recency sorting happens client-side
 // over the first page; entities beyond it are reachable by typing a name query instead.
 const REFERENCE_LIST_FETCH_LIMIT = 200
@@ -206,30 +208,77 @@ export interface EntityReferenceMentionSource {
   hasPendingReference: boolean
 }
 
-/** The chat composer's standalone `@` suggestion source for topic references. */
-export function useEntityReferenceMentionSource(options: EntityReferenceMentionOptions): EntityReferenceMentionSource {
-  const { entityType } = options
+interface AdditionalReferenceMentionItems {
+  getItems: (options: { query: string; editor: Editor }) => Promise<ComposerSuggestionItem[]>
+  onExit?: () => void
+  title: string
+}
+
+interface EntityReferenceMentionSourceOptions extends EntityReferenceMentionOptions {
+  additionalItems?: AdditionalReferenceMentionItems
+}
+
+const createGroupHeaderItem = (id: string, label: string): ComposerSuggestionItem => ({
+  id,
+  label,
+  disabled: true,
+  command: () => undefined
+})
+
+const getEntityTitle = (entityType: 'topic' | 'session', t: TFunction) =>
+  entityType === 'topic' ? t('chat.input.reference_panel.topic.title') : t('chat.input.reference_panel.session.title')
+
+const getEntityNoResultsLabel = (entityType: 'topic' | 'session', t: TFunction) =>
+  entityType === 'topic'
+    ? t('chat.input.reference_panel.topic.no_results.label')
+    : t('chat.input.reference_panel.session.no_results.label')
+
+const getEntityNoResultsDescription = (entityType: 'topic' | 'session', t: TFunction) =>
+  entityType === 'topic'
+    ? t('chat.input.reference_panel.topic.no_results.description')
+    : t('chat.input.reference_panel.session.no_results.description')
+
+/** The chat composer's standalone `@` suggestion source for conversation and optional extra references. */
+export function useEntityReferenceMentionSource({
+  entityType,
+  excludeId,
+  additionalItems
+}: EntityReferenceMentionSourceOptions): EntityReferenceMentionSource {
   const { t } = useTranslation()
-  const { getItems, hasPendingReference } = useEntityReferenceMentionItems(options)
+  const { getItems, hasPendingReference } = useEntityReferenceMentionItems({ entityType, excludeId })
 
   // The standalone panel shows a disabled empty-state row; when merged into another
   // panel (agent `@`), the raw item list stays empty so the host's empty handling wins.
   const getItemsWithEmptyState = useCallback(
     async (args: { query: string; editor: Editor }): Promise<ComposerSuggestionItem[]> => {
-      const items = await getItems(args)
-      if (items.length > 0) return items
+      const [items, extraItems] = await Promise.all([
+        getItems(args),
+        additionalItems ? additionalItems.getItems(args) : []
+      ])
+
+      if (additionalItems && !args.query.trim() && items.length > 0 && extraItems.length > 0) {
+        return [
+          createGroupHeaderItem('entity-reference:additional-header', additionalItems.title),
+          ...extraItems.slice(0, EMPTY_QUERY_GROUP_LIMIT),
+          createGroupHeaderItem(`entity-reference:${entityType}-header`, getEntityTitle(entityType, t)),
+          ...items.slice(0, EMPTY_QUERY_GROUP_LIMIT)
+        ]
+      }
+
+      const combinedItems = [...extraItems, ...items]
+      if (combinedItems.length > 0) return combinedItems
       return [
         {
           id: 'entity-reference:no-results',
-          label: t(`chat.input.reference_panel.${entityType}.no_results.label`),
-          description: t(`chat.input.reference_panel.${entityType}.no_results.description`),
+          label: additionalItems ? t('common.no_results') : getEntityNoResultsLabel(entityType, t),
+          description: additionalItems ? undefined : getEntityNoResultsDescription(entityType, t),
           icon: entityType === 'topic' ? <MessageSquare size={16} /> : <MousePointerClick size={16} />,
           disabled: true,
           command: () => undefined
         }
       ]
     },
-    [entityType, getItems, t]
+    [additionalItems, entityType, getItems, t]
   )
 
   const sources = useMemo(
@@ -237,12 +286,13 @@ export function useEntityReferenceMentionSource(options: EntityReferenceMentionO
       {
         pluginKey: 'entity-reference-mention-suggestion',
         char: '@',
-        title: t(`chat.input.reference_panel.${entityType}.title`),
+        title: additionalItems ? t('chat.input.reference_panel.title') : getEntityTitle(entityType, t),
         allowedPrefixes: [' ', '\n'],
+        onExit: additionalItems?.onExit,
         items: getItemsWithEmptyState
       }
     ],
-    [entityType, getItemsWithEmptyState, t]
+    [additionalItems, entityType, getItemsWithEmptyState, t]
   )
 
   return { sources, hasPendingReference }

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "Keine Sitzungen entsprechen Ihrer Suche",
   "chat.input.reference_panel.session.no_results.label": "Keine Sitzungen gefunden",
   "chat.input.reference_panel.session.title": "Sitzungen",
+  "chat.input.reference_panel.title": "Referenzen",
   "chat.input.reference_panel.topic.no_results.description": "Keine Themen entsprechen Ihrer Suche",
   "chat.input.reference_panel.topic.no_results.label": "Keine Themen gefunden",
   "chat.input.reference_panel.topic.title": "Themen",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "Δεν υπάρχουν συνεδρίες που να ταιριάζουν με την αναζήτησή σας",
   "chat.input.reference_panel.session.no_results.label": "Δεν Βρέθηκαν Συνεδρίες",
   "chat.input.reference_panel.session.title": "Συνεδρίες",
+  "chat.input.reference_panel.title": "Αναφορές",
   "chat.input.reference_panel.topic.no_results.description": "Δεν βρέθηκαν θέματα που να ταιριάζουν με την αναζήτησή σας",
   "chat.input.reference_panel.topic.no_results.label": "Δεν βρέθηκαν θέματα",
   "chat.input.reference_panel.topic.title": "Θέματα",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "No sessions match your search",
   "chat.input.reference_panel.session.no_results.label": "No Sessions Found",
   "chat.input.reference_panel.session.title": "Sessions",
+  "chat.input.reference_panel.title": "References",
   "chat.input.reference_panel.topic.no_results.description": "No topics match your search",
   "chat.input.reference_panel.topic.no_results.label": "No Topics Found",
   "chat.input.reference_panel.topic.title": "Topics",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "No hay sesiones que coincidan con tu búsqueda",
   "chat.input.reference_panel.session.no_results.label": "No se encontraron sesiones",
   "chat.input.reference_panel.session.title": "Sesiones",
+  "chat.input.reference_panel.title": "Referencias",
   "chat.input.reference_panel.topic.no_results.description": "No hay temas que coincidan con tu búsqueda",
   "chat.input.reference_panel.topic.no_results.label": "No se encontraron temas",
   "chat.input.reference_panel.topic.title": "Temas",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "Aucune session ne correspond à votre recherche",
   "chat.input.reference_panel.session.no_results.label": "Aucune session trouvée",
   "chat.input.reference_panel.session.title": "Séances",
+  "chat.input.reference_panel.title": "Références",
   "chat.input.reference_panel.topic.no_results.description": "Aucun sujet ne correspond à votre recherche",
   "chat.input.reference_panel.topic.no_results.label": "Aucun sujet trouvé",
   "chat.input.reference_panel.topic.title": "Sujets",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "検索条件に一致するセッションはありません",
   "chat.input.reference_panel.session.no_results.label": "セッションが見つかりません",
   "chat.input.reference_panel.session.title": "セッション",
+  "chat.input.reference_panel.title": "参照",
   "chat.input.reference_panel.topic.no_results.description": "検索に一致するトピックはありません",
   "chat.input.reference_panel.topic.no_results.label": "トピックが見つかりません",
   "chat.input.reference_panel.topic.title": "トピック",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "Nenhuma sessão corresponde à sua pesquisa",
   "chat.input.reference_panel.session.no_results.label": "Nenhuma sessão encontrada",
   "chat.input.reference_panel.session.title": "Sessões",
+  "chat.input.reference_panel.title": "Referências",
   "chat.input.reference_panel.topic.no_results.description": "Nenhum tópico corresponde à sua pesquisa",
   "chat.input.reference_panel.topic.no_results.label": "Nenhum tópico encontrado",
   "chat.input.reference_panel.topic.title": "Tópicos",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "Nicio sesiune nu corespunde căutării tale",
   "chat.input.reference_panel.session.no_results.label": "Nu s-au găsit sesiuni",
   "chat.input.reference_panel.session.title": "Sesiuni",
+  "chat.input.reference_panel.title": "Referințe",
   "chat.input.reference_panel.topic.no_results.description": "Niciun subiect nu corespunde căutării tale",
   "chat.input.reference_panel.topic.no_results.label": "Niciun subiect găsit",
   "chat.input.reference_panel.topic.title": "Subiecte",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "Нет сеансов, соответствующих вашему поиску",
   "chat.input.reference_panel.session.no_results.label": "Сеансы не найдены",
   "chat.input.reference_panel.session.title": "Сессии",
+  "chat.input.reference_panel.title": "Ссылки",
   "chat.input.reference_panel.topic.no_results.description": "Нет тем, соответствующих вашему поиску",
   "chat.input.reference_panel.topic.no_results.label": "Темы не найдены",
   "chat.input.reference_panel.topic.title": "Темы",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "Aramayla eşleşen oturum yok",
   "chat.input.reference_panel.session.no_results.label": "Oturum Bulunamadı",
   "chat.input.reference_panel.session.title": "Oturumlar",
+  "chat.input.reference_panel.title": "Referanslar",
   "chat.input.reference_panel.topic.no_results.description": "Aramayla eşleşen konu yok",
   "chat.input.reference_panel.topic.no_results.label": "Konu Bulunamadı",
   "chat.input.reference_panel.topic.title": "Konular",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "Không có phiên nào khớp với tìm kiếm của bạn",
   "chat.input.reference_panel.session.no_results.label": "Không tìm thấy phiên làm việc nào",
   "chat.input.reference_panel.session.title": "Phiên họp",
+  "chat.input.reference_panel.title": "Tham chiếu",
   "chat.input.reference_panel.topic.no_results.description": "Không có chủ đề nào khớp với tìm kiếm của bạn",
   "chat.input.reference_panel.topic.no_results.label": "Không Tìm Thấy Chủ Đề Nào",
   "chat.input.reference_panel.topic.title": "Chủ đề",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "没有名称匹配的会话",
   "chat.input.reference_panel.session.no_results.label": "无匹配会话",
   "chat.input.reference_panel.session.title": "会话",
+  "chat.input.reference_panel.title": "引用",
   "chat.input.reference_panel.topic.no_results.description": "没有名称匹配的话题",
   "chat.input.reference_panel.topic.no_results.label": "无匹配话题",
   "chat.input.reference_panel.topic.title": "话题",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -636,6 +636,7 @@
   "chat.input.reference_panel.session.no_results.description": "沒有符合您搜尋條件的工作階段",
   "chat.input.reference_panel.session.no_results.label": "找不到工作階段",
   "chat.input.reference_panel.session.title": "工作階段",
+  "chat.input.reference_panel.title": "引用",
   "chat.input.reference_panel.topic.no_results.description": "沒有符合您搜尋的主題",
   "chat.input.reference_panel.topic.no_results.label": "找不到主題",
   "chat.input.reference_panel.topic.title": "主題",

--- a/src/renderer/services/NotesService.ts
+++ b/src/renderer/services/NotesService.ts
@@ -2,6 +2,7 @@ import { loggerService } from '@logger'
 import { ipcApi } from '@renderer/ipc'
 import type { NotesSortType, NotesTreeNode } from '@renderer/types/note'
 import { getFileDirectory } from '@renderer/utils/file'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
 import type { TreeDirRoot, TreeNode } from '@shared/utils/file'
 
 const logger = loggerService.withContext('NotesService')
@@ -153,7 +154,7 @@ export async function resolveNotesPath(parentPath: string): Promise<ResolvedNote
   }
 
   try {
-    const isValid = await window.api.file.validateNotesDirectory(basePath)
+    const isValid = await ipcApi.request('file.validate_notes_directory', AbsoluteFilePathSchema.parse(basePath))
     if (isValid) {
       return {
         path: basePath,

--- a/src/renderer/services/__tests__/NotesService.test.ts
+++ b/src/renderer/services/__tests__/NotesService.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ResolvedNotesPath } from '../NotesService'
+
+const mocks = vi.hoisted(() => ({
+  request: vi.fn(),
+  warn: vi.fn()
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ warn: mocks.warn })
+  }
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    request: (...args: unknown[]) => mocks.request(...args)
+  }
+}))
+
+vi.mock('@renderer/utils/file', () => ({
+  getFileDirectory: vi.fn()
+}))
+
+let resolveNotesPath: (parentPath: string) => Promise<ResolvedNotesPath>
+
+describe('resolveNotesPath', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mocks.request.mockImplementation((channel: string) => {
+      if (channel === 'app.get_info') return Promise.resolve({ notesPath: '/default-notes' })
+      throw new Error(`Unexpected IPC route: ${channel}`)
+    })
+    ;({ resolveNotesPath } = await import('../NotesService'))
+  })
+
+  it('keeps a valid configured Notes path through the typed file route', async () => {
+    mocks.request.mockImplementation((channel: string) => {
+      if (channel === 'app.get_info') return Promise.resolve({ notesPath: '/default-notes' })
+      if (channel === 'file.validate_notes_directory') return Promise.resolve(true)
+      throw new Error(`Unexpected IPC route: ${channel}`)
+    })
+
+    await expect(resolveNotesPath('/configured-notes')).resolves.toEqual({
+      path: '/configured-notes',
+      isFallback: false
+    })
+    expect(mocks.request).toHaveBeenNthCalledWith(1, 'app.get_info')
+    expect(mocks.request).toHaveBeenNthCalledWith(2, 'file.validate_notes_directory', '/configured-notes')
+  })
+
+  it('falls back to the default Notes directory when typed validation rejects a configured path', async () => {
+    mocks.request.mockImplementation((channel: string) => {
+      if (channel === 'app.get_info') return Promise.resolve({ notesPath: '/default-notes' })
+      if (channel === 'file.validate_notes_directory') return Promise.resolve(false)
+      throw new Error(`Unexpected IPC route: ${channel}`)
+    })
+
+    await expect(resolveNotesPath('/invalid-notes')).resolves.toEqual({
+      path: '/default-notes',
+      isFallback: true
+    })
+    expect(mocks.request).toHaveBeenNthCalledWith(2, 'file.validate_notes_directory', '/invalid-notes')
+  })
+})

--- a/src/shared/ipc/schemas/file.ts
+++ b/src/shared/ipc/schemas/file.ts
@@ -164,6 +164,7 @@ export const fileRequestSchemas = {
   }),
   'file.open': defineRoute({ input: FileHandleSchema, output: z.void() }),
   'file.show_in_folder': defineRoute({ input: FileHandleSchema, output: z.void() }),
+  'file.validate_notes_directory': defineRoute({ input: AbsoluteFilePathSchema, output: z.boolean() }),
 
   // DirectoryTreeBuilder primitive. `create` returns the snapshot with its revision;
   // `activate` releases the buffered mutations once the renderer mirror is listening.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The chat composer's `@` panel could reference conversations, but Notes were only available through the separate Reference Note tool.

After this PR:

The same `@` panel also searches Markdown notes by name or relative path. Selecting a note reuses the existing file attachment and composer-token flow, so sending, persistence, duplicate prevention, and model input keep their current behavior. Empty-query results are grouped into Notes and Topics for quick keyboard navigation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19931

### Why we need it and why it was done in this way

The existing Reference Note flow already defines how a note becomes a chat attachment. This change exposes that capability through the composer's existing `@` suggestion source instead of introducing another reference format or message contract.

The following tradeoffs were made:

- Notes are enumerated lazily when the `@` panel opens and cached only for that panel session. This avoids repeated filesystem work while ensuring a reopened panel sees newly added notes.
- Mixed empty-query results show a small group from each source; typing searches the full cached note list and the existing topic search in parallel.

The following alternatives were considered:

- Expanding Agent sessions with every Chat feature is substantially larger than the focused alternative requested in the issue.
- A new note-specific token would duplicate the established file attachment lifecycle without adding user-visible value.

Links to places where the discussion took place: #19931

### Breaking changes

<!-- optional -->

None. Existing topic references and the Reference Note tool remain available.

### Special notes for your reviewer

<!-- optional -->

- Design gate: this is an input/search interaction only. It reuses the existing Quick Panel, NotebookPen icon, keyboard navigation, focus behavior, and attachment chip; no new layout, styling, custom control, or animation was introduced.
- `pnpm test:renderer ChatComposer.test.tsx noteReferenceTool.test.tsx useNoteReferenceMentionItems.test.tsx` — 155 tests passed.
- `pnpm lint` and `pnpm test:lint` passed. Changed files have zero Oxlint/ESLint warnings; the 42 printed ESLint warnings are pre-existing in untouched files.
- `pnpm run typecheck:web`, `pnpm i18n:check`, and `git diff --check` passed as part of the validation.
- Validation ran with Node 22.22.3; the repository currently requests Node `>=24.11.1 <24.16.0`.
- No user-guide change is required for this small extension of the existing note-reference workflow; the user-facing change is covered by the release note below.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Composer] Reference Notes directly from the chat input with @ and search by note name or path.
```
