### PR TITLE
fix(knowledge-base): skip dependencies and unblock deletion

### DIFF
--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -17,6 +17,7 @@ import type * as PathStorage from '../pathStorage'
 const {
   cancelManyMock,
   cancelMock,
+  loggerErrorMock,
   getIndexStoreMock,
   deleteStoreMock,
   enqueueMock,
@@ -60,6 +61,7 @@ const {
 } = vi.hoisted(() => ({
   cancelManyMock: vi.fn(),
   cancelMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
   getIndexStoreMock: vi.fn(),
   deleteStoreMock: vi.fn(),
   enqueueMock: vi.fn(),
@@ -131,7 +133,7 @@ vi.mock('@logger', () => ({
   loggerService: {
     withContext: () => ({
       debug: vi.fn(),
-      error: vi.fn(),
+      error: loggerErrorMock,
       info: vi.fn(),
       warn: vi.fn()
     })
@@ -337,6 +339,7 @@ describe('KnowledgeService', () => {
     createdItemBaseIds.clear()
     knowledgeBaseCreateMock.mockReturnValue(createBase())
     knowledgeBaseDeleteMock.mockReturnValue(undefined)
+    deleteStoreMock.mockResolvedValue(undefined)
     knowledgeBaseGetByIdMock.mockReturnValue(createBase())
     knowledgeBaseListAllIdsMock.mockReturnValue(new Set())
     knowledgeBaseListForDiscoveryMock.mockReturnValue({ items: [], total: 0 })
@@ -620,10 +623,13 @@ describe('KnowledgeService', () => {
     expect(getIndexStoreMock).toHaveBeenCalledWith(base)
   })
 
-  it('deletes base jobs before vector artifacts and SQLite base', async () => {
+  it('deletes the SQLite base without waiting for slow artifact cleanup', async () => {
     const service = new KnowledgeService()
+    const cleanup = createDeferred()
+    deleteStoreMock.mockReturnValueOnce(cleanup.promise)
 
-    await service.deleteBase('kb-1')
+    const deletion = service.deleteBase('kb-1')
+    await flushMicrotasks()
 
     expect(listMock).toHaveBeenCalledWith({
       queue: 'base.kb-1',
@@ -640,9 +646,24 @@ describe('KnowledgeService', () => {
     expect(deleteStoreMock).toHaveBeenCalledWith('kb-1')
     expect(knowledgeBaseDeleteMock).toHaveBeenCalledWith('kb-1')
     expect(listMock.mock.invocationCallOrder[0]).toBeLessThan(deleteStoreMock.mock.invocationCallOrder[0])
-    expect(deleteStoreMock.mock.invocationCallOrder[0]).toBeLessThan(
-      knowledgeBaseDeleteMock.mock.invocationCallOrder[0]
-    )
+    await expect(deletion).resolves.toBeUndefined()
+
+    cleanup.resolve()
+    await cleanup.promise
+  })
+
+  it('keeps a logically deleted base removed when background artifact cleanup fails', async () => {
+    const service = new KnowledgeService()
+    const cleanupError = new Error('directory busy')
+    deleteStoreMock.mockRejectedValueOnce(cleanupError)
+
+    await expect(service.deleteBase('kb-1')).resolves.toBeUndefined()
+    await flushMicrotasks()
+
+    expect(knowledgeBaseDeleteMock).toHaveBeenCalledWith('kb-1')
+    expect(loggerErrorMock).toHaveBeenCalledWith('Failed to delete knowledge base vector artifacts', cleanupError, {
+      baseId: 'kb-1'
+    })
   })
 
   it('cancels file-processing jobs linked by active knowledge checks before deleting a base', async () => {
@@ -668,48 +689,6 @@ describe('KnowledgeService', () => {
     expect(cancelMock).toHaveBeenCalledWith('fp-job-1', 'delete-base')
     expect(cancelMock.mock.invocationCallOrder[0]).toBeLessThan(deleteStoreMock.mock.invocationCallOrder[0])
     expect(cancelMock.mock.invocationCallOrder[1]).toBeLessThan(deleteStoreMock.mock.invocationCallOrder[0])
-  })
-
-  it('serializes concurrent deleteBase cleanup for the same base', async () => {
-    const service = new KnowledgeService()
-    const firstDeleteStoreEntered = createDeferred()
-    const releaseFirstDeleteStore = createDeferred()
-    const cleanupEvents: string[] = []
-    let deleteStoreCallCount = 0
-    deleteStoreMock.mockImplementation(async (baseId: string) => {
-      deleteStoreCallCount += 1
-      const callNumber = deleteStoreCallCount
-      cleanupEvents.push(`delete-store-${callNumber}-start:${baseId}`)
-      if (callNumber === 1) {
-        firstDeleteStoreEntered.resolve()
-        await releaseFirstDeleteStore.promise
-      }
-      cleanupEvents.push(`delete-store-${callNumber}-end:${baseId}`)
-    })
-    knowledgeBaseDeleteMock.mockImplementation((baseId: string) => {
-      cleanupEvents.push(`sqlite-${cleanupEvents.filter((event) => event.startsWith('sqlite-')).length + 1}:${baseId}`)
-    })
-
-    const firstDelete = service.deleteBase('kb-1')
-    await firstDeleteStoreEntered.promise
-    const secondDelete = service.deleteBase('kb-1')
-    await flushMicrotasks()
-
-    expect(deleteStoreMock).toHaveBeenCalledTimes(1)
-    expect(knowledgeBaseDeleteMock).not.toHaveBeenCalled()
-    expect(cleanupEvents).toEqual(['delete-store-1-start:kb-1'])
-
-    releaseFirstDeleteStore.resolve()
-    await Promise.all([firstDelete, secondDelete])
-
-    expect(cleanupEvents).toEqual([
-      'delete-store-1-start:kb-1',
-      'delete-store-1-end:kb-1',
-      'sqlite-1:kb-1',
-      'delete-store-2-start:kb-1',
-      'delete-store-2-end:kb-1',
-      'sqlite-2:kb-1'
-    ])
   })
 
   it('restores a failed base by creating a new base and enqueueing restored root items', async () => {
@@ -906,7 +885,7 @@ describe('KnowledgeService', () => {
     )
   })
 
-  it('surfaces restored base id when restore item failure cleanup also fails', async () => {
+  it('removes a failed restored base even when background artifact cleanup also fails', async () => {
     const service = new KnowledgeService()
     const sourceBase = createBase({ id: 'source-kb', embeddingModelId: 'provider::embed', dimensions: 3 })
     const restoredBase = createBase({ id: 'restored-kb', embeddingModelId: 'provider::embed', dimensions: 3 })
@@ -925,8 +904,14 @@ describe('KnowledgeService', () => {
         embeddingModelId: 'provider::embed',
         dimensions: 3
       })
-    ).rejects.toThrow(
-      "Restored knowledge base 'restored-kb' could not be cleaned up automatically: delete store failed"
+    ).rejects.toThrow('Failed to restore knowledge items: enqueue failed')
+
+    await flushMicrotasks()
+    expect(knowledgeBaseDeleteMock).toHaveBeenCalledWith('restored-kb')
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'Failed to delete knowledge base vector artifacts',
+      expect.objectContaining({ message: 'delete store failed' }),
+      { baseId: 'restored-kb' }
     )
   })
 

--- a/src/main/features/knowledge/base/KnowledgeBaseAdminService.ts
+++ b/src/main/features/knowledge/base/KnowledgeBaseAdminService.ts
@@ -69,25 +69,31 @@ export class KnowledgeBaseAdminService {
     await cancelActiveKnowledgeJobs(baseId, 'delete-base', { onCancelTimeout: 'proceed' })
 
     await this.knowledgeLockManager.runExclusive(baseId, async () => {
+      let artifactCleanup: Promise<void>
       try {
         const vectorStoreService = application.get('KnowledgeVectorStoreService')
-        await vectorStoreService.deleteStore(baseId)
+        artifactCleanup = vectorStoreService.deleteStore(baseId)
       } catch (error) {
         const normalizedError = error instanceof Error ? error : new Error(String(error))
         logger.error('Failed to delete knowledge base vector artifacts', normalizedError, { baseId })
         throw error
       }
 
+      void artifactCleanup.catch((error) => {
+        const normalizedError = error instanceof Error ? error : new Error(String(error))
+        logger.error('Failed to delete knowledge base vector artifacts', normalizedError, { baseId })
+      })
+
       try {
         knowledgeBaseService.delete(baseId)
       } catch (error) {
         const normalizedError = error instanceof Error ? error : new Error(String(error))
-        logger.error('Failed to delete knowledge base SQLite row after artifact cleanup', normalizedError, {
+        logger.error('Failed to delete knowledge base SQLite row after artifact cleanup started', normalizedError, {
           baseId
         })
         throw DataApiErrorFactory.invalidOperation(
           'deleteBase',
-          `Vector artifacts were deleted, but SQLite knowledge base cleanup failed: ${normalizedError.message}`
+          `Vector artifact cleanup started, but SQLite knowledge base cleanup failed: ${normalizedError.message}`
         )
       }
     })

--- a/src/main/features/knowledge/pipeline/sources/__tests__/directory.test.ts
+++ b/src/main/features/knowledge/pipeline/sources/__tests__/directory.test.ts
@@ -270,6 +270,71 @@ describe('expandDirectoryOwnerToTree', () => {
     )
   })
 
+  it('skips common development dependency directories from copying and progress', async () => {
+    tempRoot = createTempRoot()
+    const rootDir = path.join(tempRoot, 'workspace')
+    const dependencyDirectories = [
+      'node_modules',
+      'bower_components',
+      'jspm_packages',
+      'vendor',
+      'Pods',
+      'Carthage',
+      'venv',
+      '__pypackages__'
+    ]
+    realFs.mkdirSync(rootDir, { recursive: true })
+    realFs.writeFileSync(path.join(rootDir, 'readme.md'), '# readme')
+    for (const directory of dependencyDirectories) {
+      const dependencyDir = path.join(rootDir, directory)
+      realFs.mkdirSync(dependencyDir, { recursive: true })
+      realFs.writeFileSync(path.join(dependencyDir, 'dependency.md'), '# dependency')
+    }
+
+    copyFileIntoKnowledgeBaseAtMock.mockClear()
+    const onCopyProgress = vi.fn()
+    const owner = createDirectoryOwner(rootDir)
+    const children = await expandDirectoryOwnerToTree(
+      owner,
+      'kb-1',
+      chooseDirectoryPathPrefix(owner, new Set()),
+      createSignal(),
+      onCopyProgress
+    )
+
+    expect(children).toEqual([
+      {
+        type: 'file',
+        data: {
+          source: path.join(rootDir, 'readme.md'),
+          relativePath: 'workspace/readme.md'
+        }
+      }
+    ])
+    expect(copyFileIntoKnowledgeBaseAtMock).toHaveBeenCalledTimes(1)
+    expect(onCopyProgress.mock.calls.map(([percent]) => percent)).toEqual([0, 100])
+  })
+
+  it('does not import a dependency directory selected as the root', async () => {
+    tempRoot = createTempRoot()
+    const rootDir = path.join(tempRoot, 'NODE_MODULES')
+    realFs.mkdirSync(rootDir, { recursive: true })
+    realFs.writeFileSync(path.join(rootDir, 'dependency.md'), '# dependency')
+
+    copyFileIntoKnowledgeBaseAtMock.mockClear()
+    const owner = createDirectoryOwner(rootDir)
+    const children = await expandDirectoryOwnerToTree(
+      owner,
+      'kb-1',
+      chooseDirectoryPathPrefix(owner, new Set()),
+      createSignal(),
+      ignoreCopyProgress
+    )
+
+    expect(children).toEqual([])
+    expect(copyFileIntoKnowledgeBaseAtMock).not.toHaveBeenCalled()
+  })
+
   it('reports copied files against the supported-file total', async () => {
     tempRoot = createTempRoot()
     const rootDir = path.join(tempRoot, 'workspace')

--- a/src/main/features/knowledge/pipeline/sources/directory.ts
+++ b/src/main/features/knowledge/pipeline/sources/directory.ts
@@ -8,6 +8,20 @@ import { knowledgeSupportedFileExts } from '@shared/utils/file'
 import { assertSafeKnowledgeRelativePath, copyFileIntoKnowledgeBaseAt } from '../../pathStorage'
 
 const KNOWLEDGE_SUPPORTED_FILE_EXT_SET = new Set<string>(knowledgeSupportedFileExts)
+const DEVELOPMENT_DEPENDENCY_DIRECTORY_NAMES = new Set([
+  '__pypackages__',
+  'bower_components',
+  'carthage',
+  'jspm_packages',
+  'node_modules',
+  'pods',
+  'vendor',
+  'venv'
+])
+
+function isDevelopmentDependencyDirectory(name: string): boolean {
+  return DEVELOPMENT_DEPENDENCY_DIRECTORY_NAMES.has(name.toLowerCase())
+}
 
 /** A scanned filesystem entry under a directory owner — only the fields this module reads. */
 interface DirectoryEntryNode {
@@ -43,7 +57,7 @@ async function readDirectoryTree(
   for (const entry of entries) {
     signal.throwIfAborted()
 
-    if (entry.name.startsWith('.')) {
+    if (entry.name.startsWith('.') || (entry.isDirectory() && isDevelopmentDependencyDirectory(entry.name))) {
       continue
     }
 
@@ -185,6 +199,9 @@ export async function expandDirectoryOwnerToTree(
   }
 
   const resolvedPath = path.resolve(owner.data.source)
+  if (isDevelopmentDependencyDirectory(path.basename(resolvedPath))) {
+    return []
+  }
   const children = await readDirectoryTree(resolvedPath, signal)
   const expandedChildren: ExpandedDirectoryNode[] = []
   const totalFiles = countSupportedFiles(children)

--- a/src/main/features/knowledge/pipeline/vectorstore/KnowledgeVectorStoreService.ts
+++ b/src/main/features/knowledge/pipeline/vectorstore/KnowledgeVectorStoreService.ts
@@ -83,16 +83,18 @@ export class KnowledgeVectorStoreService extends BaseService {
    * (`feature.knowledgebase.data/{baseId}`) — source files, processed artifacts
    * and `index.sqlite` alike. Only safe when deleting the whole base.
    */
-  async deleteStore(baseId: string): Promise<void> {
+  deleteStore(baseId: string): Promise<void> {
     const store = this.instanceCache.get(baseId)
 
     try {
       this.closeStoreInstance(store)
-      await deleteKnowledgeBaseDir(baseId)
-      logger.info('Deleted knowledge index store', { baseId, hadCachedStore: Boolean(store) })
     } finally {
       this.instanceCache.delete(baseId)
     }
+
+    return deleteKnowledgeBaseDir(baseId).then(() => {
+      logger.info('Deleted knowledge index store', { baseId, hadCachedStore: Boolean(store) })
+    })
   }
 
   protected async onStop(): Promise<void> {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- Directory imports traversed common dependency folders such as `node_modules`, copying and indexing their supported files.
- Deleting a knowledge base waited for its entire artifact directory to be removed before deleting the SQLite row, so interrupted large imports could remain visible and appear undeletable.

After this PR:

- Directory imports skip common dependency directories before scanning, copying, progress calculation, and indexing.
- Knowledge base deletion closes cached stores synchronously, removes the SQLite row without waiting for recursive artifact cleanup, and logs background cleanup failures.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20201

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Logical deletion is prioritized over potentially slow filesystem cleanup. A failed background cleanup may leave orphaned artifacts, but it no longer keeps the user-visible knowledge base entry alive.
- Dependency folders are matched by conventional directory names, case-insensitively, keeping the change independent of project-specific ignore files.

The following alternatives were considered:

- Continuing to await recursive artifact deletion preserves strict cleanup ordering but reproduces the unresponsive deletion behavior for large interrupted imports.
- Reading each project's ignore file would add project-specific semantics and complexity beyond excluding common dependency directories.

Links to places where the discussion took place: #20201

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Dependency-directory exclusions cover `node_modules`, `bower_components`, `jspm_packages`, `vendor`, `Pods`, `Carthage`, `venv`, and `__pypackages__`; existing dot-directory exclusion continues to cover `.git`, `.venv`, and similar directories.
- Focused main-process tests cover skipped copying/progress, selecting a dependency directory as the import root, non-blocking logical deletion, and background cleanup failure.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Knowledge base directory imports now skip common dependency folders, and deleting interrupted imports no longer waits for artifact cleanup.
```
