### PR TITLE
fix(provider-registry): own Kimi sampling constraints

### DIFF
--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -17951,6 +17951,32 @@
       }
     },
     {
+      "apiModelId": "kimi-k2.7-code",
+      "modelId": "kimi-k2-7-code",
+      "parameterSupport": {
+        "temperature": {
+          "supported": false
+        },
+        "topP": {
+          "supported": false
+        }
+      },
+      "providerId": "moonshot"
+    },
+    {
+      "apiModelId": "kimi-k2.7-code-highspeed",
+      "modelId": "kimi-k2-7-code-highspeed",
+      "parameterSupport": {
+        "temperature": {
+          "supported": false
+        },
+        "topP": {
+          "supported": false
+        }
+      },
+      "providerId": "moonshot"
+    },
+    {
       "modelId": "kimi-k3",
       "parameterSupport": {
         "temperature": {

--- a/packages/provider-registry/src/__tests__/provider-parameter-support.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-parameter-support.test.ts
@@ -18,7 +18,7 @@ const overrideOf = (providerId: string, modelId: string) => {
 }
 
 describe('moonshot parameter support', () => {
-  it.each(['kimi-k2-5', 'kimi-k2-6', 'kimi-k3'])(
+  it.each(['kimi-k2-5', 'kimi-k2-6', 'kimi-k2-7-code', 'kimi-k2-7-code-highspeed', 'kimi-k3'])(
     'omits the fixed temperature and top_p parameters for %s',
     (modelId) => {
       const { parameterSupport } = overrideOf('moonshot', modelId)

--- a/packages/provider-registry/src/providers/moonshot.ts
+++ b/packages/provider-registry/src/providers/moonshot.ts
@@ -48,6 +48,10 @@ export default openaiCompatible({
       reasoningContracts: {
         'openai-chat-completions': { wire: effortWire }
       }
+    })),
+    ...['kimi-k2.7-code', 'kimi-k2.7-code-highspeed'].map((modelId) => ({
+      modelId,
+      parameterSupport: fixedSamplingParameterSupport
     }))
   ]
 })

--- a/src/main/ai/utils/__tests__/modelParameters.test.ts
+++ b/src/main/ai/utils/__tests__/modelParameters.test.ts
@@ -87,10 +87,10 @@ describe('getTemperature', () => {
   })
 
   it.each(['kimi-k2.5', 'kimi-k2.7-code', 'kimi-k3'])(
-    'omits fixed temperature for a custom %s model without registry metadata',
+    'does not infer Moonshot temperature constraints for a third-party %s model',
     (id) => {
       const a = makeSampling({ temperature: 0.7 })
-      expect(getTemperature(a, makeModel({ id: `custom::${id}` }), OMIT_REASONING)).toBeUndefined()
+      expect(getTemperature(a, makeModel({ id: `third-party::${id}` }), OMIT_REASONING)).toBe(0.7)
     }
   )
 
@@ -135,10 +135,10 @@ describe('getTopP', () => {
   })
 
   it.each(['kimi-k2.5', 'kimi-k2.7-code', 'kimi-k3'])(
-    'omits fixed topP for a custom %s model without registry metadata',
+    'does not infer Moonshot topP constraints for a third-party %s model',
     (id) => {
       const a = makeSampling({ enableTopP: true, topP: 1 })
-      expect(getTopP(a, makeModel({ id: `custom::${id}` }), OMIT_REASONING)).toBeUndefined()
+      expect(getTopP(a, makeModel({ id: `third-party::${id}` }), OMIT_REASONING)).toBe(1)
     }
   )
 

--- a/src/main/data/services/ModelService.ts
+++ b/src/main/data/services/ModelService.ts
@@ -761,6 +761,9 @@ class ModelService {
         if (model.maxOutputTokens === undefined && registryModel?.maxOutputTokens !== undefined) {
           updates.maxOutputTokens = registryModel.maxOutputTokens
         }
+        if (model.parameterSupport === undefined && registryModel?.parameterSupport !== undefined) {
+          updates.parameterSupport = registryModel.parameterSupport
+        }
         if (model.pricing === undefined && registryModel?.pricing !== undefined) {
           updates.pricing = registryModel.pricing
         }

--- a/src/main/data/services/__tests__/ModelService.test.ts
+++ b/src/main/data/services/__tests__/ModelService.test.ts
@@ -1178,7 +1178,11 @@ describe('ModelService.list — registry enrichment', () => {
         inputModalities: ['text', 'image'],
         outputModalities: ['image'],
         endpointTypes: ['openai-responses'],
-        limits: { contextWindow: 256_000, maxOutputTokens: 32_768 }
+        limits: { contextWindow: 256_000, maxOutputTokens: 32_768 },
+        parameterSupport: {
+          temperature: { supported: false, range: { min: 0, max: 1 } },
+          topP: { supported: false, range: { min: 0, max: 1 } }
+        }
       },
       reasoningProfile: OPENAI_CHAT_REASONING_PROFILE
     })
@@ -1196,6 +1200,10 @@ describe('ModelService.list — registry enrichment', () => {
       contextWindow: 256_000,
       maxInputTokens: 120_000,
       maxOutputTokens: 4096,
+      parameterSupport: expect.objectContaining({
+        temperature: expect.objectContaining({ supported: false }),
+        topP: expect.objectContaining({ supported: false })
+      }),
       pricing: {
         input: { perMillionTokens: 5 },
         output: { perMillionTokens: 15 }
@@ -1215,7 +1223,13 @@ describe('ModelService.list — registry enrichment', () => {
           name: 'Future Model',
           description: 'Custom description',
           inputModalities: ['audio'],
-          outputModalities: ['video']
+          outputModalities: ['video'],
+          parameterSupport: {
+            temperature: { supported: true, range: { min: 0, max: 2 } },
+            maxTokens: true,
+            stopSequences: true,
+            systemMessage: true
+          }
         }
       }
     ])
@@ -1232,7 +1246,10 @@ describe('ModelService.list — registry enrichment', () => {
       },
       registryOverride: {
         inputModalities: ['text', 'image'],
-        outputModalities: ['image']
+        outputModalities: ['image'],
+        parameterSupport: {
+          temperature: { supported: false, range: { min: 0, max: 1 } }
+        }
       },
       reasoningProfile: OPENAI_CHAT_REASONING_PROFILE
     })
@@ -1245,7 +1262,10 @@ describe('ModelService.list — registry enrichment', () => {
       name: 'Future Model',
       description: 'Custom description',
       inputModalities: ['audio'],
-      outputModalities: ['video']
+      outputModalities: ['video'],
+      parameterSupport: expect.objectContaining({
+        temperature: { supported: true, range: { min: 0, max: 2 } }
+      })
     })
     expect(storedAfterRegistryUpdate).toEqual(storedBeforeRegistryUpdate)
   })

--- a/src/main/data/services/__tests__/ProviderRegistryService.test.ts
+++ b/src/main/data/services/__tests__/ProviderRegistryService.test.ts
@@ -188,6 +188,42 @@ function setupRegistryData() {
   } as ReturnType<typeof readProviderRegistry>)
 }
 
