### PR TITLE
fix(word-export): render indented code, ordered lists, images and strikethrough

### DIFF
--- a/src/main/services/ExportService.ts
+++ b/src/main/services/ExportService.ts
@@ -28,7 +28,7 @@ export class ExportService {
     } = docx
     const tokens = md.parse(markdown, {})
     const elements: any[] = []
-    let listLevel = 0
+    const listCounters: Array<number | null> = []
     let quoteLevel = 0
     const quoteBorder = { left: { style: BorderStyle.SINGLE, size: 3, color: 'CCCCCC' } }
     let currentTable: Table | null = null
@@ -36,6 +36,24 @@ export class ExportService {
     let isHeaderRow = false
     let tableColumnCount = 0
     let tableRows: TableRow[] = [] // Store rows temporarily
+
+    const inlineText = (tokens: any[]): string =>
+      tokens
+        .map((token) => {
+          switch (token.type) {
+            case 'text':
+            case 'code_inline':
+              return token.content
+            case 'softbreak':
+            case 'hardbreak':
+              return ' '
+            case 'image':
+              return inlineText(token.children)
+            default:
+              return ''
+          }
+        })
+        .join('')
 
     const processInlineTokens = (
       tokens: any[],
@@ -47,6 +65,15 @@ export class ExportService {
       let linkUrl = ''
       let boldStack = 0 // 跟踪嵌套的粗体标记
       let italicStack = 0 // 跟踪嵌套的斜体标记
+      let strikeStack = 0
+
+      // Off flags are omitted rather than written as `false`: an explicit off overrides the
+      // paragraph style, e.g. the italics of Heading 4.
+      const runFormat = (): Docx.IRunOptions => ({
+        bold: isHeaderRow || boldStack > 0 || undefined,
+        italics: isQuote || italicStack > 0 || undefined,
+        strike: strikeStack > 0 || undefined
+      })
 
       const pushRun = (options: Docx.IRunOptions) => {
         if (linkUrl) {
@@ -82,6 +109,12 @@ export class ExportService {
           case 'em_close':
             italicStack--
             break
+          case 's_open':
+            strikeStack++
+            break
+          case 's_close':
+            strikeStack--
+            break
           case 'softbreak':
             pushRun({ text: ' ' })
             break
@@ -89,20 +122,13 @@ export class ExportService {
             pushRun({ break: 1 })
             break
           case 'text':
-            pushRun({
-              text: token.content,
-              bold: isHeaderRow || boldStack > 0,
-              italics: isQuote || italicStack > 0
-            })
+            pushRun({ text: token.content, ...runFormat() })
+            break
+          case 'image':
+            pushRun({ text: inlineText(token.children), ...runFormat() })
             break
           case 'code_inline':
-            pushRun({
-              text: token.content,
-              font: 'Consolas',
-              size: 20,
-              bold: isHeaderRow || boldStack > 0,
-              italics: isQuote || italicStack > 0
-            })
+            pushRun({ text: token.content, font: 'Consolas', size: 20, ...runFormat() })
             break
         }
       }
@@ -115,10 +141,9 @@ export class ExportService {
         case 'heading_open':
           // 获取标题级别 (h1 -> h6)
           const level = parseInt(token.tag.slice(1)) as 1 | 2 | 3 | 4 | 5 | 6
-          const headingText = tokens[i + 1].content
           elements.push(
             new Paragraph({
-              text: headingText,
+              children: processInlineTokens(tokens[i + 1].children || [], false),
               heading: HeadingLevel[`HEADING_${level}`],
               spacing: {
                 before: 240,
@@ -146,44 +171,54 @@ export class ExportService {
           break
 
         case 'bullet_list_open':
-          listLevel++
+          listCounters.push(null)
+          break
+
+        case 'ordered_list_open':
+          listCounters.push(Number(token.attrGet('start') ?? 1))
           break
 
         case 'bullet_list_close':
-          listLevel--
+        case 'ordered_list_close':
+          listCounters.pop()
           break
 
         case 'list_item_open':
-          // Nested blocks must reach their own handlers so container levels stay balanced.
-          if (tokens[i + 1].type !== 'paragraph_open') {
-            break
+          const itemNumber = listCounters[listCounters.length - 1]
+          if (itemNumber != null) {
+            listCounters[listCounters.length - 1] = itemNumber + 1
           }
-          const itemInlineTokens = tokens[i + 2].children || []
+          // Only a leading paragraph is inlined behind the marker; any other first block (code,
+          // quote, nested list) reaches its own handler so container levels stay balanced.
+          const hasLeadParagraph = tokens[i + 1].type === 'paragraph_open'
           elements.push(
             new Paragraph({
               children: [
-                new TextRun({ text: '•', bold: true }),
+                new TextRun({ text: itemNumber == null ? '•' : `${itemNumber}.`, bold: true }),
                 new TextRun({ text: '\t' }),
-                ...processInlineTokens(itemInlineTokens, false, quoteLevel > 0)
+                ...(hasLeadParagraph ? processInlineTokens(tokens[i + 2].children || [], false, quoteLevel > 0) : [])
               ],
-              indent: { left: (listLevel + quoteLevel) * 720 },
+              indent: { left: (listCounters.length + quoteLevel) * 720 },
               ...(quoteLevel > 0 ? { border: quoteBorder } : {})
             })
           )
-          i += 3
+          if (hasLeadParagraph) {
+            i += 3
+          }
           break
 
+        case 'code_block':
         case 'fence': // 代码块
-          const codeLines = token.content.split('\n')
+          const codeLines = token.content.replace(/\n$/, '').split('\n')
           elements.push(
             new Paragraph({
               children: codeLines.map(
-                (line) =>
+                (line, index) =>
                   new TextRun({
-                    text: line + '\n',
+                    text: line,
                     font: 'Consolas',
                     size: 20,
-                    break: 1
+                    break: index === 0 ? 0 : 1
                   })
               ),
               shading: {

--- a/src/main/services/ExportService.ts
+++ b/src/main/services/ExportService.ts
@@ -221,6 +221,7 @@ export class ExportService {
                     break: index === 0 ? 0 : 1
                   })
               ),
+              indent: { left: (listCounters.length + quoteLevel) * 720 },
               shading: {
                 type: ShadingType.SOLID,
                 color: 'F5F5F5'

--- a/src/main/services/__tests__/ExportService.test.ts
+++ b/src/main/services/__tests__/ExportService.test.ts
@@ -218,5 +218,154 @@ describe('ExportService.exportToWord', () => {
       expect(documentXml).not.toContain('Hyperlink')
       expect(textsOf(documentXml)).toEqual(['empty'])
     })
+
+    // Catches the block switch dropping markdown-it's `code_block` token: four-space-indented
+    // code used to vanish from the document while the export still reported success.
+    it('exports indented code as a monospace code block', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('Intro\n\n    const answer = 42\n    return answer\n', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      const runs = documentXml.match(/<w:r>[\s\S]*?<\/w:r>/g) ?? []
+      const codeRuns = runs.filter((run) => /const answer = 42|return answer/.test(run))
+      expect(codeRuns).toHaveLength(2)
+      expect(codeRuns.every((run) => run.includes('Consolas'))).toBe(true)
+    })
+
+    // Catches ordered lists falling through the block switch: items came out as unindented
+    // bullets, and a nested ordered list did not push the indent level.
+    it('numbers ordered list items from their start value and indents nested lists', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('- a\n  1. b\n  2. c\n- d\n\n5. e\n6. f\n', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      const paragraphs = documentXml.match(/<w:p>[\s\S]*?<\/w:p>/g) ?? []
+      const items = paragraphs.map((paragraph) => {
+        const texts = textsOf(paragraph)
+        return { marker: texts[0], text: texts[texts.length - 1], indent: paragraph.match(/w:left="(\d+)"/)?.[1] }
+      })
+      expect(items).toEqual([
+        { marker: '•', text: 'a', indent: '720' },
+        { marker: '1.', text: 'b', indent: '1440' },
+        { marker: '2.', text: 'c', indent: '1440' },
+        { marker: '•', text: 'd', indent: '720' },
+        { marker: '5.', text: 'e', indent: '720' },
+        { marker: '6.', text: 'f', indent: '720' }
+      ])
+    })
+
+    // Catches the code paragraph putting a line break before every line and keeping the
+    // trailing newline: the shaded box used to open and close with an empty line.
+    it('exports a code block without leading or trailing blank lines', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('```\nline1\nline2\n```\n', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      const paragraphs = documentXml.match(/<w:p>[\s\S]*?<\/w:p>/g) ?? []
+      expect(paragraphs).toHaveLength(1)
+      const [codeParagraph = ''] = paragraphs
+      expect(textsOf(codeParagraph)).toEqual(['line1', 'line2'])
+      expect(codeParagraph.match(/<w:br\/>/g)).toHaveLength(1)
+    })
+
+    // Catches the inline switch dropping the `image` token together with its alt text.
+    it('exports image alt text as plain text', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('before ![alt **text**](x.png) after', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      expect(textsOf(documentXml)).toEqual(['before ', 'alt text', ' after'])
+    })
+
+    // Catches alt text being built from token.content alone: soft and hard breaks carry an
+    // empty content, so a multi-line alt used to glue its words together.
+    it('keeps word boundaries across lines in image alt text', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('![first\nsecond  \nthird `code` ![inner](y.png) tail](x.png)', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      expect(textsOf(documentXml)).toEqual(['first second third code inner tail'])
+    })
+
+    // Catches `s_open` / `s_close` being ignored: struck text came out as plain text.
+    it('strikes through text wrapped in ~~', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('keep ~~gone~~ tail', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      const runs = documentXml.match(/<w:r>[\s\S]*?<\/w:r>/g) ?? []
+      expect(runs.map((run) => textsOf(run)[0])).toEqual(['keep ', 'gone', ' tail'])
+      expect(runs.map((run) => run.includes('<w:strike/>'))).toEqual([false, true, false])
+    })
+
+    // Catches the heading handler exporting the raw inline source: `# Title ![alt](x.png) ~~old~~`
+    // came out as literal markdown, with no alt text and no strikethrough.
+    it('renders inline markdown in headings', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('# Head ![alt **x**](a.png) ~~gone~~ **b** tail', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      const paragraphs = documentXml.match(/<w:p>[\s\S]*?<\/w:p>/g) ?? []
+      expect(paragraphs).toHaveLength(1)
+      const [heading = ''] = paragraphs
+      expect(heading).toContain('<w:pStyle w:val="Heading1"/>')
+      const runs = heading.match(/<w:r>[\s\S]*?<\/w:r>/g) ?? []
+      expect(runs.map((run) => textsOf(run)[0])).toEqual(['Head ', 'alt x', ' ', 'gone', ' ', 'b', ' tail'])
+      expect(runs.map((run) => run.includes('<w:strike/>'))).toEqual([false, false, false, true, false, false, false])
+      expect(runs.map((run) => run.includes('<w:b/>'))).toEqual([false, false, false, false, false, true, false])
+    })
+
+    // Catches runs writing off flags as `w:val="false"`: an explicit off overrides the
+    // paragraph style, so Heading 4 lost the italics its style defines.
+    it('does not override heading style formatting with off flags', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('#### Title', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      const [heading = ''] = documentXml.match(/<w:p>[\s\S]*?<\/w:p>/g) ?? []
+      expect(heading).toContain('<w:pStyle w:val="Heading4"/>')
+      expect(textsOf(heading)).toEqual(['Title'])
+      expect(heading).not.toContain('w:val="false"')
+    })
+
+    // Catches `list_item_open` skipping items whose first block is not a paragraph: the code
+    // block or nested list was rendered, but the item's own number or bullet was dropped.
+    it('keeps the marker of a list item whose first block is not a paragraph', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('1. ```\n   code\n   ```\n2. two\n\n- - nested\n- top\n', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      const paragraphs = documentXml.match(/<w:p>[\s\S]*?<\/w:p>/g) ?? []
+      const items = paragraphs.map((paragraph) => ({
+        texts: textsOf(paragraph).filter((text) => text !== '\t'),
+        indent: paragraph.match(/w:left="(\d+)"/)?.[1]
+      }))
+      expect(items).toEqual([
+        { texts: ['1.'], indent: '720' },
+        { texts: ['code'], indent: undefined },
+        { texts: ['2.', 'two'], indent: '720' },
+        { texts: ['•'], indent: '720' },
+        { texts: ['•', 'nested'], indent: '1440' },
+        { texts: ['•', 'top'], indent: '720' }
+      ])
+    })
   })
 })

--- a/src/main/services/__tests__/ExportService.test.ts
+++ b/src/main/services/__tests__/ExportService.test.ts
@@ -360,12 +360,30 @@ describe('ExportService.exportToWord', () => {
       }))
       expect(items).toEqual([
         { texts: ['1.'], indent: '720' },
-        { texts: ['code'], indent: undefined },
+        { texts: ['code'], indent: '720' },
         { texts: ['2.', 'two'], indent: '720' },
         { texts: ['•'], indent: '720' },
         { texts: ['•', 'nested'], indent: '1440' },
         { texts: ['•', 'top'], indent: '720' }
       ])
+    })
+    it.each([
+      ['1. ```\n   code\n   ```', 720],
+      ['1.     code', 720],
+      ['- 1. ```\n     code\n     ```', 1440],
+      ['> 1. ```\n>    code\n>    ```', 1440]
+    ])('keeps code inside its list in %j without indenting following content', async (markdown, indent) => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+      const service = await freshService()
+      await service.exportToWord(`${markdown}\n\noutside`, 'doc.docx')
+
+      const xml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      const paragraphs = xml.match(/<w:p>[\s\S]*?<\/w:p>/g) ?? []
+      const code = paragraphs.find((paragraph) => textsOf(paragraph).includes('code'))
+      const outside = paragraphs.find((paragraph) => textsOf(paragraph).includes('outside'))
+      expect(code).toContain(`<w:ind w:left="${indent}"`)
+      expect(outside).toBeDefined()
+      expect(outside).not.toContain('<w:ind')
     })
   })
 })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The markdown-to-docx converter in `ExportService` handles block and inline tokens through a `switch` with no `default` branch, so any markdown-it token it does not name is dropped silently while the export still reports success. Four kinds of content were affected:

- Four-space-indented code (`code_block`) lost its whole body; only fenced code was rendered.
- Ordered lists came out as unindented `•` bullets, and a nested ordered list did not push the indent level.
- Images vanished together with their alt text.
- `~~strikethrough~~` lost its formatting.

The code box also opened and closed with an empty line, because every line was preceded by a line break and the trailing newline of the block was kept.

After this PR:

- `code_block` shares the fenced-code handler, so indented code renders as the same Consolas shaded box.
- Ordered lists are numbered from their `start` value and indent correctly when nested (a `listCounters` stack replaces the bullet-only `listLevel` counter).
- Image alt text is exported as plain text, built per token type so multi-line alt keeps its word boundaries.
- Struck text carries `strike` in the docx run.
- Code boxes no longer have a leading or trailing blank line (fenced and indented alike).
- Headings render their inline markdown (image alt text, strikethrough, bold, links, inline code) through the same run path as paragraphs instead of exporting the raw source. Runs omit off flags rather than writing them as `false`, which would override the heading styles (Heading 4 is italic by default).
- A list item whose first block is a code fence, a blockquote or a nested list keeps its number or bullet; the block is rendered below the marker. Fenced and indented code blocks inherit the active list and quote indentation, including mixed nested lists.

Fixes # N/A

### Why we need it and why it was done in this way

Users writing notes in source mode with indented code, numbered lists, images, or strikethrough got a Word file that looked complete but silently omitted content. The fix keeps the existing token-switch structure and adds the missing cases in place, matching how the neighbouring handlers are written.

The following tradeoffs were made:

- Line breaks inside image alt text become a space rather than `\n`: `\n` inside a `<w:t>` element is not rendered as a break by Word, and this converter already emits a space for soft breaks in prose.
- Inline code inside alt text keeps its words. markdown-it skips `code_inline` when rendering an HTML `alt` attribute, but in Word the alt text is the only visible placeholder for the image, so dropping words would leave the description incomplete.
- Ordered items are numbered from a counter seeded by the list's `start` attribute, not from each item's literal source number, so the docx numbering matches the note preview (`1. 1. 1.` renders as 1, 2, 3).

The following alternatives were considered:

- Adding a `default` branch that logs unhandled tokens: useful diagnostics but does not fix the export; can be a follow-up.
- Using Word's native numbering (`numbering` config) for lists: a larger change than the bullet-style markers the converter already uses; kept consistent with the existing `•` + tab approach.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The focused Word export suite passes all 31 tests. The list indentation regression cases fail before this correction and pass afterwards. Tests inspect the generated `word/document.xml`, including fenced and indented code, mixed nested lists, quoted lists, and the following unindented paragraph.

`pnpm lint` passes, including type checks, i18n validation, and formatting.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Word export now renders four-space-indented code blocks, numbered lists, image alt text and strikethrough (including inside headings), keeps the marker of list items that start with code or a nested list, and code boxes no longer start and end with a blank line.
```

