### PR TITLE
fix(agent-task): keep run log session link for failed and cancelled runs

### DIFF
--- a/src/main/ai/agents/__tests__/agentTaskJobHandler.test.ts
+++ b/src/main/ai/agents/__tests__/agentTaskJobHandler.test.ts
@@ -126,7 +126,7 @@ describe('AgentTaskJobHandler', () => {
 
   describe('execute', () => {
     it('delegates to runAgentTask with the JobContext', async () => {
-      vi.mocked(runAgentTask).mockResolvedValueOnce({ sessionId: 'sess-1', result: 'ok' })
+      vi.mocked(runAgentTask).mockResolvedValueOnce({ result: 'ok' })
       const ctx = {
         jobId: 'j1',
         input: { agentId: 'a', prompt: 'p', timeoutMinutes: 2, workspace: WORKSPACE_SOURCE, reuseRevision: 0 }
@@ -134,7 +134,7 @@ describe('AgentTaskJobHandler', () => {
 
       const out = await agentTaskJobHandler.execute(ctx)
 
-      expect(out).toEqual({ sessionId: 'sess-1', result: 'ok' })
+      expect(out).toEqual({ result: 'ok' })
       expect(runAgentTask).toHaveBeenCalledWith(ctx)
     })
 
@@ -142,7 +142,7 @@ describe('AgentTaskJobHandler', () => {
       vi.mocked(jobService.getById).mockReturnValueOnce(makeTerminal('completed', 'j1'))
       vi.mocked(runAgentTask).mockImplementationOnce(async () => {
         expect(agentTaskService.notifyReadModelChange).toHaveBeenCalledWith(['s1'])
-        return { sessionId: 'sess-1', result: 'ok' }
+        return { result: 'ok' }
       })
 
       await agentTaskJobHandler.execute({ jobId: 'j1' } as JobContext<AgentTaskInput>)

--- a/src/main/ai/agents/__tests__/runAgentTask.test.ts
+++ b/src/main/ai/agents/__tests__/runAgentTask.test.ts
@@ -244,7 +244,7 @@ describe('runAgentTask', () => {
 
     const out = await runAgentTask(makeCtx())
 
-    expect(out).toEqual({ sessionId: null, result: 'Skipped (disabled)' })
+    expect(out).toEqual({ result: 'Skipped (disabled)' })
     expect(agentSessionService.create).not.toHaveBeenCalled()
     expect(readHeartbeat).not.toHaveBeenCalled()
   })
@@ -258,7 +258,7 @@ describe('runAgentTask', () => {
 
     const out = await runAgentTask(makeCtx())
 
-    expect(out).toEqual({ sessionId: null, result: 'Skipped (disabled)' })
+    expect(out).toEqual({ result: 'Skipped (disabled)' })
     expect(agentSessionService.create).not.toHaveBeenCalled()
     expect(mockStartRun).not.toHaveBeenCalled()
   })
@@ -299,7 +299,7 @@ describe('runAgentTask', () => {
       makeCtx({ input: { agentId: 'a1', prompt: '__heartbeat__', timeoutMinutes: 2, workspace: { type: 'system' } } })
     )
 
-    expect(out).toEqual({ sessionId: null, result: 'Skipped (no file)' })
+    expect(out).toEqual({ result: 'Skipped (no file)' })
     expect(agentSessionService.create).not.toHaveBeenCalled()
     expect(agentWorkspaceService.getById).not.toHaveBeenCalled()
     expect(readHeartbeat).not.toHaveBeenCalled()
@@ -314,7 +314,7 @@ describe('runAgentTask', () => {
       makeCtx({ input: { agentId: 'a1', prompt: '__heartbeat__', timeoutMinutes: 2, workspace: { type: 'system' } } })
     )
 
-    expect(out).toEqual({ sessionId: null, result: 'Skipped (no file)' })
+    expect(out).toEqual({ result: 'Skipped (no file)' })
     expect(agentSessionService.create).not.toHaveBeenCalled()
     expect(agentWorkspaceService.getById).not.toHaveBeenCalled()
     expect(readHeartbeat).not.toHaveBeenCalled()
@@ -330,7 +330,7 @@ describe('runAgentTask', () => {
 
     const out = await runAgentTask(makeCtx())
 
-    expect(out).toEqual({ sessionId: null, result: 'Skipped (workspace deleted)' })
+    expect(out).toEqual({ result: 'Skipped (workspace deleted)' })
     expect(agentSessionService.create).not.toHaveBeenCalled()
     expect(readHeartbeat).not.toHaveBeenCalled()
   })
@@ -359,7 +359,7 @@ describe('runAgentTask', () => {
 
     const out = await runAgentTask(makeCtx())
 
-    expect(out).toEqual({ sessionId: null, result: 'Skipped (no file)' })
+    expect(out).toEqual({ result: 'Skipped (no file)' })
     expect(agentSessionService.create).not.toHaveBeenCalled()
     expect(readHeartbeat).toHaveBeenCalledWith('/ws/a')
   })
@@ -430,9 +430,9 @@ describe('runAgentTask', () => {
     it('creates a fresh session per fire and writes no pointer when reuse is off', async () => {
       vi.mocked(agentSessionService.create).mockReturnValueOnce(makeSession('/ws/a'))
 
-      const out = await runToCompletion({})
+      await runToCompletion({})
 
-      expect(out.sessionId).toBe('sess-new')
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-new' }))
       expect(agentSessionService.getByTaskScheduleId).not.toHaveBeenCalled()
       expect(mockBindTaskSessionReuse).not.toHaveBeenCalled()
     })
@@ -440,9 +440,9 @@ describe('runAgentTask', () => {
     it('binds the created session onto the schedule on the first reusing fire', async () => {
       vi.mocked(agentSessionService.create).mockReturnValueOnce(makeSession('/ws/a'))
 
-      const out = await runToCompletion(REUSE_ON)
+      await runToCompletion(REUSE_ON)
 
-      expect(out.sessionId).toBe('sess-new')
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-new' }))
       expect(mockBindTaskSessionReuse).toHaveBeenCalledWith({
         scheduleId: 's1',
         sessionId: 'sess-new',
@@ -456,9 +456,9 @@ describe('runAgentTask', () => {
       const bound = { ...makeSession('/ws/a'), id: 'sess-sticky' }
       vi.mocked(agentSessionService.getByTaskScheduleId).mockReturnValueOnce(bound)
 
-      const out = await runToCompletion({ reuse: { enabled: true, revision: 0 } })
+      await runToCompletion({ reuse: { enabled: true, revision: 0 } })
 
-      expect(out.sessionId).toBe('sess-sticky')
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-sticky' }))
       expect(agentSessionService.create).not.toHaveBeenCalled()
       // Already bound — no pointer rewrite.
       expect(mockBindTaskSessionReuse).not.toHaveBeenCalled()
@@ -480,7 +480,8 @@ describe('runAgentTask', () => {
       await vi.waitFor(() => expect(mockStartRun).toHaveBeenCalled())
       captured.listeners[0].onDone({ status: 'completed' })
 
-      await expect(promise).resolves.toMatchObject({ sessionId: 'sess-new' })
+      await expect(promise).resolves.toEqual({ result: 'Completed' })
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-new' }))
       expect(agentSessionService.getByTaskScheduleId).not.toHaveBeenCalled()
       expect(mockBindTaskSessionReuse).not.toHaveBeenCalled()
     })
@@ -490,9 +491,9 @@ describe('runAgentTask', () => {
       vi.mocked(agentSessionService.getByTaskScheduleId).mockReturnValueOnce(null)
       vi.mocked(agentSessionService.create).mockReturnValueOnce(makeSession('/ws/a'))
 
-      const out = await runToCompletion(REUSE_ON)
+      await runToCompletion(REUSE_ON)
 
-      expect(out.sessionId).toBe('sess-new')
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-new' }))
       expect(mockBindTaskSessionReuse).toHaveBeenCalledTimes(1)
     })
 
@@ -500,18 +501,18 @@ describe('runAgentTask', () => {
       vi.mocked(agentSessionService.getByTaskScheduleId).mockReturnValueOnce({ ...makeSession('/ws/a'), agentId: 'a2' })
       vi.mocked(agentSessionService.create).mockReturnValueOnce(makeSession('/ws/a'))
 
-      const out = await runToCompletion(REUSE_ON)
+      await runToCompletion(REUSE_ON)
 
-      expect(out.sessionId).toBe('sess-new')
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-new' }))
       expect(agentSessionService.create).toHaveBeenCalled()
     })
 
     it('delegates pointer admission to the command owner when reuse changes during the fire', async () => {
       vi.mocked(agentSessionService.create).mockReturnValueOnce(makeSession('/ws/a'))
 
-      const out = await runToCompletion(REUSE_ON)
+      await runToCompletion(REUSE_ON)
 
-      expect(out.sessionId).toBe('sess-new')
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-new' }))
       expect(mockBindTaskSessionReuse).toHaveBeenCalledTimes(1)
     })
 
@@ -531,7 +532,8 @@ describe('runAgentTask', () => {
         makeCtx({ input: { agentId: 'a1', prompt: 'hi', timeoutMinutes: 0, workspace: { type: 'system' } } })
       )
 
-      expect(out).toEqual({ sessionId: 'sess-sticky', result: 'Skipped (session busy)' })
+      expect(out).toEqual({ result: 'Skipped (session busy)' })
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-sticky' }))
       expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ requireIdle: { expectedAgentId: 'a1' } }))
       expect(mockAbort).not.toHaveBeenCalled()
       expect(agentSessionService.create).not.toHaveBeenCalled()
@@ -558,9 +560,9 @@ describe('runAgentTask', () => {
 
     it('starts a freshly created session through the locked require-idle path', async () => {
       vi.mocked(agentSessionService.create).mockReturnValueOnce(makeSession('/ws/a'))
-      const out = await runToCompletion(REUSE_ON)
+      await runToCompletion(REUSE_ON)
 
-      expect(out.sessionId).toBe('sess-new')
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-new' }))
       expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({ requireIdle: { expectedAgentId: 'a1' } }))
     })
 
@@ -600,7 +602,7 @@ describe('runAgentTask', () => {
     sentinel.onDone({ status: 'completed' })
 
     const out = await promise
-    expect(out).toEqual({ sessionId: 'sess-new', result: 'Hello world' })
+    expect(out).toEqual({ result: 'Hello world' })
   })
 
   it('builds listeners only for subscribed channels owned by the task agent', async () => {
@@ -665,7 +667,7 @@ describe('runAgentTask', () => {
     const doneResult = { status: 'success' }
     await Promise.all(captured.listeners.map((listener) => Promise.resolve(listener.onDone?.(doneResult as never))))
 
-    await expect(promise).resolves.toEqual({ sessionId: 'sess-new', result: 'daily summary' })
+    await expect(promise).resolves.toEqual({ result: 'daily summary' })
     expect(adapter.sendMessage).toHaveBeenCalledTimes(1)
     expect(adapter.sendMessage).toHaveBeenCalledWith('chat-1', 'daily summary', undefined)
     expect(adapter.onStreamComplete).toHaveBeenCalledTimes(1)
@@ -700,7 +702,7 @@ describe('runAgentTask', () => {
     const pausedResult = { status: 'paused' }
     await Promise.all(captured.listeners.map((listener) => Promise.resolve(listener.onPaused?.(pausedResult as never))))
 
-    await expect(promise).resolves.toEqual({ sessionId: 'sess-new', result: 'partial summary' })
+    await expect(promise).resolves.toEqual({ result: 'partial summary' })
     expect(adapter.sendMessage).toHaveBeenCalledTimes(1)
     expect(adapter.sendMessage).toHaveBeenCalledWith('chat-1', 'partial summary\n\n_(stopped)_', undefined)
     expect(adapter.onStreamComplete).toHaveBeenCalledTimes(1)
@@ -830,7 +832,7 @@ describe('runAgentTask', () => {
 
     await expect(
       runAgentTask(makeCtx({ signal: controller.signal, input: { agentId: 'a1', prompt: 'hi', timeoutMinutes: 0 } }))
-    ).resolves.toEqual({ sessionId: 'sess-new', result: 'Completed' })
+    ).resolves.toEqual({ result: 'Completed' })
 
     expect(mockAbort).not.toHaveBeenCalled()
     expect(mockRemoveListener).toHaveBeenCalledWith(buildAgentSessionTopicId('sess-new'), 'agent-task:s1')
@@ -875,12 +877,34 @@ describe('runAgentTask', () => {
         return { mode: 'started' }
       })
 
-    const promise = runAgentTask(makeCtx({ input: { agentId: 'a1', prompt: 'hi', timeoutMinutes: 0 } }))
+    const ctx = makeCtx({ input: { agentId: 'a1', prompt: 'hi', timeoutMinutes: 0 } })
+    const promise = runAgentTask(ctx)
     await vi.waitFor(() => expect(mockStartRun).toHaveBeenCalledTimes(2))
     captured.listeners[0].onDone({ status: 'completed' })
 
-    await expect(promise).resolves.toMatchObject({ sessionId: 'sess-rebound' })
+    await expect(promise).resolves.toEqual({ result: 'Completed' })
     expect(agentSessionService.create).toHaveBeenCalledTimes(2)
+    expect(mockStartRun.mock.calls[1][0]).toMatchObject({ sessionId: 'sess-rebound' })
+    expect(vi.mocked(ctx.patchMetadata).mock.lastCall).toEqual([{ sessionId: 'sess-rebound' }])
+  })
+
+  it('persists the run→session link before the run starts so a failed run keeps it', async () => {
+    vi.mocked(jobService.getById).mockReturnValueOnce(makeJobSnapshot())
+    vi.mocked(jobScheduleService.getById).mockReturnValueOnce(makeSchedule('daily-summary'))
+    vi.mocked(agentService.getAgent).mockReturnValueOnce(makeAgent())
+    vi.mocked(agentSessionService.create).mockReturnValueOnce(makeSession('/ws/a'))
+
+    const ctx = makeCtx({ input: { agentId: 'a1', prompt: 'hi', timeoutMinutes: 0 } })
+    const promise = runAgentTask(ctx)
+
+    await vi.waitFor(() => expect(mockStartRun).toHaveBeenCalled())
+    const patch = vi.mocked(ctx.patchMetadata)
+    expect(patch).toHaveBeenCalledWith({ sessionId: 'sess-new' })
+    expect(patch.mock.invocationCallOrder[0]).toBeLessThan(mockStartRun.mock.invocationCallOrder[0])
+
+    captured.listeners[0].onError({ error: new Error('boom'), status: 'error' })
+
+    await expect(promise).rejects.toThrow('boom')
   })
 
   // agents-jobs-5: a non-zero `timeoutMinutes` arms a per-task timeout timer in

--- a/src/main/ai/agents/runAgentTask.ts
+++ b/src/main/ai/agents/runAgentTask.ts
@@ -17,9 +17,10 @@
  * a reusing fire stands down when that session already has a turn in flight.
  * Admission is enforced under the stream manager's per-topic dispatch lock.
  *
- * Either way the session used by a fire is recorded in `job.output.sessionId`
- * for the run log; the reuse pointer is read from the constrained relation,
- * never from there (job rows are GC'd).
+ * Either way the session used by a fire is recorded in `job.metadata.sessionId`
+ * before the run starts, so the run log keeps the link when the fire fails,
+ * times out, or is cancelled; the reuse pointer is read from the constrained
+ * relation, never from there (job rows are GC'd).
  */
 
 import { application } from '@application'
@@ -55,10 +56,6 @@ export type AgentTaskInput = {
 }
 
 export type AgentTaskOutput = {
-  /** Session this fire ran in — created fresh, or the sticky one under
-   *  `reuseSession`. Persisted to `jobTable.output` purely as an audit trail;
-   *  continuity is driven by the schedule's reuse pointer, never by this. */
-  sessionId: string | null
   /** First 200 chars of the assistant reply, or a status marker for skipped runs. */
   result: string
 }
@@ -163,12 +160,12 @@ export async function runAgentTask(ctx: JobContext<AgentTaskInput>): Promise<Age
   if (isHeartbeat) {
     if (config.heartbeat_enabled === false) {
       logger.debug('Heartbeat skipped (disabled)', { agentId, scheduleId })
-      return { sessionId: null, result: 'Skipped (disabled)' }
+      return { result: 'Skipped (disabled)' }
     }
     switch (workspace.type) {
       case AGENT_WORKSPACE_TYPE.SYSTEM:
         logger.debug('Heartbeat skipped (no file)', { agentId, scheduleId })
-        return { sessionId: null, result: 'Skipped (no file)' }
+        return { result: 'Skipped (no file)' }
       case AGENT_WORKSPACE_TYPE.USER:
         break
       default: {
@@ -186,7 +183,7 @@ export async function runAgentTask(ctx: JobContext<AgentTaskInput>): Promise<Age
           scheduleId,
           workspaceId: workspace.workspaceId
         })
-        return { sessionId: null, result: 'Skipped (workspace deleted)' }
+        return { result: 'Skipped (workspace deleted)' }
       }
       throw error
     }
@@ -197,7 +194,7 @@ export async function runAgentTask(ctx: JobContext<AgentTaskInput>): Promise<Age
     const content = await readHeartbeat(workspacePath)
     if (!content) {
       logger.debug('Heartbeat skipped (no heartbeat.md)', { agentId, scheduleId })
-      return { sessionId: null, result: 'Skipped (no file)' }
+      return { result: 'Skipped (no file)' }
     }
     effectivePrompt = [
       '[Heartbeat]',
@@ -310,6 +307,7 @@ export async function runAgentTask(ctx: JobContext<AgentTaskInput>): Promise<Age
   try {
     let rebound = false
     while (true) {
+      await ctx.patchMetadata({ sessionId: session.id })
       const started = await startAgentSessionRun({
         sessionId: session.id,
         userParts: [{ type: 'text', text: effectivePrompt }],
@@ -326,7 +324,7 @@ export async function runAgentTask(ctx: JobContext<AgentTaskInput>): Promise<Age
       }
       if (started.reason === 'busy') {
         completionActive = false
-        return { sessionId: session.id, result: 'Skipped (session busy)' }
+        return { result: 'Skipped (session busy)' }
       }
       if (rebound) throw new Error(`Agent session ${session.id} became invalid while starting task`)
       rebound = true
@@ -364,10 +362,7 @@ export async function runAgentTask(ctx: JobContext<AgentTaskInput>): Promise<Age
     dispose()
   }
 
-  return {
-    sessionId: session.id,
-    result: resultText.slice(0, 200) || 'Completed'
-  }
+  return { result: resultText.slice(0, 200) || 'Completed' }
 }
 
 async function notifyTaskError(

--- a/src/main/data/services/AgentTaskService.ts
+++ b/src/main/data/services/AgentTaskService.ts
@@ -309,7 +309,10 @@ export class AgentTaskService {
   }
 
   private toTaskRunLogEntity(job: JobSnapshot): TaskRunLogEntity {
-    const output = job.output as { sessionId?: string; result?: string } | null
+    const output = job.output as { result?: string } | null
+    // runAgentTask writes the link via patchMetadata before the run starts, so
+    // failed/cancelled rows (which never get an output) keep it.
+    const sessionId = job.metadata.sessionId
     const startedAt = job.startedAt ?? job.scheduledAt
     // A cancel-requested row's fate is sealed (live cancel and startup recovery
     // both end it as cancelled) — show the outcome before the row settles.
@@ -336,7 +339,7 @@ export class AgentTaskService {
     return {
       id: job.id,
       scheduleId: job.scheduleId ?? '',
-      sessionId: output?.sessionId ?? null,
+      sessionId: typeof sessionId === 'string' ? sessionId : null,
       startedAt,
       durationMs,
       status,

--- a/src/main/data/services/AgentTaskService.ts
+++ b/src/main/data/services/AgentTaskService.ts
@@ -309,10 +309,9 @@ export class AgentTaskService {
   }
 
   private toTaskRunLogEntity(job: JobSnapshot): TaskRunLogEntity {
-    const output = job.output as { result?: string } | null
-    // runAgentTask writes the link via patchMetadata before the run starts, so
-    // failed/cancelled rows (which never get an output) keep it.
-    const sessionId = job.metadata.sessionId
+    const output = job.output as { result?: string; sessionId?: string } | null
+    // New runs persist the link before execution; older v2 job rows only have it in output.
+    const sessionId = job.metadata.sessionId ?? output?.sessionId
     const startedAt = job.startedAt ?? job.scheduledAt
     // A cancel-requested row's fate is sealed (live cancel and startup recovery
     // both end it as cancelled) — show the outcome before the row settles.

--- a/src/main/data/services/__tests__/AgentTaskService.test.ts
+++ b/src/main/data/services/__tests__/AgentTaskService.test.ts
@@ -87,12 +87,12 @@ function makeJobSnapshot(overrides: Partial<JobSnapshot> = {}): JobSnapshot {
     attempt: 0,
     maxAttempts: 1,
     input: {},
-    output: { sessionId: 'sess-1', result: 'ok' },
+    output: { result: 'ok' },
     error: null,
     parentId: null,
     cancelRequested: false,
     cancelRequestedAt: null,
-    metadata: {},
+    metadata: { sessionId: 'sess-1' },
     timeoutMs: null,
     createdAt: '2026-05-20T00:00:00.000Z',
     updatedAt: '2026-05-20T00:00:05.000Z',
@@ -337,6 +337,32 @@ describe('AgentTaskService (read side)', () => {
       expect(result.logs[0]).not.toHaveProperty('taskId')
       expect(result.logs[0]).not.toHaveProperty('runAt')
       expect(result.logs[0]).toHaveProperty('startedAt')
+    })
+
+    it('links a failed run to its session from metadata when no output was persisted', () => {
+      vi.mocked(jobService.list).mockReturnValueOnce([
+        makeJobSnapshot({
+          id: 'j1',
+          status: 'failed',
+          output: null,
+          error: { code: 'X', message: 'boom', retryable: false },
+          metadata: { sessionId: 'sess-meta' }
+        })
+      ])
+
+      const result = agentTaskService.getTaskLogs(TASK_ID)
+
+      expect(result.logs).toEqual([expect.objectContaining({ id: 'j1', status: 'failed', sessionId: 'sess-meta' })])
+    })
+
+    it('links a run that never reached the session step to no session', () => {
+      vi.mocked(jobService.list).mockReturnValueOnce([
+        makeJobSnapshot({ id: 'j1', status: 'cancelled', output: null, metadata: {} })
+      ])
+
+      const result = agentTaskService.getTaskLogs(TASK_ID)
+
+      expect(result.logs).toEqual([expect.objectContaining({ id: 'j1', status: 'cancelled', sessionId: null })])
     })
 
     it('returns a null duration while a run is still in flight', () => {

--- a/src/main/data/services/__tests__/AgentTaskService.test.ts
+++ b/src/main/data/services/__tests__/AgentTaskService.test.ts
@@ -339,6 +339,22 @@ describe('AgentTaskService (read side)', () => {
       expect(result.logs[0]).toHaveProperty('startedAt')
     })
 
+    it('preserves pre-metadata session links while preferring the current metadata link', () => {
+      vi.mocked(jobService.list).mockReturnValueOnce([
+        makeJobSnapshot({ id: 'old', metadata: {}, output: { result: 'ok', sessionId: 'old-session' } }),
+        makeJobSnapshot({
+          id: 'rebound',
+          metadata: { sessionId: 'replacement-session' },
+          output: { result: 'ok', sessionId: 'old-session' }
+        })
+      ])
+
+      expect(agentTaskService.getTaskLogs(TASK_ID).logs).toEqual([
+        expect.objectContaining({ id: 'old', sessionId: 'old-session', result: 'ok' }),
+        expect.objectContaining({ id: 'rebound', sessionId: 'replacement-session', result: 'ok' })
+      ])
+    })
+
     it('links a failed run to its session from metadata when no output was persisted', () => {
       vi.mocked(jobService.list).mockReturnValueOnce([
         makeJobSnapshot({


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The task run log resolved its "view session" link from `job.output.sessionId`. `JobManager.finalizeJob` only persists `output` on success, so a fire that had already produced a reply or tool calls and then errored, timed out, or was cancelled lost the link. The "view session" button disappeared from that row and refreshing could not bring it back, even though the session itself still existed.

After this PR:

`runAgentTask` writes the link to `job.metadata.sessionId` through `ctx.patchMetadata` before `startAgentSessionRun`, and re-patches it when an ownership race forces a rebind onto a replacement session. `AgentTaskService.toTaskRunLogEntity` reads the link from metadata. Failed, timed-out, and cancelled runs keep their "view session" button. `sessionId` is removed from `AgentTaskOutput`, so metadata is the source for new runs; the read mapper falls back to `output.sessionId` only for older v2 rows that have no metadata link.

Fixes #

### Why we need it and why it was done in this way

`ctx.patchMetadata` is the job runtime's existing mechanism for persisting handler state independently of the terminal outcome (the cross-restart hand-off pattern in `docs/references/job-and-scheduler/handler-authoring.md`). The link is written before the run starts, so every path that can end the run afterwards leaves it intact. The terminal write in `JobService.setTerminalTx` never touches the metadata column.

The following tradeoffs were made:

- Existing v2 rows retain their session links through a read-only fallback to `output.sessionId` when the metadata link is absent. New runs write only metadata, and metadata takes precedence after a session rebind. No migration or dual write is needed.
- Because the link now lands before the run starts, in-flight and cancel-requested rows also show the "view session" button. Sticky sessions were already user-reachable mid-run, so this adds no new hazard.

The following alternatives were considered:

- Continue writing `sessionId` in `AgentTaskOutput`. Rejected: new runs need only the metadata link. Supporting existing persisted output in the read mapper preserves prior logs without introducing dual writes.
- Store the link on the session row instead. Rejected: job rows are GC'd, so a session-to-job reference would dangle; the link is a job-owned audit trail, which is what the job row already modelled.

Links to places where the discussion took place: None

### Breaking changes

None. `TaskRunLogEntity.sessionId` and the DataApi endpoint are unchanged.

### Special notes for your reviewer

The focused AgentTaskService suite passes all 35 tests. The compatibility regression fails before the correction and passes afterwards: old successful rows retain their output-only session link, while metadata wins when both locations are present. Existing failed/cancelled-run metadata coverage remains passing.

`pnpm lint` passes, including type checks, i18n validation, and formatting.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the task run log losing its "view session" link when a scheduled agent run failed, timed out, or was cancelled after it had started.
```