+function setupMoonshotRegistryData() {
+  mockReadModels.mockReturnValue({
+    version: '1.0',
+    models: [{ id: 'kimi-k2-7-code', name: 'Kimi K2.7 Code', capabilities: ['reasoning'] }]
+  } as ReturnType<typeof readModelRegistry>)
+
+  mockReadProviderModels.mockReturnValue({
+    version: '1.0',
+    overrides: [
+      {
+        providerId: 'moonshot',
+        modelId: 'kimi-k2-7-code',
+        apiModelId: 'kimi-k2.7-code',
+        parameterSupport: {
+          temperature: { supported: false },
+          topP: { supported: false }
+        }
+      }
+    ]
+  } as ReturnType<typeof readProviderModelRegistry>)
+
+  mockReadProviders.mockReturnValue({
+    version: '1.0',
+    providers: [
+      {
+        id: 'moonshot',
+        name: 'Moonshot AI',
+        endpointConfigs: {
+          'openai-chat-completions': { baseUrl: 'https://api.moonshot.cn/v1' }
+        },
+        defaultChatEndpoint: 'openai-chat-completions'
+      }
+    ]
+  } as ReturnType<typeof readProviderRegistry>)
+}
+
 function clearServiceCache() {
   providerRegistryService.clearCache()
 }
@@ -268,6 +304,35 @@ describe('ProviderRegistryService', () => {
       })
 
       expect(() => providerRegistryService.lookupModel('openai', 'gpt-4o')).toThrow('ENOENT')
+    })
+  })
+
+  describe('provider-model ownership', () => {
+    it('applies Moonshot sampling constraints only through a persisted Moonshot preset identity', async () => {
+      setupMoonshotRegistryData()
+      await dbh.db.insert(userProviderTable).values([
+        {
+          providerId: 'moonshot-clone',
+          presetProviderId: 'moonshot',
+          name: 'Moonshot Clone',
+          orderKey: 'a0'
+        },
+        {
+          providerId: 'generic-relay',
+          presetProviderId: null,
+          name: 'Generic Relay',
+          orderKey: 'a1'
+        }
+      ])
+
+      const linked = providerRegistryService.lookupModel('moonshot-clone', 'kimi-k2.7-code')
+      const unrelated = providerRegistryService.lookupModel('generic-relay', 'kimi-k2.7-code')
+
+      expect(linked.registryOverride?.parameterSupport).toMatchObject({
+        temperature: { supported: false },
+        topP: { supported: false }
+      })
+      expect(unrelated.registryOverride).toBeNull()
     })
   })
 

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -136,22 +136,12 @@ export const getModelSupportedReasoningEffortOptions = (model: Model | undefined
 // Parameter support checks
 // ---------------------------------------------------------------------------
 
-const isKimiFixedSamplingModel = (model: Model): boolean => {
-  const id = getLowerBaseModelName(getRawModelId(model))
-  return /^kimi-k(?:2[.-][5-9]\d*|[3-9]\d*)(?:[-_.]|$)/i.test(id)
-}
-
 /** Check if model supports temperature parameter */
-export const isSupportTemperatureModel = (model: Model): boolean => {
-  if (model.parameterSupport?.temperature) return model.parameterSupport.temperature.supported !== false
-  return !isKimiFixedSamplingModel(model)
-}
+export const isSupportTemperatureModel = (model: Model): boolean =>
+  model.parameterSupport?.temperature?.supported !== false
 
 /** Check if model supports top_p parameter */
-export const isSupportTopPModel = (model: Model): boolean => {
-  if (model.parameterSupport?.topP) return model.parameterSupport.topP.supported !== false
-  return !isKimiFixedSamplingModel(model)
-}
+export const isSupportTopPModel = (model: Model): boolean => model.parameterSupport?.topP?.supported !== false
 
 /** Whether temperature and top_p are mutually exclusive for this model */
 export const isTemperatureTopPMutuallyExclusiveModel = (model: Model): boolean => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Moonshot's fixed-sampling declarations did not cover Kimi K2.7 Code or its high-speed variant. Historical custom model rows also failed to inherit newly available registry `parameterSupport`, while a shared Kimi ID regex suppressed temperature and top-p for unrelated third-party providers.

After this PR:

Moonshot owns the Kimi K2.7 Code sampling constraints in the provider registry. Historical custom rows inherit resolved parameter support at runtime only when they have no persisted override, explicit user settings remain authoritative, and unrelated providers no longer receive Moonshot behavior based solely on a Kimi-like model ID.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19661

### Why we need it and why it was done in this way

Provider request constraints belong to the existing preset → provider override → persisted user delta → runtime model pipeline. Keeping the decision there prevents generic request helpers from accumulating provider-specific model-name knowledge and lets registry updates reach historical rows without freezing a new snapshot in SQLite.

The following tradeoffs were made:

- Kimi K2.5 remains declared for compatibility with persisted historical rows even though the official endpoint has retired it.
- Kimi K2.7 Code and `kimi-k2.7-code-highspeed` are listed explicitly because the [official API](https://platform.kimi.com/docs/api/models-overview) documents them as the same model with identical parameter constraints.
- Runtime enrichment is missing-value-only; any non-null persisted `parameters` value continues to win.

The following alternatives were considered:

- Keeping or extending the shared Kimi ID regex was rejected because it leaks Moonshot-specific behavior into arbitrary OpenAI-compatible providers.
- Persisting refreshed registry metadata into existing rows was rejected because it would freeze a registry snapshot and weaken future preset updates.

Links to places where the discussion took place: #19661, #19601, #19603

### Breaking changes

None.

### Special notes for your reviewer

The generated registry was refreshed from source, then unrelated live-catalog drift was excluded; `catalog-source-sync` verifies that the committed Moonshot rows exactly match the TypeScript declarations.

Verification:

- `pnpm test:provider-registry` — 407 passed
- `pnpm test:main src/main/data/services/__tests__/ModelService.test.ts src/main/data/services/__tests__/ProviderRegistryService.test.ts src/main/ai/utils/__tests__/modelParameters.test.ts` — 157 passed
- `pnpm test:shared src/shared/utils/__tests__/model.test.ts` — 35 passed
- `pnpm test:lint` — passed; Oxlint reported 0 warnings/errors
- Node and Web `tsgo` checks passed sequentially with `--incremental false`; AI Core typecheck passed
- i18n check passed (69,771 entries); focused Biome and ESLint checks passed

The combined `pnpm lint` reached its parallel typecheck stage after lint passed, but the simultaneous Node/Web `tsgo` processes exhausted the local Windows virtual-memory limit. The equivalent typechecks were rerun sequentially and passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
<!--LANG:en-->
[Models] Fixed Moonshot Kimi K2.5+ requests failing when custom sampling settings are enabled.
<!--LANG:zh-CN-->
[模型] 修复启用自定义采样设置时 Moonshot Kimi K2.5 及更新模型请求失败的问题。
<!--LANG:END-->
```
