### PR TITLE
fix(registry-sync): restore catalog publishing and refresh older schema dirs

### DIFF
--- a/.github/workflows/sync-registry-data.yml
+++ b/.github/workflows/sync-registry-data.yml
@@ -91,6 +91,14 @@ jobs:
           echo "version=$VER" >> "$GITHUB_OUTPUT"
           echo "min_app_version=$MIN_APP_VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Provide the frozen baselines' runtime dependency
+        run: |
+          # v2's baseline was generated before the bundler inlined every dependency,
+          # and a published baseline is immutable — so supply `semver` here instead.
+          npm install --no-save --prefix "$RUNNER_TEMP/baseline-deps" semver@^7.7.1
+          mkdir -p main/node_modules
+          cp -R "$RUNNER_TEMP/baseline-deps/node_modules/semver" main/node_modules/
+
       - name: Validate catalog against frozen schema
         run: |
           node "main/packages/provider-registry/compat/v${{ steps.ver.outputs.version }}-validator.mjs" \

--- a/.github/workflows/sync-registry-data.yml
+++ b/.github/workflows/sync-registry-data.yml
@@ -14,6 +14,10 @@ name: Sync provider-registry data
 # compatibility range and monotonic workflow revision. Clients only download
 # the model metadata files; provider routing always remains bundled.
 #
+# Every published v{N}/ is refreshed, not just the current one: an older dir gets
+# the catalog down-converted against its own frozen validator, so shipped apps on
+# an older schema keep receiving new models (see scripts/publishRegistryCatalog.js).
+#
 # One-time setup (both required before this is useful):
 #   1. Create the orphan branch, from a clean repo:
 #        git checkout --orphan x-files/provider-registry && git rm -rf .
@@ -30,7 +34,10 @@ on:
     paths:
       - '.github/workflows/sync-registry-data.yml'
       - 'packages/provider-registry/data/**'
+      # A new frozen baseline adds a publish dir; the publisher decides what each holds.
+      - 'packages/provider-registry/compat/**'
       - 'scripts/buildRegistrySyncRequest.js'
+      - 'scripts/publishRegistryCatalog.js'
       # A REGISTRY_SCHEMA_VERSION bump changes the publish dir (v{N}); watch its
       # source so a version-only change still creates the new vN/ directory.
       - 'packages/provider-registry/src/registry-loader.ts'
@@ -81,7 +88,6 @@ jobs:
             echo "Could not resolve REGISTRY_MIN_APP_VERSION from registry-loader.ts" >&2
             exit 1
           fi
-          echo "dir=v$VER" >> "$GITHUB_OUTPUT"
           echo "version=$VER" >> "$GITHUB_OUTPUT"
           echo "min_app_version=$MIN_APP_VERSION" >> "$GITHUB_OUTPUT"
 
@@ -90,16 +96,8 @@ jobs:
           node "main/packages/provider-registry/compat/v${{ steps.ver.outputs.version }}-validator.mjs" \
             main/packages/provider-registry/data
 
-      - name: Copy catalog into version dir
-        run: |
-          DEST="pub/${{ steps.ver.outputs.dir }}"
-          mkdir -p "$DEST"
-          cp main/packages/provider-registry/data/models.json \
-             main/packages/provider-registry/data/providers.json \
-             main/packages/provider-registry/data/provider-models.json \
-             "$DEST/"
-
-      - name: Write release manifest
+      - name: Publish catalog into version dirs
+        id: publish
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -117,17 +115,15 @@ jobs:
           if [ -z "$SOURCE_APP_VERSION" ] || [ "$SOURCE_APP_VERSION" = "null" ]; then
             SOURCE_APP_VERSION=$(jq -r '.version' main/package.json)
           fi
-          DEST="pub/${{ steps.ver.outputs.dir }}"
-          jq -n \
-            --arg sourceAppVersion "$SOURCE_APP_VERSION" \
-            --arg minAppVersion "${{ steps.ver.outputs.min_app_version }}" \
-            --argjson revision "${{ github.run_number }}" \
-            --argjson schema "${{ steps.ver.outputs.version }}" \
-            --arg models "$(jq -r '.version' "$DEST/models.json")" \
-            --arg providers "$(jq -r '.version' "$DEST/providers.json")" \
-            --arg providerModels "$(jq -r '.version' "$DEST/provider-models.json")" \
-            '{minAppVersion: $minAppVersion, sourceAppVersion: $sourceAppVersion, revision: $revision, schemaVersion: $schema, files: {"models.json": $models, "providers.json": $providers, "provider-models.json": $providerModels}}' \
-            > "$DEST/manifest.json"
+          DIRS=$(REGISTRY_PUBLISH_SOURCE=main/packages/provider-registry/data \
+            REGISTRY_PUBLISH_COMPAT=main/packages/provider-registry/compat \
+            REGISTRY_PUBLISH_DEST=pub \
+            REGISTRY_PUBLISH_CURRENT_VERSION="${{ steps.ver.outputs.version }}" \
+            REGISTRY_PUBLISH_MIN_APP_VERSION="${{ steps.ver.outputs.min_app_version }}" \
+            REGISTRY_PUBLISH_SOURCE_APP_VERSION="$SOURCE_APP_VERSION" \
+            REGISTRY_PUBLISH_REVISION="${{ github.run_number }}" \
+            node main/scripts/publishRegistryCatalog.js)
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
         working-directory: pub
@@ -136,7 +132,7 @@ jobs:
         run: |
           # Commits go through GraphQL rather than `git push`: GitHub signs
           # API-authored commits, which the branch's required-signatures rule demands.
-          git add "${{ steps.ver.outputs.dir }}"
+          git add ${{ steps.publish.outputs.dirs }}
           if git diff --cached --quiet; then
             echo "No catalog changes to publish."
             exit 0
@@ -153,7 +149,7 @@ jobs:
           trap 'rm -f "$REQUEST_FILE"' EXIT
           REGISTRY_SYNC_REF_ID="$REF_ID" \
           REGISTRY_SYNC_EXPECTED_HEAD_OID="$HEAD_OID" \
-          REGISTRY_SYNC_HEADLINE="chore(provider-registry): sync catalog to ${{ steps.ver.outputs.dir }}" \
+          REGISTRY_SYNC_HEADLINE="chore(provider-registry): sync catalog to ${{ steps.publish.outputs.dirs }}" \
           REGISTRY_SYNC_BODY="Source: ${{ github.repository }}@${{ github.sha }}
           Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             node ../main/scripts/buildRegistrySyncRequest.js "$REQUEST_FILE"

--- a/packages/provider-registry/compat/v2-validator.mjs
+++ b/packages/provider-registry/compat/v2-validator.mjs
@@ -3,1200 +3,9 @@
 import { readFileSync as e } from 'node:fs'
 import t from 'node:path'
 import { fileURLToPath as n } from 'node:url'
-Object.create,
-  Object.defineProperty,
-  Object.getOwnPropertyDescriptor,
-  Object.getOwnPropertyNames,
-  Object.getPrototypeOf,
-  Object.prototype.hasOwnProperty
-var r = (e, t) => () => (t || e((t = { exports: {} }).exports, t), t.exports),
-  i = r((e, t) => {
-    t.exports = {
-      MAX_LENGTH: 256,
-      MAX_SAFE_COMPONENT_LENGTH: 16,
-      MAX_SAFE_BUILD_LENGTH: 250,
-      MAX_SAFE_INTEGER: 2 ** 53 - 1 || 9007199254740991,
-      RELEASE_TYPES: [`major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, `prerelease`],
-      SEMVER_SPEC_VERSION: `2.0.0`,
-      FLAG_INCLUDE_PRERELEASE: 1,
-      FLAG_LOOSE: 2
-    }
-  }),
-  a = r((e, t) => {
-    t.exports =
-      typeof process == `object` && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG)
-        ? (...e) => console.error(`SEMVER`, ...e)
-        : () => {}
-  }),
-  o = r((e, t) => {
-    let { MAX_SAFE_COMPONENT_LENGTH: n, MAX_SAFE_BUILD_LENGTH: r, MAX_LENGTH: o } = i(),
-      s = a()
-    e = t.exports = {}
-    let c = (e.re = []),
-      l = (e.safeRe = []),
-      u = (e.src = []),
-      d = (e.safeSrc = []),
-      f = (e.t = {}),
-      p = 0,
-      m = `[a-zA-Z0-9-]`,
-      h = [
-        [`\\s`, 1],
-        [`\\d`, o],
-        [m, r]
-      ],
-      g = (e) => {
-        for (let [t, n] of h) e = e.split(`${t}*`).join(`${t}{0,${n}}`).split(`${t}+`).join(`${t}{1,${n}}`)
-        return e
-      },
-      _ = (e, t, n) => {
-        let r = g(t),
-          i = p++
-        s(e, i, t),
-          (f[e] = i),
-          (u[i] = t),
-          (d[i] = r),
-          (c[i] = new RegExp(t, n ? `g` : void 0)),
-          (l[i] = new RegExp(r, n ? `g` : void 0))
-      }
-    _(`NUMERICIDENTIFIER`, `0|[1-9]\\d*`),
-      _(`NUMERICIDENTIFIERLOOSE`, `\\d+`),
-      _(`NONNUMERICIDENTIFIER`, `\\d*[a-zA-Z-]${m}*`),
-      _(`MAINVERSION`, `(${u[f.NUMERICIDENTIFIER]})\\.(${u[f.NUMERICIDENTIFIER]})\\.(${u[f.NUMERICIDENTIFIER]})`),
-      _(
-        `MAINVERSIONLOOSE`,
-        `(${u[f.NUMERICIDENTIFIERLOOSE]})\\.(${u[f.NUMERICIDENTIFIERLOOSE]})\\.(${u[f.NUMERICIDENTIFIERLOOSE]})`
-      ),
-      _(`PRERELEASEIDENTIFIER`, `(?:${u[f.NUMERICIDENTIFIER]}|${u[f.NONNUMERICIDENTIFIER]})`),
-      _(`PRERELEASEIDENTIFIERLOOSE`, `(?:${u[f.NUMERICIDENTIFIERLOOSE]}|${u[f.NONNUMERICIDENTIFIER]})`),
-      _(`PRERELEASE`, `(?:-(${u[f.PRERELEASEIDENTIFIER]}(?:\\.${u[f.PRERELEASEIDENTIFIER]})*))`),
-      _(`PRERELEASELOOSE`, `(?:-?(${u[f.PRERELEASEIDENTIFIERLOOSE]}(?:\\.${u[f.PRERELEASEIDENTIFIERLOOSE]})*))`),
-      _(`BUILDIDENTIFIER`, `${m}+`),
-      _(`BUILD`, `(?:\\+(${u[f.BUILDIDENTIFIER]}(?:\\.${u[f.BUILDIDENTIFIER]})*))`),
-      _(`FULLPLAIN`, `v?${u[f.MAINVERSION]}${u[f.PRERELEASE]}?${u[f.BUILD]}?`),
-      _(`FULL`, `^${u[f.FULLPLAIN]}$`),
-      _(`LOOSEPLAIN`, `[v=\\s]*${u[f.MAINVERSIONLOOSE]}${u[f.PRERELEASELOOSE]}?${u[f.BUILD]}?`),
-      _(`LOOSE`, `^${u[f.LOOSEPLAIN]}$`),
-      _(`GTLT`, `((?:<|>)?=?)`),
-      _(`XRANGEIDENTIFIERLOOSE`, `${u[f.NUMERICIDENTIFIERLOOSE]}|x|X|\\*`),
-      _(`XRANGEIDENTIFIER`, `${u[f.NUMERICIDENTIFIER]}|x|X|\\*`),
-      _(
-        `XRANGEPLAIN`,
-        `[v=\\s]*(${u[f.XRANGEIDENTIFIER]})(?:\\.(${u[f.XRANGEIDENTIFIER]})(?:\\.(${u[f.XRANGEIDENTIFIER]})(?:${u[f.PRERELEASE]})?${u[f.BUILD]}?)?)?`
-      ),
-      _(
-        `XRANGEPLAINLOOSE`,
-        `[v=\\s]*(${u[f.XRANGEIDENTIFIERLOOSE]})(?:\\.(${u[f.XRANGEIDENTIFIERLOOSE]})(?:\\.(${u[f.XRANGEIDENTIFIERLOOSE]})(?:${u[f.PRERELEASELOOSE]})?${u[f.BUILD]}?)?)?`
-      ),
-      _(`XRANGE`, `^${u[f.GTLT]}\\s*${u[f.XRANGEPLAIN]}$`),
-      _(`XRANGELOOSE`, `^${u[f.GTLT]}\\s*${u[f.XRANGEPLAINLOOSE]}$`),
-      _(`COERCEPLAIN`, `(^|[^\\d])(\\d{1,${n}})(?:\\.(\\d{1,${n}}))?(?:\\.(\\d{1,${n}}))?`),
-      _(`COERCE`, `${u[f.COERCEPLAIN]}(?:$|[^\\d])`),
-      _(`COERCEFULL`, u[f.COERCEPLAIN] + `(?:${u[f.PRERELEASE]})?(?:${u[f.BUILD]})?(?:$|[^\\d])`),
-      _(`COERCERTL`, u[f.COERCE], !0),
-      _(`COERCERTLFULL`, u[f.COERCEFULL], !0),
-      _(`LONETILDE`, `(?:~>?)`),
-      _(`TILDETRIM`, `(\\s*)${u[f.LONETILDE]}\\s+`, !0),
-      (e.tildeTrimReplace = `$1~`),
-      _(`TILDE`, `^${u[f.LONETILDE]}${u[f.XRANGEPLAIN]}$`),
-      _(`TILDELOOSE`, `^${u[f.LONETILDE]}${u[f.XRANGEPLAINLOOSE]}$`),
-      _(`LONECARET`, `(?:\\^)`),
-      _(`CARETTRIM`, `(\\s*)${u[f.LONECARET]}\\s+`, !0),
-      (e.caretTrimReplace = `$1^`),
-      _(`CARET`, `^${u[f.LONECARET]}${u[f.XRANGEPLAIN]}$`),
-      _(`CARETLOOSE`, `^${u[f.LONECARET]}${u[f.XRANGEPLAINLOOSE]}$`),
-      _(`COMPARATORLOOSE`, `^${u[f.GTLT]}\\s*(${u[f.LOOSEPLAIN]})$|^$`),
-      _(`COMPARATOR`, `^${u[f.GTLT]}\\s*(${u[f.FULLPLAIN]})$|^$`),
-      _(`COMPARATORTRIM`, `(\\s*)${u[f.GTLT]}\\s*(${u[f.LOOSEPLAIN]}|${u[f.XRANGEPLAIN]})`, !0),
-      (e.comparatorTrimReplace = `$1$2$3`),
-      _(`HYPHENRANGE`, `^\\s*(${u[f.XRANGEPLAIN]})\\s+-\\s+(${u[f.XRANGEPLAIN]})\\s*$`),
-      _(`HYPHENRANGELOOSE`, `^\\s*(${u[f.XRANGEPLAINLOOSE]})\\s+-\\s+(${u[f.XRANGEPLAINLOOSE]})\\s*$`),
-      _(`STAR`, `(<|>)?=?\\s*\\*`),
-      _(`GTE0`, `^\\s*>=\\s*0\\.0\\.0\\s*$`),
-      _(`GTE0PRE`, `^\\s*>=\\s*0\\.0\\.0-0\\s*$`)
-  }),
-  s = r((e, t) => {
-    let n = Object.freeze({ loose: !0 }),
-      r = Object.freeze({})
-    t.exports = (e) => (e ? (typeof e == `object` ? e : n) : r)
-  }),
-  c = r((e, t) => {
-    let n = /^[0-9]+$/,
-      r = (e, t) => {
-        let r = n.test(e),
-          i = n.test(t)
-        return r && i && ((e = +e), (t = +t)), e === t ? 0 : r && !i ? -1 : i && !r ? 1 : e < t ? -1 : 1
-      }
-    t.exports = { compareIdentifiers: r, rcompareIdentifiers: (e, t) => r(t, e) }
-  }),
-  l = r((e, t) => {
-    let n = a(),
-      { MAX_LENGTH: r, MAX_SAFE_INTEGER: l } = i(),
-      { safeRe: u, safeSrc: d, t: f } = o(),
-      p = s(),
-      { compareIdentifiers: m } = c()
-    t.exports = class e {
-      constructor(t, i) {
-        if (((i = p(i)), t instanceof e)) {
-          if (t.loose === !!i.loose && t.includePrerelease === !!i.includePrerelease) return t
-          t = t.version
-        } else if (typeof t != `string`) throw TypeError(`Invalid version. Must be a string. Got type "${typeof t}".`)
-        if (t.length > r) throw TypeError(`version is longer than ${r} characters`)
-        n(`SemVer`, t, i),
-          (this.options = i),
-          (this.loose = !!i.loose),
-          (this.includePrerelease = !!i.includePrerelease)
-        let a = t.trim().match(i.loose ? u[f.LOOSE] : u[f.FULL])
-        if (!a) throw TypeError(`Invalid Version: ${t}`)
-        if (
-          ((this.raw = t),
-          (this.major = +a[1]),
-          (this.minor = +a[2]),
-          (this.patch = +a[3]),
-          this.major > l || this.major < 0)
-        )
-          throw TypeError(`Invalid major version`)
-        if (this.minor > l || this.minor < 0) throw TypeError(`Invalid minor version`)
-        if (this.patch > l || this.patch < 0) throw TypeError(`Invalid patch version`)
-        a[4]
-          ? (this.prerelease = a[4].split(`.`).map((e) => {
-              if (/^[0-9]+$/.test(e)) {
-                let t = +e
-                if (t >= 0 && t < l) return t
-              }
-              return e
-            }))
-          : (this.prerelease = []),
-          (this.build = a[5] ? a[5].split(`.`) : []),
-          this.format()
-      }
-      format() {
-        return (
-          (this.version = `${this.major}.${this.minor}.${this.patch}`),
-          this.prerelease.length && (this.version += `-${this.prerelease.join(`.`)}`),
-          this.version
-        )
-      }
-      toString() {
-        return this.version
-      }
-      compare(t) {
-        if ((n(`SemVer.compare`, this.version, this.options, t), !(t instanceof e))) {
-          if (typeof t == `string` && t === this.version) return 0
-          t = new e(t, this.options)
-        }
-        return t.version === this.version ? 0 : this.compareMain(t) || this.comparePre(t)
-      }
-      compareMain(t) {
-        return (
-          t instanceof e || (t = new e(t, this.options)),
-          m(this.major, t.major) || m(this.minor, t.minor) || m(this.patch, t.patch)
-        )
-      }
-      comparePre(t) {
-        if ((t instanceof e || (t = new e(t, this.options)), this.prerelease.length && !t.prerelease.length)) return -1
-        if (!this.prerelease.length && t.prerelease.length) return 1
-        if (!this.prerelease.length && !t.prerelease.length) return 0
-        let r = 0
-        do {
-          let e = this.prerelease[r],
-            i = t.prerelease[r]
-          if ((n(`prerelease compare`, r, e, i), e === void 0 && i === void 0)) return 0
-          if (i === void 0) return 1
-          if (e === void 0) return -1
-          if (e === i) continue
-          return m(e, i)
-        } while (++r)
-      }
-      compareBuild(t) {
-        t instanceof e || (t = new e(t, this.options))
-        let r = 0
-        do {
-          let e = this.build[r],
-            i = t.build[r]
-          if ((n(`build compare`, r, e, i), e === void 0 && i === void 0)) return 0
-          if (i === void 0) return 1
-          if (e === void 0) return -1
-          if (e === i) continue
-          return m(e, i)
-        } while (++r)
-      }
-      inc(e, t, n) {
-        if (e.startsWith(`pre`)) {
-          if (!t && n === !1) throw Error(`invalid increment argument: identifier is empty`)
-          if (t) {
-            let e = RegExp(`^${this.options.loose ? d[f.PRERELEASELOOSE] : d[f.PRERELEASE]}$`),
-              n = `-${t}`.match(e)
-            if (!n || n[1] !== t) throw Error(`invalid identifier: ${t}`)
-          }
-        }
-        switch (e) {
-          case `premajor`:
-            ;(this.prerelease.length = 0), (this.patch = 0), (this.minor = 0), this.major++, this.inc(`pre`, t, n)
-            break
-          case `preminor`:
-            ;(this.prerelease.length = 0), (this.patch = 0), this.minor++, this.inc(`pre`, t, n)
-            break
-          case `prepatch`:
-            ;(this.prerelease.length = 0), this.inc(`patch`, t, n), this.inc(`pre`, t, n)
-            break
-          case `prerelease`:
-            this.prerelease.length === 0 && this.inc(`patch`, t, n), this.inc(`pre`, t, n)
-            break
-          case `release`:
-            if (this.prerelease.length === 0) throw Error(`version ${this.raw} is not a prerelease`)
-            this.prerelease.length = 0
-            break
-          case `major`:
-            ;(this.minor !== 0 || this.patch !== 0 || this.prerelease.length === 0) && this.major++,
-              (this.minor = 0),
-              (this.patch = 0),
-              (this.prerelease = [])
-            break
-          case `minor`:
-            ;(this.patch !== 0 || this.prerelease.length === 0) && this.minor++,
-              (this.patch = 0),
-              (this.prerelease = [])
-            break
-          case `patch`:
-            this.prerelease.length === 0 && this.patch++, (this.prerelease = [])
-            break
-          case `pre`: {
-            let e = Number(n) ? 1 : 0
-            if (this.prerelease.length === 0) this.prerelease = [e]
-            else {
-              let r = this.prerelease.length
-              for (; --r >= 0; ) typeof this.prerelease[r] == `number` && (this.prerelease[r]++, (r = -2))
-              if (r === -1) {
-                if (t === this.prerelease.join(`.`) && n === !1)
-                  throw Error(`invalid increment argument: identifier already exists`)
-                this.prerelease.push(e)
-              }
-            }
-            if (t) {
-              let r = [t, e]
-              n === !1 && (r = [t]),
-                m(this.prerelease[0], t) === 0
-                  ? isNaN(this.prerelease[1]) && (this.prerelease = r)
-                  : (this.prerelease = r)
-            }
-            break
-          }
-          default:
-            throw Error(`invalid increment argument: ${e}`)
-        }
-        return (this.raw = this.format()), this.build.length && (this.raw += `+${this.build.join(`.`)}`), this
-      }
-    }
-  }),
-  u = r((e, t) => {
-    let n = l()
-    t.exports = (e, t, r = !1) => {
-      if (e instanceof n) return e
-      try {
-        return new n(e, t)
-      } catch (e) {
-        if (!r) return null
-        throw e
-      }
-    }
-  }),
-  d = r((e, t) => {
-    let n = u()
-    t.exports = (e, t) => {
-      let r = n(e, t)
-      return r ? r.version : null
-    }
-  }),
-  f = r((e, t) => {
-    let n = u()
-    t.exports = (e, t) => {
-      let r = n(e.trim().replace(/^[=v]+/, ``), t)
-      return r ? r.version : null
-    }
-  }),
-  p = r((e, t) => {
-    let n = l()
-    t.exports = (e, t, r, i, a) => {
-      typeof r == `string` && ((a = i), (i = r), (r = void 0))
-      try {
-        return new n(e instanceof n ? e.version : e, r).inc(t, i, a).version
-      } catch {
-        return null
-      }
-    }
-  }),
-  m = r((e, t) => {
-    let n = u()
-    t.exports = (e, t) => {
-      let r = n(e, null, !0),
-        i = n(t, null, !0),
-        a = r.compare(i)
-      if (a === 0) return null
-      let o = a > 0,
-        s = o ? r : i,
-        c = o ? i : r,
-        l = !!s.prerelease.length
-      if (c.prerelease.length && !l) {
-        if (!c.patch && !c.minor) return `major`
-        if (c.compareMain(s) === 0) return c.minor && !c.patch ? `minor` : `patch`
-      }
-      let u = l ? `pre` : ``
-      return r.major === i.major
-        ? r.minor === i.minor
-          ? r.patch === i.patch
-            ? `prerelease`
-            : u + `patch`
-          : u + `minor`
-        : u + `major`
-    }
-  }),
-  h = r((e, t) => {
-    let n = l()
-    t.exports = (e, t) => new n(e, t).major
-  }),
-  g = r((e, t) => {
-    let n = l()
-    t.exports = (e, t) => new n(e, t).minor
-  }),
-  _ = r((e, t) => {
-    let n = l()
-    t.exports = (e, t) => new n(e, t).patch
-  }),
-  v = r((e, t) => {
-    let n = u()
-    t.exports = (e, t) => {
-      let r = n(e, t)
-      return r && r.prerelease.length ? r.prerelease : null
-    }
-  }),
-  y = r((e, t) => {
-    let n = l()
-    t.exports = (e, t, r) => new n(e, r).compare(new n(t, r))
-  }),
-  ee = r((e, t) => {
-    let n = y()
-    t.exports = (e, t, r) => n(t, e, r)
-  }),
-  te = r((e, t) => {
-    let n = y()
-    t.exports = (e, t) => n(e, t, !0)
-  }),
-  ne = r((e, t) => {
-    let n = l()
-    t.exports = (e, t, r) => {
-      let i = new n(e, r),
-        a = new n(t, r)
-      return i.compare(a) || i.compareBuild(a)
-    }
-  }),
-  re = r((e, t) => {
-    let n = ne()
-    t.exports = (e, t) => e.sort((e, r) => n(e, r, t))
-  }),
-  b = r((e, t) => {
-    let n = ne()
-    t.exports = (e, t) => e.sort((e, r) => n(r, e, t))
-  }),
-  ie = r((e, t) => {
-    let n = y()
-    t.exports = (e, t, r) => n(e, t, r) > 0
-  }),
-  ae = r((e, t) => {
-    let n = y()
-    t.exports = (e, t, r) => n(e, t, r) < 0
-  }),
-  oe = r((e, t) => {
-    let n = y()
-    t.exports = (e, t, r) => n(e, t, r) === 0
-  }),
-  se = r((e, t) => {
-    let n = y()
-    t.exports = (e, t, r) => n(e, t, r) !== 0
-  }),
-  ce = r((e, t) => {
-    let n = y()
-    t.exports = (e, t, r) => n(e, t, r) >= 0
-  }),
-  le = r((e, t) => {
-    let n = y()
-    t.exports = (e, t, r) => n(e, t, r) <= 0
-  }),
-  ue = r((e, t) => {
-    let n = oe(),
-      r = se(),
-      i = ie(),
-      a = ce(),
-      o = ae(),
-      s = le()
-    t.exports = (e, t, c, l) => {
-      switch (t) {
-        case `===`:
-          return typeof e == `object` && (e = e.version), typeof c == `object` && (c = c.version), e === c
-        case `!==`:
-          return typeof e == `object` && (e = e.version), typeof c == `object` && (c = c.version), e !== c
-        case ``:
-        case `=`:
-        case `==`:
-          return n(e, c, l)
-        case `!=`:
-          return r(e, c, l)
-        case `>`:
-          return i(e, c, l)
-        case `>=`:
-          return a(e, c, l)
-        case `<`:
-          return o(e, c, l)
-        case `<=`:
-          return s(e, c, l)
-        default:
-          throw TypeError(`Invalid operator: ${t}`)
-      }
-    }
-  }),
-  de = r((e, t) => {
-    let n = l(),
-      r = u(),
-      { safeRe: i, t: a } = o()
-    t.exports = (e, t) => {
-      if (e instanceof n) return e
-      if ((typeof e == `number` && (e = String(e)), typeof e != `string`)) return null
-      t ||= {}
-      let o = null
-      if (!t.rtl) o = e.match(t.includePrerelease ? i[a.COERCEFULL] : i[a.COERCE])
-      else {
-        let n = t.includePrerelease ? i[a.COERCERTLFULL] : i[a.COERCERTL],
-          r
-        for (; (r = n.exec(e)) && (!o || o.index + o[0].length !== e.length); )
-          (!o || r.index + r[0].length !== o.index + o[0].length) && (o = r),
-            (n.lastIndex = r.index + r[1].length + r[2].length)
-        n.lastIndex = -1
-      }
-      if (o === null) return null
-      let s = o[2]
-      return r(
-        `${s}.${o[3] || `0`}.${o[4] || `0`}${t.includePrerelease && o[5] ? `-${o[5]}` : ``}${t.includePrerelease && o[6] ? `+${o[6]}` : ``}`,
-        t
-      )
-    }
-  }),
-  fe = r((e, t) => {
-    t.exports = class {
-      constructor() {
-        ;(this.max = 1e3), (this.map = new Map())
-      }
-      get(e) {
-        let t = this.map.get(e)
-        if (t !== void 0) return this.map.delete(e), this.map.set(e, t), t
-      }
-      delete(e) {
-        return this.map.delete(e)
-      }
-      set(e, t) {
-        if (!this.delete(e) && t !== void 0) {
-          if (this.map.size >= this.max) {
-            let e = this.map.keys().next().value
-            this.delete(e)
-          }
-          this.map.set(e, t)
-        }
-        return this
-      }
-    }
-  }),
-  x = r((e, t) => {
-    let n = /\s+/g
-    t.exports = class e {
-      constructor(t, r) {
-        if (((r = c(r)), t instanceof e))
-          return t.loose === !!r.loose && t.includePrerelease === !!r.includePrerelease ? t : new e(t.raw, r)
-        if (t instanceof u) return (this.raw = t.value), (this.set = [[t]]), (this.formatted = void 0), this
-        if (
-          ((this.options = r),
-          (this.loose = !!r.loose),
-          (this.includePrerelease = !!r.includePrerelease),
-          (this.raw = t.trim().replace(n, ` `)),
-          (this.set = this.raw
-            .split(`||`)
-            .map((e) => this.parseRange(e.trim()))
-            .filter((e) => e.length)),
-          !this.set.length)
-        )
-          throw TypeError(`Invalid SemVer Range: ${this.raw}`)
-        if (this.set.length > 1) {
-          let e = this.set[0]
-          if (((this.set = this.set.filter((e) => !ee(e[0]))), this.set.length === 0)) this.set = [e]
-          else if (this.set.length > 1) {
-            for (let e of this.set)
-              if (e.length === 1 && te(e[0])) {
-                this.set = [e]
-                break
-              }
-          }
-        }
-        this.formatted = void 0
-      }
-      get range() {
-        if (this.formatted === void 0) {
-          this.formatted = ``
-          for (let e = 0; e < this.set.length; e++) {
-            e > 0 && (this.formatted += `||`)
-            let t = this.set[e]
-            for (let e = 0; e < t.length; e++)
-              e > 0 && (this.formatted += ` `), (this.formatted += t[e].toString().trim())
-          }
-        }
-        return this.formatted
-      }
-      format() {
-        return this.range
-      }
-      toString() {
-        return this.range
-      }
-      parseRange(e) {
-        let t = ((this.options.includePrerelease && v) | (this.options.loose && y)) + `:` + e,
-          n = r.get(t)
-        if (n) return n
-        let i = this.options.loose,
-          a = i ? p[m.HYPHENRANGELOOSE] : p[m.HYPHENRANGE]
-        ;(e = e.replace(a, x(this.options.includePrerelease))),
-          d(`hyphen replace`, e),
-          (e = e.replace(p[m.COMPARATORTRIM], h)),
-          d(`comparator trim`, e),
-          (e = e.replace(p[m.TILDETRIM], g)),
-          d(`tilde trim`, e),
-          (e = e.replace(p[m.CARETTRIM], _)),
-          d(`caret trim`, e)
-        let o = e
-          .split(` `)
-          .map((e) => re(e, this.options))
-          .join(` `)
-          .split(/\s+/)
-          .map((e) => de(e, this.options))
-        i && (o = o.filter((e) => (d(`loose invalid filter`, e, this.options), !!e.match(p[m.COMPARATORLOOSE])))),
-          d(`range list`, o)
-        let s = new Map(),
-          c = o.map((e) => new u(e, this.options))
-        for (let e of c) {
-          if (ee(e)) return [e]
-          s.set(e.value, e)
-        }
-        s.size > 1 && s.has(``) && s.delete(``)
-        let l = [...s.values()]
-        return r.set(t, l), l
-      }
-      intersects(t, n) {
-        if (!(t instanceof e)) throw TypeError(`a Range is required`)
-        return this.set.some(
-          (e) => ne(e, n) && t.set.some((t) => ne(t, n) && e.every((e) => t.every((t) => e.intersects(t, n))))
-        )
-      }
-      test(e) {
-        if (!e) return !1
-        if (typeof e == `string`)
-          try {
-            e = new f(e, this.options)
-          } catch {
-            return !1
-          }
-        for (let t = 0; t < this.set.length; t++) if (me(this.set[t], e, this.options)) return !0
-        return !1
-      }
-    }
-    let r = new (fe())(),
-      c = s(),
-      u = pe(),
-      d = a(),
-      f = l(),
-      { safeRe: p, t: m, comparatorTrimReplace: h, tildeTrimReplace: g, caretTrimReplace: _ } = o(),
-      { FLAG_INCLUDE_PRERELEASE: v, FLAG_LOOSE: y } = i(),
-      ee = (e) => e.value === `<0.0.0-0`,
-      te = (e) => e.value === ``,
-      ne = (e, t) => {
-        let n = !0,
-          r = e.slice(),
-          i = r.pop()
-        for (; n && r.length; ) (n = r.every((e) => i.intersects(e, t))), (i = r.pop())
-        return n
-      },
-      re = (e, t) => (
-        d(`comp`, e, t),
-        (e = oe(e, t)),
-        d(`caret`, e),
-        (e = ie(e, t)),
-        d(`tildes`, e),
-        (e = ce(e, t)),
-        d(`xrange`, e),
-        (e = ue(e, t)),
-        d(`stars`, e),
-        e
-      ),
-      b = (e) => !e || e.toLowerCase() === `x` || e === `*`,
-      ie = (e, t) =>
-        e
-          .trim()
-          .split(/\s+/)
-          .map((e) => ae(e, t))
-          .join(` `),
-      ae = (e, t) => {
-        let n = t.loose ? p[m.TILDELOOSE] : p[m.TILDE]
-        return e.replace(n, (t, n, r, i, a) => {
-          d(`tilde`, e, t, n, r, i, a)
-          let o
-          return (
-            b(n)
-              ? (o = ``)
-              : b(r)
-                ? (o = `>=${n}.0.0 <${+n + 1}.0.0-0`)
-                : b(i)
-                  ? (o = `>=${n}.${r}.0 <${n}.${+r + 1}.0-0`)
-                  : a
-                    ? (d(`replaceTilde pr`, a), (o = `>=${n}.${r}.${i}-${a} <${n}.${+r + 1}.0-0`))
-                    : (o = `>=${n}.${r}.${i} <${n}.${+r + 1}.0-0`),
-            d(`tilde return`, o),
-            o
-          )
-        })
-      },
-      oe = (e, t) =>
-        e
-          .trim()
-          .split(/\s+/)
-          .map((e) => se(e, t))
-          .join(` `),
-      se = (e, t) => {
-        d(`caret`, e, t)
-        let n = t.loose ? p[m.CARETLOOSE] : p[m.CARET],
-          r = t.includePrerelease ? `-0` : ``
-        return e.replace(n, (t, n, i, a, o) => {
-          d(`caret`, e, t, n, i, a, o)
-          let s
-          return (
-            b(n)
-              ? (s = ``)
-              : b(i)
-                ? (s = `>=${n}.0.0${r} <${+n + 1}.0.0-0`)
-                : b(a)
-                  ? (s = n === `0` ? `>=${n}.${i}.0${r} <${n}.${+i + 1}.0-0` : `>=${n}.${i}.0${r} <${+n + 1}.0.0-0`)
-                  : o
-                    ? (d(`replaceCaret pr`, o),
-                      (s =
-                        n === `0`
-                          ? i === `0`
-                            ? `>=${n}.${i}.${a}-${o} <${n}.${i}.${+a + 1}-0`
-                            : `>=${n}.${i}.${a}-${o} <${n}.${+i + 1}.0-0`
-                          : `>=${n}.${i}.${a}-${o} <${+n + 1}.0.0-0`))
-                    : (d(`no pr`),
-                      (s =
-                        n === `0`
-                          ? i === `0`
-                            ? `>=${n}.${i}.${a}${r} <${n}.${i}.${+a + 1}-0`
-                            : `>=${n}.${i}.${a}${r} <${n}.${+i + 1}.0-0`
-                          : `>=${n}.${i}.${a} <${+n + 1}.0.0-0`)),
-            d(`caret return`, s),
-            s
-          )
-        })
-      },
-      ce = (e, t) => (
-        d(`replaceXRanges`, e, t),
-        e
-          .split(/\s+/)
-          .map((e) => le(e, t))
-          .join(` `)
-      ),
-      le = (e, t) => {
-        e = e.trim()
-        let n = t.loose ? p[m.XRANGELOOSE] : p[m.XRANGE]
-        return e.replace(n, (n, r, i, a, o, s) => {
-          d(`xRange`, e, n, r, i, a, o, s)
-          let c = b(i),
-            l = c || b(a),
-            u = l || b(o),
-            f = u
-          return (
-            r === `=` && f && (r = ``),
-            (s = t.includePrerelease ? `-0` : ``),
-            c
-              ? (n = r === `>` || r === `<` ? `<0.0.0-0` : `*`)
-              : r && f
-                ? (l && (a = 0),
-                  (o = 0),
-                  r === `>`
-                    ? ((r = `>=`), l ? ((i = +i + 1), (a = 0), (o = 0)) : ((a = +a + 1), (o = 0)))
-                    : r === `<=` && ((r = `<`), l ? (i = +i + 1) : (a = +a + 1)),
-                  r === `<` && (s = `-0`),
-                  (n = `${r + i}.${a}.${o}${s}`))
-                : l
-                  ? (n = `>=${i}.0.0${s} <${+i + 1}.0.0-0`)
-                  : u && (n = `>=${i}.${a}.0${s} <${i}.${+a + 1}.0-0`),
-            d(`xRange return`, n),
-            n
-          )
-        })
-      },
-      ue = (e, t) => (d(`replaceStars`, e, t), e.trim().replace(p[m.STAR], ``)),
-      de = (e, t) => (d(`replaceGTE0`, e, t), e.trim().replace(p[t.includePrerelease ? m.GTE0PRE : m.GTE0], ``)),
-      x = (e) => (t, n, r, i, a, o, s, c, l, u, d, f) => (
-        (n = b(r)
-          ? ``
-          : b(i)
-            ? `>=${r}.0.0${e ? `-0` : ``}`
-            : b(a)
-              ? `>=${r}.${i}.0${e ? `-0` : ``}`
-              : o
-                ? `>=${n}`
-                : `>=${n}${e ? `-0` : ``}`),
-        (c = b(l)
-          ? ``
-          : b(u)
-            ? `<${+l + 1}.0.0-0`
-            : b(d)
-              ? `<${l}.${+u + 1}.0-0`
-              : f
-                ? `<=${l}.${u}.${d}-${f}`
-                : e
-                  ? `<${l}.${u}.${+d + 1}-0`
-                  : `<=${c}`),
-        `${n} ${c}`.trim()
-      ),
-      me = (e, t, n) => {
-        for (let n = 0; n < e.length; n++) if (!e[n].test(t)) return !1
-        if (t.prerelease.length && !n.includePrerelease) {
-          for (let n = 0; n < e.length; n++)
-            if ((d(e[n].semver), e[n].semver !== u.ANY && e[n].semver.prerelease.length > 0)) {
-              let r = e[n].semver
-              if (r.major === t.major && r.minor === t.minor && r.patch === t.patch) return !0
-            }
-          return !1
-        }
-        return !0
-      }
-  }),
-  pe = r((e, t) => {
-    let n = Symbol(`SemVer ANY`)
-    t.exports = class e {
-      static get ANY() {
-        return n
-      }
-      constructor(t, i) {
-        if (((i = r(i)), t instanceof e)) {
-          if (t.loose === !!i.loose) return t
-          t = t.value
-        }
-        ;(t = t.trim().split(/\s+/).join(` `)),
-          d(`comparator`, t, i),
-          (this.options = i),
-          (this.loose = !!i.loose),
-          this.parse(t),
-          this.semver === n ? (this.value = ``) : (this.value = this.operator + this.semver.version),
-          d(`comp`, this)
-      }
-      parse(e) {
-        let t = this.options.loose ? i[c.COMPARATORLOOSE] : i[c.COMPARATOR],
-          r = e.match(t)
-        if (!r) throw TypeError(`Invalid comparator: ${e}`)
-        ;(this.operator = r[1] === void 0 ? `` : r[1]),
-          this.operator === `=` && (this.operator = ``),
-          r[2] ? (this.semver = new f(r[2], this.options.loose)) : (this.semver = n)
-      }
-      toString() {
-        return this.value
-      }
-      test(e) {
-        if ((d(`Comparator.test`, e, this.options.loose), this.semver === n || e === n)) return !0
-        if (typeof e == `string`)
-          try {
-            e = new f(e, this.options)
-          } catch {
-            return !1
-          }
-        return u(e, this.operator, this.semver, this.options)
-      }
-      intersects(t, n) {
-        if (!(t instanceof e)) throw TypeError(`a Comparator is required`)
-        return this.operator === ``
-          ? this.value === ``
-            ? !0
-            : new p(t.value, n).test(this.value)
-          : t.operator === ``
-            ? t.value === ``
-              ? !0
-              : new p(this.value, n).test(t.semver)
-            : ((n = r(n)),
-              (n.includePrerelease && (this.value === `<0.0.0-0` || t.value === `<0.0.0-0`)) ||
-              (!n.includePrerelease && (this.value.startsWith(`<0.0.0`) || t.value.startsWith(`<0.0.0`)))
-                ? !1
-                : !!(
-                    (this.operator.startsWith(`>`) && t.operator.startsWith(`>`)) ||
-                    (this.operator.startsWith(`<`) && t.operator.startsWith(`<`)) ||
-                    (this.semver.version === t.semver.version &&
-                      this.operator.includes(`=`) &&
-                      t.operator.includes(`=`)) ||
-                    (u(this.semver, `<`, t.semver, n) && this.operator.startsWith(`>`) && t.operator.startsWith(`<`)) ||
-                    (u(this.semver, `>`, t.semver, n) && this.operator.startsWith(`<`) && t.operator.startsWith(`>`))
-                  ))
-      }
-    }
-    let r = s(),
-      { safeRe: i, t: c } = o(),
-      u = ue(),
-      d = a(),
-      f = l(),
-      p = x()
-  }),
-  me = r((e, t) => {
-    let n = x()
-    t.exports = (e, t, r) => {
-      try {
-        t = new n(t, r)
-      } catch {
-        return !1
-      }
-      return t.test(e)
-    }
-  }),
-  he = r((e, t) => {
-    let n = x()
-    t.exports = (e, t) =>
-      new n(e, t).set.map((e) =>
-        e
-          .map((e) => e.value)
-          .join(` `)
-          .trim()
-          .split(` `)
-      )
-  }),
-  ge = r((e, t) => {
-    let n = l(),
-      r = x()
-    t.exports = (e, t, i) => {
-      let a = null,
-        o = null,
-        s = null
-      try {
-        s = new r(t, i)
-      } catch {
-        return null
-      }
-      return (
-        e.forEach((e) => {
-          s.test(e) && (!a || o.compare(e) === -1) && ((a = e), (o = new n(a, i)))
-        }),
-        a
-      )
-    }
-  }),
-  _e = r((e, t) => {
-    let n = l(),
-      r = x()
-    t.exports = (e, t, i) => {
-      let a = null,
-        o = null,
-        s = null
-      try {
-        s = new r(t, i)
-      } catch {
-        return null
-      }
-      return (
-        e.forEach((e) => {
-          s.test(e) && (!a || o.compare(e) === 1) && ((a = e), (o = new n(a, i)))
-        }),
-        a
-      )
-    }
-  }),
-  ve = r((e, t) => {
-    let n = l(),
-      r = x(),
-      i = ie()
-    t.exports = (e, t) => {
-      e = new r(e, t)
-      let a = new n(`0.0.0`)
-      if (e.test(a) || ((a = new n(`0.0.0-0`)), e.test(a))) return a
-      a = null
-      for (let t = 0; t < e.set.length; ++t) {
-        let r = e.set[t],
-          o = null
-        r.forEach((e) => {
-          let t = new n(e.semver.version)
-          switch (e.operator) {
-            case `>`:
-              t.prerelease.length === 0 ? t.patch++ : t.prerelease.push(0), (t.raw = t.format())
-            case ``:
-            case `>=`:
-              ;(!o || i(t, o)) && (o = t)
-              break
-            case `<`:
-            case `<=`:
-              break
-            default:
-              throw Error(`Unexpected operation: ${e.operator}`)
-          }
-        }),
-          o && (!a || i(a, o)) && (a = o)
-      }
-      return a && e.test(a) ? a : null
-    }
-  }),
-  ye = r((e, t) => {
-    let n = x()
-    t.exports = (e, t) => {
-      try {
-        return new n(e, t).range || `*`
-      } catch {
-        return null
-      }
-    }
-  }),
-  be = r((e, t) => {
-    let n = l(),
-      r = pe(),
-      { ANY: i } = r,
-      a = x(),
-      o = me(),
-      s = ie(),
-      c = ae(),
-      u = le(),
-      d = ce()
-    t.exports = (e, t, l, f) => {
-      ;(e = new n(e, f)), (t = new a(t, f))
-      let p, m, h, g, _
-      switch (l) {
-        case `>`:
-          ;(p = s), (m = u), (h = c), (g = `>`), (_ = `>=`)
-          break
-        case `<`:
-          ;(p = c), (m = d), (h = s), (g = `<`), (_ = `<=`)
-          break
-        default:
-          throw TypeError(`Must provide a hilo val of "<" or ">"`)
-      }
-      if (o(e, t, f)) return !1
-      for (let n = 0; n < t.set.length; ++n) {
-        let a = t.set[n],
-          o = null,
-          s = null
-        if (
-          (a.forEach((e) => {
-            e.semver === i && (e = new r(`>=0.0.0`)),
-              (o ||= e),
-              (s ||= e),
-              p(e.semver, o.semver, f) ? (o = e) : h(e.semver, s.semver, f) && (s = e)
-          }),
-          o.operator === g ||
-            o.operator === _ ||
-            ((!s.operator || s.operator === g) && m(e, s.semver)) ||
-            (s.operator === _ && h(e, s.semver)))
-        )
-          return !1
-      }
-      return !0
-    }
-  }),
-  xe = r((e, t) => {
-    let n = be()
-    t.exports = (e, t, r) => n(e, t, `>`, r)
-  }),
-  Se = r((e, t) => {
-    let n = be()
-    t.exports = (e, t, r) => n(e, t, `<`, r)
-  }),
-  Ce = r((e, t) => {
-    let n = x()
-    t.exports = (e, t, r) => ((e = new n(e, r)), (t = new n(t, r)), e.intersects(t, r))
-  }),
-  we = r((e, t) => {
-    let n = me(),
-      r = y()
-    t.exports = (e, t, i) => {
-      let a = [],
-        o = null,
-        s = null,
-        c = e.sort((e, t) => r(e, t, i))
-      for (let e of c) n(e, t, i) ? ((s = e), (o ||= e)) : (s && a.push([o, s]), (s = null), (o = null))
-      o && a.push([o, null])
-      let l = []
-      for (let [e, t] of a)
-        e === t
-          ? l.push(e)
-          : !t && e === c[0]
-            ? l.push(`*`)
-            : t
-              ? e === c[0]
-                ? l.push(`<=${t}`)
-                : l.push(`${e} - ${t}`)
-              : l.push(`>=${e}`)
-      let u = l.join(` || `),
-        d = typeof t.raw == `string` ? t.raw : String(t)
-      return u.length < d.length ? u : t
-    }
-  }),
-  Te = r((e, t) => {
-    let n = x(),
-      r = pe(),
-      { ANY: i } = r,
-      a = me(),
-      o = y(),
-      s = (e, t, r = {}) => {
-        if (e === t) return !0
-        ;(e = new n(e, r)), (t = new n(t, r))
-        let i = !1
-        OUTER: for (let n of e.set) {
-          for (let e of t.set) {
-            let t = u(n, e, r)
-            if (((i ||= t !== null), t)) continue OUTER
-          }
-          if (i) return !1
-        }
-        return !0
-      },
-      c = [new r(`>=0.0.0-0`)],
-      l = [new r(`>=0.0.0`)],
-      u = (e, t, n) => {
-        if (e === t) return !0
-        if (e.length === 1 && e[0].semver === i) {
-          if (t.length === 1 && t[0].semver === i) return !0
-          e = n.includePrerelease ? c : l
-        }
-        if (t.length === 1 && t[0].semver === i) {
-          if (n.includePrerelease) return !0
-          t = l
-        }
-        let r = new Set(),
-          s,
-          u
-        for (let t of e)
-          t.operator === `>` || t.operator === `>=`
-            ? (s = d(s, t, n))
-            : t.operator === `<` || t.operator === `<=`
-              ? (u = f(u, t, n))
-              : r.add(t.semver)
-        if (r.size > 1) return null
-        let p
-        if (
-          s &&
-          u &&
-          ((p = o(s.semver, u.semver, n)), p > 0 || (p === 0 && (s.operator !== `>=` || u.operator !== `<=`)))
-        )
-          return null
-        for (let e of r) {
-          if ((s && !a(e, String(s), n)) || (u && !a(e, String(u), n))) return null
-          for (let r of t) if (!a(e, String(r), n)) return !1
-          return !0
-        }
-        let m,
-          h,
-          g,
-          _,
-          v = u && !n.includePrerelease && u.semver.prerelease.length ? u.semver : !1,
-          y = s && !n.includePrerelease && s.semver.prerelease.length ? s.semver : !1
-        v && v.prerelease.length === 1 && u.operator === `<` && v.prerelease[0] === 0 && (v = !1)
-        for (let e of t) {
-          if (
-            ((_ = _ || e.operator === `>` || e.operator === `>=`),
-            (g = g || e.operator === `<` || e.operator === `<=`),
-            s)
-          ) {
-            if (
-              (y &&
-                e.semver.prerelease &&
-                e.semver.prerelease.length &&
-                e.semver.major === y.major &&
-                e.semver.minor === y.minor &&
-                e.semver.patch === y.patch &&
-                (y = !1),
-              e.operator === `>` || e.operator === `>=`)
-            ) {
-              if (((m = d(s, e, n)), m === e && m !== s)) return !1
-            } else if (s.operator === `>=` && !a(s.semver, String(e), n)) return !1
-          }
-          if (u) {
-            if (
-              (v &&
-                e.semver.prerelease &&
-                e.semver.prerelease.length &&
-                e.semver.major === v.major &&
-                e.semver.minor === v.minor &&
-                e.semver.patch === v.patch &&
-                (v = !1),
-              e.operator === `<` || e.operator === `<=`)
-            ) {
-              if (((h = f(u, e, n)), h === e && h !== u)) return !1
-            } else if (u.operator === `<=` && !a(u.semver, String(e), n)) return !1
-          }
-          if (!e.operator && (u || s) && p !== 0) return !1
-        }
-        return !((s && g && !u && p !== 0) || (u && _ && !s && p !== 0) || y || v)
-      },
-      d = (e, t, n) => {
-        if (!e) return t
-        let r = o(e.semver, t.semver, n)
-        return r > 0 ? e : r < 0 || (t.operator === `>` && e.operator === `>=`) ? t : e
-      },
-      f = (e, t, n) => {
-        if (!e) return t
-        let r = o(e.semver, t.semver, n)
-        return r < 0 ? e : r > 0 || (t.operator === `<` && e.operator === `<=`) ? t : e
-      }
-    t.exports = s
-  }),
-  Ee = r((e, t) => {
-    let n = o(),
-      r = i(),
-      a = l(),
-      s = c()
-    t.exports = {
-      parse: u(),
-      valid: d(),
-      clean: f(),
-      inc: p(),
-      diff: m(),
-      major: h(),
-      minor: g(),
-      patch: _(),
-      prerelease: v(),
-      compare: y(),
-      rcompare: ee(),
-      compareLoose: te(),
-      compareBuild: ne(),
-      sort: re(),
-      rsort: b(),
-      gt: ie(),
-      lt: ae(),
-      eq: oe(),
-      neq: se(),
-      gte: ce(),
-      lte: le(),
-      cmp: ue(),
-      coerce: de(),
-      Comparator: pe(),
-      Range: x(),
-      satisfies: me(),
-      toComparators: he(),
-      maxSatisfying: ge(),
-      minSatisfying: _e(),
-      minVersion: ve(),
-      validRange: ye(),
-      outside: be(),
-      gtr: xe(),
-      ltr: Se(),
-      intersects: Ce(),
-      simplifyRange: we(),
-      subset: Te(),
-      SemVer: a,
-      re: n.re,
-      src: n.src,
-      tokens: n.t,
-      SEMVER_SPEC_VERSION: r.SEMVER_SPEC_VERSION,
-      RELEASE_TYPES: r.RELEASE_TYPES,
-      compareIdentifiers: s.compareIdentifiers,
-      rcompareIdentifiers: s.rcompareIdentifiers
-    }
-  })
+import 'semver'
 Object.freeze({ status: `aborted` })
-function S(e, t, n) {
+function r(e, t, n) {
   function r(n, r) {
     if (
       (n._zod || Object.defineProperty(n, `_zod`, { value: { def: r, constr: o, traits: new Set() }, enumerable: !1 }),
@@ -1230,30 +39,30 @@ function S(e, t, n) {
     o
   )
 }
-var De = class extends Error {
+var i = class extends Error {
     constructor() {
       super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`)
     }
   },
-  Oe = class extends Error {
+  a = class extends Error {
     constructor(e) {
       super(`Encountered unidirectional transform during encode: ${e}`), (this.name = `ZodEncodeError`)
     }
   }
-const ke = {}
-function C(e) {
-  return e && Object.assign(ke, e), ke
+const o = {}
+function s(e) {
+  return e && Object.assign(o, e), o
 }
-function Ae(e) {
+function c(e) {
   let t = Object.values(e).filter((e) => typeof e == `number`)
   return Object.entries(e)
     .filter(([e, n]) => t.indexOf(+e) === -1)
     .map(([e, t]) => t)
 }
-function je(e, t) {
+function l(e, t) {
   return typeof t == `bigint` ? t.toString() : t
 }
-function Me(e) {
+function u(e) {
   return {
     get value() {
       {
@@ -1264,15 +73,15 @@ function Me(e) {
     }
   }
 }
-function Ne(e) {
+function ee(e) {
   return e == null
 }
-function Pe(e) {
+function d(e) {
   let t = e.startsWith(`^`) ? 1 : 0,
     n = e.endsWith(`$`) ? e.length - 1 : e.length
   return e.slice(t, n)
 }
-function Fe(e, t) {
+function te(e, t) {
   let n = (e.toString().split(`.`)[1] || ``).length,
     r = t.toString(),
     i = (r.split(`.`)[1] || ``).length
@@ -1283,12 +92,12 @@ function Fe(e, t) {
   let a = n > i ? n : i
   return (Number.parseInt(e.toFixed(a).replace(`.`, ``)) % Number.parseInt(t.toFixed(a).replace(`.`, ``))) / 10 ** a
 }
-const Ie = Symbol(`evaluating`)
-function w(e, t, n) {
+const ne = Symbol(`evaluating`)
+function f(e, t, n) {
   let r
   Object.defineProperty(e, t, {
     get() {
-      if (r !== Ie) return r === void 0 && ((r = Ie), (r = n())), r
+      if (r !== ne) return r === void 0 && ((r = ne), (r = n())), r
     },
     set(n) {
       Object.defineProperty(e, t, { value: n })
@@ -1296,10 +105,10 @@ function w(e, t, n) {
     configurable: !0
   })
 }
-function T(e, t, n) {
+function p(e, t, n) {
   Object.defineProperty(e, t, { value: n, writable: !0, enumerable: !0, configurable: !0 })
 }
-function E(...e) {
+function m(...e) {
   let t = {}
   for (let n of e) {
     let e = Object.getOwnPropertyDescriptors(n)
@@ -1307,10 +116,10 @@ function E(...e) {
   }
   return Object.defineProperties({}, t)
 }
-function Le(e) {
+function re(e) {
   return JSON.stringify(e)
 }
-function Re(e) {
+function ie(e) {
   return e
     .toLowerCase()
     .trim()
@@ -1318,11 +127,11 @@ function Re(e) {
     .replace(/[\s_-]+/g, `-`)
     .replace(/^-+|-+$/g, ``)
 }
-const ze = `captureStackTrace` in Error ? Error.captureStackTrace : (...e) => {}
-function Be(e) {
+const ae = `captureStackTrace` in Error ? Error.captureStackTrace : (...e) => {}
+function h(e) {
   return typeof e == `object` && !!e && !Array.isArray(e)
 }
-const Ve = Me(() => {
+const oe = u(() => {
   if (typeof navigator < `u` && navigator?.userAgent?.includes(`Cloudflare`)) return !1
   try {
     return Function(``), !0
@@ -1330,25 +139,25 @@ const Ve = Me(() => {
     return !1
   }
 })
-function D(e) {
-  if (Be(e) === !1) return !1
+function g(e) {
+  if (h(e) === !1) return !1
   let t = e.constructor
   if (t === void 0 || typeof t != `function`) return !0
   let n = t.prototype
-  return !(Be(n) === !1 || Object.prototype.hasOwnProperty.call(n, `isPrototypeOf`) === !1)
+  return !(h(n) === !1 || Object.prototype.hasOwnProperty.call(n, `isPrototypeOf`) === !1)
 }
-function He(e) {
-  return D(e) ? { ...e } : Array.isArray(e) ? [...e] : e
+function se(e) {
+  return g(e) ? { ...e } : Array.isArray(e) ? [...e] : e
 }
-const Ue = new Set([`string`, `number`, `symbol`])
-function We(e) {
+const ce = new Set([`string`, `number`, `symbol`])
+function _(e) {
   return e.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`)
 }
-function O(e, t, n) {
+function v(e, t, n) {
   let r = new e._zod.constr(t ?? e._zod.def)
   return (!t || n?.parent) && (r._zod.parent = e), r
 }
-function k(e) {
+function y(e) {
   let t = e
   if (!t) return {}
   if (typeof t == `string`) return { error: () => t }
@@ -1358,56 +167,56 @@ function k(e) {
   }
   return delete t.message, typeof t.error == `string` ? { ...t, error: () => t.error } : t
 }
-function Ge(e) {
+function le(e) {
   return Object.keys(e).filter((t) => e[t]._zod.optin === `optional` && e[t]._zod.optout === `optional`)
 }
-const Ke = {
+const ue = {
   safeint: [-(2 ** 53 - 1), 2 ** 53 - 1],
   int32: [-2147483648, 2147483647],
   uint32: [0, 4294967295],
   float32: [-34028234663852886e22, 34028234663852886e22],
   float64: [-Number.MAX_VALUE, Number.MAX_VALUE]
 }
-function qe(e, t) {
+function de(e, t) {
   let n = e._zod.def,
     r = n.checks
   if (r && r.length > 0) throw Error(`.pick() cannot be used on object schemas containing refinements`)
-  return O(
+  return v(
     e,
-    E(e._zod.def, {
+    m(e._zod.def, {
       get shape() {
         let e = {}
         for (let r in t) {
           if (!(r in n.shape)) throw Error(`Unrecognized key: "${r}"`)
           t[r] && (e[r] = n.shape[r])
         }
-        return T(this, `shape`, e), e
+        return p(this, `shape`, e), e
       },
       checks: []
     })
   )
 }
-function Je(e, t) {
+function fe(e, t) {
   let n = e._zod.def,
     r = n.checks
   if (r && r.length > 0) throw Error(`.omit() cannot be used on object schemas containing refinements`)
-  return O(
+  return v(
     e,
-    E(e._zod.def, {
+    m(e._zod.def, {
       get shape() {
         let r = { ...e._zod.def.shape }
         for (let e in t) {
           if (!(e in n.shape)) throw Error(`Unrecognized key: "${e}"`)
           t[e] && delete r[e]
         }
-        return T(this, `shape`, r), r
+        return p(this, `shape`, r), r
       },
       checks: []
     })
   )
 }
-function Ye(e, t) {
-  if (!D(t)) throw Error(`Invalid input to extend: expected a plain object`)
+function pe(e, t) {
+  if (!g(t)) throw Error(`Invalid input to extend: expected a plain object`)
   let n = e._zod.def.checks
   if (n && n.length > 0) {
     let n = e._zod.def.shape
@@ -1415,35 +224,35 @@ function Ye(e, t) {
       if (Object.getOwnPropertyDescriptor(n, e) !== void 0)
         throw Error('Cannot overwrite keys on object schemas containing refinements. Use `.safeExtend()` instead.')
   }
-  return O(
+  return v(
     e,
-    E(e._zod.def, {
+    m(e._zod.def, {
       get shape() {
         let n = { ...e._zod.def.shape, ...t }
-        return T(this, `shape`, n), n
+        return p(this, `shape`, n), n
       }
     })
   )
 }
-function Xe(e, t) {
-  if (!D(t)) throw Error(`Invalid input to safeExtend: expected a plain object`)
-  return O(
+function me(e, t) {
+  if (!g(t)) throw Error(`Invalid input to safeExtend: expected a plain object`)
+  return v(
     e,
-    E(e._zod.def, {
+    m(e._zod.def, {
       get shape() {
         let n = { ...e._zod.def.shape, ...t }
-        return T(this, `shape`, n), n
+        return p(this, `shape`, n), n
       }
     })
   )
 }
-function Ze(e, t) {
-  return O(
+function he(e, t) {
+  return v(
     e,
-    E(e._zod.def, {
+    m(e._zod.def, {
       get shape() {
         let n = { ...e._zod.def.shape, ...t._zod.def.shape }
-        return T(this, `shape`, n), n
+        return p(this, `shape`, n), n
       },
       get catchall() {
         return t._zod.def.catchall
@@ -1452,12 +261,12 @@ function Ze(e, t) {
     })
   )
 }
-function Qe(e, t, n) {
+function ge(e, t, n) {
   let r = t._zod.def.checks
   if (r && r.length > 0) throw Error(`.partial() cannot be used on object schemas containing refinements`)
-  return O(
+  return v(
     t,
-    E(t._zod.def, {
+    m(t._zod.def, {
       get shape() {
         let r = t._zod.def.shape,
           i = { ...r }
@@ -1467,16 +276,16 @@ function Qe(e, t, n) {
             n[t] && (i[t] = e ? new e({ type: `optional`, innerType: r[t] }) : r[t])
           }
         else for (let t in r) i[t] = e ? new e({ type: `optional`, innerType: r[t] }) : r[t]
-        return T(this, `shape`, i), i
+        return p(this, `shape`, i), i
       },
       checks: []
     })
   )
 }
-function $e(e, t, n) {
-  return O(
+function _e(e, t, n) {
+  return v(
     t,
-    E(t._zod.def, {
+    m(t._zod.def, {
       get shape() {
         let r = t._zod.def.shape,
           i = { ...r }
@@ -1486,34 +295,34 @@ function $e(e, t, n) {
             n[t] && (i[t] = new e({ type: `nonoptional`, innerType: r[t] }))
           }
         else for (let t in r) i[t] = new e({ type: `nonoptional`, innerType: r[t] })
-        return T(this, `shape`, i), i
+        return p(this, `shape`, i), i
       }
     })
   )
 }
-function et(e, t = 0) {
+function b(e, t = 0) {
   if (e.aborted === !0) return !0
   for (let n = t; n < e.issues.length; n++) if (e.issues[n]?.continue !== !0) return !0
   return !1
 }
-function tt(e, t) {
+function x(e, t) {
   return t.map((t) => {
     var n
     return (n = t).path ?? (n.path = []), t.path.unshift(e), t
   })
 }
-function nt(e) {
+function ve(e) {
   return typeof e == `string` ? e : e?.message
 }
-function A(e, t, n) {
+function S(e, t, n) {
   let r = { ...e, path: e.path ?? [] }
   return (
     e.message ||
       (r.message =
-        nt(e.inst?._zod.def?.error?.(e)) ??
-        nt(t?.error?.(e)) ??
-        nt(n.customError?.(e)) ??
-        nt(n.localeError?.(e)) ??
+        ve(e.inst?._zod.def?.error?.(e)) ??
+        ve(t?.error?.(e)) ??
+        ve(n.customError?.(e)) ??
+        ve(n.localeError?.(e)) ??
         `Invalid input`),
     delete r.inst,
     delete r.continue,
@@ -1521,30 +330,30 @@ function A(e, t, n) {
     r
   )
 }
-function rt(e) {
+function ye(e) {
   return Array.isArray(e) ? `array` : typeof e == `string` ? `string` : `unknown`
 }
-function it(...e) {
+function C(...e) {
   let [t, n, r] = e
   return typeof t == `string` ? { message: t, code: `custom`, input: n, inst: r } : { ...t }
 }
-const at = (e, t) => {
+const be = (e, t) => {
     ;(e.name = `$ZodError`),
       Object.defineProperty(e, `_zod`, { value: e._zod, enumerable: !1 }),
       Object.defineProperty(e, `issues`, { value: t, enumerable: !1 }),
-      (e.message = JSON.stringify(t, je, 2)),
+      (e.message = JSON.stringify(t, l, 2)),
       Object.defineProperty(e, `toString`, { value: () => e.message, enumerable: !1 })
   },
-  ot = S(`$ZodError`, at),
-  st = S(`$ZodError`, at, { Parent: Error })
-function ct(e, t = (e) => e.message) {
+  xe = r(`$ZodError`, be),
+  Se = r(`$ZodError`, be, { Parent: Error })
+function Ce(e, t = (e) => e.message) {
   let n = {},
     r = []
   for (let i of e.issues)
     i.path.length > 0 ? ((n[i.path[0]] = n[i.path[0]] || []), n[i.path[0]].push(t(i))) : r.push(t(i))
   return { formErrors: r, fieldErrors: n }
 }
-function lt(e, t = (e) => e.message) {
+function we(e, t = (e) => e.message) {
   let n = { _errors: [] },
     r = (e) => {
       for (let i of e.issues)
@@ -1567,95 +376,95 @@ function lt(e, t = (e) => e.message) {
     }
   return r(e), n
 }
-const ut = (e) => (t, n, r, i) => {
-    let a = r ? Object.assign(r, { async: !1 }) : { async: !1 },
-      o = t._zod.run({ value: n, issues: [] }, a)
-    if (o instanceof Promise) throw new De()
-    if (o.issues.length) {
-      let t = new (i?.Err ?? e)(o.issues.map((e) => A(e, a, C())))
-      throw (ze(t, i?.callee), t)
+const Te = (e) => (t, n, r, a) => {
+    let o = r ? Object.assign(r, { async: !1 }) : { async: !1 },
+      c = t._zod.run({ value: n, issues: [] }, o)
+    if (c instanceof Promise) throw new i()
+    if (c.issues.length) {
+      let t = new (a?.Err ?? e)(c.issues.map((e) => S(e, o, s())))
+      throw (ae(t, a?.callee), t)
     }
-    return o.value
+    return c.value
   },
-  dt = (e) => async (t, n, r, i) => {
+  Ee = (e) => async (t, n, r, i) => {
     let a = r ? Object.assign(r, { async: !0 }) : { async: !0 },
       o = t._zod.run({ value: n, issues: [] }, a)
     if ((o instanceof Promise && (o = await o), o.issues.length)) {
-      let t = new (i?.Err ?? e)(o.issues.map((e) => A(e, a, C())))
-      throw (ze(t, i?.callee), t)
+      let t = new (i?.Err ?? e)(o.issues.map((e) => S(e, a, s())))
+      throw (ae(t, i?.callee), t)
     }
     return o.value
   },
-  ft = (e) => (t, n, r) => {
-    let i = r ? { ...r, async: !1 } : { async: !1 },
-      a = t._zod.run({ value: n, issues: [] }, i)
-    if (a instanceof Promise) throw new De()
-    return a.issues.length
-      ? { success: !1, error: new (e ?? ot)(a.issues.map((e) => A(e, i, C()))) }
-      : { success: !0, data: a.value }
+  De = (e) => (t, n, r) => {
+    let a = r ? { ...r, async: !1 } : { async: !1 },
+      o = t._zod.run({ value: n, issues: [] }, a)
+    if (o instanceof Promise) throw new i()
+    return o.issues.length
+      ? { success: !1, error: new (e ?? xe)(o.issues.map((e) => S(e, a, s()))) }
+      : { success: !0, data: o.value }
   },
-  pt = ft(st),
-  mt = (e) => async (t, n, r) => {
+  Oe = De(Se),
+  ke = (e) => async (t, n, r) => {
     let i = r ? Object.assign(r, { async: !0 }) : { async: !0 },
       a = t._zod.run({ value: n, issues: [] }, i)
     return (
       a instanceof Promise && (a = await a),
       a.issues.length
-        ? { success: !1, error: new e(a.issues.map((e) => A(e, i, C()))) }
+        ? { success: !1, error: new e(a.issues.map((e) => S(e, i, s()))) }
         : { success: !0, data: a.value }
     )
   },
-  ht = mt(st),
-  gt = (e) => (t, n, r) => {
+  Ae = ke(Se),
+  je = (e) => (t, n, r) => {
     let i = r ? Object.assign(r, { direction: `backward` }) : { direction: `backward` }
-    return ut(e)(t, n, i)
+    return Te(e)(t, n, i)
   },
-  _t = (e) => (t, n, r) => ut(e)(t, n, r),
-  vt = (e) => async (t, n, r) => {
+  Me = (e) => (t, n, r) => Te(e)(t, n, r),
+  Ne = (e) => async (t, n, r) => {
     let i = r ? Object.assign(r, { direction: `backward` }) : { direction: `backward` }
-    return dt(e)(t, n, i)
+    return Ee(e)(t, n, i)
   },
-  yt = (e) => async (t, n, r) => dt(e)(t, n, r),
-  bt = (e) => (t, n, r) => {
+  Pe = (e) => async (t, n, r) => Ee(e)(t, n, r),
+  Fe = (e) => (t, n, r) => {
     let i = r ? Object.assign(r, { direction: `backward` }) : { direction: `backward` }
-    return ft(e)(t, n, i)
+    return De(e)(t, n, i)
   },
-  xt = (e) => (t, n, r) => ft(e)(t, n, r),
-  St = (e) => async (t, n, r) => {
+  Ie = (e) => (t, n, r) => De(e)(t, n, r),
+  Le = (e) => async (t, n, r) => {
     let i = r ? Object.assign(r, { direction: `backward` }) : { direction: `backward` }
-    return mt(e)(t, n, i)
+    return ke(e)(t, n, i)
   },
-  Ct = (e) => async (t, n, r) => mt(e)(t, n, r),
-  wt = /^[cC][^\s-]{8,}$/,
-  Tt = /^[0-9a-z]+$/,
-  Et = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/,
-  Dt = /^[0-9a-vA-V]{20}$/,
-  Ot = /^[A-Za-z0-9]{27}$/,
-  kt = /^[a-zA-Z0-9_-]{21}$/,
-  At = /^P(?:(\d+W)|(?!.*W)(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+([.,]\d+)?S)?)?)$/,
-  jt = /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/,
-  Mt = (e) =>
+  Re = (e) => async (t, n, r) => ke(e)(t, n, r),
+  ze = /^[cC][^\s-]{8,}$/,
+  Be = /^[0-9a-z]+$/,
+  Ve = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/,
+  He = /^[0-9a-vA-V]{20}$/,
+  Ue = /^[A-Za-z0-9]{27}$/,
+  We = /^[a-zA-Z0-9_-]{21}$/,
+  Ge = /^P(?:(\d+W)|(?!.*W)(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+([.,]\d+)?S)?)?)$/,
+  Ke = /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/,
+  qe = (e) =>
     e
       ? RegExp(`^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-${e}[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$`)
       : /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/,
-  Nt = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/
-function Pt() {
+  Je = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/
+function Ye() {
   return RegExp(`^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`, `u`)
 }
-const Ft =
+const Xe =
     /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/,
-  It =
+  Ze =
     /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$/,
-  Lt =
+  Qe =
     /^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\/([0-9]|[1-2][0-9]|3[0-2])$/,
-  Rt =
+  $e =
     /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|::|([0-9a-fA-F]{1,4})?::([0-9a-fA-F]{1,4}:?){0,6})\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/,
-  zt = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/,
-  Bt = /^[A-Za-z0-9_-]*$/,
-  Vt = /^\+[1-9]\d{6,14}$/,
-  Ht = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`,
-  Ut = RegExp(`^${Ht}$`)
-function Wt(e) {
+  et = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/,
+  tt = /^[A-Za-z0-9_-]*$/,
+  nt = /^\+[1-9]\d{6,14}$/,
+  rt = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`,
+  it = RegExp(`^${rt}$`)
+function at(e) {
   let t = `(?:[01]\\d|2[0-3]):[0-5]\\d`
   return typeof e.precision == `number`
     ? e.precision === -1
@@ -1665,33 +474,33 @@ function Wt(e) {
         : `${t}:[0-5]\\d\\.\\d{${e.precision}}`
     : `${t}(?::[0-5]\\d(?:\\.\\d+)?)?`
 }
-function Gt(e) {
-  return RegExp(`^${Wt(e)}$`)
+function ot(e) {
+  return RegExp(`^${at(e)}$`)
 }
-function Kt(e) {
-  let t = Wt({ precision: e.precision }),
+function st(e) {
+  let t = at({ precision: e.precision }),
     n = [`Z`]
   e.local && n.push(``), e.offset && n.push(`([+-](?:[01]\\d|2[0-3]):[0-5]\\d)`)
   let r = `${t}(?:${n.join(`|`)})`
-  return RegExp(`^${Ht}T(?:${r})$`)
+  return RegExp(`^${rt}T(?:${r})$`)
 }
-const qt = (e) => {
+const ct = (e) => {
     let t = e ? `[\\s\\S]{${e?.minimum ?? 0},${e?.maximum ?? ``}}` : `[\\s\\S]*`
     return RegExp(`^${t}$`)
   },
-  Jt = /^-?\d+$/,
-  Yt = /^-?\d+(?:\.\d+)?$/,
-  Xt = /^(?:true|false)$/i,
-  Zt = /^[^A-Z]*$/,
-  Qt = /^[^a-z]*$/,
-  j = S(`$ZodCheck`, (e, t) => {
+  lt = /^-?\d+$/,
+  ut = /^-?\d+(?:\.\d+)?$/,
+  dt = /^(?:true|false)$/i,
+  ft = /^[^A-Z]*$/,
+  pt = /^[^a-z]*$/,
+  w = r(`$ZodCheck`, (e, t) => {
     var n
     ;(e._zod ??= {}), (e._zod.def = t), (n = e._zod).onattach ?? (n.onattach = [])
   }),
-  $t = { number: `number`, bigint: `bigint`, object: `date` },
-  en = S(`$ZodCheckLessThan`, (e, t) => {
-    j.init(e, t)
-    let n = $t[typeof t.value]
+  mt = { number: `number`, bigint: `bigint`, object: `date` },
+  ht = r(`$ZodCheckLessThan`, (e, t) => {
+    w.init(e, t)
+    let n = mt[typeof t.value]
     e._zod.onattach.push((e) => {
       let n = e._zod.bag,
         r = (t.inclusive ? n.maximum : n.exclusiveMaximum) ?? 1 / 0
@@ -1710,9 +519,9 @@ const qt = (e) => {
           })
       })
   }),
-  tn = S(`$ZodCheckGreaterThan`, (e, t) => {
-    j.init(e, t)
-    let n = $t[typeof t.value]
+  gt = r(`$ZodCheckGreaterThan`, (e, t) => {
+    w.init(e, t)
+    let n = mt[typeof t.value]
     e._zod.onattach.push((e) => {
       let n = e._zod.bag,
         r = (t.inclusive ? n.minimum : n.exclusiveMinimum) ?? -1 / 0
@@ -1731,15 +540,15 @@ const qt = (e) => {
           })
       })
   }),
-  nn = S(`$ZodCheckMultipleOf`, (e, t) => {
-    j.init(e, t),
+  _t = r(`$ZodCheckMultipleOf`, (e, t) => {
+    w.init(e, t),
       e._zod.onattach.push((e) => {
         var n
         ;(n = e._zod.bag).multipleOf ?? (n.multipleOf = t.value)
       }),
       (e._zod.check = (n) => {
         if (typeof n.value != typeof t.value) throw Error(`Cannot mix number and bigint in multiple_of check.`)
-        ;(typeof n.value == `bigint` ? n.value % t.value === BigInt(0) : Fe(n.value, t.value) === 0) ||
+        ;(typeof n.value == `bigint` ? n.value % t.value === BigInt(0) : te(n.value, t.value) === 0) ||
           n.issues.push({
             origin: typeof n.value,
             code: `not_multiple_of`,
@@ -1750,14 +559,14 @@ const qt = (e) => {
           })
       })
   }),
-  rn = S(`$ZodCheckNumberFormat`, (e, t) => {
-    j.init(e, t), (t.format = t.format || `float64`)
+  vt = r(`$ZodCheckNumberFormat`, (e, t) => {
+    w.init(e, t), (t.format = t.format || `float64`)
     let n = t.format?.includes(`int`),
       r = n ? `int` : `number`,
-      [i, a] = Ke[t.format]
+      [i, a] = ue[t.format]
     e._zod.onattach.push((e) => {
       let r = e._zod.bag
-      ;(r.format = t.format), (r.minimum = i), (r.maximum = a), n && (r.pattern = Jt)
+      ;(r.format = t.format), (r.minimum = i), (r.maximum = a), n && (r.pattern = lt)
     }),
       (e._zod.check = (o) => {
         let s = o.value
@@ -1813,13 +622,13 @@ const qt = (e) => {
             })
       })
   }),
-  an = S(`$ZodCheckMaxLength`, (e, t) => {
+  yt = r(`$ZodCheckMaxLength`, (e, t) => {
     var n
-    j.init(e, t),
+    w.init(e, t),
       (n = e._zod.def).when ??
         (n.when = (e) => {
           let t = e.value
-          return !Ne(t) && t.length !== void 0
+          return !ee(t) && t.length !== void 0
         }),
       e._zod.onattach.push((e) => {
         let n = e._zod.bag.maximum ?? 1 / 0
@@ -1828,7 +637,7 @@ const qt = (e) => {
       (e._zod.check = (n) => {
         let r = n.value
         if (r.length <= t.maximum) return
-        let i = rt(r)
+        let i = ye(r)
         n.issues.push({
           origin: i,
           code: `too_big`,
@@ -1840,13 +649,13 @@ const qt = (e) => {
         })
       })
   }),
-  on = S(`$ZodCheckMinLength`, (e, t) => {
+  bt = r(`$ZodCheckMinLength`, (e, t) => {
     var n
-    j.init(e, t),
+    w.init(e, t),
       (n = e._zod.def).when ??
         (n.when = (e) => {
           let t = e.value
-          return !Ne(t) && t.length !== void 0
+          return !ee(t) && t.length !== void 0
         }),
       e._zod.onattach.push((e) => {
         let n = e._zod.bag.minimum ?? -1 / 0
@@ -1855,7 +664,7 @@ const qt = (e) => {
       (e._zod.check = (n) => {
         let r = n.value
         if (r.length >= t.minimum) return
-        let i = rt(r)
+        let i = ye(r)
         n.issues.push({
           origin: i,
           code: `too_small`,
@@ -1867,13 +676,13 @@ const qt = (e) => {
         })
       })
   }),
-  sn = S(`$ZodCheckLengthEquals`, (e, t) => {
+  xt = r(`$ZodCheckLengthEquals`, (e, t) => {
     var n
-    j.init(e, t),
+    w.init(e, t),
       (n = e._zod.def).when ??
         (n.when = (e) => {
           let t = e.value
-          return !Ne(t) && t.length !== void 0
+          return !ee(t) && t.length !== void 0
         }),
       e._zod.onattach.push((e) => {
         let n = e._zod.bag
@@ -1883,7 +692,7 @@ const qt = (e) => {
         let r = n.value,
           i = r.length
         if (i === t.length) return
-        let a = rt(r),
+        let a = ye(r),
           o = i > t.length
         n.issues.push({
           origin: a,
@@ -1896,9 +705,9 @@ const qt = (e) => {
         })
       })
   }),
-  cn = S(`$ZodCheckStringFormat`, (e, t) => {
+  St = r(`$ZodCheckStringFormat`, (e, t) => {
     var n, r
-    j.init(e, t),
+    w.init(e, t),
       e._zod.onattach.push((e) => {
         let n = e._zod.bag
         ;(n.format = t.format), t.pattern && ((n.patterns ??= new Set()), n.patterns.add(t.pattern))
@@ -1920,8 +729,8 @@ const qt = (e) => {
           }))
         : ((r = e._zod).check ?? (r.check = () => {}))
   }),
-  ln = S(`$ZodCheckRegex`, (e, t) => {
-    cn.init(e, t),
+  Ct = r(`$ZodCheckRegex`, (e, t) => {
+    St.init(e, t),
       (e._zod.check = (n) => {
         ;(t.pattern.lastIndex = 0),
           !t.pattern.test(n.value) &&
@@ -1936,15 +745,15 @@ const qt = (e) => {
             })
       })
   }),
-  un = S(`$ZodCheckLowerCase`, (e, t) => {
-    ;(t.pattern ??= Zt), cn.init(e, t)
+  wt = r(`$ZodCheckLowerCase`, (e, t) => {
+    ;(t.pattern ??= ft), St.init(e, t)
   }),
-  dn = S(`$ZodCheckUpperCase`, (e, t) => {
-    ;(t.pattern ??= Qt), cn.init(e, t)
+  Tt = r(`$ZodCheckUpperCase`, (e, t) => {
+    ;(t.pattern ??= pt), St.init(e, t)
   }),
-  fn = S(`$ZodCheckIncludes`, (e, t) => {
-    j.init(e, t)
-    let n = We(t.includes),
+  Et = r(`$ZodCheckIncludes`, (e, t) => {
+    w.init(e, t)
+    let n = _(t.includes),
       r = new RegExp(typeof t.position == `number` ? `^.{${t.position}}${n}` : n)
     ;(t.pattern = r),
       e._zod.onattach.push((e) => {
@@ -1964,9 +773,9 @@ const qt = (e) => {
           })
       })
   }),
-  pn = S(`$ZodCheckStartsWith`, (e, t) => {
-    j.init(e, t)
-    let n = RegExp(`^${We(t.prefix)}.*`)
+  Dt = r(`$ZodCheckStartsWith`, (e, t) => {
+    w.init(e, t)
+    let n = RegExp(`^${_(t.prefix)}.*`)
     ;(t.pattern ??= n),
       e._zod.onattach.push((e) => {
         let t = e._zod.bag
@@ -1985,9 +794,9 @@ const qt = (e) => {
           })
       })
   }),
-  mn = S(`$ZodCheckEndsWith`, (e, t) => {
-    j.init(e, t)
-    let n = RegExp(`.*${We(t.suffix)}$`)
+  Ot = r(`$ZodCheckEndsWith`, (e, t) => {
+    w.init(e, t)
+    let n = RegExp(`.*${_(t.suffix)}$`)
     ;(t.pattern ??= n),
       e._zod.onattach.push((e) => {
         let t = e._zod.bag
@@ -2006,13 +815,13 @@ const qt = (e) => {
           })
       })
   }),
-  hn = S(`$ZodCheckOverwrite`, (e, t) => {
-    j.init(e, t),
+  kt = r(`$ZodCheckOverwrite`, (e, t) => {
+    w.init(e, t),
       (e._zod.check = (e) => {
         e.value = t.tx(e.value)
       })
   })
-var gn = class {
+var At = class {
   constructor(e = []) {
     ;(this.content = []), (this.indent = 0), this && (this.args = e)
   }
@@ -2043,10 +852,10 @@ var gn = class {
     )
   }
 }
-const _n = { major: 4, minor: 3, patch: 6 },
-  M = S(`$ZodType`, (e, t) => {
+const jt = { major: 4, minor: 3, patch: 6 },
+  T = r(`$ZodType`, (e, t) => {
     var n
-    ;(e ??= {}), (e._zod.def = t), (e._zod.bag = e._zod.bag || {}), (e._zod.version = _n)
+    ;(e ??= {}), (e._zod.def = t), (e._zod.bag = e._zod.bag || {}), (e._zod.version = jt)
     let r = [...(e._zod.def.checks ?? [])]
     e._zod.traits.has(`$ZodCheck`) && r.unshift(e)
     for (let t of r) for (let n of t._zod.onattach) n(e)
@@ -2057,65 +866,65 @@ const _n = { major: 4, minor: 3, patch: 6 },
         })
     else {
       let t = (e, t, n) => {
-          let r = et(e),
-            i
-          for (let a of t) {
-            if (a._zod.def.when) {
-              if (!a._zod.def.when(e)) continue
+          let r = b(e),
+            a
+          for (let o of t) {
+            if (o._zod.def.when) {
+              if (!o._zod.def.when(e)) continue
             } else if (r) continue
             let t = e.issues.length,
-              o = a._zod.check(e)
-            if (o instanceof Promise && n?.async === !1) throw new De()
-            if (i || o instanceof Promise)
-              i = (i ?? Promise.resolve()).then(async () => {
-                await o, e.issues.length !== t && (r ||= et(e, t))
+              s = o._zod.check(e)
+            if (s instanceof Promise && n?.async === !1) throw new i()
+            if (a || s instanceof Promise)
+              a = (a ?? Promise.resolve()).then(async () => {
+                await s, e.issues.length !== t && (r ||= b(e, t))
               })
             else {
               if (e.issues.length === t) continue
-              r ||= et(e, t)
+              r ||= b(e, t)
             }
           }
-          return i ? i.then(() => e) : e
+          return a ? a.then(() => e) : e
         },
-        n = (n, i, a) => {
-          if (et(n)) return (n.aborted = !0), n
-          let o = t(i, r, a)
-          if (o instanceof Promise) {
-            if (a.async === !1) throw new De()
-            return o.then((t) => e._zod.parse(t, a))
+        n = (n, a, o) => {
+          if (b(n)) return (n.aborted = !0), n
+          let s = t(a, r, o)
+          if (s instanceof Promise) {
+            if (o.async === !1) throw new i()
+            return s.then((t) => e._zod.parse(t, o))
           }
-          return e._zod.parse(o, a)
+          return e._zod.parse(s, o)
         }
-      e._zod.run = (i, a) => {
-        if (a.skipChecks) return e._zod.parse(i, a)
-        if (a.direction === `backward`) {
-          let t = e._zod.parse({ value: i.value, issues: [] }, { ...a, skipChecks: !0 })
-          return t instanceof Promise ? t.then((e) => n(e, i, a)) : n(t, i, a)
+      e._zod.run = (a, o) => {
+        if (o.skipChecks) return e._zod.parse(a, o)
+        if (o.direction === `backward`) {
+          let t = e._zod.parse({ value: a.value, issues: [] }, { ...o, skipChecks: !0 })
+          return t instanceof Promise ? t.then((e) => n(e, a, o)) : n(t, a, o)
         }
-        let o = e._zod.parse(i, a)
-        if (o instanceof Promise) {
-          if (a.async === !1) throw new De()
-          return o.then((e) => t(e, r, a))
+        let s = e._zod.parse(a, o)
+        if (s instanceof Promise) {
+          if (o.async === !1) throw new i()
+          return s.then((e) => t(e, r, o))
         }
-        return t(o, r, a)
+        return t(s, r, o)
       }
     }
-    w(e, `~standard`, () => ({
+    f(e, `~standard`, () => ({
       validate: (t) => {
         try {
-          let n = pt(e, t)
+          let n = Oe(e, t)
           return n.success ? { value: n.data } : { issues: n.error?.issues }
         } catch {
-          return ht(e, t).then((e) => (e.success ? { value: e.data } : { issues: e.error?.issues }))
+          return Ae(e, t).then((e) => (e.success ? { value: e.data } : { issues: e.error?.issues }))
         }
       },
       vendor: `zod`,
       version: 1
     }))
   }),
-  vn = S(`$ZodString`, (e, t) => {
-    M.init(e, t),
-      (e._zod.pattern = [...(e?._zod.bag?.patterns ?? [])].pop() ?? qt(e._zod.bag)),
+  Mt = r(`$ZodString`, (e, t) => {
+    T.init(e, t),
+      (e._zod.pattern = [...(e?._zod.bag?.patterns ?? [])].pop() ?? ct(e._zod.bag)),
       (e._zod.parse = (n, r) => {
         if (t.coerce)
           try {
@@ -2128,25 +937,25 @@ const _n = { major: 4, minor: 3, patch: 6 },
         )
       })
   }),
-  N = S(`$ZodStringFormat`, (e, t) => {
-    cn.init(e, t), vn.init(e, t)
+  E = r(`$ZodStringFormat`, (e, t) => {
+    St.init(e, t), Mt.init(e, t)
   }),
-  yn = S(`$ZodGUID`, (e, t) => {
-    ;(t.pattern ??= jt), N.init(e, t)
+  Nt = r(`$ZodGUID`, (e, t) => {
+    ;(t.pattern ??= Ke), E.init(e, t)
   }),
-  bn = S(`$ZodUUID`, (e, t) => {
+  Pt = r(`$ZodUUID`, (e, t) => {
     if (t.version) {
       let e = { v1: 1, v2: 2, v3: 3, v4: 4, v5: 5, v6: 6, v7: 7, v8: 8 }[t.version]
       if (e === void 0) throw Error(`Invalid UUID version: "${t.version}"`)
-      t.pattern ??= Mt(e)
-    } else t.pattern ??= Mt()
-    N.init(e, t)
+      t.pattern ??= qe(e)
+    } else t.pattern ??= qe()
+    E.init(e, t)
   }),
-  xn = S(`$ZodEmail`, (e, t) => {
-    ;(t.pattern ??= Nt), N.init(e, t)
+  Ft = r(`$ZodEmail`, (e, t) => {
+    ;(t.pattern ??= Je), E.init(e, t)
   }),
-  Sn = S(`$ZodURL`, (e, t) => {
-    N.init(e, t),
+  It = r(`$ZodURL`, (e, t) => {
+    E.init(e, t),
       (e._zod.check = (n) => {
         try {
           let r = n.value.trim(),
@@ -2182,45 +991,45 @@ const _n = { major: 4, minor: 3, patch: 6 },
         }
       })
   }),
-  Cn = S(`$ZodEmoji`, (e, t) => {
-    ;(t.pattern ??= Pt()), N.init(e, t)
+  Lt = r(`$ZodEmoji`, (e, t) => {
+    ;(t.pattern ??= Ye()), E.init(e, t)
   }),
-  wn = S(`$ZodNanoID`, (e, t) => {
-    ;(t.pattern ??= kt), N.init(e, t)
+  Rt = r(`$ZodNanoID`, (e, t) => {
+    ;(t.pattern ??= We), E.init(e, t)
   }),
-  Tn = S(`$ZodCUID`, (e, t) => {
-    ;(t.pattern ??= wt), N.init(e, t)
+  zt = r(`$ZodCUID`, (e, t) => {
+    ;(t.pattern ??= ze), E.init(e, t)
   }),
-  En = S(`$ZodCUID2`, (e, t) => {
-    ;(t.pattern ??= Tt), N.init(e, t)
+  Bt = r(`$ZodCUID2`, (e, t) => {
+    ;(t.pattern ??= Be), E.init(e, t)
   }),
-  Dn = S(`$ZodULID`, (e, t) => {
-    ;(t.pattern ??= Et), N.init(e, t)
+  Vt = r(`$ZodULID`, (e, t) => {
+    ;(t.pattern ??= Ve), E.init(e, t)
   }),
-  On = S(`$ZodXID`, (e, t) => {
-    ;(t.pattern ??= Dt), N.init(e, t)
+  Ht = r(`$ZodXID`, (e, t) => {
+    ;(t.pattern ??= He), E.init(e, t)
   }),
-  kn = S(`$ZodKSUID`, (e, t) => {
-    ;(t.pattern ??= Ot), N.init(e, t)
+  Ut = r(`$ZodKSUID`, (e, t) => {
+    ;(t.pattern ??= Ue), E.init(e, t)
   }),
-  An = S(`$ZodISODateTime`, (e, t) => {
-    ;(t.pattern ??= Kt(t)), N.init(e, t)
+  Wt = r(`$ZodISODateTime`, (e, t) => {
+    ;(t.pattern ??= st(t)), E.init(e, t)
   }),
-  jn = S(`$ZodISODate`, (e, t) => {
-    ;(t.pattern ??= Ut), N.init(e, t)
+  Gt = r(`$ZodISODate`, (e, t) => {
+    ;(t.pattern ??= it), E.init(e, t)
   }),
-  Mn = S(`$ZodISOTime`, (e, t) => {
-    ;(t.pattern ??= Gt(t)), N.init(e, t)
+  Kt = r(`$ZodISOTime`, (e, t) => {
+    ;(t.pattern ??= ot(t)), E.init(e, t)
   }),
-  Nn = S(`$ZodISODuration`, (e, t) => {
-    ;(t.pattern ??= At), N.init(e, t)
+  qt = r(`$ZodISODuration`, (e, t) => {
+    ;(t.pattern ??= Ge), E.init(e, t)
   }),
-  Pn = S(`$ZodIPv4`, (e, t) => {
-    ;(t.pattern ??= Ft), N.init(e, t), (e._zod.bag.format = `ipv4`)
+  Jt = r(`$ZodIPv4`, (e, t) => {
+    ;(t.pattern ??= Xe), E.init(e, t), (e._zod.bag.format = `ipv4`)
   }),
-  Fn = S(`$ZodIPv6`, (e, t) => {
-    ;(t.pattern ??= It),
-      N.init(e, t),
+  Yt = r(`$ZodIPv6`, (e, t) => {
+    ;(t.pattern ??= Ze),
+      E.init(e, t),
       (e._zod.bag.format = `ipv6`),
       (e._zod.check = (n) => {
         try {
@@ -2230,12 +1039,12 @@ const _n = { major: 4, minor: 3, patch: 6 },
         }
       })
   }),
-  In = S(`$ZodCIDRv4`, (e, t) => {
-    ;(t.pattern ??= Lt), N.init(e, t)
+  Xt = r(`$ZodCIDRv4`, (e, t) => {
+    ;(t.pattern ??= Qe), E.init(e, t)
   }),
-  Ln = S(`$ZodCIDRv6`, (e, t) => {
-    ;(t.pattern ??= Rt),
-      N.init(e, t),
+  Zt = r(`$ZodCIDRv6`, (e, t) => {
+    ;(t.pattern ??= $e),
+      E.init(e, t),
       (e._zod.check = (n) => {
         let r = n.value.split(`/`)
         try {
@@ -2250,7 +1059,7 @@ const _n = { major: 4, minor: 3, patch: 6 },
         }
       })
   })
-function Rn(e) {
+function Qt(e) {
   if (e === ``) return !0
   if (e.length % 4 != 0) return !1
   try {
@@ -2259,33 +1068,33 @@ function Rn(e) {
     return !1
   }
 }
-const zn = S(`$ZodBase64`, (e, t) => {
-  ;(t.pattern ??= zt),
-    N.init(e, t),
+const $t = r(`$ZodBase64`, (e, t) => {
+  ;(t.pattern ??= et),
+    E.init(e, t),
     (e._zod.bag.contentEncoding = `base64`),
     (e._zod.check = (n) => {
-      Rn(n.value) ||
+      Qt(n.value) ||
         n.issues.push({ code: `invalid_format`, format: `base64`, input: n.value, inst: e, continue: !t.abort })
     })
 })
-function Bn(e) {
-  if (!Bt.test(e)) return !1
+function en(e) {
+  if (!tt.test(e)) return !1
   let t = e.replace(/[-_]/g, (e) => (e === `-` ? `+` : `/`))
-  return Rn(t.padEnd(Math.ceil(t.length / 4) * 4, `=`))
+  return Qt(t.padEnd(Math.ceil(t.length / 4) * 4, `=`))
 }
-const Vn = S(`$ZodBase64URL`, (e, t) => {
-    ;(t.pattern ??= Bt),
-      N.init(e, t),
+const tn = r(`$ZodBase64URL`, (e, t) => {
+    ;(t.pattern ??= tt),
+      E.init(e, t),
       (e._zod.bag.contentEncoding = `base64url`),
       (e._zod.check = (n) => {
-        Bn(n.value) ||
+        en(n.value) ||
           n.issues.push({ code: `invalid_format`, format: `base64url`, input: n.value, inst: e, continue: !t.abort })
       })
   }),
-  Hn = S(`$ZodE164`, (e, t) => {
-    ;(t.pattern ??= Vt), N.init(e, t)
+  nn = r(`$ZodE164`, (e, t) => {
+    ;(t.pattern ??= nt), E.init(e, t)
   })
-function Un(e, t = null) {
+function rn(e, t = null) {
   try {
     let n = e.split(`.`)
     if (n.length !== 3) return !1
@@ -2297,16 +1106,16 @@ function Un(e, t = null) {
     return !1
   }
 }
-const Wn = S(`$ZodJWT`, (e, t) => {
-    N.init(e, t),
+const an = r(`$ZodJWT`, (e, t) => {
+    E.init(e, t),
       (e._zod.check = (n) => {
-        Un(n.value, t.alg) ||
+        rn(n.value, t.alg) ||
           n.issues.push({ code: `invalid_format`, format: `jwt`, input: n.value, inst: e, continue: !t.abort })
       })
   }),
-  Gn = S(`$ZodNumber`, (e, t) => {
-    M.init(e, t),
-      (e._zod.pattern = e._zod.bag.pattern ?? Yt),
+  on = r(`$ZodNumber`, (e, t) => {
+    T.init(e, t),
+      (e._zod.pattern = e._zod.bag.pattern ?? ut),
       (e._zod.parse = (n, r) => {
         if (t.coerce)
           try {
@@ -2321,12 +1130,12 @@ const Wn = S(`$ZodJWT`, (e, t) => {
         )
       })
   }),
-  Kn = S(`$ZodNumberFormat`, (e, t) => {
-    rn.init(e, t), Gn.init(e, t)
+  sn = r(`$ZodNumberFormat`, (e, t) => {
+    vt.init(e, t), on.init(e, t)
   }),
-  qn = S(`$ZodBoolean`, (e, t) => {
-    M.init(e, t),
-      (e._zod.pattern = Xt),
+  cn = r(`$ZodBoolean`, (e, t) => {
+    T.init(e, t),
+      (e._zod.pattern = dt),
       (e._zod.parse = (n, r) => {
         if (t.coerce)
           try {
@@ -2338,20 +1147,20 @@ const Wn = S(`$ZodJWT`, (e, t) => {
         )
       })
   }),
-  Jn = S(`$ZodUnknown`, (e, t) => {
-    M.init(e, t), (e._zod.parse = (e) => e)
+  ln = r(`$ZodUnknown`, (e, t) => {
+    T.init(e, t), (e._zod.parse = (e) => e)
   }),
-  Yn = S(`$ZodNever`, (e, t) => {
-    M.init(e, t),
+  un = r(`$ZodNever`, (e, t) => {
+    T.init(e, t),
       (e._zod.parse = (t, n) => (
         t.issues.push({ expected: `never`, code: `invalid_type`, input: t.value, inst: e }), t
       ))
   })
-function Xn(e, t, n) {
-  e.issues.length && t.issues.push(...tt(n, e.issues)), (t.value[n] = e.value)
+function dn(e, t, n) {
+  e.issues.length && t.issues.push(...x(n, e.issues)), (t.value[n] = e.value)
 }
-const Zn = S(`$ZodArray`, (e, t) => {
-  M.init(e, t),
+const fn = r(`$ZodArray`, (e, t) => {
+  T.init(e, t),
     (e._zod.parse = (n, r) => {
       let i = n.value
       if (!Array.isArray(i)) return n.issues.push({ expected: `array`, code: `invalid_type`, input: i, inst: e }), n
@@ -2360,27 +1169,27 @@ const Zn = S(`$ZodArray`, (e, t) => {
       for (let e = 0; e < i.length; e++) {
         let o = i[e],
           s = t.element._zod.run({ value: o, issues: [] }, r)
-        s instanceof Promise ? a.push(s.then((t) => Xn(t, n, e))) : Xn(s, n, e)
+        s instanceof Promise ? a.push(s.then((t) => dn(t, n, e))) : dn(s, n, e)
       }
       return a.length ? Promise.all(a).then(() => n) : n
     })
 })
-function Qn(e, t, n, r, i) {
+function pn(e, t, n, r, i) {
   if (e.issues.length) {
     if (i && !(n in r)) return
-    t.issues.push(...tt(n, e.issues))
+    t.issues.push(...x(n, e.issues))
   }
   e.value === void 0 ? n in r && (t.value[n] = void 0) : (t.value[n] = e.value)
 }
-function $n(e) {
+function mn(e) {
   let t = Object.keys(e.shape)
   for (let n of t)
     if (!e.shape?.[n]?._zod?.traits?.has(`$ZodType`))
       throw Error(`Invalid element at key "${n}": expected a Zod schema`)
-  let n = Ge(e.shape)
+  let n = le(e.shape)
   return { ...e, keys: t, keySet: new Set(t), numKeys: t.length, optionalKeys: new Set(n) }
 }
-function er(e, t, n, r, i, a) {
+function hn(e, t, n, r, i, a) {
   let o = [],
     s = i.keySet,
     c = i.catchall._zod,
@@ -2393,15 +1202,15 @@ function er(e, t, n, r, i, a) {
       continue
     }
     let a = c.run({ value: t[i], issues: [] }, r)
-    a instanceof Promise ? e.push(a.then((e) => Qn(e, n, i, t, u))) : Qn(a, n, i, t, u)
+    a instanceof Promise ? e.push(a.then((e) => pn(e, n, i, t, u))) : pn(a, n, i, t, u)
   }
   return (
     o.length && n.issues.push({ code: `unrecognized_keys`, keys: o, input: t, inst: a }),
     e.length ? Promise.all(e).then(() => n) : n
   )
 }
-const tr = S(`$ZodObject`, (e, t) => {
-    if ((M.init(e, t), !Object.getOwnPropertyDescriptor(t, `shape`)?.get)) {
+const gn = r(`$ZodObject`, (e, t) => {
+    if ((T.init(e, t), !Object.getOwnPropertyDescriptor(t, `shape`)?.get)) {
       let e = t.shape
       Object.defineProperty(t, `shape`, {
         get: () => {
@@ -2410,8 +1219,8 @@ const tr = S(`$ZodObject`, (e, t) => {
         }
       })
     }
-    let n = Me(() => $n(t))
-    w(e._zod, `propValues`, () => {
+    let n = u(() => mn(t))
+    f(e._zod, `propValues`, () => {
       let e = t.shape,
         n = {}
       for (let t in e) {
@@ -2423,7 +1232,7 @@ const tr = S(`$ZodObject`, (e, t) => {
       }
       return n
     })
-    let r = Be,
+    let r = h,
       i = t.catchall,
       a
     e._zod.parse = (t, o) => {
@@ -2437,20 +1246,20 @@ const tr = S(`$ZodObject`, (e, t) => {
         let n = l[e],
           r = n._zod.optout === `optional`,
           i = n._zod.run({ value: s[e], issues: [] }, o)
-        i instanceof Promise ? c.push(i.then((n) => Qn(n, t, e, s, r))) : Qn(i, t, e, s, r)
+        i instanceof Promise ? c.push(i.then((n) => pn(n, t, e, s, r))) : pn(i, t, e, s, r)
       }
-      return i ? er(c, s, t, o, n.value, e) : c.length ? Promise.all(c).then(() => t) : t
+      return i ? hn(c, s, t, o, n.value, e) : c.length ? Promise.all(c).then(() => t) : t
     }
   }),
-  nr = S(`$ZodObjectJIT`, (e, t) => {
-    tr.init(e, t)
+  _n = r(`$ZodObjectJIT`, (e, t) => {
+    gn.init(e, t)
     let n = e._zod.parse,
-      r = Me(() => $n(t)),
+      r = u(() => mn(t)),
       i = (e) => {
-        let t = new gn([`shape`, `payload`, `ctx`]),
+        let t = new At([`shape`, `payload`, `ctx`]),
           n = r.value,
           i = (e) => {
-            let t = Le(e)
+            let t = re(e)
             return `shape[${t}]._zod.run({ value: input[${t}], issues: [] }, ctx)`
           }
         t.write(`const input = payload.value;`)
@@ -2460,7 +1269,7 @@ const tr = S(`$ZodObject`, (e, t) => {
         t.write(`const newResult = {};`)
         for (let r of n.keys) {
           let n = a[r],
-            o = Le(r),
+            o = re(r),
             s = e[r]?._zod?.optout === `optional`
           t.write(`const ${n} = ${i(r)};`),
             s
@@ -2506,45 +1315,45 @@ const tr = S(`$ZodObject`, (e, t) => {
         return (t, n) => s(e, t, n)
       },
       a,
-      o = Be,
-      s = !ke.jitless,
-      c = s && Ve.value,
-      l = t.catchall,
-      u
-    e._zod.parse = (d, f) => {
-      u ??= r.value
-      let p = d.value
-      return o(p)
-        ? s && c && f?.async === !1 && f.jitless !== !0
-          ? ((a ||= i(t.shape)), (d = a(d, f)), l ? er([], p, d, f, u, e) : d)
-          : n(d, f)
-        : (d.issues.push({ expected: `object`, code: `invalid_type`, input: p, inst: e }), d)
+      s = h,
+      c = !o.jitless,
+      l = c && oe.value,
+      ee = t.catchall,
+      d
+    e._zod.parse = (o, u) => {
+      d ??= r.value
+      let te = o.value
+      return s(te)
+        ? c && l && u?.async === !1 && u.jitless !== !0
+          ? ((a ||= i(t.shape)), (o = a(o, u)), ee ? hn([], te, o, u, d, e) : o)
+          : n(o, u)
+        : (o.issues.push({ expected: `object`, code: `invalid_type`, input: te, inst: e }), o)
     }
   })
-function rr(e, t, n, r) {
+function vn(e, t, n, r) {
   for (let n of e) if (n.issues.length === 0) return (t.value = n.value), t
-  let i = e.filter((e) => !et(e))
+  let i = e.filter((e) => !b(e))
   return i.length === 1
     ? ((t.value = i[0].value), i[0])
     : (t.issues.push({
         code: `invalid_union`,
         input: t.value,
         inst: n,
-        errors: e.map((e) => e.issues.map((e) => A(e, r, C())))
+        errors: e.map((e) => e.issues.map((e) => S(e, r, s())))
       }),
       t)
 }
-const ir = S(`$ZodUnion`, (e, t) => {
-    M.init(e, t),
-      w(e._zod, `optin`, () => (t.options.some((e) => e._zod.optin === `optional`) ? `optional` : void 0)),
-      w(e._zod, `optout`, () => (t.options.some((e) => e._zod.optout === `optional`) ? `optional` : void 0)),
-      w(e._zod, `values`, () => {
+const yn = r(`$ZodUnion`, (e, t) => {
+    T.init(e, t),
+      f(e._zod, `optin`, () => (t.options.some((e) => e._zod.optin === `optional`) ? `optional` : void 0)),
+      f(e._zod, `optout`, () => (t.options.some((e) => e._zod.optout === `optional`) ? `optional` : void 0)),
+      f(e._zod, `values`, () => {
         if (t.options.every((e) => e._zod.values)) return new Set(t.options.flatMap((e) => Array.from(e._zod.values)))
       }),
-      w(e._zod, `pattern`, () => {
+      f(e._zod, `pattern`, () => {
         if (t.options.every((e) => e._zod.pattern)) {
           let e = t.options.map((e) => e._zod.pattern)
-          return RegExp(`^(${e.map((e) => Pe(e.source)).join(`|`)})$`)
+          return RegExp(`^(${e.map((e) => d(e.source)).join(`|`)})$`)
         }
       })
     let n = t.options.length === 1,
@@ -2561,13 +1370,13 @@ const ir = S(`$ZodUnion`, (e, t) => {
           s.push(t)
         }
       }
-      return o ? Promise.all(s).then((t) => rr(t, i, e, a)) : rr(s, i, e, a)
+      return o ? Promise.all(s).then((t) => vn(t, i, e, a)) : vn(s, i, e, a)
     }
   }),
-  ar = S(`$ZodDiscriminatedUnion`, (e, t) => {
-    ;(t.inclusive = !1), ir.init(e, t)
+  bn = r(`$ZodDiscriminatedUnion`, (e, t) => {
+    ;(t.inclusive = !1), yn.init(e, t)
     let n = e._zod.parse
-    w(e._zod, `propValues`, () => {
+    f(e._zod, `propValues`, () => {
       let e = {}
       for (let n of t.options) {
         let r = n._zod.propValues
@@ -2580,7 +1389,7 @@ const ir = S(`$ZodUnion`, (e, t) => {
       }
       return e
     })
-    let r = Me(() => {
+    let r = u(() => {
       let e = t.options,
         n = new Map()
       for (let r of e) {
@@ -2595,7 +1404,7 @@ const ir = S(`$ZodUnion`, (e, t) => {
     })
     e._zod.parse = (i, a) => {
       let o = i.value
-      if (!Be(o)) return i.issues.push({ code: `invalid_type`, expected: `object`, input: o, inst: e }), i
+      if (!h(o)) return i.issues.push({ code: `invalid_type`, expected: `object`, input: o, inst: e }), i
       let s = r.value.get(o?.[t.discriminator])
       return s
         ? s._zod.run(i, a)
@@ -2613,25 +1422,25 @@ const ir = S(`$ZodUnion`, (e, t) => {
             i)
     }
   }),
-  or = S(`$ZodIntersection`, (e, t) => {
-    M.init(e, t),
+  xn = r(`$ZodIntersection`, (e, t) => {
+    T.init(e, t),
       (e._zod.parse = (e, n) => {
         let r = e.value,
           i = t.left._zod.run({ value: r, issues: [] }, n),
           a = t.right._zod.run({ value: r, issues: [] }, n)
         return i instanceof Promise || a instanceof Promise
-          ? Promise.all([i, a]).then(([t, n]) => cr(e, t, n))
-          : cr(e, i, a)
+          ? Promise.all([i, a]).then(([t, n]) => Cn(e, t, n))
+          : Cn(e, i, a)
       })
   })
-function sr(e, t) {
+function Sn(e, t) {
   if (e === t || (e instanceof Date && t instanceof Date && +e == +t)) return { valid: !0, data: e }
-  if (D(e) && D(t)) {
+  if (g(e) && g(t)) {
     let n = Object.keys(t),
       r = Object.keys(e).filter((e) => n.indexOf(e) !== -1),
       i = { ...e, ...t }
     for (let n of r) {
-      let r = sr(e[n], t[n])
+      let r = Sn(e[n], t[n])
       if (!r.valid) return { valid: !1, mergeErrorPath: [n, ...r.mergeErrorPath] }
       i[n] = r.data
     }
@@ -2643,7 +1452,7 @@ function sr(e, t) {
     for (let r = 0; r < e.length; r++) {
       let i = e[r],
         a = t[r],
-        o = sr(i, a)
+        o = Sn(i, a)
       if (!o.valid) return { valid: !1, mergeErrorPath: [r, ...o.mergeErrorPath] }
       n.push(o.data)
     }
@@ -2651,7 +1460,7 @@ function sr(e, t) {
   }
   return { valid: !1, mergeErrorPath: [] }
 }
-function cr(e, t, n) {
+function Cn(e, t, n) {
   let r = new Map(),
     i
   for (let n of t.issues)
@@ -2663,16 +1472,16 @@ function cr(e, t, n) {
     if (t.code === `unrecognized_keys`) for (let e of t.keys) r.has(e) || r.set(e, {}), (r.get(e).r = !0)
     else e.issues.push(t)
   let a = [...r].filter(([, e]) => e.l && e.r).map(([e]) => e)
-  if ((a.length && i && e.issues.push({ ...i, keys: a }), et(e))) return e
-  let o = sr(t.value, n.value)
+  if ((a.length && i && e.issues.push({ ...i, keys: a }), b(e))) return e
+  let o = Sn(t.value, n.value)
   if (!o.valid) throw Error(`Unmergable intersection. Error path: ${JSON.stringify(o.mergeErrorPath)}`)
   return (e.value = o.data), e
 }
-const lr = S(`$ZodRecord`, (e, t) => {
-    M.init(e, t),
+const wn = r(`$ZodRecord`, (e, t) => {
+    T.init(e, t),
       (e._zod.parse = (n, r) => {
         let i = n.value
-        if (!D(i)) return n.issues.push({ expected: `record`, code: `invalid_type`, input: i, inst: e }), n
+        if (!g(i)) return n.issues.push({ expected: `record`, code: `invalid_type`, input: i, inst: e }), n
         let a = [],
           o = t.keyType._zod.values
         if (o) {
@@ -2685,10 +1494,10 @@ const lr = S(`$ZodRecord`, (e, t) => {
               o instanceof Promise
                 ? a.push(
                     o.then((t) => {
-                      t.issues.length && n.issues.push(...tt(e, t.issues)), (n.value[e] = t.value)
+                      t.issues.length && n.issues.push(...x(e, t.issues)), (n.value[e] = t.value)
                     })
                   )
-                : (o.issues.length && n.issues.push(...tt(e, o.issues)), (n.value[e] = o.value))
+                : (o.issues.length && n.issues.push(...x(e, o.issues)), (n.value[e] = o.value))
             }
           let c
           for (let e in i) s.has(e) || ((c ??= []), c.push(e))
@@ -2697,48 +1506,48 @@ const lr = S(`$ZodRecord`, (e, t) => {
           n.value = {}
           for (let o of Reflect.ownKeys(i)) {
             if (o === `__proto__`) continue
-            let s = t.keyType._zod.run({ value: o, issues: [] }, r)
-            if (s instanceof Promise) throw Error(`Async schemas not supported in object keys currently`)
-            if (typeof o == `string` && Yt.test(o) && s.issues.length) {
+            let c = t.keyType._zod.run({ value: o, issues: [] }, r)
+            if (c instanceof Promise) throw Error(`Async schemas not supported in object keys currently`)
+            if (typeof o == `string` && ut.test(o) && c.issues.length) {
               let e = t.keyType._zod.run({ value: Number(o), issues: [] }, r)
               if (e instanceof Promise) throw Error(`Async schemas not supported in object keys currently`)
-              e.issues.length === 0 && (s = e)
+              e.issues.length === 0 && (c = e)
             }
-            if (s.issues.length) {
+            if (c.issues.length) {
               t.mode === `loose`
                 ? (n.value[o] = i[o])
                 : n.issues.push({
                     code: `invalid_key`,
                     origin: `record`,
-                    issues: s.issues.map((e) => A(e, r, C())),
+                    issues: c.issues.map((e) => S(e, r, s())),
                     input: o,
                     path: [o],
                     inst: e
                   })
               continue
             }
-            let c = t.valueType._zod.run({ value: i[o], issues: [] }, r)
-            c instanceof Promise
+            let l = t.valueType._zod.run({ value: i[o], issues: [] }, r)
+            l instanceof Promise
               ? a.push(
-                  c.then((e) => {
-                    e.issues.length && n.issues.push(...tt(o, e.issues)), (n.value[s.value] = e.value)
+                  l.then((e) => {
+                    e.issues.length && n.issues.push(...x(o, e.issues)), (n.value[c.value] = e.value)
                   })
                 )
-              : (c.issues.length && n.issues.push(...tt(o, c.issues)), (n.value[s.value] = c.value))
+              : (l.issues.length && n.issues.push(...x(o, l.issues)), (n.value[c.value] = l.value))
           }
         }
         return a.length ? Promise.all(a).then(() => n) : n
       })
   }),
-  ur = S(`$ZodEnum`, (e, t) => {
-    M.init(e, t)
-    let n = Ae(t.entries),
+  Tn = r(`$ZodEnum`, (e, t) => {
+    T.init(e, t)
+    let n = c(t.entries),
       r = new Set(n)
     ;(e._zod.values = r),
       (e._zod.pattern = RegExp(
         `^(${n
-          .filter((e) => Ue.has(typeof e))
-          .map((e) => (typeof e == `string` ? We(e) : e.toString()))
+          .filter((e) => ce.has(typeof e))
+          .map((e) => (typeof e == `string` ? _(e) : e.toString()))
           .join(`|`)})$`
       )),
       (e._zod.parse = (t, i) => {
@@ -2746,99 +1555,99 @@ const lr = S(`$ZodRecord`, (e, t) => {
         return r.has(a) || t.issues.push({ code: `invalid_value`, values: n, input: a, inst: e }), t
       })
   }),
-  dr = S(`$ZodLiteral`, (e, t) => {
-    if ((M.init(e, t), t.values.length === 0)) throw Error(`Cannot create literal schema with no valid values`)
+  En = r(`$ZodLiteral`, (e, t) => {
+    if ((T.init(e, t), t.values.length === 0)) throw Error(`Cannot create literal schema with no valid values`)
     let n = new Set(t.values)
     ;(e._zod.values = n),
       (e._zod.pattern = RegExp(
-        `^(${t.values.map((e) => (typeof e == `string` ? We(e) : e ? We(e.toString()) : String(e))).join(`|`)})$`
+        `^(${t.values.map((e) => (typeof e == `string` ? _(e) : e ? _(e.toString()) : String(e))).join(`|`)})$`
       )),
       (e._zod.parse = (r, i) => {
         let a = r.value
         return n.has(a) || r.issues.push({ code: `invalid_value`, values: t.values, input: a, inst: e }), r
       })
   }),
-  fr = S(`$ZodTransform`, (e, t) => {
-    M.init(e, t),
+  Dn = r(`$ZodTransform`, (e, t) => {
+    T.init(e, t),
       (e._zod.parse = (n, r) => {
-        if (r.direction === `backward`) throw new Oe(e.constructor.name)
-        let i = t.transform(n.value, n)
-        if (r.async) return (i instanceof Promise ? i : Promise.resolve(i)).then((e) => ((n.value = e), n))
-        if (i instanceof Promise) throw new De()
-        return (n.value = i), n
+        if (r.direction === `backward`) throw new a(e.constructor.name)
+        let o = t.transform(n.value, n)
+        if (r.async) return (o instanceof Promise ? o : Promise.resolve(o)).then((e) => ((n.value = e), n))
+        if (o instanceof Promise) throw new i()
+        return (n.value = o), n
       })
   })
-function pr(e, t) {
+function On(e, t) {
   return e.issues.length && t === void 0 ? { issues: [], value: void 0 } : e
 }
-const mr = S(`$ZodOptional`, (e, t) => {
-    M.init(e, t),
+const kn = r(`$ZodOptional`, (e, t) => {
+    T.init(e, t),
       (e._zod.optin = `optional`),
       (e._zod.optout = `optional`),
-      w(e._zod, `values`, () => (t.innerType._zod.values ? new Set([...t.innerType._zod.values, void 0]) : void 0)),
-      w(e._zod, `pattern`, () => {
+      f(e._zod, `values`, () => (t.innerType._zod.values ? new Set([...t.innerType._zod.values, void 0]) : void 0)),
+      f(e._zod, `pattern`, () => {
         let e = t.innerType._zod.pattern
-        return e ? RegExp(`^(${Pe(e.source)})?$`) : void 0
+        return e ? RegExp(`^(${d(e.source)})?$`) : void 0
       }),
       (e._zod.parse = (e, n) => {
         if (t.innerType._zod.optin === `optional`) {
           let r = t.innerType._zod.run(e, n)
-          return r instanceof Promise ? r.then((t) => pr(t, e.value)) : pr(r, e.value)
+          return r instanceof Promise ? r.then((t) => On(t, e.value)) : On(r, e.value)
         }
         return e.value === void 0 ? e : t.innerType._zod.run(e, n)
       })
   }),
-  hr = S(`$ZodExactOptional`, (e, t) => {
-    mr.init(e, t),
-      w(e._zod, `values`, () => t.innerType._zod.values),
-      w(e._zod, `pattern`, () => t.innerType._zod.pattern),
+  An = r(`$ZodExactOptional`, (e, t) => {
+    kn.init(e, t),
+      f(e._zod, `values`, () => t.innerType._zod.values),
+      f(e._zod, `pattern`, () => t.innerType._zod.pattern),
       (e._zod.parse = (e, n) => t.innerType._zod.run(e, n))
   }),
-  gr = S(`$ZodNullable`, (e, t) => {
-    M.init(e, t),
-      w(e._zod, `optin`, () => t.innerType._zod.optin),
-      w(e._zod, `optout`, () => t.innerType._zod.optout),
-      w(e._zod, `pattern`, () => {
+  jn = r(`$ZodNullable`, (e, t) => {
+    T.init(e, t),
+      f(e._zod, `optin`, () => t.innerType._zod.optin),
+      f(e._zod, `optout`, () => t.innerType._zod.optout),
+      f(e._zod, `pattern`, () => {
         let e = t.innerType._zod.pattern
-        return e ? RegExp(`^(${Pe(e.source)}|null)$`) : void 0
+        return e ? RegExp(`^(${d(e.source)}|null)$`) : void 0
       }),
-      w(e._zod, `values`, () => (t.innerType._zod.values ? new Set([...t.innerType._zod.values, null]) : void 0)),
+      f(e._zod, `values`, () => (t.innerType._zod.values ? new Set([...t.innerType._zod.values, null]) : void 0)),
       (e._zod.parse = (e, n) => (e.value === null ? e : t.innerType._zod.run(e, n)))
   }),
-  _r = S(`$ZodDefault`, (e, t) => {
-    M.init(e, t),
+  Mn = r(`$ZodDefault`, (e, t) => {
+    T.init(e, t),
       (e._zod.optin = `optional`),
-      w(e._zod, `values`, () => t.innerType._zod.values),
+      f(e._zod, `values`, () => t.innerType._zod.values),
       (e._zod.parse = (e, n) => {
         if (n.direction === `backward`) return t.innerType._zod.run(e, n)
         if (e.value === void 0) return (e.value = t.defaultValue), e
         let r = t.innerType._zod.run(e, n)
-        return r instanceof Promise ? r.then((e) => vr(e, t)) : vr(r, t)
+        return r instanceof Promise ? r.then((e) => Nn(e, t)) : Nn(r, t)
       })
   })
-function vr(e, t) {
+function Nn(e, t) {
   return e.value === void 0 && (e.value = t.defaultValue), e
 }
-const yr = S(`$ZodPrefault`, (e, t) => {
-    M.init(e, t),
+const Pn = r(`$ZodPrefault`, (e, t) => {
+    T.init(e, t),
       (e._zod.optin = `optional`),
-      w(e._zod, `values`, () => t.innerType._zod.values),
+      f(e._zod, `values`, () => t.innerType._zod.values),
       (e._zod.parse = (e, n) => (
         n.direction === `backward` || (e.value === void 0 && (e.value = t.defaultValue)), t.innerType._zod.run(e, n)
       ))
   }),
-  br = S(`$ZodNonOptional`, (e, t) => {
-    M.init(e, t),
-      w(e._zod, `values`, () => {
+  Fn = r(`$ZodNonOptional`, (e, t) => {
+    T.init(e, t),
+      f(e._zod, `values`, () => {
         let e = t.innerType._zod.values
         return e ? new Set([...e].filter((e) => e !== void 0)) : void 0
       }),
       (e._zod.parse = (n, r) => {
         let i = t.innerType._zod.run(n, r)
-        return i instanceof Promise ? i.then((t) => xr(t, e)) : xr(i, e)
+        return i instanceof Promise ? i.then((t) => In(t, e)) : In(i, e)
       })
   })
-function xr(e, t) {
+function In(e, t) {
   return (
     !e.issues.length &&
       e.value === void 0 &&
@@ -2846,11 +1655,11 @@ function xr(e, t) {
     e
   )
 }
-const Sr = S(`$ZodCatch`, (e, t) => {
-    M.init(e, t),
-      w(e._zod, `optin`, () => t.innerType._zod.optin),
-      w(e._zod, `optout`, () => t.innerType._zod.optout),
-      w(e._zod, `values`, () => t.innerType._zod.values),
+const Ln = r(`$ZodCatch`, (e, t) => {
+    T.init(e, t),
+      f(e._zod, `optin`, () => t.innerType._zod.optin),
+      f(e._zod, `optout`, () => t.innerType._zod.optout),
+      f(e._zod, `values`, () => t.innerType._zod.values),
       (e._zod.parse = (e, n) => {
         if (n.direction === `backward`) return t.innerType._zod.run(e, n)
         let r = t.innerType._zod.run(e, n)
@@ -2861,7 +1670,7 @@ const Sr = S(`$ZodCatch`, (e, t) => {
                 r.issues.length &&
                   ((e.value = t.catchValue({
                     ...e,
-                    error: { issues: r.issues.map((e) => A(e, n, C())) },
+                    error: { issues: r.issues.map((e) => S(e, n, s())) },
                     input: e.value
                   })),
                   (e.issues = [])),
@@ -2870,63 +1679,63 @@ const Sr = S(`$ZodCatch`, (e, t) => {
             )
           : ((e.value = r.value),
             r.issues.length &&
-              ((e.value = t.catchValue({ ...e, error: { issues: r.issues.map((e) => A(e, n, C())) }, input: e.value })),
+              ((e.value = t.catchValue({ ...e, error: { issues: r.issues.map((e) => S(e, n, s())) }, input: e.value })),
               (e.issues = [])),
             e)
       })
   }),
-  Cr = S(`$ZodPipe`, (e, t) => {
-    M.init(e, t),
-      w(e._zod, `values`, () => t.in._zod.values),
-      w(e._zod, `optin`, () => t.in._zod.optin),
-      w(e._zod, `optout`, () => t.out._zod.optout),
-      w(e._zod, `propValues`, () => t.in._zod.propValues),
+  Rn = r(`$ZodPipe`, (e, t) => {
+    T.init(e, t),
+      f(e._zod, `values`, () => t.in._zod.values),
+      f(e._zod, `optin`, () => t.in._zod.optin),
+      f(e._zod, `optout`, () => t.out._zod.optout),
+      f(e._zod, `propValues`, () => t.in._zod.propValues),
       (e._zod.parse = (e, n) => {
         if (n.direction === `backward`) {
           let r = t.out._zod.run(e, n)
-          return r instanceof Promise ? r.then((e) => wr(e, t.in, n)) : wr(r, t.in, n)
+          return r instanceof Promise ? r.then((e) => D(e, t.in, n)) : D(r, t.in, n)
         }
         let r = t.in._zod.run(e, n)
-        return r instanceof Promise ? r.then((e) => wr(e, t.out, n)) : wr(r, t.out, n)
+        return r instanceof Promise ? r.then((e) => D(e, t.out, n)) : D(r, t.out, n)
       })
   })
-function wr(e, t, n) {
+function D(e, t, n) {
   return e.issues.length ? ((e.aborted = !0), e) : t._zod.run({ value: e.value, issues: e.issues }, n)
 }
-const Tr = S(`$ZodReadonly`, (e, t) => {
-  M.init(e, t),
-    w(e._zod, `propValues`, () => t.innerType._zod.propValues),
-    w(e._zod, `values`, () => t.innerType._zod.values),
-    w(e._zod, `optin`, () => t.innerType?._zod?.optin),
-    w(e._zod, `optout`, () => t.innerType?._zod?.optout),
+const zn = r(`$ZodReadonly`, (e, t) => {
+  T.init(e, t),
+    f(e._zod, `propValues`, () => t.innerType._zod.propValues),
+    f(e._zod, `values`, () => t.innerType._zod.values),
+    f(e._zod, `optin`, () => t.innerType?._zod?.optin),
+    f(e._zod, `optout`, () => t.innerType?._zod?.optout),
     (e._zod.parse = (e, n) => {
       if (n.direction === `backward`) return t.innerType._zod.run(e, n)
       let r = t.innerType._zod.run(e, n)
-      return r instanceof Promise ? r.then(Er) : Er(r)
+      return r instanceof Promise ? r.then(Bn) : Bn(r)
     })
 })
-function Er(e) {
+function Bn(e) {
   return (e.value = Object.freeze(e.value)), e
 }
-const Dr = S(`$ZodCustom`, (e, t) => {
-  j.init(e, t),
-    M.init(e, t),
+const Vn = r(`$ZodCustom`, (e, t) => {
+  w.init(e, t),
+    T.init(e, t),
     (e._zod.parse = (e, t) => e),
     (e._zod.check = (n) => {
       let r = n.value,
         i = t.fn(r)
-      if (i instanceof Promise) return i.then((t) => Or(t, n, r, e))
-      Or(i, n, r, e)
+      if (i instanceof Promise) return i.then((t) => Hn(t, n, r, e))
+      Hn(i, n, r, e)
     })
 })
-function Or(e, t, n, r) {
+function Hn(e, t, n, r) {
   if (!e) {
     let e = { code: `custom`, input: n, inst: r, path: [...(r._zod.def.path ?? [])], continue: !r._zod.def.abort }
-    r._zod.def.params && (e.params = r._zod.def.params), t.issues.push(it(e))
+    r._zod.def.params && (e.params = r._zod.def.params), t.issues.push(C(e))
   }
 }
-var kr,
-  Ar = class {
+var Un,
+  Wn = class {
     constructor() {
       ;(this._map = new WeakMap()), (this._idmap = new Map())
     }
@@ -2955,81 +1764,81 @@ var kr,
       return this._map.has(e)
     }
   }
-function jr() {
-  return new Ar()
+function Gn() {
+  return new Wn()
 }
-;(kr = globalThis).__zod_globalRegistry ?? (kr.__zod_globalRegistry = jr())
-const Mr = globalThis.__zod_globalRegistry
-function Nr(e, t) {
-  return new e({ type: `string`, ...k(t) })
+;(Un = globalThis).__zod_globalRegistry ?? (Un.__zod_globalRegistry = Gn())
+const O = globalThis.__zod_globalRegistry
+function Kn(e, t) {
+  return new e({ type: `string`, ...y(t) })
 }
-function Pr(e, t) {
-  return new e({ type: `string`, format: `email`, check: `string_format`, abort: !1, ...k(t) })
+function qn(e, t) {
+  return new e({ type: `string`, format: `email`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Fr(e, t) {
-  return new e({ type: `string`, format: `guid`, check: `string_format`, abort: !1, ...k(t) })
+function Jn(e, t) {
+  return new e({ type: `string`, format: `guid`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Ir(e, t) {
-  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, ...k(t) })
+function Yn(e, t) {
+  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Lr(e, t) {
-  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v4`, ...k(t) })
+function Xn(e, t) {
+  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v4`, ...y(t) })
 }
-function Rr(e, t) {
-  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v6`, ...k(t) })
+function Zn(e, t) {
+  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v6`, ...y(t) })
 }
-function zr(e, t) {
-  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v7`, ...k(t) })
+function Qn(e, t) {
+  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v7`, ...y(t) })
 }
-function Br(e, t) {
-  return new e({ type: `string`, format: `url`, check: `string_format`, abort: !1, ...k(t) })
+function $n(e, t) {
+  return new e({ type: `string`, format: `url`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Vr(e, t) {
-  return new e({ type: `string`, format: `emoji`, check: `string_format`, abort: !1, ...k(t) })
+function er(e, t) {
+  return new e({ type: `string`, format: `emoji`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Hr(e, t) {
-  return new e({ type: `string`, format: `nanoid`, check: `string_format`, abort: !1, ...k(t) })
+function tr(e, t) {
+  return new e({ type: `string`, format: `nanoid`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Ur(e, t) {
-  return new e({ type: `string`, format: `cuid`, check: `string_format`, abort: !1, ...k(t) })
+function nr(e, t) {
+  return new e({ type: `string`, format: `cuid`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Wr(e, t) {
-  return new e({ type: `string`, format: `cuid2`, check: `string_format`, abort: !1, ...k(t) })
+function rr(e, t) {
+  return new e({ type: `string`, format: `cuid2`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Gr(e, t) {
-  return new e({ type: `string`, format: `ulid`, check: `string_format`, abort: !1, ...k(t) })
+function ir(e, t) {
+  return new e({ type: `string`, format: `ulid`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Kr(e, t) {
-  return new e({ type: `string`, format: `xid`, check: `string_format`, abort: !1, ...k(t) })
+function ar(e, t) {
+  return new e({ type: `string`, format: `xid`, check: `string_format`, abort: !1, ...y(t) })
 }
-function qr(e, t) {
-  return new e({ type: `string`, format: `ksuid`, check: `string_format`, abort: !1, ...k(t) })
+function or(e, t) {
+  return new e({ type: `string`, format: `ksuid`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Jr(e, t) {
-  return new e({ type: `string`, format: `ipv4`, check: `string_format`, abort: !1, ...k(t) })
+function sr(e, t) {
+  return new e({ type: `string`, format: `ipv4`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Yr(e, t) {
-  return new e({ type: `string`, format: `ipv6`, check: `string_format`, abort: !1, ...k(t) })
+function cr(e, t) {
+  return new e({ type: `string`, format: `ipv6`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Xr(e, t) {
-  return new e({ type: `string`, format: `cidrv4`, check: `string_format`, abort: !1, ...k(t) })
+function lr(e, t) {
+  return new e({ type: `string`, format: `cidrv4`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Zr(e, t) {
-  return new e({ type: `string`, format: `cidrv6`, check: `string_format`, abort: !1, ...k(t) })
+function ur(e, t) {
+  return new e({ type: `string`, format: `cidrv6`, check: `string_format`, abort: !1, ...y(t) })
 }
-function Qr(e, t) {
-  return new e({ type: `string`, format: `base64`, check: `string_format`, abort: !1, ...k(t) })
+function dr(e, t) {
+  return new e({ type: `string`, format: `base64`, check: `string_format`, abort: !1, ...y(t) })
 }
-function $r(e, t) {
-  return new e({ type: `string`, format: `base64url`, check: `string_format`, abort: !1, ...k(t) })
+function fr(e, t) {
+  return new e({ type: `string`, format: `base64url`, check: `string_format`, abort: !1, ...y(t) })
 }
-function ei(e, t) {
-  return new e({ type: `string`, format: `e164`, check: `string_format`, abort: !1, ...k(t) })
+function pr(e, t) {
+  return new e({ type: `string`, format: `e164`, check: `string_format`, abort: !1, ...y(t) })
 }
-function ti(e, t) {
-  return new e({ type: `string`, format: `jwt`, check: `string_format`, abort: !1, ...k(t) })
+function mr(e, t) {
+  return new e({ type: `string`, format: `jwt`, check: `string_format`, abort: !1, ...y(t) })
 }
-function ni(e, t) {
+function hr(e, t) {
   return new e({
     type: `string`,
     format: `datetime`,
@@ -3037,104 +1846,104 @@ function ni(e, t) {
     offset: !1,
     local: !1,
     precision: null,
-    ...k(t)
+    ...y(t)
   })
 }
-function ri(e, t) {
-  return new e({ type: `string`, format: `date`, check: `string_format`, ...k(t) })
+function gr(e, t) {
+  return new e({ type: `string`, format: `date`, check: `string_format`, ...y(t) })
 }
-function ii(e, t) {
-  return new e({ type: `string`, format: `time`, check: `string_format`, precision: null, ...k(t) })
+function _r(e, t) {
+  return new e({ type: `string`, format: `time`, check: `string_format`, precision: null, ...y(t) })
 }
-function ai(e, t) {
-  return new e({ type: `string`, format: `duration`, check: `string_format`, ...k(t) })
+function vr(e, t) {
+  return new e({ type: `string`, format: `duration`, check: `string_format`, ...y(t) })
 }
-function oi(e, t) {
-  return new e({ type: `number`, checks: [], ...k(t) })
+function yr(e, t) {
+  return new e({ type: `number`, checks: [], ...y(t) })
 }
-function si(e, t) {
-  return new e({ type: `number`, check: `number_format`, abort: !1, format: `safeint`, ...k(t) })
+function br(e, t) {
+  return new e({ type: `number`, check: `number_format`, abort: !1, format: `safeint`, ...y(t) })
 }
-function ci(e, t) {
-  return new e({ type: `boolean`, ...k(t) })
+function xr(e, t) {
+  return new e({ type: `boolean`, ...y(t) })
 }
-function li(e) {
+function Sr(e) {
   return new e({ type: `unknown` })
 }
-function ui(e, t) {
-  return new e({ type: `never`, ...k(t) })
+function Cr(e, t) {
+  return new e({ type: `never`, ...y(t) })
 }
-function di(e, t) {
-  return new en({ check: `less_than`, ...k(t), value: e, inclusive: !1 })
+function wr(e, t) {
+  return new ht({ check: `less_than`, ...y(t), value: e, inclusive: !1 })
 }
-function fi(e, t) {
-  return new en({ check: `less_than`, ...k(t), value: e, inclusive: !0 })
+function Tr(e, t) {
+  return new ht({ check: `less_than`, ...y(t), value: e, inclusive: !0 })
 }
-function pi(e, t) {
-  return new tn({ check: `greater_than`, ...k(t), value: e, inclusive: !1 })
+function Er(e, t) {
+  return new gt({ check: `greater_than`, ...y(t), value: e, inclusive: !1 })
 }
-function mi(e, t) {
-  return new tn({ check: `greater_than`, ...k(t), value: e, inclusive: !0 })
+function Dr(e, t) {
+  return new gt({ check: `greater_than`, ...y(t), value: e, inclusive: !0 })
 }
-function hi(e, t) {
-  return new nn({ check: `multiple_of`, ...k(t), value: e })
+function Or(e, t) {
+  return new _t({ check: `multiple_of`, ...y(t), value: e })
 }
-function gi(e, t) {
-  return new an({ check: `max_length`, ...k(t), maximum: e })
+function kr(e, t) {
+  return new yt({ check: `max_length`, ...y(t), maximum: e })
 }
-function _i(e, t) {
-  return new on({ check: `min_length`, ...k(t), minimum: e })
+function Ar(e, t) {
+  return new bt({ check: `min_length`, ...y(t), minimum: e })
 }
-function vi(e, t) {
-  return new sn({ check: `length_equals`, ...k(t), length: e })
+function jr(e, t) {
+  return new xt({ check: `length_equals`, ...y(t), length: e })
 }
-function yi(e, t) {
-  return new ln({ check: `string_format`, format: `regex`, ...k(t), pattern: e })
+function Mr(e, t) {
+  return new Ct({ check: `string_format`, format: `regex`, ...y(t), pattern: e })
 }
-function bi(e) {
-  return new un({ check: `string_format`, format: `lowercase`, ...k(e) })
+function Nr(e) {
+  return new wt({ check: `string_format`, format: `lowercase`, ...y(e) })
 }
-function xi(e) {
-  return new dn({ check: `string_format`, format: `uppercase`, ...k(e) })
+function Pr(e) {
+  return new Tt({ check: `string_format`, format: `uppercase`, ...y(e) })
 }
-function Si(e, t) {
-  return new fn({ check: `string_format`, format: `includes`, ...k(t), includes: e })
+function Fr(e, t) {
+  return new Et({ check: `string_format`, format: `includes`, ...y(t), includes: e })
 }
-function Ci(e, t) {
-  return new pn({ check: `string_format`, format: `starts_with`, ...k(t), prefix: e })
+function Ir(e, t) {
+  return new Dt({ check: `string_format`, format: `starts_with`, ...y(t), prefix: e })
 }
-function wi(e, t) {
-  return new mn({ check: `string_format`, format: `ends_with`, ...k(t), suffix: e })
+function Lr(e, t) {
+  return new Ot({ check: `string_format`, format: `ends_with`, ...y(t), suffix: e })
 }
-function P(e) {
-  return new hn({ check: `overwrite`, tx: e })
+function k(e) {
+  return new kt({ check: `overwrite`, tx: e })
 }
-function Ti(e) {
-  return P((t) => t.normalize(e))
+function Rr(e) {
+  return k((t) => t.normalize(e))
 }
-function Ei() {
-  return P((e) => e.trim())
+function zr() {
+  return k((e) => e.trim())
 }
-function Di() {
-  return P((e) => e.toLowerCase())
+function Br() {
+  return k((e) => e.toLowerCase())
 }
-function Oi() {
-  return P((e) => e.toUpperCase())
+function Vr() {
+  return k((e) => e.toUpperCase())
 }
-function ki() {
-  return P((e) => Re(e))
+function Hr() {
+  return k((e) => ie(e))
 }
-function Ai(e, t, n) {
-  return new e({ type: `array`, element: t, ...k(n) })
+function Ur(e, t, n) {
+  return new e({ type: `array`, element: t, ...y(n) })
 }
-function ji(e, t, n) {
-  return new e({ type: `custom`, check: `custom`, fn: t, ...k(n) })
+function Wr(e, t, n) {
+  return new e({ type: `custom`, check: `custom`, fn: t, ...y(n) })
 }
-function Mi(e) {
-  let t = Ni(
+function Gr(e) {
+  let t = Kr(
     (n) => (
       (n.addIssue = (e) => {
-        if (typeof e == `string`) n.issues.push(it(e, n.value, t._zod.def))
+        if (typeof e == `string`) n.issues.push(C(e, n.value, t._zod.def))
         else {
           let r = e
           r.fatal && (r.continue = !1),
@@ -3142,7 +1951,7 @@ function Mi(e) {
             (r.input ??= n.value),
             (r.inst ??= t),
             (r.continue ??= !t._zod.def.abort),
-            n.issues.push(it(r))
+            n.issues.push(C(r))
         }
       }),
       e(n.value, n)
@@ -3150,18 +1959,18 @@ function Mi(e) {
   )
   return t
 }
-function Ni(e, t) {
-  let n = new j({ check: `custom`, ...k(t) })
+function Kr(e, t) {
+  let n = new w({ check: `custom`, ...y(t) })
   return (n._zod.check = e), n
 }
-function Pi(e) {
+function qr(e) {
   let t = e?.target ?? `draft-2020-12`
   return (
     t === `draft-4` && (t = `draft-04`),
     t === `draft-7` && (t = `draft-07`),
     {
       processors: e.processors ?? {},
-      metadataRegistry: e?.metadata ?? Mr,
+      metadataRegistry: e?.metadata ?? O,
       target: t,
       unrepresentable: e?.unrepresentable ?? `throw`,
       override: e?.override ?? (() => {}),
@@ -3174,7 +1983,7 @@ function Pi(e) {
     }
   )
 }
-function F(e, t, n = { path: [], schemaPath: [] }) {
+function A(e, t, n = { path: [], schemaPath: [] }) {
   var r
   let i = e._zod.def,
     a = t.seen.get(e)
@@ -3193,18 +2002,18 @@ function F(e, t, n = { path: [], schemaPath: [] }) {
       a(e, t, n, r)
     }
     let a = e._zod.parent
-    a && ((o.ref ||= a), F(a, t, r), (t.seen.get(a).isParent = !0))
+    a && ((o.ref ||= a), A(a, t, r), (t.seen.get(a).isParent = !0))
   }
   let c = t.metadataRegistry.get(e)
   return (
     c && Object.assign(o.schema, c),
-    t.io === `input` && I(e) && (delete o.schema.examples, delete o.schema.default),
+    t.io === `input` && j(e) && (delete o.schema.examples, delete o.schema.default),
     t.io === `input` && o.schema._prefault && ((r = o.schema).default ?? (r.default = o.schema._prefault)),
     delete o.schema._prefault,
     t.seen.get(e).schema
   )
 }
-function Fi(e, t) {
+function Jr(e, t) {
   let n = e.seen.get(t)
   if (!n) throw Error(`Unprocessed schema. This is a bug in Zod.`)
   let r = new Map()
@@ -3277,7 +2086,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   }
 }
-function Ii(e, t) {
+function Yr(e, t) {
   let n = e.seen.get(t)
   if (!n) throw Error(`Unprocessed schema. This is a bug in Zod.`)
   let r = (t) => {
@@ -3345,7 +2154,7 @@ function Ii(e, t) {
       Object.defineProperty(n, `~standard`, {
         value: {
           ...t[`~standard`],
-          jsonSchema: { input: Ri(t, `input`, e.processors), output: Ri(t, `output`, e.processors) }
+          jsonSchema: { input: Zr(t, `input`, e.processors), output: Zr(t, `output`, e.processors) }
         },
         enumerable: !1,
         writable: !1
@@ -3356,15 +2165,15 @@ function Ii(e, t) {
     throw Error(`Error converting schema to JSON.`)
   }
 }
-function I(e, t) {
+function j(e, t) {
   let n = t ?? { seen: new Set() }
   if (n.seen.has(e)) return !1
   n.seen.add(e)
   let r = e._zod.def
   if (r.type === `transform`) return !0
-  if (r.type === `array`) return I(r.element, n)
-  if (r.type === `set`) return I(r.valueType, n)
-  if (r.type === `lazy`) return I(r.getter(), n)
+  if (r.type === `array`) return j(r.element, n)
+  if (r.type === `set`) return j(r.valueType, n)
+  if (r.type === `lazy`) return j(r.getter(), n)
   if (
     r.type === `promise` ||
     r.type === `optional` ||
@@ -3374,46 +2183,46 @@ function I(e, t) {
     r.type === `default` ||
     r.type === `prefault`
   )
-    return I(r.innerType, n)
-  if (r.type === `intersection`) return I(r.left, n) || I(r.right, n)
-  if (r.type === `record` || r.type === `map`) return I(r.keyType, n) || I(r.valueType, n)
-  if (r.type === `pipe`) return I(r.in, n) || I(r.out, n)
+    return j(r.innerType, n)
+  if (r.type === `intersection`) return j(r.left, n) || j(r.right, n)
+  if (r.type === `record` || r.type === `map`) return j(r.keyType, n) || j(r.valueType, n)
+  if (r.type === `pipe`) return j(r.in, n) || j(r.out, n)
   if (r.type === `object`) {
-    for (let e in r.shape) if (I(r.shape[e], n)) return !0
+    for (let e in r.shape) if (j(r.shape[e], n)) return !0
     return !1
   }
   if (r.type === `union`) {
-    for (let e of r.options) if (I(e, n)) return !0
+    for (let e of r.options) if (j(e, n)) return !0
     return !1
   }
   if (r.type === `tuple`) {
-    for (let e of r.items) if (I(e, n)) return !0
-    return !!(r.rest && I(r.rest, n))
+    for (let e of r.items) if (j(e, n)) return !0
+    return !!(r.rest && j(r.rest, n))
   }
   return !1
 }
-const Li =
+const Xr =
     (e, t = {}) =>
     (n) => {
-      let r = Pi({ ...n, processors: t })
-      return F(e, r), Fi(r, e), Ii(r, e)
+      let r = qr({ ...n, processors: t })
+      return A(e, r), Jr(r, e), Yr(r, e)
     },
-  Ri =
+  Zr =
     (e, t, n = {}) =>
     (r) => {
       let { libraryOptions: i, target: a } = r ?? {},
-        o = Pi({ ...(i ?? {}), target: a, io: t, processors: n })
-      return F(e, o), Fi(o, e), Ii(o, e)
+        o = qr({ ...(i ?? {}), target: a, io: t, processors: n })
+      return A(e, o), Jr(o, e), Yr(o, e)
     },
-  zi = { guid: `uuid`, url: `uri`, datetime: `date-time`, json_string: `json-string`, regex: `` },
-  Bi = (e, t, n, r) => {
+  Qr = { guid: `uuid`, url: `uri`, datetime: `date-time`, json_string: `json-string`, regex: `` },
+  $r = (e, t, n, r) => {
     let i = n
     i.type = `string`
     let { minimum: a, maximum: o, format: s, patterns: c, contentEncoding: l } = e._zod.bag
     if (
       (typeof a == `number` && (i.minLength = a),
       typeof o == `number` && (i.maxLength = o),
-      s && ((i.format = zi[s] ?? s), i.format === `` && delete i.format, s === `time` && delete i.format),
+      s && ((i.format = Qr[s] ?? s), i.format === `` && delete i.format, s === `time` && delete i.format),
       l && (i.contentEncoding = l),
       c && c.size > 0)
     ) {
@@ -3431,7 +2240,7 @@ const Li =
           ])
     }
   },
-  Vi = (e, t, n, r) => {
+  ei = (e, t, n, r) => {
     let i = n,
       { minimum: a, maximum: o, format: s, multipleOf: c, exclusiveMaximum: l, exclusiveMinimum: u } = e._zod.bag
     typeof s == `string` && s.includes(`int`) ? (i.type = `integer`) : (i.type = `number`),
@@ -3451,20 +2260,20 @@ const Li =
         typeof l == `number` && t.target !== `draft-04` && (l <= o ? delete i.maximum : delete i.exclusiveMaximum)),
       typeof c == `number` && (i.multipleOf = c)
   },
-  Hi = (e, t, n, r) => {
+  ti = (e, t, n, r) => {
     n.type = `boolean`
   },
-  Ui = (e, t, n, r) => {
+  ni = (e, t, n, r) => {
     n.not = {}
   },
-  Wi = (e, t, n, r) => {
+  ri = (e, t, n, r) => {
     let i = e._zod.def,
-      a = Ae(i.entries)
+      a = c(i.entries)
     a.every((e) => typeof e == `number`) && (n.type = `number`),
       a.every((e) => typeof e == `string`) && (n.type = `string`),
       (n.enum = a)
   },
-  Gi = (e, t, n, r) => {
+  ii = (e, t, n, r) => {
     let i = e._zod.def,
       a = []
     for (let e of i.values)
@@ -3486,27 +2295,27 @@ const Li =
           a.every((e) => e === null) && (n.type = `null`),
           (n.enum = a)
   },
-  Ki = (e, t, n, r) => {
+  ai = (e, t, n, r) => {
     if (t.unrepresentable === `throw`) throw Error(`Custom types cannot be represented in JSON Schema`)
   },
-  qi = (e, t, n, r) => {
+  oi = (e, t, n, r) => {
     if (t.unrepresentable === `throw`) throw Error(`Transforms cannot be represented in JSON Schema`)
   },
-  Ji = (e, t, n, r) => {
+  si = (e, t, n, r) => {
     let i = n,
       a = e._zod.def,
       { minimum: o, maximum: s } = e._zod.bag
     typeof o == `number` && (i.minItems = o),
       typeof s == `number` && (i.maxItems = s),
       (i.type = `array`),
-      (i.items = F(a.element, t, { ...r, path: [...r.path, `items`] }))
+      (i.items = A(a.element, t, { ...r, path: [...r.path, `items`] }))
   },
-  Yi = (e, t, n, r) => {
+  ci = (e, t, n, r) => {
     let i = n,
       a = e._zod.def
     ;(i.type = `object`), (i.properties = {})
     let o = a.shape
-    for (let e in o) i.properties[e] = F(o[e], t, { ...r, path: [...r.path, `properties`, e] })
+    for (let e in o) i.properties[e] = A(o[e], t, { ...r, path: [...r.path, `properties`, e] })
     let s = new Set(Object.keys(o)),
       c = new Set(
         [...s].filter((e) => {
@@ -3519,69 +2328,69 @@ const Li =
         ? (i.additionalProperties = !1)
         : a.catchall
           ? a.catchall &&
-            (i.additionalProperties = F(a.catchall, t, { ...r, path: [...r.path, `additionalProperties`] }))
+            (i.additionalProperties = A(a.catchall, t, { ...r, path: [...r.path, `additionalProperties`] }))
           : t.io === `output` && (i.additionalProperties = !1)
   },
-  Xi = (e, t, n, r) => {
+  li = (e, t, n, r) => {
     let i = e._zod.def,
       a = i.inclusive === !1,
-      o = i.options.map((e, n) => F(e, t, { ...r, path: [...r.path, a ? `oneOf` : `anyOf`, n] }))
+      o = i.options.map((e, n) => A(e, t, { ...r, path: [...r.path, a ? `oneOf` : `anyOf`, n] }))
     a ? (n.oneOf = o) : (n.anyOf = o)
   },
-  Zi = (e, t, n, r) => {
+  ui = (e, t, n, r) => {
     let i = e._zod.def,
-      a = F(i.left, t, { ...r, path: [...r.path, `allOf`, 0] }),
-      o = F(i.right, t, { ...r, path: [...r.path, `allOf`, 1] }),
+      a = A(i.left, t, { ...r, path: [...r.path, `allOf`, 0] }),
+      o = A(i.right, t, { ...r, path: [...r.path, `allOf`, 1] }),
       s = (e) => `allOf` in e && Object.keys(e).length === 1
     n.allOf = [...(s(a) ? a.allOf : [a]), ...(s(o) ? o.allOf : [o])]
   },
-  Qi = (e, t, n, r) => {
+  di = (e, t, n, r) => {
     let i = n,
       a = e._zod.def
     i.type = `object`
     let o = a.keyType,
       s = o._zod.bag?.patterns
     if (a.mode === `loose` && s && s.size > 0) {
-      let e = F(a.valueType, t, { ...r, path: [...r.path, `patternProperties`, `*`] })
+      let e = A(a.valueType, t, { ...r, path: [...r.path, `patternProperties`, `*`] })
       i.patternProperties = {}
       for (let t of s) i.patternProperties[t.source] = e
     } else
       (t.target === `draft-07` || t.target === `draft-2020-12`) &&
-        (i.propertyNames = F(a.keyType, t, { ...r, path: [...r.path, `propertyNames`] })),
-        (i.additionalProperties = F(a.valueType, t, { ...r, path: [...r.path, `additionalProperties`] }))
+        (i.propertyNames = A(a.keyType, t, { ...r, path: [...r.path, `propertyNames`] })),
+        (i.additionalProperties = A(a.valueType, t, { ...r, path: [...r.path, `additionalProperties`] }))
     let c = o._zod.values
     if (c) {
       let e = [...c].filter((e) => typeof e == `string` || typeof e == `number`)
       e.length > 0 && (i.required = e)
     }
   },
-  $i = (e, t, n, r) => {
+  fi = (e, t, n, r) => {
     let i = e._zod.def,
-      a = F(i.innerType, t, r),
+      a = A(i.innerType, t, r),
       o = t.seen.get(e)
     t.target === `openapi-3.0` ? ((o.ref = i.innerType), (n.nullable = !0)) : (n.anyOf = [a, { type: `null` }])
   },
-  ea = (e, t, n, r) => {
+  pi = (e, t, n, r) => {
     let i = e._zod.def
-    F(i.innerType, t, r)
+    A(i.innerType, t, r)
     let a = t.seen.get(e)
     a.ref = i.innerType
   },
-  ta = (e, t, n, r) => {
+  mi = (e, t, n, r) => {
     let i = e._zod.def
-    F(i.innerType, t, r)
+    A(i.innerType, t, r)
     let a = t.seen.get(e)
     ;(a.ref = i.innerType), (n.default = JSON.parse(JSON.stringify(i.defaultValue)))
   },
-  na = (e, t, n, r) => {
+  hi = (e, t, n, r) => {
     let i = e._zod.def
-    F(i.innerType, t, r)
+    A(i.innerType, t, r)
     let a = t.seen.get(e)
     ;(a.ref = i.innerType), t.io === `input` && (n._prefault = JSON.parse(JSON.stringify(i.defaultValue)))
   },
-  ra = (e, t, n, r) => {
+  gi = (e, t, n, r) => {
     let i = e._zod.def
-    F(i.innerType, t, r)
+    A(i.innerType, t, r)
     let a = t.seen.get(e)
     a.ref = i.innerType
     let o
@@ -3592,63 +2401,63 @@ const Li =
     }
     n.default = o
   },
-  ia = (e, t, n, r) => {
+  _i = (e, t, n, r) => {
     let i = e._zod.def,
       a = t.io === `input` ? (i.in._zod.def.type === `transform` ? i.out : i.in) : i.out
-    F(a, t, r)
+    A(a, t, r)
     let o = t.seen.get(e)
     o.ref = a
   },
-  aa = (e, t, n, r) => {
+  vi = (e, t, n, r) => {
     let i = e._zod.def
-    F(i.innerType, t, r)
+    A(i.innerType, t, r)
     let a = t.seen.get(e)
     ;(a.ref = i.innerType), (n.readOnly = !0)
   },
-  oa = (e, t, n, r) => {
+  yi = (e, t, n, r) => {
     let i = e._zod.def
-    F(i.innerType, t, r)
+    A(i.innerType, t, r)
     let a = t.seen.get(e)
     a.ref = i.innerType
   },
-  sa = S(`ZodISODateTime`, (e, t) => {
-    An.init(e, t), B.init(e, t)
+  bi = r(`ZodISODateTime`, (e, t) => {
+    Wt.init(e, t), F.init(e, t)
   })
-function ca(e) {
-  return ni(sa, e)
+function xi(e) {
+  return hr(bi, e)
 }
-const la = S(`ZodISODate`, (e, t) => {
-  jn.init(e, t), B.init(e, t)
+const Si = r(`ZodISODate`, (e, t) => {
+  Gt.init(e, t), F.init(e, t)
 })
-function ua(e) {
-  return ri(la, e)
+function Ci(e) {
+  return gr(Si, e)
 }
-const da = S(`ZodISOTime`, (e, t) => {
-  Mn.init(e, t), B.init(e, t)
+const wi = r(`ZodISOTime`, (e, t) => {
+  Kt.init(e, t), F.init(e, t)
 })
-function fa(e) {
-  return ii(da, e)
+function Ti(e) {
+  return _r(wi, e)
 }
-const pa = S(`ZodISODuration`, (e, t) => {
-  Nn.init(e, t), B.init(e, t)
+const Ei = r(`ZodISODuration`, (e, t) => {
+  qt.init(e, t), F.init(e, t)
 })
-function ma(e) {
-  return ai(pa, e)
+function Di(e) {
+  return vr(Ei, e)
 }
-const ha = (e, t) => {
-  ot.init(e, t),
+const Oi = (e, t) => {
+  xe.init(e, t),
     (e.name = `ZodError`),
     Object.defineProperties(e, {
-      format: { value: (t) => lt(e, t) },
-      flatten: { value: (t) => ct(e, t) },
+      format: { value: (t) => we(e, t) },
+      flatten: { value: (t) => Ce(e, t) },
       addIssue: {
         value: (t) => {
-          e.issues.push(t), (e.message = JSON.stringify(e.issues, je, 2))
+          e.issues.push(t), (e.message = JSON.stringify(e.issues, l, 2))
         }
       },
       addIssues: {
         value: (t) => {
-          e.issues.push(...t), (e.message = JSON.stringify(e.issues, je, 2))
+          e.issues.push(...t), (e.message = JSON.stringify(e.issues, l, 2))
         }
       },
       isEmpty: {
@@ -3658,32 +2467,32 @@ const ha = (e, t) => {
       }
     })
 }
-S(`ZodError`, ha)
-const L = S(`ZodError`, ha, { Parent: Error }),
-  ga = ut(L),
-  _a = dt(L),
-  va = ft(L),
-  ya = mt(L),
-  ba = gt(L),
-  xa = _t(L),
-  Sa = vt(L),
-  Ca = yt(L),
-  wa = bt(L),
-  Ta = xt(L),
-  Ea = St(L),
-  Da = Ct(L),
-  R = S(
+r(`ZodError`, Oi)
+const M = r(`ZodError`, Oi, { Parent: Error }),
+  ki = Te(M),
+  Ai = Ee(M),
+  ji = De(M),
+  Mi = ke(M),
+  Ni = je(M),
+  Pi = Me(M),
+  Fi = Ne(M),
+  Ii = Pe(M),
+  Li = Fe(M),
+  Ri = Ie(M),
+  zi = Le(M),
+  Bi = Re(M),
+  N = r(
     `ZodType`,
     (e, t) => (
-      M.init(e, t),
-      Object.assign(e[`~standard`], { jsonSchema: { input: Ri(e, `input`), output: Ri(e, `output`) } }),
-      (e.toJSONSchema = Li(e, {})),
+      T.init(e, t),
+      Object.assign(e[`~standard`], { jsonSchema: { input: Zr(e, `input`), output: Zr(e, `output`) } }),
+      (e.toJSONSchema = Xr(e, {})),
       (e.def = t),
       (e.type = t.type),
       Object.defineProperty(e, `_def`, { value: t }),
       (e.check = (...n) =>
         e.clone(
-          E(t, {
+          m(t, {
             checks: [
               ...(t.checks ?? []),
               ...n.map((e) =>
@@ -3694,53 +2503,53 @@ const L = S(`ZodError`, ha, { Parent: Error }),
           { parent: !0 }
         )),
       (e.with = e.check),
-      (e.clone = (t, n) => O(e, t, n)),
+      (e.clone = (t, n) => v(e, t, n)),
       (e.brand = () => e),
       (e.register = (t, n) => (t.add(e, n), e)),
-      (e.parse = (t, n) => ga(e, t, n, { callee: e.parse })),
-      (e.safeParse = (t, n) => va(e, t, n)),
-      (e.parseAsync = async (t, n) => _a(e, t, n, { callee: e.parseAsync })),
-      (e.safeParseAsync = async (t, n) => ya(e, t, n)),
+      (e.parse = (t, n) => ki(e, t, n, { callee: e.parse })),
+      (e.safeParse = (t, n) => ji(e, t, n)),
+      (e.parseAsync = async (t, n) => Ai(e, t, n, { callee: e.parseAsync })),
+      (e.safeParseAsync = async (t, n) => Mi(e, t, n)),
       (e.spa = e.safeParseAsync),
-      (e.encode = (t, n) => ba(e, t, n)),
-      (e.decode = (t, n) => xa(e, t, n)),
-      (e.encodeAsync = async (t, n) => Sa(e, t, n)),
-      (e.decodeAsync = async (t, n) => Ca(e, t, n)),
-      (e.safeEncode = (t, n) => wa(e, t, n)),
-      (e.safeDecode = (t, n) => Ta(e, t, n)),
-      (e.safeEncodeAsync = async (t, n) => Ea(e, t, n)),
-      (e.safeDecodeAsync = async (t, n) => Da(e, t, n)),
-      (e.refine = (t, n) => e.check(Lo(t, n))),
-      (e.superRefine = (t) => e.check(Ro(t))),
-      (e.overwrite = (t) => e.check(P(t))),
-      (e.optional = () => yo(e)),
-      (e.exactOptional = () => xo(e)),
-      (e.nullable = () => Co(e)),
-      (e.nullish = () => yo(Co(e))),
-      (e.nonoptional = (t) => ko(e, t)),
-      (e.array = () => W(e)),
-      (e.or = (t) => oo([e, t])),
-      (e.and = (t) => lo(e, t)),
-      (e.transform = (t) => No(e, _o(t))),
-      (e.default = (t) => To(e, t)),
-      (e.prefault = (t) => Do(e, t)),
-      (e.catch = (t) => jo(e, t)),
-      (e.pipe = (t) => No(e, t)),
-      (e.readonly = () => Fo(e)),
+      (e.encode = (t, n) => Ni(e, t, n)),
+      (e.decode = (t, n) => Pi(e, t, n)),
+      (e.encodeAsync = async (t, n) => Fi(e, t, n)),
+      (e.decodeAsync = async (t, n) => Ii(e, t, n)),
+      (e.safeEncode = (t, n) => Li(e, t, n)),
+      (e.safeDecode = (t, n) => Ri(e, t, n)),
+      (e.safeEncodeAsync = async (t, n) => zi(e, t, n)),
+      (e.safeDecodeAsync = async (t, n) => Bi(e, t, n)),
+      (e.refine = (t, n) => e.check(Ka(t, n))),
+      (e.superRefine = (t) => e.check(qa(t))),
+      (e.overwrite = (t) => e.check(k(t))),
+      (e.optional = () => Oa(e)),
+      (e.exactOptional = () => Aa(e)),
+      (e.nullable = () => Ma(e)),
+      (e.nullish = () => Oa(Ma(e))),
+      (e.nonoptional = (t) => Ra(e, t)),
+      (e.array = () => V(e)),
+      (e.or = (t) => _a([e, t])),
+      (e.and = (t) => ba(e, t)),
+      (e.transform = (t) => Ha(e, Ea(t))),
+      (e.default = (t) => Pa(e, t)),
+      (e.prefault = (t) => Ia(e, t)),
+      (e.catch = (t) => Ba(e, t)),
+      (e.pipe = (t) => Ha(e, t)),
+      (e.readonly = () => Wa(e)),
       (e.describe = (t) => {
         let n = e.clone()
-        return Mr.add(n, { description: t }), n
+        return O.add(n, { description: t }), n
       }),
       Object.defineProperty(e, `description`, {
         get() {
-          return Mr.get(e)?.description
+          return O.get(e)?.description
         },
         configurable: !0
       }),
       (e.meta = (...t) => {
-        if (t.length === 0) return Mr.get(e)
+        if (t.length === 0) return O.get(e)
         let n = e.clone()
-        return Mr.add(n, t[0]), n
+        return O.add(n, t[0]), n
       }),
       (e.isOptional = () => e.safeParse(void 0).success),
       (e.isNullable = () => e.safeParse(null).success),
@@ -3748,143 +2557,143 @@ const L = S(`ZodError`, ha, { Parent: Error }),
       e
     )
   ),
-  Oa = S(`_ZodString`, (e, t) => {
-    vn.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Bi(e, t, n, r))
+  Vi = r(`_ZodString`, (e, t) => {
+    Mt.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => $r(e, t, n, r))
     let n = e._zod.bag
     ;(e.format = n.format ?? null),
       (e.minLength = n.minimum ?? null),
       (e.maxLength = n.maximum ?? null),
-      (e.regex = (...t) => e.check(yi(...t))),
-      (e.includes = (...t) => e.check(Si(...t))),
-      (e.startsWith = (...t) => e.check(Ci(...t))),
-      (e.endsWith = (...t) => e.check(wi(...t))),
-      (e.min = (...t) => e.check(_i(...t))),
-      (e.max = (...t) => e.check(gi(...t))),
-      (e.length = (...t) => e.check(vi(...t))),
-      (e.nonempty = (...t) => e.check(_i(1, ...t))),
-      (e.lowercase = (t) => e.check(bi(t))),
-      (e.uppercase = (t) => e.check(xi(t))),
-      (e.trim = () => e.check(Ei())),
-      (e.normalize = (...t) => e.check(Ti(...t))),
-      (e.toLowerCase = () => e.check(Di())),
-      (e.toUpperCase = () => e.check(Oi())),
-      (e.slugify = () => e.check(ki()))
+      (e.regex = (...t) => e.check(Mr(...t))),
+      (e.includes = (...t) => e.check(Fr(...t))),
+      (e.startsWith = (...t) => e.check(Ir(...t))),
+      (e.endsWith = (...t) => e.check(Lr(...t))),
+      (e.min = (...t) => e.check(Ar(...t))),
+      (e.max = (...t) => e.check(kr(...t))),
+      (e.length = (...t) => e.check(jr(...t))),
+      (e.nonempty = (...t) => e.check(Ar(1, ...t))),
+      (e.lowercase = (t) => e.check(Nr(t))),
+      (e.uppercase = (t) => e.check(Pr(t))),
+      (e.trim = () => e.check(zr())),
+      (e.normalize = (...t) => e.check(Rr(...t))),
+      (e.toLowerCase = () => e.check(Br())),
+      (e.toUpperCase = () => e.check(Vr())),
+      (e.slugify = () => e.check(Hr()))
   }),
-  ka = S(`ZodString`, (e, t) => {
-    vn.init(e, t),
-      Oa.init(e, t),
-      (e.email = (t) => e.check(Pr(Aa, t))),
-      (e.url = (t) => e.check(Br(Na, t))),
-      (e.jwt = (t) => e.check(ti(Ja, t))),
-      (e.emoji = (t) => e.check(Vr(Pa, t))),
-      (e.guid = (t) => e.check(Fr(ja, t))),
-      (e.uuid = (t) => e.check(Ir(Ma, t))),
-      (e.uuidv4 = (t) => e.check(Lr(Ma, t))),
-      (e.uuidv6 = (t) => e.check(Rr(Ma, t))),
-      (e.uuidv7 = (t) => e.check(zr(Ma, t))),
-      (e.nanoid = (t) => e.check(Hr(Fa, t))),
-      (e.guid = (t) => e.check(Fr(ja, t))),
-      (e.cuid = (t) => e.check(Ur(Ia, t))),
-      (e.cuid2 = (t) => e.check(Wr(La, t))),
-      (e.ulid = (t) => e.check(Gr(Ra, t))),
-      (e.base64 = (t) => e.check(Qr(Ga, t))),
-      (e.base64url = (t) => e.check($r(Ka, t))),
-      (e.xid = (t) => e.check(Kr(za, t))),
-      (e.ksuid = (t) => e.check(qr(Ba, t))),
-      (e.ipv4 = (t) => e.check(Jr(Va, t))),
-      (e.ipv6 = (t) => e.check(Yr(Ha, t))),
-      (e.cidrv4 = (t) => e.check(Xr(Ua, t))),
-      (e.cidrv6 = (t) => e.check(Zr(Wa, t))),
-      (e.e164 = (t) => e.check(ei(qa, t))),
-      (e.datetime = (t) => e.check(ca(t))),
-      (e.date = (t) => e.check(ua(t))),
-      (e.time = (t) => e.check(fa(t))),
-      (e.duration = (t) => e.check(ma(t)))
+  Hi = r(`ZodString`, (e, t) => {
+    Mt.init(e, t),
+      Vi.init(e, t),
+      (e.email = (t) => e.check(qn(Ui, t))),
+      (e.url = (t) => e.check($n(Gi, t))),
+      (e.jwt = (t) => e.check(mr(oa, t))),
+      (e.emoji = (t) => e.check(er(Ki, t))),
+      (e.guid = (t) => e.check(Jn(Wi, t))),
+      (e.uuid = (t) => e.check(Yn(I, t))),
+      (e.uuidv4 = (t) => e.check(Xn(I, t))),
+      (e.uuidv6 = (t) => e.check(Zn(I, t))),
+      (e.uuidv7 = (t) => e.check(Qn(I, t))),
+      (e.nanoid = (t) => e.check(tr(qi, t))),
+      (e.guid = (t) => e.check(Jn(Wi, t))),
+      (e.cuid = (t) => e.check(nr(Ji, t))),
+      (e.cuid2 = (t) => e.check(rr(Yi, t))),
+      (e.ulid = (t) => e.check(ir(Xi, t))),
+      (e.base64 = (t) => e.check(dr(ra, t))),
+      (e.base64url = (t) => e.check(fr(ia, t))),
+      (e.xid = (t) => e.check(ar(Zi, t))),
+      (e.ksuid = (t) => e.check(or(Qi, t))),
+      (e.ipv4 = (t) => e.check(sr($i, t))),
+      (e.ipv6 = (t) => e.check(cr(ea, t))),
+      (e.cidrv4 = (t) => e.check(lr(ta, t))),
+      (e.cidrv6 = (t) => e.check(ur(na, t))),
+      (e.e164 = (t) => e.check(pr(aa, t))),
+      (e.datetime = (t) => e.check(xi(t))),
+      (e.date = (t) => e.check(Ci(t))),
+      (e.time = (t) => e.check(Ti(t))),
+      (e.duration = (t) => e.check(Di(t)))
   })
-function z(e) {
-  return Nr(ka, e)
+function P(e) {
+  return Kn(Hi, e)
 }
-const B = S(`ZodStringFormat`, (e, t) => {
-    N.init(e, t), Oa.init(e, t)
+const F = r(`ZodStringFormat`, (e, t) => {
+    E.init(e, t), Vi.init(e, t)
   }),
-  Aa = S(`ZodEmail`, (e, t) => {
-    xn.init(e, t), B.init(e, t)
+  Ui = r(`ZodEmail`, (e, t) => {
+    Ft.init(e, t), F.init(e, t)
   }),
-  ja = S(`ZodGUID`, (e, t) => {
-    yn.init(e, t), B.init(e, t)
+  Wi = r(`ZodGUID`, (e, t) => {
+    Nt.init(e, t), F.init(e, t)
   }),
-  Ma = S(`ZodUUID`, (e, t) => {
-    bn.init(e, t), B.init(e, t)
+  I = r(`ZodUUID`, (e, t) => {
+    Pt.init(e, t), F.init(e, t)
   }),
-  Na = S(`ZodURL`, (e, t) => {
-    Sn.init(e, t), B.init(e, t)
+  Gi = r(`ZodURL`, (e, t) => {
+    It.init(e, t), F.init(e, t)
   })
-function V(e) {
-  return Br(Na, e)
+function L(e) {
+  return $n(Gi, e)
 }
-const Pa = S(`ZodEmoji`, (e, t) => {
-    Cn.init(e, t), B.init(e, t)
+const Ki = r(`ZodEmoji`, (e, t) => {
+    Lt.init(e, t), F.init(e, t)
   }),
-  Fa = S(`ZodNanoID`, (e, t) => {
-    wn.init(e, t), B.init(e, t)
+  qi = r(`ZodNanoID`, (e, t) => {
+    Rt.init(e, t), F.init(e, t)
   }),
-  Ia = S(`ZodCUID`, (e, t) => {
-    Tn.init(e, t), B.init(e, t)
+  Ji = r(`ZodCUID`, (e, t) => {
+    zt.init(e, t), F.init(e, t)
   }),
-  La = S(`ZodCUID2`, (e, t) => {
-    En.init(e, t), B.init(e, t)
+  Yi = r(`ZodCUID2`, (e, t) => {
+    Bt.init(e, t), F.init(e, t)
   }),
-  Ra = S(`ZodULID`, (e, t) => {
-    Dn.init(e, t), B.init(e, t)
+  Xi = r(`ZodULID`, (e, t) => {
+    Vt.init(e, t), F.init(e, t)
   }),
-  za = S(`ZodXID`, (e, t) => {
-    On.init(e, t), B.init(e, t)
+  Zi = r(`ZodXID`, (e, t) => {
+    Ht.init(e, t), F.init(e, t)
   }),
-  Ba = S(`ZodKSUID`, (e, t) => {
-    kn.init(e, t), B.init(e, t)
+  Qi = r(`ZodKSUID`, (e, t) => {
+    Ut.init(e, t), F.init(e, t)
   }),
-  Va = S(`ZodIPv4`, (e, t) => {
-    Pn.init(e, t), B.init(e, t)
+  $i = r(`ZodIPv4`, (e, t) => {
+    Jt.init(e, t), F.init(e, t)
   }),
-  Ha = S(`ZodIPv6`, (e, t) => {
-    Fn.init(e, t), B.init(e, t)
+  ea = r(`ZodIPv6`, (e, t) => {
+    Yt.init(e, t), F.init(e, t)
   }),
-  Ua = S(`ZodCIDRv4`, (e, t) => {
-    In.init(e, t), B.init(e, t)
+  ta = r(`ZodCIDRv4`, (e, t) => {
+    Xt.init(e, t), F.init(e, t)
   }),
-  Wa = S(`ZodCIDRv6`, (e, t) => {
-    Ln.init(e, t), B.init(e, t)
+  na = r(`ZodCIDRv6`, (e, t) => {
+    Zt.init(e, t), F.init(e, t)
   }),
-  Ga = S(`ZodBase64`, (e, t) => {
-    zn.init(e, t), B.init(e, t)
+  ra = r(`ZodBase64`, (e, t) => {
+    $t.init(e, t), F.init(e, t)
   }),
-  Ka = S(`ZodBase64URL`, (e, t) => {
-    Vn.init(e, t), B.init(e, t)
+  ia = r(`ZodBase64URL`, (e, t) => {
+    tn.init(e, t), F.init(e, t)
   }),
-  qa = S(`ZodE164`, (e, t) => {
-    Hn.init(e, t), B.init(e, t)
+  aa = r(`ZodE164`, (e, t) => {
+    nn.init(e, t), F.init(e, t)
   }),
-  Ja = S(`ZodJWT`, (e, t) => {
-    Wn.init(e, t), B.init(e, t)
+  oa = r(`ZodJWT`, (e, t) => {
+    an.init(e, t), F.init(e, t)
   }),
-  Ya = S(`ZodNumber`, (e, t) => {
-    Gn.init(e, t),
-      R.init(e, t),
-      (e._zod.processJSONSchema = (t, n, r) => Vi(e, t, n, r)),
-      (e.gt = (t, n) => e.check(pi(t, n))),
-      (e.gte = (t, n) => e.check(mi(t, n))),
-      (e.min = (t, n) => e.check(mi(t, n))),
-      (e.lt = (t, n) => e.check(di(t, n))),
-      (e.lte = (t, n) => e.check(fi(t, n))),
-      (e.max = (t, n) => e.check(fi(t, n))),
-      (e.int = (t) => e.check(Za(t))),
-      (e.safe = (t) => e.check(Za(t))),
-      (e.positive = (t) => e.check(pi(0, t))),
-      (e.nonnegative = (t) => e.check(mi(0, t))),
-      (e.negative = (t) => e.check(di(0, t))),
-      (e.nonpositive = (t) => e.check(fi(0, t))),
-      (e.multipleOf = (t, n) => e.check(hi(t, n))),
-      (e.step = (t, n) => e.check(hi(t, n))),
+  sa = r(`ZodNumber`, (e, t) => {
+    on.init(e, t),
+      N.init(e, t),
+      (e._zod.processJSONSchema = (t, n, r) => ei(e, t, n, r)),
+      (e.gt = (t, n) => e.check(Er(t, n))),
+      (e.gte = (t, n) => e.check(Dr(t, n))),
+      (e.min = (t, n) => e.check(Dr(t, n))),
+      (e.lt = (t, n) => e.check(wr(t, n))),
+      (e.lte = (t, n) => e.check(Tr(t, n))),
+      (e.max = (t, n) => e.check(Tr(t, n))),
+      (e.int = (t) => e.check(la(t))),
+      (e.safe = (t) => e.check(la(t))),
+      (e.positive = (t) => e.check(Er(0, t))),
+      (e.nonnegative = (t) => e.check(Dr(0, t))),
+      (e.negative = (t) => e.check(wr(0, t))),
+      (e.nonpositive = (t) => e.check(Tr(0, t))),
+      (e.multipleOf = (t, n) => e.check(Or(t, n))),
+      (e.step = (t, n) => e.check(Or(t, n))),
       (e.finite = () => e)
     let n = e._zod.bag
     ;(e.minValue = Math.max(n.minimum ?? -1 / 0, n.exclusiveMinimum ?? -1 / 0) ?? null),
@@ -3893,105 +2702,105 @@ const Pa = S(`ZodEmoji`, (e, t) => {
       (e.isFinite = !0),
       (e.format = n.format ?? null)
   })
-function H(e) {
-  return oi(Ya, e)
+function R(e) {
+  return yr(sa, e)
 }
-const Xa = S(`ZodNumberFormat`, (e, t) => {
-  Kn.init(e, t), Ya.init(e, t)
+const ca = r(`ZodNumberFormat`, (e, t) => {
+  sn.init(e, t), sa.init(e, t)
 })
-function Za(e) {
-  return si(Xa, e)
+function la(e) {
+  return br(ca, e)
 }
-const Qa = S(`ZodBoolean`, (e, t) => {
-  qn.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Hi(e, t, n, r))
+const ua = r(`ZodBoolean`, (e, t) => {
+  cn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ti(e, t, n, r))
 })
-function U(e) {
-  return ci(Qa, e)
+function z(e) {
+  return xr(ua, e)
 }
-const $a = S(`ZodUnknown`, (e, t) => {
-  Jn.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (e, t, n) => void 0)
+const da = r(`ZodUnknown`, (e, t) => {
+  ln.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (e, t, n) => void 0)
 })
-function eo() {
-  return li($a)
+function B() {
+  return Sr(da)
 }
-const to = S(`ZodNever`, (e, t) => {
-  Yn.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Ui(e, t, n, r))
+const fa = r(`ZodNever`, (e, t) => {
+  un.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ni(e, t, n, r))
 })
-function no(e) {
-  return ui(to, e)
+function pa(e) {
+  return Cr(fa, e)
 }
-const ro = S(`ZodArray`, (e, t) => {
-  Zn.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => Ji(e, t, n, r)),
+const ma = r(`ZodArray`, (e, t) => {
+  fn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => si(e, t, n, r)),
     (e.element = t.element),
-    (e.min = (t, n) => e.check(_i(t, n))),
-    (e.nonempty = (t) => e.check(_i(1, t))),
-    (e.max = (t, n) => e.check(gi(t, n))),
-    (e.length = (t, n) => e.check(vi(t, n))),
+    (e.min = (t, n) => e.check(Ar(t, n))),
+    (e.nonempty = (t) => e.check(Ar(1, t))),
+    (e.max = (t, n) => e.check(kr(t, n))),
+    (e.length = (t, n) => e.check(jr(t, n))),
     (e.unwrap = () => e.element)
 })
-function W(e, t) {
-  return Ai(ro, e, t)
+function V(e, t) {
+  return Ur(ma, e, t)
 }
-const io = S(`ZodObject`, (e, t) => {
-  nr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => Yi(e, t, n, r)),
-    w(e, `shape`, () => t.shape),
-    (e.keyof = () => q(Object.keys(e._zod.def.shape))),
+const ha = r(`ZodObject`, (e, t) => {
+  _n.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => ci(e, t, n, r)),
+    f(e, `shape`, () => t.shape),
+    (e.keyof = () => G(Object.keys(e._zod.def.shape))),
     (e.catchall = (t) => e.clone({ ...e._zod.def, catchall: t })),
-    (e.passthrough = () => e.clone({ ...e._zod.def, catchall: eo() })),
-    (e.loose = () => e.clone({ ...e._zod.def, catchall: eo() })),
-    (e.strict = () => e.clone({ ...e._zod.def, catchall: no() })),
+    (e.passthrough = () => e.clone({ ...e._zod.def, catchall: B() })),
+    (e.loose = () => e.clone({ ...e._zod.def, catchall: B() })),
+    (e.strict = () => e.clone({ ...e._zod.def, catchall: pa() })),
     (e.strip = () => e.clone({ ...e._zod.def, catchall: void 0 })),
-    (e.extend = (t) => Ye(e, t)),
-    (e.safeExtend = (t) => Xe(e, t)),
-    (e.merge = (t) => Ze(e, t)),
-    (e.pick = (t) => qe(e, t)),
-    (e.omit = (t) => Je(e, t)),
-    (e.partial = (...t) => Qe(vo, e, t[0])),
-    (e.required = (...t) => $e(Oo, e, t[0]))
+    (e.extend = (t) => pe(e, t)),
+    (e.safeExtend = (t) => me(e, t)),
+    (e.merge = (t) => he(e, t)),
+    (e.pick = (t) => de(e, t)),
+    (e.omit = (t) => fe(e, t)),
+    (e.partial = (...t) => ge(Da, e, t[0])),
+    (e.required = (...t) => _e(La, e, t[0]))
 })
-function G(e, t) {
-  return new io({ type: `object`, shape: e ?? {}, ...k(t) })
+function H(e, t) {
+  return new ha({ type: `object`, shape: e ?? {}, ...y(t) })
 }
-const ao = S(`ZodUnion`, (e, t) => {
-  ir.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Xi(e, t, n, r)), (e.options = t.options)
+const ga = r(`ZodUnion`, (e, t) => {
+  yn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => li(e, t, n, r)), (e.options = t.options)
 })
-function oo(e, t) {
-  return new ao({ type: `union`, options: e, ...k(t) })
+function _a(e, t) {
+  return new ga({ type: `union`, options: e, ...y(t) })
 }
-const so = S(`ZodDiscriminatedUnion`, (e, t) => {
-  ao.init(e, t), ar.init(e, t)
+const va = r(`ZodDiscriminatedUnion`, (e, t) => {
+  ga.init(e, t), bn.init(e, t)
 })
-function K(e, t, n) {
-  return new so({ type: `union`, options: t, discriminator: e, ...k(n) })
+function U(e, t, n) {
+  return new va({ type: `union`, options: t, discriminator: e, ...y(n) })
 }
-const co = S(`ZodIntersection`, (e, t) => {
-  or.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Zi(e, t, n, r))
+const ya = r(`ZodIntersection`, (e, t) => {
+  xn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ui(e, t, n, r))
 })
-function lo(e, t) {
-  return new co({ type: `intersection`, left: e, right: t })
+function ba(e, t) {
+  return new ya({ type: `intersection`, left: e, right: t })
 }
-const uo = S(`ZodRecord`, (e, t) => {
-  lr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => Qi(e, t, n, r)),
+const xa = r(`ZodRecord`, (e, t) => {
+  wn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => di(e, t, n, r)),
     (e.keyType = t.keyType),
     (e.valueType = t.valueType)
 })
-function fo(e, t, n) {
-  return new uo({ type: `record`, keyType: e, valueType: t, ...k(n) })
+function Sa(e, t, n) {
+  return new xa({ type: `record`, keyType: e, valueType: t, ...y(n) })
 }
-function po(e, t, n) {
-  let r = O(e)
-  return (r._zod.values = void 0), new uo({ type: `record`, keyType: r, valueType: t, ...k(n) })
+function W(e, t, n) {
+  let r = v(e)
+  return (r._zod.values = void 0), new xa({ type: `record`, keyType: r, valueType: t, ...y(n) })
 }
-const mo = S(`ZodEnum`, (e, t) => {
-  ur.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => Wi(e, t, n, r)),
+const Ca = r(`ZodEnum`, (e, t) => {
+  Tn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => ri(e, t, n, r)),
     (e.enum = t.entries),
     (e.options = Object.values(t.entries))
   let n = new Set(Object.keys(t.entries))
@@ -4000,23 +2809,23 @@ const mo = S(`ZodEnum`, (e, t) => {
     for (let r of e)
       if (n.has(r)) i[r] = t.entries[r]
       else throw Error(`Key ${r} not found in enum`)
-    return new mo({ ...t, checks: [], ...k(r), entries: i })
+    return new Ca({ ...t, checks: [], ...y(r), entries: i })
   }),
     (e.exclude = (e, r) => {
       let i = { ...t.entries }
       for (let t of e)
         if (n.has(t)) delete i[t]
         else throw Error(`Key ${t} not found in enum`)
-      return new mo({ ...t, checks: [], ...k(r), entries: i })
+      return new Ca({ ...t, checks: [], ...y(r), entries: i })
     })
 })
-function q(e, t) {
-  return new mo({ type: `enum`, entries: Array.isArray(e) ? Object.fromEntries(e.map((e) => [e, e])) : e, ...k(t) })
+function G(e, t) {
+  return new Ca({ type: `enum`, entries: Array.isArray(e) ? Object.fromEntries(e.map((e) => [e, e])) : e, ...y(t) })
 }
-const ho = S(`ZodLiteral`, (e, t) => {
-  dr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => Gi(e, t, n, r)),
+const wa = r(`ZodLiteral`, (e, t) => {
+  En.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => ii(e, t, n, r)),
     (e.values = new Set(t.values)),
     Object.defineProperty(e, `value`, {
       get() {
@@ -4026,136 +2835,135 @@ const ho = S(`ZodLiteral`, (e, t) => {
       }
     })
 })
-function J(e, t) {
-  return new ho({ type: `literal`, values: Array.isArray(e) ? e : [e], ...k(t) })
+function K(e, t) {
+  return new wa({ type: `literal`, values: Array.isArray(e) ? e : [e], ...y(t) })
 }
-const go = S(`ZodTransform`, (e, t) => {
-  fr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => qi(e, t, n, r)),
+const Ta = r(`ZodTransform`, (e, t) => {
+  Dn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => oi(e, t, n, r)),
     (e._zod.parse = (n, r) => {
-      if (r.direction === `backward`) throw new Oe(e.constructor.name)
+      if (r.direction === `backward`) throw new a(e.constructor.name)
       n.addIssue = (r) => {
-        if (typeof r == `string`) n.issues.push(it(r, n.value, t))
+        if (typeof r == `string`) n.issues.push(C(r, n.value, t))
         else {
           let t = r
           t.fatal && (t.continue = !1),
             (t.code ??= `custom`),
             (t.input ??= n.value),
             (t.inst ??= e),
-            n.issues.push(it(t))
+            n.issues.push(C(t))
         }
       }
       let i = t.transform(n.value, n)
       return i instanceof Promise ? i.then((e) => ((n.value = e), n)) : ((n.value = i), n)
     })
 })
-function _o(e) {
-  return new go({ type: `transform`, transform: e })
+function Ea(e) {
+  return new Ta({ type: `transform`, transform: e })
 }
-const vo = S(`ZodOptional`, (e, t) => {
-  mr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => oa(e, t, n, r)),
+const Da = r(`ZodOptional`, (e, t) => {
+  kn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => yi(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function yo(e) {
-  return new vo({ type: `optional`, innerType: e })
+function Oa(e) {
+  return new Da({ type: `optional`, innerType: e })
 }
-const bo = S(`ZodExactOptional`, (e, t) => {
-  hr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => oa(e, t, n, r)),
+const ka = r(`ZodExactOptional`, (e, t) => {
+  An.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => yi(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function xo(e) {
-  return new bo({ type: `optional`, innerType: e })
+function Aa(e) {
+  return new ka({ type: `optional`, innerType: e })
 }
-const So = S(`ZodNullable`, (e, t) => {
-  gr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => $i(e, t, n, r)),
+const ja = r(`ZodNullable`, (e, t) => {
+  jn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => fi(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Co(e) {
-  return new So({ type: `nullable`, innerType: e })
+function Ma(e) {
+  return new ja({ type: `nullable`, innerType: e })
 }
-const wo = S(`ZodDefault`, (e, t) => {
-  _r.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => ta(e, t, n, r)),
+const Na = r(`ZodDefault`, (e, t) => {
+  Mn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => mi(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType),
     (e.removeDefault = e.unwrap)
 })
-function To(e, t) {
-  return new wo({
+function Pa(e, t) {
+  return new Na({
     type: `default`,
     innerType: e,
     get defaultValue() {
-      return typeof t == `function` ? t() : He(t)
+      return typeof t == `function` ? t() : se(t)
     }
   })
 }
-const Eo = S(`ZodPrefault`, (e, t) => {
-  yr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => na(e, t, n, r)),
+const Fa = r(`ZodPrefault`, (e, t) => {
+  Pn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => hi(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Do(e, t) {
-  return new Eo({
+function Ia(e, t) {
+  return new Fa({
     type: `prefault`,
     innerType: e,
     get defaultValue() {
-      return typeof t == `function` ? t() : He(t)
+      return typeof t == `function` ? t() : se(t)
     }
   })
 }
-const Oo = S(`ZodNonOptional`, (e, t) => {
-  br.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => ea(e, t, n, r)),
+const La = r(`ZodNonOptional`, (e, t) => {
+  Fn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => pi(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function ko(e, t) {
-  return new Oo({ type: `nonoptional`, innerType: e, ...k(t) })
+function Ra(e, t) {
+  return new La({ type: `nonoptional`, innerType: e, ...y(t) })
 }
-const Ao = S(`ZodCatch`, (e, t) => {
-  Sr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => ra(e, t, n, r)),
+const za = r(`ZodCatch`, (e, t) => {
+  Ln.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => gi(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType),
     (e.removeCatch = e.unwrap)
 })
-function jo(e, t) {
-  return new Ao({ type: `catch`, innerType: e, catchValue: typeof t == `function` ? t : () => t })
+function Ba(e, t) {
+  return new za({ type: `catch`, innerType: e, catchValue: typeof t == `function` ? t : () => t })
 }
-const Mo = S(`ZodPipe`, (e, t) => {
-  Cr.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ia(e, t, n, r)), (e.in = t.in), (e.out = t.out)
+const Va = r(`ZodPipe`, (e, t) => {
+  Rn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => _i(e, t, n, r)), (e.in = t.in), (e.out = t.out)
 })
-function No(e, t) {
-  return new Mo({ type: `pipe`, in: e, out: t })
+function Ha(e, t) {
+  return new Va({ type: `pipe`, in: e, out: t })
 }
-const Po = S(`ZodReadonly`, (e, t) => {
-  Tr.init(e, t),
-    R.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => aa(e, t, n, r)),
+const Ua = r(`ZodReadonly`, (e, t) => {
+  zn.init(e, t),
+    N.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => vi(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Fo(e) {
-  return new Po({ type: `readonly`, innerType: e })
+function Wa(e) {
+  return new Ua({ type: `readonly`, innerType: e })
 }
-const Io = S(`ZodCustom`, (e, t) => {
-  Dr.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Ki(e, t, n, r))
+const Ga = r(`ZodCustom`, (e, t) => {
+  Vn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ai(e, t, n, r))
 })
-function Lo(e, t = {}) {
-  return ji(Io, e, t)
+function Ka(e, t = {}) {
+  return Wr(Ga, e, t)
 }
-function Ro(e) {
-  return Mi(e)
+function qa(e) {
+  return Gr(e)
 }
-Ee()
-const Y = {
+const q = {
     ANTHROPIC_MESSAGES: `anthropic-messages`,
     GOOGLE_GENERATE_CONTENT: `google-generate-content`,
     JINA_RERANK: `jina-rerank`,
@@ -4172,7 +2980,7 @@ const Y = {
     OPENAI_TEXT_TO_SPEECH: `openai-text-to-speech`,
     OPENAI_VIDEO_GENERATION: `openai-video-generation`
   },
-  zo = {
+  Ja = {
     FUNCTION_CALL: `function-call`,
     REASONING: `reasoning`,
     IMAGE_RECOGNITION: `image-recognition`,
@@ -4190,9 +2998,9 @@ const Y = {
     FILE_SEARCH: `file-search`,
     COMPUTER_USE: `computer-use`
   },
-  Bo = { WEB_SEARCH: `web-search`, URL_CONTEXT: `url-context` },
-  Vo = { ALL_CHAT_MODELS: `all-chat-models`, MODEL_DEPENDENT: `model-dependent` },
-  Ho = {
+  Ya = { WEB_SEARCH: `web-search`, URL_CONTEXT: `url-context` },
+  Xa = { ALL_CHAT_MODELS: `all-chat-models`, MODEL_DEPENDENT: `model-dependent` },
+  J = {
     ADD_WATERMARK: `addWatermark`,
     ASPECT_RATIO: `aspectRatio`,
     BACKGROUND: `background`,
@@ -4238,9 +3046,9 @@ const Y = {
     TOP_SCALE: `topScale`,
     UPSCALE_FACTOR: `upscaleFactor`
   },
-  Uo = { TEXT: `text`, IMAGE: `image`, AUDIO: `audio`, VIDEO: `video`, VECTOR: `vector` },
-  Wo = { USD: `USD`, CNY: `CNY` },
-  Go = {
+  Za = { TEXT: `text`, IMAGE: `image`, AUDIO: `audio`, VIDEO: `video`, VECTOR: `vector` },
+  Qa = { USD: `USD`, CNY: `CNY` },
+  $a = {
     NONE: `none`,
     MINIMAL: `minimal`,
     LOW: `low`,
@@ -4251,19 +3059,19 @@ const Y = {
     ULTRA: `ultra`,
     AUTO: `auto`
   }
-function X(e) {
+function Y(e) {
   return Object.values(e)
 }
-const Ko = z().min(1),
-  qo = z().min(1),
-  Jo = z().min(1),
-  Yo = G({ min: H(), max: H() }).refine((e) => e.min <= e.max, { message: `min must be less than or equal to max` })
-G({ min: z(), max: z() })
-const Xo = q(X(Wo)).optional(),
-  Z = G({ perMillionTokens: H().nonnegative().nullable(), currency: Xo }),
-  Zo = fo(z(), eo()).optional()
-function Q(e, { min: t } = {}) {
-  let n = W(eo()).transform((t) =>
+const eo = P().min(1),
+  to = P().min(1),
+  no = P().min(1),
+  ro = H({ min: R(), max: R() }).refine((e) => e.min <= e.max, { message: `min must be less than or equal to max` })
+H({ min: P(), max: P() })
+const io = G(Y(Qa)).optional(),
+  X = H({ perMillionTokens: R().nonnegative().nullable(), currency: io }),
+  ao = Sa(P(), B()).optional()
+function Z(e, { min: t } = {}) {
+  let n = V(B()).transform((t) =>
     t.reduce((t, n) => {
       let r = e.safeParse(n)
       return r.success && t.push(r.data), t
@@ -4271,184 +3079,23 @@ function Q(e, { min: t } = {}) {
   )
   return t === void 0 ? n : n.refine((e) => e.length >= t, { message: `expected at least ${t} recognized value(s)` })
 }
-const Qo = {
-    anthropic: /^(?:anthropic\.)?claude/i,
-    gemini: /^(?:gemini|palm|veo|imagen|learnlm|lyria)/i,
-    gemma: /^gemma(?:[-:\d]|$)/i,
-    grok: /^grok/i,
-    openai: /\bgpt\b|^o[134]|^chatgpt|^codex|^davinci|^babbage|^dall-e|^text-moderation|^text-embedding-(?:3|ada)/i,
-    qwen: /^qwen|^qwq|^qvq|^tongyi/i,
-    doubao: /^(?:doubao|skylark|seed|seedance|seedream|ep-)/i,
-    hunyuan: /^(?:hunyuan|hy-|hy\d)/i,
-    kimi: /^(?:kimi|moonshot|k3(?:[-_.]|$))/i,
-    deepseek: /^deepseek/i,
-    perplexity: /^sonar/i,
-    baichuan: /^baichuan/i,
-    mimo: /^mimo-/i,
-    ling: /^(?:ling|ring)-/i,
-    minimax: /^(?:minimax|abab)/i,
-    step: /^step-/i,
-    zhipu: /^(?:glm|chatglm|cogview|cogvideo|codegeex)/i,
-    mistral: /^(?:open-|labs-)?(?:mistral|pixtral|codestral|ministral|voxtral|devstral|mixtral|magistral)/i
-  },
-  $o = q(
-    `reasoningEffort,reasoningSummary,reasoning_effort,reasoning.effort,reasoning.enabled,reasoning.exclude,reasoning.max_tokens,thinking.type,thinking.budget_tokens,thinking.budgetTokens,thinking.display,effort,sendReasoning,enable_thinking,thinking_budget,incremental_output,disable_reasoning,reasoning_budget,chat_template_kwargs.enable_thinking,chat_template_kwargs.thinking,chat_template_kwargs.thinking_mode,chat_template_kwargs.thinking_budget,extra_body.google.thinking_config.thinking_budget,extra_body.google.thinking_config.include_thoughts,extra_body.thinking.type,extra_body.thinking_budget,extra_body.reasoning_effort,thinkingConfig.includeThoughts,thinkingConfig.thinkingBudget,thinkingConfig.thinkingLevel,reasoningConfig.type,reasoningConfig.budgetTokens,reasoningConfig.maxReasoningEffort,think`.split(
-      `,`
-    )
-  ),
-  es = q(X(Go)),
-  ts = G({
-    target: $o,
-    value: K(`source`, [
-      G({ source: J(`literal`), value: oo([z(), H(), U()]) }),
-      G({ source: J(`effort`) }),
-      G({ source: J(`budget`) }),
-      G({ source: J(`assistant-summary`) })
-    ])
-  }),
-  ns = G({
-    target: $o,
-    value: K(`source`, [
-      G({ source: J(`literal`), value: oo([z(), H(), U()]) }),
-      G({ source: J(`effort`) }),
-      G({ source: J(`assistant-summary`) })
-    ])
-  }),
-  rs = G({
-    min: H().nonnegative().optional(),
-    autoValue: H().optional(),
-    clampToMaxTokens: U().optional(),
-    missing: K(`type`, [
-      G({ type: J(`omit-value`) }),
-      G({ type: J(`omit-mode`) }),
-      G({ type: J(`fallback`), value: H() })
-    ])
-  }),
-  is = po(es, es).optional(),
-  as = oo([
-    G({ operations: W(ns).min(1), effortMap: is }),
-    G({
-      operations: W(ts)
-        .min(1)
-        .refine((e) => e.some((e) => e.value.source === `budget`), {
-          message: `reasoning budget mode must contain a budget operation`
-        }),
-      effortMap: is,
-      budget: rs
-    })
-  ]),
-  os = G({
-    disabled: J(!0).optional(),
-    default: as.optional(),
-    off: as.optional(),
-    auto: as.optional(),
-    effort: as.optional()
-  }).refine((e) => e.disabled === !0 || e.default || e.off || e.auto || e.effort, {
-    message: `reasoning wire profile must declare a mode or be disabled`
-  })
-G({ wire: os, budgetWire: os.optional() })
-const ss = q(X(Y)),
-  cs = X(Y),
-  ls = q([`global`, `cn`]),
-  us = q([`openai-priority`, `claude-code`]),
-  ds = q([`standard`, `auto`, `fast`, `flex`]),
-  fs = W(ds)
-    .min(1)
-    .refine((e) => new Set(e).size === e.length, { message: `service tier options must be unique` })
-    .refine((e) => e.includes(`standard`), { message: `service tier options must include standard` }),
-  ps = G({
-    default: ds,
-    options: fs,
-    wire: G({
-      delivery: K(`type`, [
-        G({ type: J(`provider-option`), key: z().min(1) }),
-        G({ type: J(`request-body`), key: z().min(1) })
-      ]),
-      values: po(ds, z().min(1))
-    })
-  }).superRefine((e, t) => {
-    e.options.includes(e.default) ||
-      t.addIssue({ code: `custom`, message: `service tier default must be one of its options`, path: [`default`] })
-    for (let n of e.options)
-      e.wire.values[n] ||
-        t.addIssue({
-          code: `custom`,
-          message: `service tier option '${n}' must have a wire value`,
-          path: [`wire`, `values`, n]
-        })
-  }),
-  ms = G({
-    id: q(X(Bo)),
-    modelScope: q(X(Vo)).default(Vo.MODEL_DEPENDENT),
-    endpointTypes: Q(ss).optional(),
-    vendors: Q(q(Object.keys(Qo))).optional()
-  }),
-  $ = (e) => G({ type: J(e), wire: os.optional() }),
-  hs = K(`type`, [$(`openai-chat`), $(`openai-responses`), $(`anthropic`), $(`gemini`), $(`ollama`), $(`none`)])
-hs.options.map((e) => e.shape.type.value)
-const gs = G({
-    website: G({ official: V().optional(), docs: V().optional(), apiKey: V().optional(), models: V().optional() })
-  }),
-  _s = G({ streamOptions: U().optional(), developerRole: U().optional(), reasoningSummary: U().optional() }),
-  vs = G({
-    baseUrl: V().optional(),
-    modelsApiUrls: G({
-      default: V().optional(),
-      embedding: V().optional(),
-      image: V().optional(),
-      reranker: V().optional()
-    }).optional(),
-    reasoningFormat: hs.optional(),
-    adapterFamily: z().optional(),
-    dialect: _s.optional(),
-    requestControls: G({ serviceTier: ps.optional() }).optional()
-  }),
-  ys = G({
-    version: Jo,
-    providers: Q(
-      G({
-        id: qo,
-        presetProviderId: qo.optional(),
-        name: z(),
-        availableInEditions: Q(ls, { min: 1 }).optional(),
-        description: z().optional(),
-        endpointConfigs: fo(
-          z().refine((e) => cs.includes(e), {
-            message: `Invalid endpoint type key, must be one of: ${X(Y).join(`, `)}`
-          }),
-          vs
-        ).optional(),
-        defaultChatEndpoint: ss.nullable().default(null),
-        modelListSource: q([`api`, `registry`]).default(`api`),
-        authMethods: Q(q([`api-key`, `oauth`, `external-cli`])).optional(),
-        authOptional: U().default(!1),
-        serverTools: Q(ms).default([]),
-        reportsActualCost: U().default(!1),
-        reportedCostCurrency: Xo,
-        fastMode: G({ transport: us, serviceTier: z().optional() }).optional(),
-        metadata: Zo.and(gs)
-      }).refine((e) => (e.endpointConfigs && e.defaultChatEndpoint ? e.defaultChatEndpoint in e.endpointConfigs : !0), {
-        message: `defaultChatEndpoint must exist as a key in endpointConfigs`
-      })
-    )
-  }),
-  bs = q(X(Uo)),
-  xs = q(X(zo)),
-  Ss = q(X(Ho)),
-  Cs = G({ min: H().nonnegative().optional(), max: H().positive().optional(), default: H().nonnegative().optional() })
+const oo = G(Y(Za)),
+  so = G(Y(Ja)),
+  co = G(Y(J)),
+  lo = H({ min: R().nonnegative().optional(), max: R().positive().optional(), default: R().nonnegative().optional() })
     .refine((e) => (e.min == null) == (e.max == null), { message: `min and max must be both present or both absent` })
     .refine((e) => e.min == null || e.max == null || e.min <= e.max, {
       message: `min must be less than or equal to max`
     }),
-  ws = q(X(Go)),
-  Ts = K(`kind`, [
-    G({ kind: J(`effort`), values: Q(ws, { min: 1 }), default: ws.optional() }),
-    G({ kind: J(`budget`), min: H().nonnegative(), max: H().positive(), default: H().nonnegative().optional() }),
-    G({ kind: J(`toggle`), default: U().optional() })
+  Q = G(Y($a)),
+  uo = U(`kind`, [
+    H({ kind: K(`effort`), values: Z(Q, { min: 1 }), default: Q.optional() }),
+    H({ kind: K(`budget`), min: R().nonnegative(), max: R().positive(), default: R().nonnegative().optional() }),
+    H({ kind: K(`toggle`), default: z().optional() })
   ]),
-  Es = q([`effort`, `budget`])
-G({
-  pattern: z().refine(
+  fo = G([`effort`, `budget`])
+H({
+  pattern: P().refine(
     (e) => {
       try {
         return new RegExp(e, `i`), !0
@@ -4458,24 +3105,24 @@ G({
     },
     { message: `pattern must be a valid regular expression` }
   ),
-  effort: Q(ws, { min: 1 }).optional(),
-  toggle: U().optional(),
-  budget: G({ min: H().nonnegative(), max: H().positive() })
+  effort: Z(Q, { min: 1 }).optional(),
+  toggle: z().optional(),
+  budget: H({ min: R().nonnegative(), max: R().positive() })
     .refine((e) => e.min <= e.max, { message: `budget min must be <= max` })
     .optional(),
-  template: J(!0).optional(),
-  wireDialect: Es.optional()
+  template: K(!0).optional(),
+  wireDialect: fo.optional()
 }).refine(
   (e) =>
     e.template !== !0 || e.effort !== void 0 || e.toggle !== void 0 || e.budget !== void 0 || e.wireDialect !== void 0,
   { message: `a template rule with no knobs declares nothing — drop it or make it a profile` }
 )
-const Ds = G({
-    controls: Q(Ts).optional(),
-    thinkingTokenLimits: Cs.optional(),
-    supportedEfforts: Q(ws).optional(),
-    defaultEffort: ws.optional(),
-    wireDialect: Es.optional()
+const po = H({
+    controls: Z(uo).optional(),
+    thinkingTokenLimits: lo.optional(),
+    supportedEfforts: Z(Q).optional(),
+    defaultEffort: Q.optional(),
+    wireDialect: fo.optional()
   }).superRefine((e, t) => {
     let n = (e.controls ?? []).map((e) => e.kind)
     new Set(n).size !== n.length && t.addIssue({ code: `custom`, message: `at most one reasoning control per kind` })
@@ -4488,86 +3135,86 @@ const Ds = G({
           (n.min > n.max || (n.default != null && (n.default < n.min || n.default > n.max))) &&
           t.addIssue({ code: `custom`, message: `budget range must satisfy min <= default <= max` })
   }),
-  Os = q([`generate`, `edit`, `remix`, `upscale`, `merge`]),
-  ks = G({ type: J(`switch`), default: U().optional() }),
-  As = G({
-    type: J(`enum`),
-    options: W(z()).min(1),
-    default: z().optional(),
-    render: q([`select`, `chips`]).optional(),
-    columns: H().int().positive().optional()
+  mo = G([`generate`, `edit`, `remix`, `upscale`, `merge`]),
+  ho = H({ type: K(`switch`), default: z().optional() }),
+  go = H({
+    type: K(`enum`),
+    options: V(P()).min(1),
+    default: P().optional(),
+    render: G([`select`, `chips`]).optional(),
+    columns: R().int().positive().optional()
   }),
-  js = G({ type: J(`range`), min: H(), max: H(), default: H().optional(), step: H().optional() }).refine(
+  _o = H({ type: K(`range`), min: R(), max: R(), default: R().optional(), step: R().optional() }).refine(
     (e) => e.min <= e.max,
     { message: `min must be ≤ max` }
   ),
-  Ms = G({
-    type: J(`range`),
-    min: H().int(),
-    max: H().int(),
-    default: H().int().optional(),
-    step: H().int().positive().default(1)
+  vo = H({
+    type: K(`range`),
+    min: R().int(),
+    max: R().int(),
+    default: R().int().optional(),
+    step: R().int().positive().default(1)
   }).refine((e) => e.min <= e.max, { message: `min must be ≤ max` }),
-  Ns = K(`type`, [
-    ks,
-    As,
-    js,
-    G({ type: J(`size`), minSide: H(), maxSide: H(), pairedEnumKey: z().optional() }),
-    G({ type: J(`text`), multiline: U().optional() })
+  yo = U(`type`, [
+    ho,
+    go,
+    _o,
+    H({ type: K(`size`), minSide: R(), maxSide: R(), pairedEnumKey: P().optional() }),
+    H({ type: K(`text`), multiline: z().optional() })
   ]),
-  Ps = [Ho.NUM_IMAGES, Ho.MAX_IMAGES, Ho.NUM_INFERENCE_STEPS, Ho.SAFETY_TOLERANCE, Ho.OUTPUT_COMPRESSION],
-  Fs = G({
-    modes: po(
-      Os,
-      G({
-        supports: po(Ss, Ns).transform((e, t) => {
+  bo = [J.NUM_IMAGES, J.MAX_IMAGES, J.NUM_INFERENCE_STEPS, J.SAFETY_TOLERANCE, J.OUTPUT_COMPRESSION],
+  xo = H({
+    modes: W(
+      mo,
+      H({
+        supports: W(co, yo).transform((e, t) => {
           let n = { ...e }
-          for (let r of Ps) {
+          for (let r of bo) {
             let i = e[r]
             if (i === void 0) continue
-            let a = Ms.safeParse(i)
+            let a = vo.safeParse(i)
             if (a.success) n[r] = a.data
             else for (let e of a.error.issues) t.addIssue({ ...e, path: [r, ...e.path] })
           }
           return n
         }),
-        maxInputImages: H().int().positive().optional(),
-        vendorTransport: G({
-          endpoint: z().regex(/^\/(?!\/)/, `vendor transport endpoint must be a root-relative path, not a URL`),
-          isSync: U().optional()
+        maxInputImages: R().int().positive().optional(),
+        vendorTransport: H({
+          endpoint: P().regex(/^\/(?!\/)/, `vendor transport endpoint must be a root-relative path, not a URL`),
+          isSync: z().optional()
         }).optional(),
-        requirePrompt: U().optional()
+        requirePrompt: z().optional()
       })
     )
   }),
-  Is = G({
-    temperature: G({ supported: U(), range: Yo.optional() }).default({ supported: !0 }),
-    topP: G({ supported: U(), range: Yo.optional() }).default({ supported: !0 }),
-    topK: G({ supported: U(), range: Yo.optional() }).default({ supported: !1 }),
-    frequencyPenalty: U().default(!0),
-    presencePenalty: U().default(!0),
-    maxTokens: U().default(!0),
-    stopSequences: U().default(!0),
-    systemMessage: U().default(!0)
+  So = H({
+    temperature: H({ supported: z(), range: ro.optional() }).default({ supported: !0 }),
+    topP: H({ supported: z(), range: ro.optional() }).default({ supported: !0 }),
+    topK: H({ supported: z(), range: ro.optional() }).default({ supported: !1 }),
+    frequencyPenalty: z().default(!0),
+    presencePenalty: z().default(!0),
+    maxTokens: z().default(!0),
+    stopSequences: z().default(!0),
+    systemMessage: z().default(!0)
   }),
-  Ls = G({
-    input: Z,
-    output: Z,
-    cacheRead: Z.optional(),
-    cacheWrite: Z.optional(),
-    inputTokenTiers: W(
-      G({
-        minInputTokens: H().int().positive().refine(Number.isSafeInteger),
-        input: Z,
-        output: Z,
-        cacheRead: Z.optional(),
-        cacheWrite: Z.optional()
+  Co = H({
+    input: X,
+    output: X,
+    cacheRead: X.optional(),
+    cacheWrite: X.optional(),
+    inputTokenTiers: V(
+      H({
+        minInputTokens: R().int().positive().refine(Number.isSafeInteger),
+        input: X,
+        output: X,
+        cacheRead: X.optional(),
+        cacheWrite: X.optional()
       })
     ).optional(),
-    perImage: G({ price: H(), currency: Xo, unit: q([`image`, `pixel`]).optional() }).optional(),
-    perMinute: G({ price: H(), currency: Xo }).optional()
+    perImage: H({ price: R(), currency: io, unit: G([`image`, `pixel`]).optional() }).optional(),
+    perMinute: H({ price: R(), currency: io }).optional()
   })
-function Rs(e, t) {
+function wo(e, t) {
   for (let n = 1; n < (e.inputTokenTiers?.length ?? 0); n++)
     e.inputTokenTiers[n].minInputTokens <= e.inputTokenTiers[n - 1].minInputTokens &&
       t.addIssue({
@@ -4588,118 +3235,278 @@ function Rs(e, t) {
         ...(e.cacheWrite ? [{ rate: e.cacheWrite, path: [`inputTokenTiers`, t, `cacheWrite`] }] : [])
       ])
     ],
-    r = n[0]?.rate.currency ?? Wo.USD
+    r = n[0]?.rate.currency ?? Qa.USD
   for (let { rate: e, path: i } of n)
-    (e.currency ?? Wo.USD) !== r &&
+    (e.currency ?? Qa.USD) !== r &&
       t.addIssue({ code: `custom`, path: [...i, `currency`], message: `pricing currencies must match` })
 }
-const zs = Ls.superRefine(Rs),
-  Bs = Ls.partial().superRefine(Rs),
-  Vs = G({
-    version: Jo,
-    models: Q(
-      G({
-        id: Ko,
-        name: z(),
-        description: z().optional(),
-        capabilities: Q(xs)
+const To = Co.superRefine(wo),
+  Eo = Co.partial().superRefine(wo),
+  Do = H({
+    version: no,
+    models: Z(
+      H({
+        id: eo,
+        name: P(),
+        description: P().optional(),
+        capabilities: Z(so)
           .refine((e) => new Set(e).size === e.length, { message: `Capabilities must be unique` })
           .optional(),
-        inputModalities: Q(bs)
+        inputModalities: Z(oo)
           .refine((e) => new Set(e).size === e.length, { message: `Input modalities must be unique` })
           .optional(),
-        outputModalities: Q(bs)
+        outputModalities: Z(oo)
           .refine((e) => new Set(e).size === e.length, { message: `Output modalities must be unique` })
           .optional(),
-        endpointTypes: Q(ss).optional(),
-        contextWindow: H().optional(),
-        maxOutputTokens: H().optional(),
-        maxInputTokens: H().optional(),
-        pricing: zs.optional(),
-        reasoning: Ds.optional(),
-        parameterSupport: Is.optional(),
-        imageGeneration: Fs.optional(),
-        family: z().optional(),
-        ownedBy: z().optional(),
-        openWeights: U().optional(),
-        metadata: Zo
+        contextWindow: R().optional(),
+        maxOutputTokens: R().optional(),
+        maxInputTokens: R().optional(),
+        pricing: To.optional(),
+        reasoning: po.optional(),
+        parameterSupport: So.optional(),
+        imageGeneration: xo.optional(),
+        family: P().optional(),
+        ownedBy: P().optional(),
+        openWeights: z().optional(),
+        metadata: ao
       })
     )
   }),
-  Hs = G({ add: Q(xs).optional(), remove: Q(xs).optional(), force: Q(xs).optional() }),
-  Us = q([
-    Y.OPENAI_RESPONSES,
-    Y.OPENAI_CHAT_COMPLETIONS,
-    Y.ANTHROPIC_MESSAGES,
-    Y.GOOGLE_GENERATE_CONTENT,
-    Y.OLLAMA_CHAT,
-    Y.OLLAMA_GENERATE,
-    Y.OPENAI_TEXT_COMPLETIONS
+  Oo = {
+    anthropic: /^(?:anthropic\.)?claude/i,
+    gemini: /^(?:gemini|palm|veo|imagen|learnlm|lyria)/i,
+    gemma: /^gemma(?:[-:\d]|$)/i,
+    grok: /^grok/i,
+    openai: /\bgpt\b|^o[134]|^chatgpt|^codex|^davinci|^babbage|^dall-e|^text-moderation|^text-embedding-(?:3|ada)/i,
+    qwen: /^qwen|^qwq|^qvq|^tongyi/i,
+    doubao: /^(?:doubao|skylark|seed|seedance|seedream|ep-)/i,
+    hunyuan: /^(?:hunyuan|hy-|hy\d)/i,
+    kimi: /^(?:kimi|moonshot|k3(?:[-_.]|$))/i,
+    deepseek: /^deepseek/i,
+    perplexity: /^sonar/i,
+    baichuan: /^baichuan/i,
+    mimo: /^mimo-/i,
+    ling: /^(?:ling|ring)-/i,
+    minimax: /^(?:minimax|abab)/i,
+    step: /^step-/i,
+    zhipu: /^(?:glm|chatglm|cogview|cogvideo|codegeex)/i,
+    mistral: /^(?:open-|labs-)?(?:mistral|pixtral|codestral|ministral|voxtral|devstral|mixtral|magistral)/i
+  },
+  ko = G(
+    `reasoningEffort,reasoningSummary,reasoning_effort,reasoning.effort,reasoning.enabled,reasoning.exclude,reasoning.max_tokens,thinking.type,thinking.budget_tokens,thinking.budgetTokens,thinking.display,effort,sendReasoning,enable_thinking,thinking_budget,incremental_output,disable_reasoning,reasoning_budget,chat_template_kwargs.enable_thinking,chat_template_kwargs.thinking,chat_template_kwargs.thinking_mode,chat_template_kwargs.thinking_budget,extra_body.google.thinking_config.thinking_budget,extra_body.google.thinking_config.include_thoughts,extra_body.thinking.type,extra_body.thinking_budget,extra_body.reasoning_effort,thinkingConfig.includeThoughts,thinkingConfig.thinkingBudget,thinkingConfig.thinkingLevel,reasoningConfig.type,reasoningConfig.budgetTokens,reasoningConfig.maxReasoningEffort,think`.split(
+      `,`
+    )
+  ),
+  Ao = G(Y($a)),
+  jo = H({
+    target: ko,
+    value: U(`source`, [
+      H({ source: K(`literal`), value: _a([P(), R(), z()]) }),
+      H({ source: K(`effort`) }),
+      H({ source: K(`budget`) }),
+      H({ source: K(`assistant-summary`) })
+    ])
+  }),
+  Mo = H({
+    target: ko,
+    value: U(`source`, [
+      H({ source: K(`literal`), value: _a([P(), R(), z()]) }),
+      H({ source: K(`effort`) }),
+      H({ source: K(`assistant-summary`) })
+    ])
+  }),
+  No = H({
+    min: R().nonnegative().optional(),
+    autoValue: R().optional(),
+    clampToMaxTokens: z().optional(),
+    missing: U(`type`, [
+      H({ type: K(`omit-value`) }),
+      H({ type: K(`omit-mode`) }),
+      H({ type: K(`fallback`), value: R() })
+    ])
+  }),
+  Po = W(Ao, Ao).optional(),
+  Fo = _a([
+    H({ operations: V(Mo).min(1), effortMap: Po }),
+    H({
+      operations: V(jo)
+        .min(1)
+        .refine((e) => e.some((e) => e.value.source === `budget`), {
+          message: `reasoning budget mode must contain a budget operation`
+        }),
+      effortMap: Po,
+      budget: No
+    })
   ]),
-  Ws = G({ support: Ds.optional(), wire: os.optional() }).refine((e) => e.support || e.wire, {
+  Io = H({
+    disabled: K(!0).optional(),
+    default: Fo.optional(),
+    off: Fo.optional(),
+    auto: Fo.optional(),
+    effort: Fo.optional()
+  }).refine((e) => e.disabled === !0 || e.default || e.off || e.auto || e.effort, {
+    message: `reasoning wire profile must declare a mode or be disabled`
+  })
+H({ wire: Io, budgetWire: Io.optional() })
+const Lo = G(Y(q)),
+  Ro = Y(q),
+  zo = G([`global`, `cn`]),
+  Bo = G([`openai-priority`, `claude-code`]),
+  Vo = G([`standard`, `auto`, `fast`, `flex`]),
+  Ho = V(Vo)
+    .min(1)
+    .refine((e) => new Set(e).size === e.length, { message: `service tier options must be unique` })
+    .refine((e) => e.includes(`standard`), { message: `service tier options must include standard` }),
+  Uo = H({
+    default: Vo,
+    options: Ho,
+    wire: H({
+      delivery: U(`type`, [
+        H({ type: K(`provider-option`), key: P().min(1) }),
+        H({ type: K(`request-body`), key: P().min(1) })
+      ]),
+      values: W(Vo, P().min(1))
+    })
+  }).superRefine((e, t) => {
+    e.options.includes(e.default) ||
+      t.addIssue({ code: `custom`, message: `service tier default must be one of its options`, path: [`default`] })
+    for (let n of e.options)
+      e.wire.values[n] ||
+        t.addIssue({
+          code: `custom`,
+          message: `service tier option '${n}' must have a wire value`,
+          path: [`wire`, `values`, n]
+        })
+  }),
+  Wo = H({
+    id: G(Y(Ya)),
+    modelScope: G(Y(Xa)).default(Xa.MODEL_DEPENDENT),
+    endpointTypes: Z(Lo).optional(),
+    vendors: Z(G(Object.keys(Oo))).optional()
+  }),
+  $ = (e) => H({ type: K(e), wire: Io.optional() }),
+  Go = U(`type`, [$(`openai-chat`), $(`openai-responses`), $(`anthropic`), $(`gemini`), $(`ollama`), $(`none`)])
+Go.options.map((e) => e.shape.type.value)
+const Ko = H({
+    website: H({ official: L().optional(), docs: L().optional(), apiKey: L().optional(), models: L().optional() })
+  }),
+  qo = H({ streamOptions: z().optional(), developerRole: z().optional(), reasoningSummary: z().optional() }),
+  Jo = H({
+    baseUrl: L().optional(),
+    modelsApiUrls: H({
+      default: L().optional(),
+      embedding: L().optional(),
+      image: L().optional(),
+      reranker: L().optional()
+    }).optional(),
+    reasoningFormat: Go.optional(),
+    adapterFamily: P().optional(),
+    dialect: qo.optional(),
+    requestControls: H({ serviceTier: Uo.optional() }).optional()
+  }),
+  Yo = H({
+    version: no,
+    providers: Z(
+      H({
+        id: to,
+        presetProviderId: to.optional(),
+        name: P(),
+        availableInEditions: Z(zo, { min: 1 }).optional(),
+        description: P().optional(),
+        endpointConfigs: Sa(
+          P().refine((e) => Ro.includes(e), {
+            message: `Invalid endpoint type key, must be one of: ${Y(q).join(`, `)}`
+          }),
+          Jo
+        ).optional(),
+        defaultChatEndpoint: Lo.nullable().default(null),
+        modelListSource: G([`api`, `registry`]).default(`api`),
+        authMethods: Z(G([`api-key`, `oauth`, `external-cli`])).optional(),
+        authOptional: z().default(!1),
+        serverTools: Z(Wo).default([]),
+        reportsActualCost: z().default(!1),
+        reportedCostCurrency: io,
+        fastMode: H({ transport: Bo, serviceTier: P().optional() }).optional(),
+        metadata: ao.and(Ko)
+      }).refine((e) => (e.endpointConfigs && e.defaultChatEndpoint ? e.defaultChatEndpoint in e.endpointConfigs : !0), {
+        message: `defaultChatEndpoint must exist as a key in endpointConfigs`
+      })
+    )
+  }),
+  Xo = H({ add: Z(so).optional(), remove: Z(so).optional(), force: Z(so).optional() }),
+  Zo = G([
+    q.OPENAI_RESPONSES,
+    q.OPENAI_CHAT_COMPLETIONS,
+    q.ANTHROPIC_MESSAGES,
+    q.GOOGLE_GENERATE_CONTENT,
+    q.OLLAMA_CHAT,
+    q.OLLAMA_GENERATE,
+    q.OPENAI_TEXT_COMPLETIONS
+  ]),
+  Qo = H({ support: po.optional(), wire: Io.optional() }).refine((e) => e.support || e.wire, {
     message: `provider-model reasoning contract must declare support or wire`
   }),
-  Gs = G({
-    version: Jo,
-    overrides: Q(
-      G({
-        providerId: qo,
-        modelId: Ko,
-        apiModelId: z().optional(),
-        modelVariants: W(z().min(1)).optional(),
-        capabilities: Hs.optional(),
-        limits: G({
-          contextWindow: H().optional(),
-          maxOutputTokens: H().optional(),
-          maxInputTokens: H().optional()
+  $o = H({
+    version: no,
+    overrides: Z(
+      H({
+        providerId: to,
+        modelId: eo,
+        apiModelId: P().optional(),
+        modelVariants: V(P().min(1)).optional(),
+        capabilities: Xo.optional(),
+        limits: H({
+          contextWindow: R().optional(),
+          maxOutputTokens: R().optional(),
+          maxInputTokens: R().optional()
         }).optional(),
-        pricing: Bs.optional(),
-        reasoningContracts: po(Us, Ws).optional(),
-        supportsFastMode: U().optional(),
-        requestControls: G({ serviceTier: G({ options: fs }).optional() }).optional(),
-        parameterSupport: Is.partial().optional(),
-        endpointTypes: Q(ss).optional(),
-        inputModalities: Q(bs).optional(),
-        outputModalities: Q(bs).optional(),
-        name: z().optional(),
-        description: z().optional(),
-        family: z().optional(),
-        ownedBy: z().optional(),
-        imageGeneration: Fs.optional(),
-        disabled: U().optional(),
-        replaceWith: Ko.optional(),
-        reason: z().optional()
+        pricing: Eo.optional(),
+        reasoningContracts: W(Zo, Qo).optional(),
+        supportsFastMode: z().optional(),
+        requestControls: H({ serviceTier: H({ options: Ho }).optional() }).optional(),
+        parameterSupport: So.partial().optional(),
+        endpointTypes: Z(Lo).optional(),
+        inputModalities: Z(oo).optional(),
+        outputModalities: Z(oo).optional(),
+        name: P().optional(),
+        description: P().optional(),
+        family: P().optional(),
+        ownedBy: P().optional(),
+        imageGeneration: xo.optional(),
+        disabled: z().optional(),
+        replaceWith: eo.optional(),
+        reason: P().optional()
       })
     )
   }),
-  Ks = `anthropic|amazon|meta|google|mistralai|cohere|openai|ai21|microsoft|nvidia`
-;`${Ks}`, `${Ks}`
-const qs = [`models.json`, `providers.json`, `provider-models.json`]
-G({
-  minAppVersion: z().min(1),
-  sourceAppVersion: z().min(1),
-  revision: H().int().nonnegative(),
-  schemaVersion: H().int(),
-  files: fo(z(), z())
+  es = `anthropic|amazon|meta|google|mistralai|cohere|openai|ai21|microsoft|nvidia`
+;`${es}`, `${es}`
+const ts = [`models.json`, `providers.json`, `provider-models.json`]
+H({
+  minAppVersion: P().min(1),
+  sourceAppVersion: P().min(1),
+  revision: R().int().nonnegative(),
+  schemaVersion: R().int(),
+  files: Sa(P(), P())
 })
-const Js = { 'models.json': Vs, 'providers.json': ys, 'provider-models.json': Gs },
-  Ys = 2
-function Xs(e) {
+const ns = { 'models.json': Do, 'providers.json': Yo, 'provider-models.json': $o },
+  rs = 2
+function is(e) {
   return e && typeof e == `object` && `issues` in e
     ? JSON.stringify(e.issues)
     : e instanceof Error
       ? e.message
       : String(e)
 }
-function Zs(e, t) {
-  Js[e].parse(t)
+function as(e, t) {
+  ns[e].parse(t)
 }
-function Qs(n) {
-  for (let r of qs)
+function os(n) {
+  for (let r of ts)
     try {
-      Zs(r, JSON.parse(e(t.join(n, r), `utf8`)))
+      as(r, JSON.parse(e(t.join(n, r), `utf8`)))
     } catch (e) {
-      throw Error(`${r} is not compatible with registry schema v2: ${Xs(e)}`)
+      throw Error(`${r} is not compatible with registry schema v2: ${is(e)}`)
     }
 }
 if (process.argv[1] && t.resolve(process.argv[1]) === n(import.meta.url)) {
@@ -4707,9 +3514,9 @@ if (process.argv[1] && t.resolve(process.argv[1]) === n(import.meta.url)) {
   if (!e) console.error(`Usage: node vN-validator.mjs <catalog-data-directory>`), (process.exitCode = 1)
   else
     try {
-      Qs(t.resolve(e)), console.log(`Catalog is compatible with frozen registry schema v2`)
+      os(t.resolve(e)), console.log(`Catalog is compatible with frozen registry schema v2`)
     } catch (e) {
       console.error(e instanceof Error ? e.message : e), (process.exitCode = 1)
     }
 }
-export { Ys as schemaVersion, Qs as validateCatalogDirectory, Zs as validateCatalogFile }
+export { rs as schemaVersion, os as validateCatalogDirectory, as as validateCatalogFile }

--- a/packages/provider-registry/compat/v2-validator.mjs
+++ b/packages/provider-registry/compat/v2-validator.mjs
@@ -3,9 +3,1200 @@
 import { readFileSync as e } from 'node:fs'
 import t from 'node:path'
 import { fileURLToPath as n } from 'node:url'
-import 'semver'
+Object.create,
+  Object.defineProperty,
+  Object.getOwnPropertyDescriptor,
+  Object.getOwnPropertyNames,
+  Object.getPrototypeOf,
+  Object.prototype.hasOwnProperty
+var r = (e, t) => () => (t || e((t = { exports: {} }).exports, t), t.exports),
+  i = r((e, t) => {
+    t.exports = {
+      MAX_LENGTH: 256,
+      MAX_SAFE_COMPONENT_LENGTH: 16,
+      MAX_SAFE_BUILD_LENGTH: 250,
+      MAX_SAFE_INTEGER: 2 ** 53 - 1 || 9007199254740991,
+      RELEASE_TYPES: [`major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, `prerelease`],
+      SEMVER_SPEC_VERSION: `2.0.0`,
+      FLAG_INCLUDE_PRERELEASE: 1,
+      FLAG_LOOSE: 2
+    }
+  }),
+  a = r((e, t) => {
+    t.exports =
+      typeof process == `object` && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG)
+        ? (...e) => console.error(`SEMVER`, ...e)
+        : () => {}
+  }),
+  o = r((e, t) => {
+    let { MAX_SAFE_COMPONENT_LENGTH: n, MAX_SAFE_BUILD_LENGTH: r, MAX_LENGTH: o } = i(),
+      s = a()
+    e = t.exports = {}
+    let c = (e.re = []),
+      l = (e.safeRe = []),
+      u = (e.src = []),
+      d = (e.safeSrc = []),
+      f = (e.t = {}),
+      p = 0,
+      m = `[a-zA-Z0-9-]`,
+      h = [
+        [`\\s`, 1],
+        [`\\d`, o],
+        [m, r]
+      ],
+      g = (e) => {
+        for (let [t, n] of h) e = e.split(`${t}*`).join(`${t}{0,${n}}`).split(`${t}+`).join(`${t}{1,${n}}`)
+        return e
+      },
+      _ = (e, t, n) => {
+        let r = g(t),
+          i = p++
+        s(e, i, t),
+          (f[e] = i),
+          (u[i] = t),
+          (d[i] = r),
+          (c[i] = new RegExp(t, n ? `g` : void 0)),
+          (l[i] = new RegExp(r, n ? `g` : void 0))
+      }
+    _(`NUMERICIDENTIFIER`, `0|[1-9]\\d*`),
+      _(`NUMERICIDENTIFIERLOOSE`, `\\d+`),
+      _(`NONNUMERICIDENTIFIER`, `\\d*[a-zA-Z-]${m}*`),
+      _(`MAINVERSION`, `(${u[f.NUMERICIDENTIFIER]})\\.(${u[f.NUMERICIDENTIFIER]})\\.(${u[f.NUMERICIDENTIFIER]})`),
+      _(
+        `MAINVERSIONLOOSE`,
+        `(${u[f.NUMERICIDENTIFIERLOOSE]})\\.(${u[f.NUMERICIDENTIFIERLOOSE]})\\.(${u[f.NUMERICIDENTIFIERLOOSE]})`
+      ),
+      _(`PRERELEASEIDENTIFIER`, `(?:${u[f.NUMERICIDENTIFIER]}|${u[f.NONNUMERICIDENTIFIER]})`),
+      _(`PRERELEASEIDENTIFIERLOOSE`, `(?:${u[f.NUMERICIDENTIFIERLOOSE]}|${u[f.NONNUMERICIDENTIFIER]})`),
+      _(`PRERELEASE`, `(?:-(${u[f.PRERELEASEIDENTIFIER]}(?:\\.${u[f.PRERELEASEIDENTIFIER]})*))`),
+      _(`PRERELEASELOOSE`, `(?:-?(${u[f.PRERELEASEIDENTIFIERLOOSE]}(?:\\.${u[f.PRERELEASEIDENTIFIERLOOSE]})*))`),
+      _(`BUILDIDENTIFIER`, `${m}+`),
+      _(`BUILD`, `(?:\\+(${u[f.BUILDIDENTIFIER]}(?:\\.${u[f.BUILDIDENTIFIER]})*))`),
+      _(`FULLPLAIN`, `v?${u[f.MAINVERSION]}${u[f.PRERELEASE]}?${u[f.BUILD]}?`),
+      _(`FULL`, `^${u[f.FULLPLAIN]}$`),
+      _(`LOOSEPLAIN`, `[v=\\s]*${u[f.MAINVERSIONLOOSE]}${u[f.PRERELEASELOOSE]}?${u[f.BUILD]}?`),
+      _(`LOOSE`, `^${u[f.LOOSEPLAIN]}$`),
+      _(`GTLT`, `((?:<|>)?=?)`),
+      _(`XRANGEIDENTIFIERLOOSE`, `${u[f.NUMERICIDENTIFIERLOOSE]}|x|X|\\*`),
+      _(`XRANGEIDENTIFIER`, `${u[f.NUMERICIDENTIFIER]}|x|X|\\*`),
+      _(
+        `XRANGEPLAIN`,
+        `[v=\\s]*(${u[f.XRANGEIDENTIFIER]})(?:\\.(${u[f.XRANGEIDENTIFIER]})(?:\\.(${u[f.XRANGEIDENTIFIER]})(?:${u[f.PRERELEASE]})?${u[f.BUILD]}?)?)?`
+      ),
+      _(
+        `XRANGEPLAINLOOSE`,
+        `[v=\\s]*(${u[f.XRANGEIDENTIFIERLOOSE]})(?:\\.(${u[f.XRANGEIDENTIFIERLOOSE]})(?:\\.(${u[f.XRANGEIDENTIFIERLOOSE]})(?:${u[f.PRERELEASELOOSE]})?${u[f.BUILD]}?)?)?`
+      ),
+      _(`XRANGE`, `^${u[f.GTLT]}\\s*${u[f.XRANGEPLAIN]}$`),
+      _(`XRANGELOOSE`, `^${u[f.GTLT]}\\s*${u[f.XRANGEPLAINLOOSE]}$`),
+      _(`COERCEPLAIN`, `(^|[^\\d])(\\d{1,${n}})(?:\\.(\\d{1,${n}}))?(?:\\.(\\d{1,${n}}))?`),
+      _(`COERCE`, `${u[f.COERCEPLAIN]}(?:$|[^\\d])`),
+      _(`COERCEFULL`, u[f.COERCEPLAIN] + `(?:${u[f.PRERELEASE]})?(?:${u[f.BUILD]})?(?:$|[^\\d])`),
+      _(`COERCERTL`, u[f.COERCE], !0),
+      _(`COERCERTLFULL`, u[f.COERCEFULL], !0),
+      _(`LONETILDE`, `(?:~>?)`),
+      _(`TILDETRIM`, `(\\s*)${u[f.LONETILDE]}\\s+`, !0),
+      (e.tildeTrimReplace = `$1~`),
+      _(`TILDE`, `^${u[f.LONETILDE]}${u[f.XRANGEPLAIN]}$`),
+      _(`TILDELOOSE`, `^${u[f.LONETILDE]}${u[f.XRANGEPLAINLOOSE]}$`),
+      _(`LONECARET`, `(?:\\^)`),
+      _(`CARETTRIM`, `(\\s*)${u[f.LONECARET]}\\s+`, !0),
+      (e.caretTrimReplace = `$1^`),
+      _(`CARET`, `^${u[f.LONECARET]}${u[f.XRANGEPLAIN]}$`),
+      _(`CARETLOOSE`, `^${u[f.LONECARET]}${u[f.XRANGEPLAINLOOSE]}$`),
+      _(`COMPARATORLOOSE`, `^${u[f.GTLT]}\\s*(${u[f.LOOSEPLAIN]})$|^$`),
+      _(`COMPARATOR`, `^${u[f.GTLT]}\\s*(${u[f.FULLPLAIN]})$|^$`),
+      _(`COMPARATORTRIM`, `(\\s*)${u[f.GTLT]}\\s*(${u[f.LOOSEPLAIN]}|${u[f.XRANGEPLAIN]})`, !0),
+      (e.comparatorTrimReplace = `$1$2$3`),
+      _(`HYPHENRANGE`, `^\\s*(${u[f.XRANGEPLAIN]})\\s+-\\s+(${u[f.XRANGEPLAIN]})\\s*$`),
+      _(`HYPHENRANGELOOSE`, `^\\s*(${u[f.XRANGEPLAINLOOSE]})\\s+-\\s+(${u[f.XRANGEPLAINLOOSE]})\\s*$`),
+      _(`STAR`, `(<|>)?=?\\s*\\*`),
+      _(`GTE0`, `^\\s*>=\\s*0\\.0\\.0\\s*$`),
+      _(`GTE0PRE`, `^\\s*>=\\s*0\\.0\\.0-0\\s*$`)
+  }),
+  s = r((e, t) => {
+    let n = Object.freeze({ loose: !0 }),
+      r = Object.freeze({})
+    t.exports = (e) => (e ? (typeof e == `object` ? e : n) : r)
+  }),
+  c = r((e, t) => {
+    let n = /^[0-9]+$/,
+      r = (e, t) => {
+        let r = n.test(e),
+          i = n.test(t)
+        return r && i && ((e = +e), (t = +t)), e === t ? 0 : r && !i ? -1 : i && !r ? 1 : e < t ? -1 : 1
+      }
+    t.exports = { compareIdentifiers: r, rcompareIdentifiers: (e, t) => r(t, e) }
+  }),
+  l = r((e, t) => {
+    let n = a(),
+      { MAX_LENGTH: r, MAX_SAFE_INTEGER: l } = i(),
+      { safeRe: u, safeSrc: d, t: f } = o(),
+      p = s(),
+      { compareIdentifiers: m } = c()
+    t.exports = class e {
+      constructor(t, i) {
+        if (((i = p(i)), t instanceof e)) {
+          if (t.loose === !!i.loose && t.includePrerelease === !!i.includePrerelease) return t
+          t = t.version
+        } else if (typeof t != `string`) throw TypeError(`Invalid version. Must be a string. Got type "${typeof t}".`)
+        if (t.length > r) throw TypeError(`version is longer than ${r} characters`)
+        n(`SemVer`, t, i),
+          (this.options = i),
+          (this.loose = !!i.loose),
+          (this.includePrerelease = !!i.includePrerelease)
+        let a = t.trim().match(i.loose ? u[f.LOOSE] : u[f.FULL])
+        if (!a) throw TypeError(`Invalid Version: ${t}`)
+        if (
+          ((this.raw = t),
+          (this.major = +a[1]),
+          (this.minor = +a[2]),
+          (this.patch = +a[3]),
+          this.major > l || this.major < 0)
+        )
+          throw TypeError(`Invalid major version`)
+        if (this.minor > l || this.minor < 0) throw TypeError(`Invalid minor version`)
+        if (this.patch > l || this.patch < 0) throw TypeError(`Invalid patch version`)
+        a[4]
+          ? (this.prerelease = a[4].split(`.`).map((e) => {
+              if (/^[0-9]+$/.test(e)) {
+                let t = +e
+                if (t >= 0 && t < l) return t
+              }
+              return e
+            }))
+          : (this.prerelease = []),
+          (this.build = a[5] ? a[5].split(`.`) : []),
+          this.format()
+      }
+      format() {
+        return (
+          (this.version = `${this.major}.${this.minor}.${this.patch}`),
+          this.prerelease.length && (this.version += `-${this.prerelease.join(`.`)}`),
+          this.version
+        )
+      }
+      toString() {
+        return this.version
+      }
+      compare(t) {
+        if ((n(`SemVer.compare`, this.version, this.options, t), !(t instanceof e))) {
+          if (typeof t == `string` && t === this.version) return 0
+          t = new e(t, this.options)
+        }
+        return t.version === this.version ? 0 : this.compareMain(t) || this.comparePre(t)
+      }
+      compareMain(t) {
+        return (
+          t instanceof e || (t = new e(t, this.options)),
+          m(this.major, t.major) || m(this.minor, t.minor) || m(this.patch, t.patch)
+        )
+      }
+      comparePre(t) {
+        if ((t instanceof e || (t = new e(t, this.options)), this.prerelease.length && !t.prerelease.length)) return -1
+        if (!this.prerelease.length && t.prerelease.length) return 1
+        if (!this.prerelease.length && !t.prerelease.length) return 0
+        let r = 0
+        do {
+          let e = this.prerelease[r],
+            i = t.prerelease[r]
+          if ((n(`prerelease compare`, r, e, i), e === void 0 && i === void 0)) return 0
+          if (i === void 0) return 1
+          if (e === void 0) return -1
+          if (e === i) continue
+          return m(e, i)
+        } while (++r)
+      }
+      compareBuild(t) {
+        t instanceof e || (t = new e(t, this.options))
+        let r = 0
+        do {
+          let e = this.build[r],
+            i = t.build[r]
+          if ((n(`build compare`, r, e, i), e === void 0 && i === void 0)) return 0
+          if (i === void 0) return 1
+          if (e === void 0) return -1
+          if (e === i) continue
+          return m(e, i)
+        } while (++r)
+      }
+      inc(e, t, n) {
+        if (e.startsWith(`pre`)) {
+          if (!t && n === !1) throw Error(`invalid increment argument: identifier is empty`)
+          if (t) {
+            let e = RegExp(`^${this.options.loose ? d[f.PRERELEASELOOSE] : d[f.PRERELEASE]}$`),
+              n = `-${t}`.match(e)
+            if (!n || n[1] !== t) throw Error(`invalid identifier: ${t}`)
+          }
+        }
+        switch (e) {
+          case `premajor`:
+            ;(this.prerelease.length = 0), (this.patch = 0), (this.minor = 0), this.major++, this.inc(`pre`, t, n)
+            break
+          case `preminor`:
+            ;(this.prerelease.length = 0), (this.patch = 0), this.minor++, this.inc(`pre`, t, n)
+            break
+          case `prepatch`:
+            ;(this.prerelease.length = 0), this.inc(`patch`, t, n), this.inc(`pre`, t, n)
+            break
+          case `prerelease`:
+            this.prerelease.length === 0 && this.inc(`patch`, t, n), this.inc(`pre`, t, n)
+            break
+          case `release`:
+            if (this.prerelease.length === 0) throw Error(`version ${this.raw} is not a prerelease`)
+            this.prerelease.length = 0
+            break
+          case `major`:
+            ;(this.minor !== 0 || this.patch !== 0 || this.prerelease.length === 0) && this.major++,
+              (this.minor = 0),
+              (this.patch = 0),
+              (this.prerelease = [])
+            break
+          case `minor`:
+            ;(this.patch !== 0 || this.prerelease.length === 0) && this.minor++,
+              (this.patch = 0),
+              (this.prerelease = [])
+            break
+          case `patch`:
+            this.prerelease.length === 0 && this.patch++, (this.prerelease = [])
+            break
+          case `pre`: {
+            let e = Number(n) ? 1 : 0
+            if (this.prerelease.length === 0) this.prerelease = [e]
+            else {
+              let r = this.prerelease.length
+              for (; --r >= 0; ) typeof this.prerelease[r] == `number` && (this.prerelease[r]++, (r = -2))
+              if (r === -1) {
+                if (t === this.prerelease.join(`.`) && n === !1)
+                  throw Error(`invalid increment argument: identifier already exists`)
+                this.prerelease.push(e)
+              }
+            }
+            if (t) {
+              let r = [t, e]
+              n === !1 && (r = [t]),
+                m(this.prerelease[0], t) === 0
+                  ? isNaN(this.prerelease[1]) && (this.prerelease = r)
+                  : (this.prerelease = r)
+            }
+            break
+          }
+          default:
+            throw Error(`invalid increment argument: ${e}`)
+        }
+        return (this.raw = this.format()), this.build.length && (this.raw += `+${this.build.join(`.`)}`), this
+      }
+    }
+  }),
+  u = r((e, t) => {
+    let n = l()
+    t.exports = (e, t, r = !1) => {
+      if (e instanceof n) return e
+      try {
+        return new n(e, t)
+      } catch (e) {
+        if (!r) return null
+        throw e
+      }
+    }
+  }),
+  d = r((e, t) => {
+    let n = u()
+    t.exports = (e, t) => {
+      let r = n(e, t)
+      return r ? r.version : null
+    }
+  }),
+  f = r((e, t) => {
+    let n = u()
+    t.exports = (e, t) => {
+      let r = n(e.trim().replace(/^[=v]+/, ``), t)
+      return r ? r.version : null
+    }
+  }),
+  p = r((e, t) => {
+    let n = l()
+    t.exports = (e, t, r, i, a) => {
+      typeof r == `string` && ((a = i), (i = r), (r = void 0))
+      try {
+        return new n(e instanceof n ? e.version : e, r).inc(t, i, a).version
+      } catch {
+        return null
+      }
+    }
+  }),
+  m = r((e, t) => {
+    let n = u()
+    t.exports = (e, t) => {
+      let r = n(e, null, !0),
+        i = n(t, null, !0),
+        a = r.compare(i)
+      if (a === 0) return null
+      let o = a > 0,
+        s = o ? r : i,
+        c = o ? i : r,
+        l = !!s.prerelease.length
+      if (c.prerelease.length && !l) {
+        if (!c.patch && !c.minor) return `major`
+        if (c.compareMain(s) === 0) return c.minor && !c.patch ? `minor` : `patch`
+      }
+      let u = l ? `pre` : ``
+      return r.major === i.major
+        ? r.minor === i.minor
+          ? r.patch === i.patch
+            ? `prerelease`
+            : u + `patch`
+          : u + `minor`
+        : u + `major`
+    }
+  }),
+  h = r((e, t) => {
+    let n = l()
+    t.exports = (e, t) => new n(e, t).major
+  }),
+  g = r((e, t) => {
+    let n = l()
+    t.exports = (e, t) => new n(e, t).minor
+  }),
+  _ = r((e, t) => {
+    let n = l()
+    t.exports = (e, t) => new n(e, t).patch
+  }),
+  v = r((e, t) => {
+    let n = u()
+    t.exports = (e, t) => {
+      let r = n(e, t)
+      return r && r.prerelease.length ? r.prerelease : null
+    }
+  }),
+  y = r((e, t) => {
+    let n = l()
+    t.exports = (e, t, r) => new n(e, r).compare(new n(t, r))
+  }),
+  ee = r((e, t) => {
+    let n = y()
+    t.exports = (e, t, r) => n(t, e, r)
+  }),
+  te = r((e, t) => {
+    let n = y()
+    t.exports = (e, t) => n(e, t, !0)
+  }),
+  ne = r((e, t) => {
+    let n = l()
+    t.exports = (e, t, r) => {
+      let i = new n(e, r),
+        a = new n(t, r)
+      return i.compare(a) || i.compareBuild(a)
+    }
+  }),
+  re = r((e, t) => {
+    let n = ne()
+    t.exports = (e, t) => e.sort((e, r) => n(e, r, t))
+  }),
+  b = r((e, t) => {
+    let n = ne()
+    t.exports = (e, t) => e.sort((e, r) => n(r, e, t))
+  }),
+  ie = r((e, t) => {
+    let n = y()
+    t.exports = (e, t, r) => n(e, t, r) > 0
+  }),
+  ae = r((e, t) => {
+    let n = y()
+    t.exports = (e, t, r) => n(e, t, r) < 0
+  }),
+  oe = r((e, t) => {
+    let n = y()
+    t.exports = (e, t, r) => n(e, t, r) === 0
+  }),
+  se = r((e, t) => {
+    let n = y()
+    t.exports = (e, t, r) => n(e, t, r) !== 0
+  }),
+  ce = r((e, t) => {
+    let n = y()
+    t.exports = (e, t, r) => n(e, t, r) >= 0
+  }),
+  le = r((e, t) => {
+    let n = y()
+    t.exports = (e, t, r) => n(e, t, r) <= 0
+  }),
+  ue = r((e, t) => {
+    let n = oe(),
+      r = se(),
+      i = ie(),
+      a = ce(),
+      o = ae(),
+      s = le()
+    t.exports = (e, t, c, l) => {
+      switch (t) {
+        case `===`:
+          return typeof e == `object` && (e = e.version), typeof c == `object` && (c = c.version), e === c
+        case `!==`:
+          return typeof e == `object` && (e = e.version), typeof c == `object` && (c = c.version), e !== c
+        case ``:
+        case `=`:
+        case `==`:
+          return n(e, c, l)
+        case `!=`:
+          return r(e, c, l)
+        case `>`:
+          return i(e, c, l)
+        case `>=`:
+          return a(e, c, l)
+        case `<`:
+          return o(e, c, l)
+        case `<=`:
+          return s(e, c, l)
+        default:
+          throw TypeError(`Invalid operator: ${t}`)
+      }
+    }
+  }),
+  de = r((e, t) => {
+    let n = l(),
+      r = u(),
+      { safeRe: i, t: a } = o()
+    t.exports = (e, t) => {
+      if (e instanceof n) return e
+      if ((typeof e == `number` && (e = String(e)), typeof e != `string`)) return null
+      t ||= {}
+      let o = null
+      if (!t.rtl) o = e.match(t.includePrerelease ? i[a.COERCEFULL] : i[a.COERCE])
+      else {
+        let n = t.includePrerelease ? i[a.COERCERTLFULL] : i[a.COERCERTL],
+          r
+        for (; (r = n.exec(e)) && (!o || o.index + o[0].length !== e.length); )
+          (!o || r.index + r[0].length !== o.index + o[0].length) && (o = r),
+            (n.lastIndex = r.index + r[1].length + r[2].length)
+        n.lastIndex = -1
+      }
+      if (o === null) return null
+      let s = o[2]
+      return r(
+        `${s}.${o[3] || `0`}.${o[4] || `0`}${t.includePrerelease && o[5] ? `-${o[5]}` : ``}${t.includePrerelease && o[6] ? `+${o[6]}` : ``}`,
+        t
+      )
+    }
+  }),
+  fe = r((e, t) => {
+    t.exports = class {
+      constructor() {
+        ;(this.max = 1e3), (this.map = new Map())
+      }
+      get(e) {
+        let t = this.map.get(e)
+        if (t !== void 0) return this.map.delete(e), this.map.set(e, t), t
+      }
+      delete(e) {
+        return this.map.delete(e)
+      }
+      set(e, t) {
+        if (!this.delete(e) && t !== void 0) {
+          if (this.map.size >= this.max) {
+            let e = this.map.keys().next().value
+            this.delete(e)
+          }
+          this.map.set(e, t)
+        }
+        return this
+      }
+    }
+  }),
+  x = r((e, t) => {
+    let n = /\s+/g
+    t.exports = class e {
+      constructor(t, r) {
+        if (((r = c(r)), t instanceof e))
+          return t.loose === !!r.loose && t.includePrerelease === !!r.includePrerelease ? t : new e(t.raw, r)
+        if (t instanceof u) return (this.raw = t.value), (this.set = [[t]]), (this.formatted = void 0), this
+        if (
+          ((this.options = r),
+          (this.loose = !!r.loose),
+          (this.includePrerelease = !!r.includePrerelease),
+          (this.raw = t.trim().replace(n, ` `)),
+          (this.set = this.raw
+            .split(`||`)
+            .map((e) => this.parseRange(e.trim()))
+            .filter((e) => e.length)),
+          !this.set.length)
+        )
+          throw TypeError(`Invalid SemVer Range: ${this.raw}`)
+        if (this.set.length > 1) {
+          let e = this.set[0]
+          if (((this.set = this.set.filter((e) => !ee(e[0]))), this.set.length === 0)) this.set = [e]
+          else if (this.set.length > 1) {
+            for (let e of this.set)
+              if (e.length === 1 && te(e[0])) {
+                this.set = [e]
+                break
+              }
+          }
+        }
+        this.formatted = void 0
+      }
+      get range() {
+        if (this.formatted === void 0) {
+          this.formatted = ``
+          for (let e = 0; e < this.set.length; e++) {
+            e > 0 && (this.formatted += `||`)
+            let t = this.set[e]
+            for (let e = 0; e < t.length; e++)
+              e > 0 && (this.formatted += ` `), (this.formatted += t[e].toString().trim())
+          }
+        }
+        return this.formatted
+      }
+      format() {
+        return this.range
+      }
+      toString() {
+        return this.range
+      }
+      parseRange(e) {
+        let t = ((this.options.includePrerelease && v) | (this.options.loose && y)) + `:` + e,
+          n = r.get(t)
+        if (n) return n
+        let i = this.options.loose,
+          a = i ? p[m.HYPHENRANGELOOSE] : p[m.HYPHENRANGE]
+        ;(e = e.replace(a, x(this.options.includePrerelease))),
+          d(`hyphen replace`, e),
+          (e = e.replace(p[m.COMPARATORTRIM], h)),
+          d(`comparator trim`, e),
+          (e = e.replace(p[m.TILDETRIM], g)),
+          d(`tilde trim`, e),
+          (e = e.replace(p[m.CARETTRIM], _)),
+          d(`caret trim`, e)
+        let o = e
+          .split(` `)
+          .map((e) => re(e, this.options))
+          .join(` `)
+          .split(/\s+/)
+          .map((e) => de(e, this.options))
+        i && (o = o.filter((e) => (d(`loose invalid filter`, e, this.options), !!e.match(p[m.COMPARATORLOOSE])))),
+          d(`range list`, o)
+        let s = new Map(),
+          c = o.map((e) => new u(e, this.options))
+        for (let e of c) {
+          if (ee(e)) return [e]
+          s.set(e.value, e)
+        }
+        s.size > 1 && s.has(``) && s.delete(``)
+        let l = [...s.values()]
+        return r.set(t, l), l
+      }
+      intersects(t, n) {
+        if (!(t instanceof e)) throw TypeError(`a Range is required`)
+        return this.set.some(
+          (e) => ne(e, n) && t.set.some((t) => ne(t, n) && e.every((e) => t.every((t) => e.intersects(t, n))))
+        )
+      }
+      test(e) {
+        if (!e) return !1
+        if (typeof e == `string`)
+          try {
+            e = new f(e, this.options)
+          } catch {
+            return !1
+          }
+        for (let t = 0; t < this.set.length; t++) if (me(this.set[t], e, this.options)) return !0
+        return !1
+      }
+    }
+    let r = new (fe())(),
+      c = s(),
+      u = pe(),
+      d = a(),
+      f = l(),
+      { safeRe: p, t: m, comparatorTrimReplace: h, tildeTrimReplace: g, caretTrimReplace: _ } = o(),
+      { FLAG_INCLUDE_PRERELEASE: v, FLAG_LOOSE: y } = i(),
+      ee = (e) => e.value === `<0.0.0-0`,
+      te = (e) => e.value === ``,
+      ne = (e, t) => {
+        let n = !0,
+          r = e.slice(),
+          i = r.pop()
+        for (; n && r.length; ) (n = r.every((e) => i.intersects(e, t))), (i = r.pop())
+        return n
+      },
+      re = (e, t) => (
+        d(`comp`, e, t),
+        (e = oe(e, t)),
+        d(`caret`, e),
+        (e = ie(e, t)),
+        d(`tildes`, e),
+        (e = ce(e, t)),
+        d(`xrange`, e),
+        (e = ue(e, t)),
+        d(`stars`, e),
+        e
+      ),
+      b = (e) => !e || e.toLowerCase() === `x` || e === `*`,
+      ie = (e, t) =>
+        e
+          .trim()
+          .split(/\s+/)
+          .map((e) => ae(e, t))
+          .join(` `),
+      ae = (e, t) => {
+        let n = t.loose ? p[m.TILDELOOSE] : p[m.TILDE]
+        return e.replace(n, (t, n, r, i, a) => {
+          d(`tilde`, e, t, n, r, i, a)
+          let o
+          return (
+            b(n)
+              ? (o = ``)
+              : b(r)
+                ? (o = `>=${n}.0.0 <${+n + 1}.0.0-0`)
+                : b(i)
+                  ? (o = `>=${n}.${r}.0 <${n}.${+r + 1}.0-0`)
+                  : a
+                    ? (d(`replaceTilde pr`, a), (o = `>=${n}.${r}.${i}-${a} <${n}.${+r + 1}.0-0`))
+                    : (o = `>=${n}.${r}.${i} <${n}.${+r + 1}.0-0`),
+            d(`tilde return`, o),
+            o
+          )
+        })
+      },
+      oe = (e, t) =>
+        e
+          .trim()
+          .split(/\s+/)
+          .map((e) => se(e, t))
+          .join(` `),
+      se = (e, t) => {
+        d(`caret`, e, t)
+        let n = t.loose ? p[m.CARETLOOSE] : p[m.CARET],
+          r = t.includePrerelease ? `-0` : ``
+        return e.replace(n, (t, n, i, a, o) => {
+          d(`caret`, e, t, n, i, a, o)
+          let s
+          return (
+            b(n)
+              ? (s = ``)
+              : b(i)
+                ? (s = `>=${n}.0.0${r} <${+n + 1}.0.0-0`)
+                : b(a)
+                  ? (s = n === `0` ? `>=${n}.${i}.0${r} <${n}.${+i + 1}.0-0` : `>=${n}.${i}.0${r} <${+n + 1}.0.0-0`)
+                  : o
+                    ? (d(`replaceCaret pr`, o),
+                      (s =
+                        n === `0`
+                          ? i === `0`
+                            ? `>=${n}.${i}.${a}-${o} <${n}.${i}.${+a + 1}-0`
+                            : `>=${n}.${i}.${a}-${o} <${n}.${+i + 1}.0-0`
+                          : `>=${n}.${i}.${a}-${o} <${+n + 1}.0.0-0`))
+                    : (d(`no pr`),
+                      (s =
+                        n === `0`
+                          ? i === `0`
+                            ? `>=${n}.${i}.${a}${r} <${n}.${i}.${+a + 1}-0`
+                            : `>=${n}.${i}.${a}${r} <${n}.${+i + 1}.0-0`
+                          : `>=${n}.${i}.${a} <${+n + 1}.0.0-0`)),
+            d(`caret return`, s),
+            s
+          )
+        })
+      },
+      ce = (e, t) => (
+        d(`replaceXRanges`, e, t),
+        e
+          .split(/\s+/)
+          .map((e) => le(e, t))
+          .join(` `)
+      ),
+      le = (e, t) => {
+        e = e.trim()
+        let n = t.loose ? p[m.XRANGELOOSE] : p[m.XRANGE]
+        return e.replace(n, (n, r, i, a, o, s) => {
+          d(`xRange`, e, n, r, i, a, o, s)
+          let c = b(i),
+            l = c || b(a),
+            u = l || b(o),
+            f = u
+          return (
+            r === `=` && f && (r = ``),
+            (s = t.includePrerelease ? `-0` : ``),
+            c
+              ? (n = r === `>` || r === `<` ? `<0.0.0-0` : `*`)
+              : r && f
+                ? (l && (a = 0),
+                  (o = 0),
+                  r === `>`
+                    ? ((r = `>=`), l ? ((i = +i + 1), (a = 0), (o = 0)) : ((a = +a + 1), (o = 0)))
+                    : r === `<=` && ((r = `<`), l ? (i = +i + 1) : (a = +a + 1)),
+                  r === `<` && (s = `-0`),
+                  (n = `${r + i}.${a}.${o}${s}`))
+                : l
+                  ? (n = `>=${i}.0.0${s} <${+i + 1}.0.0-0`)
+                  : u && (n = `>=${i}.${a}.0${s} <${i}.${+a + 1}.0-0`),
+            d(`xRange return`, n),
+            n
+          )
+        })
+      },
+      ue = (e, t) => (d(`replaceStars`, e, t), e.trim().replace(p[m.STAR], ``)),
+      de = (e, t) => (d(`replaceGTE0`, e, t), e.trim().replace(p[t.includePrerelease ? m.GTE0PRE : m.GTE0], ``)),
+      x = (e) => (t, n, r, i, a, o, s, c, l, u, d, f) => (
+        (n = b(r)
+          ? ``
+          : b(i)
+            ? `>=${r}.0.0${e ? `-0` : ``}`
+            : b(a)
+              ? `>=${r}.${i}.0${e ? `-0` : ``}`
+              : o
+                ? `>=${n}`
+                : `>=${n}${e ? `-0` : ``}`),
+        (c = b(l)
+          ? ``
+          : b(u)
+            ? `<${+l + 1}.0.0-0`
+            : b(d)
+              ? `<${l}.${+u + 1}.0-0`
+              : f
+                ? `<=${l}.${u}.${d}-${f}`
+                : e
+                  ? `<${l}.${u}.${+d + 1}-0`
+                  : `<=${c}`),
+        `${n} ${c}`.trim()
+      ),
+      me = (e, t, n) => {
+        for (let n = 0; n < e.length; n++) if (!e[n].test(t)) return !1
+        if (t.prerelease.length && !n.includePrerelease) {
+          for (let n = 0; n < e.length; n++)
+            if ((d(e[n].semver), e[n].semver !== u.ANY && e[n].semver.prerelease.length > 0)) {
+              let r = e[n].semver
+              if (r.major === t.major && r.minor === t.minor && r.patch === t.patch) return !0
+            }
+          return !1
+        }
+        return !0
+      }
+  }),
+  pe = r((e, t) => {
+    let n = Symbol(`SemVer ANY`)
+    t.exports = class e {
+      static get ANY() {
+        return n
+      }
+      constructor(t, i) {
+        if (((i = r(i)), t instanceof e)) {
+          if (t.loose === !!i.loose) return t
+          t = t.value
+        }
+        ;(t = t.trim().split(/\s+/).join(` `)),
+          d(`comparator`, t, i),
+          (this.options = i),
+          (this.loose = !!i.loose),
+          this.parse(t),
+          this.semver === n ? (this.value = ``) : (this.value = this.operator + this.semver.version),
+          d(`comp`, this)
+      }
+      parse(e) {
+        let t = this.options.loose ? i[c.COMPARATORLOOSE] : i[c.COMPARATOR],
+          r = e.match(t)
+        if (!r) throw TypeError(`Invalid comparator: ${e}`)
+        ;(this.operator = r[1] === void 0 ? `` : r[1]),
+          this.operator === `=` && (this.operator = ``),
+          r[2] ? (this.semver = new f(r[2], this.options.loose)) : (this.semver = n)
+      }
+      toString() {
+        return this.value
+      }
+      test(e) {
+        if ((d(`Comparator.test`, e, this.options.loose), this.semver === n || e === n)) return !0
+        if (typeof e == `string`)
+          try {
+            e = new f(e, this.options)
+          } catch {
+            return !1
+          }
+        return u(e, this.operator, this.semver, this.options)
+      }
+      intersects(t, n) {
+        if (!(t instanceof e)) throw TypeError(`a Comparator is required`)
+        return this.operator === ``
+          ? this.value === ``
+            ? !0
+            : new p(t.value, n).test(this.value)
+          : t.operator === ``
+            ? t.value === ``
+              ? !0
+              : new p(this.value, n).test(t.semver)
+            : ((n = r(n)),
+              (n.includePrerelease && (this.value === `<0.0.0-0` || t.value === `<0.0.0-0`)) ||
+              (!n.includePrerelease && (this.value.startsWith(`<0.0.0`) || t.value.startsWith(`<0.0.0`)))
+                ? !1
+                : !!(
+                    (this.operator.startsWith(`>`) && t.operator.startsWith(`>`)) ||
+                    (this.operator.startsWith(`<`) && t.operator.startsWith(`<`)) ||
+                    (this.semver.version === t.semver.version &&
+                      this.operator.includes(`=`) &&
+                      t.operator.includes(`=`)) ||
+                    (u(this.semver, `<`, t.semver, n) && this.operator.startsWith(`>`) && t.operator.startsWith(`<`)) ||
+                    (u(this.semver, `>`, t.semver, n) && this.operator.startsWith(`<`) && t.operator.startsWith(`>`))
+                  ))
+      }
+    }
+    let r = s(),
+      { safeRe: i, t: c } = o(),
+      u = ue(),
+      d = a(),
+      f = l(),
+      p = x()
+  }),
+  me = r((e, t) => {
+    let n = x()
+    t.exports = (e, t, r) => {
+      try {
+        t = new n(t, r)
+      } catch {
+        return !1
+      }
+      return t.test(e)
+    }
+  }),
+  he = r((e, t) => {
+    let n = x()
+    t.exports = (e, t) =>
+      new n(e, t).set.map((e) =>
+        e
+          .map((e) => e.value)
+          .join(` `)
+          .trim()
+          .split(` `)
+      )
+  }),
+  ge = r((e, t) => {
+    let n = l(),
+      r = x()
+    t.exports = (e, t, i) => {
+      let a = null,
+        o = null,
+        s = null
+      try {
+        s = new r(t, i)
+      } catch {
+        return null
+      }
+      return (
+        e.forEach((e) => {
+          s.test(e) && (!a || o.compare(e) === -1) && ((a = e), (o = new n(a, i)))
+        }),
+        a
+      )
+    }
+  }),
+  _e = r((e, t) => {
+    let n = l(),
+      r = x()
+    t.exports = (e, t, i) => {
+      let a = null,
+        o = null,
+        s = null
+      try {
+        s = new r(t, i)
+      } catch {
+        return null
+      }
+      return (
+        e.forEach((e) => {
+          s.test(e) && (!a || o.compare(e) === 1) && ((a = e), (o = new n(a, i)))
+        }),
+        a
+      )
+    }
+  }),
+  ve = r((e, t) => {
+    let n = l(),
+      r = x(),
+      i = ie()
+    t.exports = (e, t) => {
+      e = new r(e, t)
+      let a = new n(`0.0.0`)
+      if (e.test(a) || ((a = new n(`0.0.0-0`)), e.test(a))) return a
+      a = null
+      for (let t = 0; t < e.set.length; ++t) {
+        let r = e.set[t],
+          o = null
+        r.forEach((e) => {
+          let t = new n(e.semver.version)
+          switch (e.operator) {
+            case `>`:
+              t.prerelease.length === 0 ? t.patch++ : t.prerelease.push(0), (t.raw = t.format())
+            case ``:
+            case `>=`:
+              ;(!o || i(t, o)) && (o = t)
+              break
+            case `<`:
+            case `<=`:
+              break
+            default:
+              throw Error(`Unexpected operation: ${e.operator}`)
+          }
+        }),
+          o && (!a || i(a, o)) && (a = o)
+      }
+      return a && e.test(a) ? a : null
+    }
+  }),
+  ye = r((e, t) => {
+    let n = x()
+    t.exports = (e, t) => {
+      try {
+        return new n(e, t).range || `*`
+      } catch {
+        return null
+      }
+    }
+  }),
+  be = r((e, t) => {
+    let n = l(),
+      r = pe(),
+      { ANY: i } = r,
+      a = x(),
+      o = me(),
+      s = ie(),
+      c = ae(),
+      u = le(),
+      d = ce()
+    t.exports = (e, t, l, f) => {
+      ;(e = new n(e, f)), (t = new a(t, f))
+      let p, m, h, g, _
+      switch (l) {
+        case `>`:
+          ;(p = s), (m = u), (h = c), (g = `>`), (_ = `>=`)
+          break
+        case `<`:
+          ;(p = c), (m = d), (h = s), (g = `<`), (_ = `<=`)
+          break
+        default:
+          throw TypeError(`Must provide a hilo val of "<" or ">"`)
+      }
+      if (o(e, t, f)) return !1
+      for (let n = 0; n < t.set.length; ++n) {
+        let a = t.set[n],
+          o = null,
+          s = null
+        if (
+          (a.forEach((e) => {
+            e.semver === i && (e = new r(`>=0.0.0`)),
+              (o ||= e),
+              (s ||= e),
+              p(e.semver, o.semver, f) ? (o = e) : h(e.semver, s.semver, f) && (s = e)
+          }),
+          o.operator === g ||
+            o.operator === _ ||
+            ((!s.operator || s.operator === g) && m(e, s.semver)) ||
+            (s.operator === _ && h(e, s.semver)))
+        )
+          return !1
+      }
+      return !0
+    }
+  }),
+  xe = r((e, t) => {
+    let n = be()
+    t.exports = (e, t, r) => n(e, t, `>`, r)
+  }),
+  Se = r((e, t) => {
+    let n = be()
+    t.exports = (e, t, r) => n(e, t, `<`, r)
+  }),
+  Ce = r((e, t) => {
+    let n = x()
+    t.exports = (e, t, r) => ((e = new n(e, r)), (t = new n(t, r)), e.intersects(t, r))
+  }),
+  we = r((e, t) => {
+    let n = me(),
+      r = y()
+    t.exports = (e, t, i) => {
+      let a = [],
+        o = null,
+        s = null,
+        c = e.sort((e, t) => r(e, t, i))
+      for (let e of c) n(e, t, i) ? ((s = e), (o ||= e)) : (s && a.push([o, s]), (s = null), (o = null))
+      o && a.push([o, null])
+      let l = []
+      for (let [e, t] of a)
+        e === t
+          ? l.push(e)
+          : !t && e === c[0]
+            ? l.push(`*`)
+            : t
+              ? e === c[0]
+                ? l.push(`<=${t}`)
+                : l.push(`${e} - ${t}`)
+              : l.push(`>=${e}`)
+      let u = l.join(` || `),
+        d = typeof t.raw == `string` ? t.raw : String(t)
+      return u.length < d.length ? u : t
+    }
+  }),
+  Te = r((e, t) => {
+    let n = x(),
+      r = pe(),
+      { ANY: i } = r,
+      a = me(),
+      o = y(),
+      s = (e, t, r = {}) => {
+        if (e === t) return !0
+        ;(e = new n(e, r)), (t = new n(t, r))
+        let i = !1
+        OUTER: for (let n of e.set) {
+          for (let e of t.set) {
+            let t = u(n, e, r)
+            if (((i ||= t !== null), t)) continue OUTER
+          }
+          if (i) return !1
+        }
+        return !0
+      },
+      c = [new r(`>=0.0.0-0`)],
+      l = [new r(`>=0.0.0`)],
+      u = (e, t, n) => {
+        if (e === t) return !0
+        if (e.length === 1 && e[0].semver === i) {
+          if (t.length === 1 && t[0].semver === i) return !0
+          e = n.includePrerelease ? c : l
+        }
+        if (t.length === 1 && t[0].semver === i) {
+          if (n.includePrerelease) return !0
+          t = l
+        }
+        let r = new Set(),
+          s,
+          u
+        for (let t of e)
+          t.operator === `>` || t.operator === `>=`
+            ? (s = d(s, t, n))
+            : t.operator === `<` || t.operator === `<=`
+              ? (u = f(u, t, n))
+              : r.add(t.semver)
+        if (r.size > 1) return null
+        let p
+        if (
+          s &&
+          u &&
+          ((p = o(s.semver, u.semver, n)), p > 0 || (p === 0 && (s.operator !== `>=` || u.operator !== `<=`)))
+        )
+          return null
+        for (let e of r) {
+          if ((s && !a(e, String(s), n)) || (u && !a(e, String(u), n))) return null
+          for (let r of t) if (!a(e, String(r), n)) return !1
+          return !0
+        }
+        let m,
+          h,
+          g,
+          _,
+          v = u && !n.includePrerelease && u.semver.prerelease.length ? u.semver : !1,
+          y = s && !n.includePrerelease && s.semver.prerelease.length ? s.semver : !1
+        v && v.prerelease.length === 1 && u.operator === `<` && v.prerelease[0] === 0 && (v = !1)
+        for (let e of t) {
+          if (
+            ((_ = _ || e.operator === `>` || e.operator === `>=`),
+            (g = g || e.operator === `<` || e.operator === `<=`),
+            s)
+          ) {
+            if (
+              (y &&
+                e.semver.prerelease &&
+                e.semver.prerelease.length &&
+                e.semver.major === y.major &&
+                e.semver.minor === y.minor &&
+                e.semver.patch === y.patch &&
+                (y = !1),
+              e.operator === `>` || e.operator === `>=`)
+            ) {
+              if (((m = d(s, e, n)), m === e && m !== s)) return !1
+            } else if (s.operator === `>=` && !a(s.semver, String(e), n)) return !1
+          }
+          if (u) {
+            if (
+              (v &&
+                e.semver.prerelease &&
+                e.semver.prerelease.length &&
+                e.semver.major === v.major &&
+                e.semver.minor === v.minor &&
+                e.semver.patch === v.patch &&
+                (v = !1),
+              e.operator === `<` || e.operator === `<=`)
+            ) {
+              if (((h = f(u, e, n)), h === e && h !== u)) return !1
+            } else if (u.operator === `<=` && !a(u.semver, String(e), n)) return !1
+          }
+          if (!e.operator && (u || s) && p !== 0) return !1
+        }
+        return !((s && g && !u && p !== 0) || (u && _ && !s && p !== 0) || y || v)
+      },
+      d = (e, t, n) => {
+        if (!e) return t
+        let r = o(e.semver, t.semver, n)
+        return r > 0 ? e : r < 0 || (t.operator === `>` && e.operator === `>=`) ? t : e
+      },
+      f = (e, t, n) => {
+        if (!e) return t
+        let r = o(e.semver, t.semver, n)
+        return r < 0 ? e : r > 0 || (t.operator === `<` && e.operator === `<=`) ? t : e
+      }
+    t.exports = s
+  }),
+  Ee = r((e, t) => {
+    let n = o(),
+      r = i(),
+      a = l(),
+      s = c()
+    t.exports = {
+      parse: u(),
+      valid: d(),
+      clean: f(),
+      inc: p(),
+      diff: m(),
+      major: h(),
+      minor: g(),
+      patch: _(),
+      prerelease: v(),
+      compare: y(),
+      rcompare: ee(),
+      compareLoose: te(),
+      compareBuild: ne(),
+      sort: re(),
+      rsort: b(),
+      gt: ie(),
+      lt: ae(),
+      eq: oe(),
+      neq: se(),
+      gte: ce(),
+      lte: le(),
+      cmp: ue(),
+      coerce: de(),
+      Comparator: pe(),
+      Range: x(),
+      satisfies: me(),
+      toComparators: he(),
+      maxSatisfying: ge(),
+      minSatisfying: _e(),
+      minVersion: ve(),
+      validRange: ye(),
+      outside: be(),
+      gtr: xe(),
+      ltr: Se(),
+      intersects: Ce(),
+      simplifyRange: we(),
+      subset: Te(),
+      SemVer: a,
+      re: n.re,
+      src: n.src,
+      tokens: n.t,
+      SEMVER_SPEC_VERSION: r.SEMVER_SPEC_VERSION,
+      RELEASE_TYPES: r.RELEASE_TYPES,
+      compareIdentifiers: s.compareIdentifiers,
+      rcompareIdentifiers: s.rcompareIdentifiers
+    }
+  })
 Object.freeze({ status: `aborted` })
-function r(e, t, n) {
+function S(e, t, n) {
   function r(n, r) {
     if (
       (n._zod || Object.defineProperty(n, `_zod`, { value: { def: r, constr: o, traits: new Set() }, enumerable: !1 }),
@@ -39,30 +1230,30 @@ function r(e, t, n) {
     o
   )
 }
-var i = class extends Error {
+var De = class extends Error {
     constructor() {
       super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`)
     }
   },
-  a = class extends Error {
+  Oe = class extends Error {
     constructor(e) {
       super(`Encountered unidirectional transform during encode: ${e}`), (this.name = `ZodEncodeError`)
     }
   }
-const o = {}
-function s(e) {
-  return e && Object.assign(o, e), o
+const ke = {}
+function C(e) {
+  return e && Object.assign(ke, e), ke
 }
-function c(e) {
+function Ae(e) {
   let t = Object.values(e).filter((e) => typeof e == `number`)
   return Object.entries(e)
     .filter(([e, n]) => t.indexOf(+e) === -1)
     .map(([e, t]) => t)
 }
-function l(e, t) {
+function je(e, t) {
   return typeof t == `bigint` ? t.toString() : t
 }
-function u(e) {
+function Me(e) {
   return {
     get value() {
       {
@@ -73,15 +1264,15 @@ function u(e) {
     }
   }
 }
-function ee(e) {
+function Ne(e) {
   return e == null
 }
-function d(e) {
+function Pe(e) {
   let t = e.startsWith(`^`) ? 1 : 0,
     n = e.endsWith(`$`) ? e.length - 1 : e.length
   return e.slice(t, n)
 }
-function te(e, t) {
+function Fe(e, t) {
   let n = (e.toString().split(`.`)[1] || ``).length,
     r = t.toString(),
     i = (r.split(`.`)[1] || ``).length
@@ -92,12 +1283,12 @@ function te(e, t) {
   let a = n > i ? n : i
   return (Number.parseInt(e.toFixed(a).replace(`.`, ``)) % Number.parseInt(t.toFixed(a).replace(`.`, ``))) / 10 ** a
 }
-const ne = Symbol(`evaluating`)
-function f(e, t, n) {
+const Ie = Symbol(`evaluating`)
+function w(e, t, n) {
   let r
   Object.defineProperty(e, t, {
     get() {
-      if (r !== ne) return r === void 0 && ((r = ne), (r = n())), r
+      if (r !== Ie) return r === void 0 && ((r = Ie), (r = n())), r
     },
     set(n) {
       Object.defineProperty(e, t, { value: n })
@@ -105,10 +1296,10 @@ function f(e, t, n) {
     configurable: !0
   })
 }
-function p(e, t, n) {
+function T(e, t, n) {
   Object.defineProperty(e, t, { value: n, writable: !0, enumerable: !0, configurable: !0 })
 }
-function m(...e) {
+function E(...e) {
   let t = {}
   for (let n of e) {
     let e = Object.getOwnPropertyDescriptors(n)
@@ -116,10 +1307,10 @@ function m(...e) {
   }
   return Object.defineProperties({}, t)
 }
-function re(e) {
+function Le(e) {
   return JSON.stringify(e)
 }
-function ie(e) {
+function Re(e) {
   return e
     .toLowerCase()
     .trim()
@@ -127,11 +1318,11 @@ function ie(e) {
     .replace(/[\s_-]+/g, `-`)
     .replace(/^-+|-+$/g, ``)
 }
-const ae = `captureStackTrace` in Error ? Error.captureStackTrace : (...e) => {}
-function h(e) {
+const ze = `captureStackTrace` in Error ? Error.captureStackTrace : (...e) => {}
+function Be(e) {
   return typeof e == `object` && !!e && !Array.isArray(e)
 }
-const oe = u(() => {
+const Ve = Me(() => {
   if (typeof navigator < `u` && navigator?.userAgent?.includes(`Cloudflare`)) return !1
   try {
     return Function(``), !0
@@ -139,25 +1330,25 @@ const oe = u(() => {
     return !1
   }
 })
-function g(e) {
-  if (h(e) === !1) return !1
+function D(e) {
+  if (Be(e) === !1) return !1
   let t = e.constructor
   if (t === void 0 || typeof t != `function`) return !0
   let n = t.prototype
-  return !(h(n) === !1 || Object.prototype.hasOwnProperty.call(n, `isPrototypeOf`) === !1)
+  return !(Be(n) === !1 || Object.prototype.hasOwnProperty.call(n, `isPrototypeOf`) === !1)
 }
-function se(e) {
-  return g(e) ? { ...e } : Array.isArray(e) ? [...e] : e
+function He(e) {
+  return D(e) ? { ...e } : Array.isArray(e) ? [...e] : e
 }
-const ce = new Set([`string`, `number`, `symbol`])
-function _(e) {
+const Ue = new Set([`string`, `number`, `symbol`])
+function We(e) {
   return e.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`)
 }
-function v(e, t, n) {
+function O(e, t, n) {
   let r = new e._zod.constr(t ?? e._zod.def)
   return (!t || n?.parent) && (r._zod.parent = e), r
 }
-function y(e) {
+function k(e) {
   let t = e
   if (!t) return {}
   if (typeof t == `string`) return { error: () => t }
@@ -167,56 +1358,56 @@ function y(e) {
   }
   return delete t.message, typeof t.error == `string` ? { ...t, error: () => t.error } : t
 }
-function le(e) {
+function Ge(e) {
   return Object.keys(e).filter((t) => e[t]._zod.optin === `optional` && e[t]._zod.optout === `optional`)
 }
-const ue = {
+const Ke = {
   safeint: [-(2 ** 53 - 1), 2 ** 53 - 1],
   int32: [-2147483648, 2147483647],
   uint32: [0, 4294967295],
   float32: [-34028234663852886e22, 34028234663852886e22],
   float64: [-Number.MAX_VALUE, Number.MAX_VALUE]
 }
-function de(e, t) {
+function qe(e, t) {
   let n = e._zod.def,
     r = n.checks
   if (r && r.length > 0) throw Error(`.pick() cannot be used on object schemas containing refinements`)
-  return v(
+  return O(
     e,
-    m(e._zod.def, {
+    E(e._zod.def, {
       get shape() {
         let e = {}
         for (let r in t) {
           if (!(r in n.shape)) throw Error(`Unrecognized key: "${r}"`)
           t[r] && (e[r] = n.shape[r])
         }
-        return p(this, `shape`, e), e
+        return T(this, `shape`, e), e
       },
       checks: []
     })
   )
 }
-function fe(e, t) {
+function Je(e, t) {
   let n = e._zod.def,
     r = n.checks
   if (r && r.length > 0) throw Error(`.omit() cannot be used on object schemas containing refinements`)
-  return v(
+  return O(
     e,
-    m(e._zod.def, {
+    E(e._zod.def, {
       get shape() {
         let r = { ...e._zod.def.shape }
         for (let e in t) {
           if (!(e in n.shape)) throw Error(`Unrecognized key: "${e}"`)
           t[e] && delete r[e]
         }
-        return p(this, `shape`, r), r
+        return T(this, `shape`, r), r
       },
       checks: []
     })
   )
 }
-function pe(e, t) {
-  if (!g(t)) throw Error(`Invalid input to extend: expected a plain object`)
+function Ye(e, t) {
+  if (!D(t)) throw Error(`Invalid input to extend: expected a plain object`)
   let n = e._zod.def.checks
   if (n && n.length > 0) {
     let n = e._zod.def.shape
@@ -224,35 +1415,35 @@ function pe(e, t) {
       if (Object.getOwnPropertyDescriptor(n, e) !== void 0)
         throw Error('Cannot overwrite keys on object schemas containing refinements. Use `.safeExtend()` instead.')
   }
-  return v(
+  return O(
     e,
-    m(e._zod.def, {
+    E(e._zod.def, {
       get shape() {
         let n = { ...e._zod.def.shape, ...t }
-        return p(this, `shape`, n), n
+        return T(this, `shape`, n), n
       }
     })
   )
 }
-function me(e, t) {
-  if (!g(t)) throw Error(`Invalid input to safeExtend: expected a plain object`)
-  return v(
+function Xe(e, t) {
+  if (!D(t)) throw Error(`Invalid input to safeExtend: expected a plain object`)
+  return O(
     e,
-    m(e._zod.def, {
+    E(e._zod.def, {
       get shape() {
         let n = { ...e._zod.def.shape, ...t }
-        return p(this, `shape`, n), n
+        return T(this, `shape`, n), n
       }
     })
   )
 }
-function he(e, t) {
-  return v(
+function Ze(e, t) {
+  return O(
     e,
-    m(e._zod.def, {
+    E(e._zod.def, {
       get shape() {
         let n = { ...e._zod.def.shape, ...t._zod.def.shape }
-        return p(this, `shape`, n), n
+        return T(this, `shape`, n), n
       },
       get catchall() {
         return t._zod.def.catchall
@@ -261,12 +1452,12 @@ function he(e, t) {
     })
   )
 }
-function ge(e, t, n) {
+function Qe(e, t, n) {
   let r = t._zod.def.checks
   if (r && r.length > 0) throw Error(`.partial() cannot be used on object schemas containing refinements`)
-  return v(
+  return O(
     t,
-    m(t._zod.def, {
+    E(t._zod.def, {
       get shape() {
         let r = t._zod.def.shape,
           i = { ...r }
@@ -276,16 +1467,16 @@ function ge(e, t, n) {
             n[t] && (i[t] = e ? new e({ type: `optional`, innerType: r[t] }) : r[t])
           }
         else for (let t in r) i[t] = e ? new e({ type: `optional`, innerType: r[t] }) : r[t]
-        return p(this, `shape`, i), i
+        return T(this, `shape`, i), i
       },
       checks: []
     })
   )
 }
-function _e(e, t, n) {
-  return v(
+function $e(e, t, n) {
+  return O(
     t,
-    m(t._zod.def, {
+    E(t._zod.def, {
       get shape() {
         let r = t._zod.def.shape,
           i = { ...r }
@@ -295,34 +1486,34 @@ function _e(e, t, n) {
             n[t] && (i[t] = new e({ type: `nonoptional`, innerType: r[t] }))
           }
         else for (let t in r) i[t] = new e({ type: `nonoptional`, innerType: r[t] })
-        return p(this, `shape`, i), i
+        return T(this, `shape`, i), i
       }
     })
   )
 }
-function b(e, t = 0) {
+function et(e, t = 0) {
   if (e.aborted === !0) return !0
   for (let n = t; n < e.issues.length; n++) if (e.issues[n]?.continue !== !0) return !0
   return !1
 }
-function x(e, t) {
+function tt(e, t) {
   return t.map((t) => {
     var n
     return (n = t).path ?? (n.path = []), t.path.unshift(e), t
   })
 }
-function ve(e) {
+function nt(e) {
   return typeof e == `string` ? e : e?.message
 }
-function S(e, t, n) {
+function A(e, t, n) {
   let r = { ...e, path: e.path ?? [] }
   return (
     e.message ||
       (r.message =
-        ve(e.inst?._zod.def?.error?.(e)) ??
-        ve(t?.error?.(e)) ??
-        ve(n.customError?.(e)) ??
-        ve(n.localeError?.(e)) ??
+        nt(e.inst?._zod.def?.error?.(e)) ??
+        nt(t?.error?.(e)) ??
+        nt(n.customError?.(e)) ??
+        nt(n.localeError?.(e)) ??
         `Invalid input`),
     delete r.inst,
     delete r.continue,
@@ -330,30 +1521,30 @@ function S(e, t, n) {
     r
   )
 }
-function ye(e) {
+function rt(e) {
   return Array.isArray(e) ? `array` : typeof e == `string` ? `string` : `unknown`
 }
-function C(...e) {
+function it(...e) {
   let [t, n, r] = e
   return typeof t == `string` ? { message: t, code: `custom`, input: n, inst: r } : { ...t }
 }
-const be = (e, t) => {
+const at = (e, t) => {
     ;(e.name = `$ZodError`),
       Object.defineProperty(e, `_zod`, { value: e._zod, enumerable: !1 }),
       Object.defineProperty(e, `issues`, { value: t, enumerable: !1 }),
-      (e.message = JSON.stringify(t, l, 2)),
+      (e.message = JSON.stringify(t, je, 2)),
       Object.defineProperty(e, `toString`, { value: () => e.message, enumerable: !1 })
   },
-  xe = r(`$ZodError`, be),
-  Se = r(`$ZodError`, be, { Parent: Error })
-function Ce(e, t = (e) => e.message) {
+  ot = S(`$ZodError`, at),
+  st = S(`$ZodError`, at, { Parent: Error })
+function ct(e, t = (e) => e.message) {
   let n = {},
     r = []
   for (let i of e.issues)
     i.path.length > 0 ? ((n[i.path[0]] = n[i.path[0]] || []), n[i.path[0]].push(t(i))) : r.push(t(i))
   return { formErrors: r, fieldErrors: n }
 }
-function we(e, t = (e) => e.message) {
+function lt(e, t = (e) => e.message) {
   let n = { _errors: [] },
     r = (e) => {
       for (let i of e.issues)
@@ -376,95 +1567,95 @@ function we(e, t = (e) => e.message) {
     }
   return r(e), n
 }
-const Te = (e) => (t, n, r, a) => {
-    let o = r ? Object.assign(r, { async: !1 }) : { async: !1 },
-      c = t._zod.run({ value: n, issues: [] }, o)
-    if (c instanceof Promise) throw new i()
-    if (c.issues.length) {
-      let t = new (a?.Err ?? e)(c.issues.map((e) => S(e, o, s())))
-      throw (ae(t, a?.callee), t)
-    }
-    return c.value
-  },
-  Ee = (e) => async (t, n, r, i) => {
-    let a = r ? Object.assign(r, { async: !0 }) : { async: !0 },
+const ut = (e) => (t, n, r, i) => {
+    let a = r ? Object.assign(r, { async: !1 }) : { async: !1 },
       o = t._zod.run({ value: n, issues: [] }, a)
-    if ((o instanceof Promise && (o = await o), o.issues.length)) {
-      let t = new (i?.Err ?? e)(o.issues.map((e) => S(e, a, s())))
-      throw (ae(t, i?.callee), t)
+    if (o instanceof Promise) throw new De()
+    if (o.issues.length) {
+      let t = new (i?.Err ?? e)(o.issues.map((e) => A(e, a, C())))
+      throw (ze(t, i?.callee), t)
     }
     return o.value
   },
-  De = (e) => (t, n, r) => {
-    let a = r ? { ...r, async: !1 } : { async: !1 },
+  dt = (e) => async (t, n, r, i) => {
+    let a = r ? Object.assign(r, { async: !0 }) : { async: !0 },
       o = t._zod.run({ value: n, issues: [] }, a)
-    if (o instanceof Promise) throw new i()
-    return o.issues.length
-      ? { success: !1, error: new (e ?? xe)(o.issues.map((e) => S(e, a, s()))) }
-      : { success: !0, data: o.value }
+    if ((o instanceof Promise && (o = await o), o.issues.length)) {
+      let t = new (i?.Err ?? e)(o.issues.map((e) => A(e, a, C())))
+      throw (ze(t, i?.callee), t)
+    }
+    return o.value
   },
-  Oe = De(Se),
-  ke = (e) => async (t, n, r) => {
+  ft = (e) => (t, n, r) => {
+    let i = r ? { ...r, async: !1 } : { async: !1 },
+      a = t._zod.run({ value: n, issues: [] }, i)
+    if (a instanceof Promise) throw new De()
+    return a.issues.length
+      ? { success: !1, error: new (e ?? ot)(a.issues.map((e) => A(e, i, C()))) }
+      : { success: !0, data: a.value }
+  },
+  pt = ft(st),
+  mt = (e) => async (t, n, r) => {
     let i = r ? Object.assign(r, { async: !0 }) : { async: !0 },
       a = t._zod.run({ value: n, issues: [] }, i)
     return (
       a instanceof Promise && (a = await a),
       a.issues.length
-        ? { success: !1, error: new e(a.issues.map((e) => S(e, i, s()))) }
+        ? { success: !1, error: new e(a.issues.map((e) => A(e, i, C()))) }
         : { success: !0, data: a.value }
     )
   },
-  Ae = ke(Se),
-  je = (e) => (t, n, r) => {
+  ht = mt(st),
+  gt = (e) => (t, n, r) => {
     let i = r ? Object.assign(r, { direction: `backward` }) : { direction: `backward` }
-    return Te(e)(t, n, i)
+    return ut(e)(t, n, i)
   },
-  Me = (e) => (t, n, r) => Te(e)(t, n, r),
-  Ne = (e) => async (t, n, r) => {
+  _t = (e) => (t, n, r) => ut(e)(t, n, r),
+  vt = (e) => async (t, n, r) => {
     let i = r ? Object.assign(r, { direction: `backward` }) : { direction: `backward` }
-    return Ee(e)(t, n, i)
+    return dt(e)(t, n, i)
   },
-  Pe = (e) => async (t, n, r) => Ee(e)(t, n, r),
-  Fe = (e) => (t, n, r) => {
+  yt = (e) => async (t, n, r) => dt(e)(t, n, r),
+  bt = (e) => (t, n, r) => {
     let i = r ? Object.assign(r, { direction: `backward` }) : { direction: `backward` }
-    return De(e)(t, n, i)
+    return ft(e)(t, n, i)
   },
-  Ie = (e) => (t, n, r) => De(e)(t, n, r),
-  Le = (e) => async (t, n, r) => {
+  xt = (e) => (t, n, r) => ft(e)(t, n, r),
+  St = (e) => async (t, n, r) => {
     let i = r ? Object.assign(r, { direction: `backward` }) : { direction: `backward` }
-    return ke(e)(t, n, i)
+    return mt(e)(t, n, i)
   },
-  Re = (e) => async (t, n, r) => ke(e)(t, n, r),
-  ze = /^[cC][^\s-]{8,}$/,
-  Be = /^[0-9a-z]+$/,
-  Ve = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/,
-  He = /^[0-9a-vA-V]{20}$/,
-  Ue = /^[A-Za-z0-9]{27}$/,
-  We = /^[a-zA-Z0-9_-]{21}$/,
-  Ge = /^P(?:(\d+W)|(?!.*W)(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+([.,]\d+)?S)?)?)$/,
-  Ke = /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/,
-  qe = (e) =>
+  Ct = (e) => async (t, n, r) => mt(e)(t, n, r),
+  wt = /^[cC][^\s-]{8,}$/,
+  Tt = /^[0-9a-z]+$/,
+  Et = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/,
+  Dt = /^[0-9a-vA-V]{20}$/,
+  Ot = /^[A-Za-z0-9]{27}$/,
+  kt = /^[a-zA-Z0-9_-]{21}$/,
+  At = /^P(?:(\d+W)|(?!.*W)(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+([.,]\d+)?S)?)?)$/,
+  jt = /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/,
+  Mt = (e) =>
     e
       ? RegExp(`^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-${e}[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$`)
       : /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/,
-  Je = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/
-function Ye() {
+  Nt = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/
+function Pt() {
   return RegExp(`^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`, `u`)
 }
-const Xe =
+const Ft =
     /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/,
-  Ze =
+  It =
     /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$/,
-  Qe =
+  Lt =
     /^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\/([0-9]|[1-2][0-9]|3[0-2])$/,
-  $e =
+  Rt =
     /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|::|([0-9a-fA-F]{1,4})?::([0-9a-fA-F]{1,4}:?){0,6})\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/,
-  et = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/,
-  tt = /^[A-Za-z0-9_-]*$/,
-  nt = /^\+[1-9]\d{6,14}$/,
-  rt = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`,
-  it = RegExp(`^${rt}$`)
-function at(e) {
+  zt = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/,
+  Bt = /^[A-Za-z0-9_-]*$/,
+  Vt = /^\+[1-9]\d{6,14}$/,
+  Ht = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`,
+  Ut = RegExp(`^${Ht}$`)
+function Wt(e) {
   let t = `(?:[01]\\d|2[0-3]):[0-5]\\d`
   return typeof e.precision == `number`
     ? e.precision === -1
@@ -474,33 +1665,33 @@ function at(e) {
         : `${t}:[0-5]\\d\\.\\d{${e.precision}}`
     : `${t}(?::[0-5]\\d(?:\\.\\d+)?)?`
 }
-function ot(e) {
-  return RegExp(`^${at(e)}$`)
+function Gt(e) {
+  return RegExp(`^${Wt(e)}$`)
 }
-function st(e) {
-  let t = at({ precision: e.precision }),
+function Kt(e) {
+  let t = Wt({ precision: e.precision }),
     n = [`Z`]
   e.local && n.push(``), e.offset && n.push(`([+-](?:[01]\\d|2[0-3]):[0-5]\\d)`)
   let r = `${t}(?:${n.join(`|`)})`
-  return RegExp(`^${rt}T(?:${r})$`)
+  return RegExp(`^${Ht}T(?:${r})$`)
 }
-const ct = (e) => {
+const qt = (e) => {
     let t = e ? `[\\s\\S]{${e?.minimum ?? 0},${e?.maximum ?? ``}}` : `[\\s\\S]*`
     return RegExp(`^${t}$`)
   },
-  lt = /^-?\d+$/,
-  ut = /^-?\d+(?:\.\d+)?$/,
-  dt = /^(?:true|false)$/i,
-  ft = /^[^A-Z]*$/,
-  pt = /^[^a-z]*$/,
-  w = r(`$ZodCheck`, (e, t) => {
+  Jt = /^-?\d+$/,
+  Yt = /^-?\d+(?:\.\d+)?$/,
+  Xt = /^(?:true|false)$/i,
+  Zt = /^[^A-Z]*$/,
+  Qt = /^[^a-z]*$/,
+  j = S(`$ZodCheck`, (e, t) => {
     var n
     ;(e._zod ??= {}), (e._zod.def = t), (n = e._zod).onattach ?? (n.onattach = [])
   }),
-  mt = { number: `number`, bigint: `bigint`, object: `date` },
-  ht = r(`$ZodCheckLessThan`, (e, t) => {
-    w.init(e, t)
-    let n = mt[typeof t.value]
+  $t = { number: `number`, bigint: `bigint`, object: `date` },
+  en = S(`$ZodCheckLessThan`, (e, t) => {
+    j.init(e, t)
+    let n = $t[typeof t.value]
     e._zod.onattach.push((e) => {
       let n = e._zod.bag,
         r = (t.inclusive ? n.maximum : n.exclusiveMaximum) ?? 1 / 0
@@ -519,9 +1710,9 @@ const ct = (e) => {
           })
       })
   }),
-  gt = r(`$ZodCheckGreaterThan`, (e, t) => {
-    w.init(e, t)
-    let n = mt[typeof t.value]
+  tn = S(`$ZodCheckGreaterThan`, (e, t) => {
+    j.init(e, t)
+    let n = $t[typeof t.value]
     e._zod.onattach.push((e) => {
       let n = e._zod.bag,
         r = (t.inclusive ? n.minimum : n.exclusiveMinimum) ?? -1 / 0
@@ -540,15 +1731,15 @@ const ct = (e) => {
           })
       })
   }),
-  _t = r(`$ZodCheckMultipleOf`, (e, t) => {
-    w.init(e, t),
+  nn = S(`$ZodCheckMultipleOf`, (e, t) => {
+    j.init(e, t),
       e._zod.onattach.push((e) => {
         var n
         ;(n = e._zod.bag).multipleOf ?? (n.multipleOf = t.value)
       }),
       (e._zod.check = (n) => {
         if (typeof n.value != typeof t.value) throw Error(`Cannot mix number and bigint in multiple_of check.`)
-        ;(typeof n.value == `bigint` ? n.value % t.value === BigInt(0) : te(n.value, t.value) === 0) ||
+        ;(typeof n.value == `bigint` ? n.value % t.value === BigInt(0) : Fe(n.value, t.value) === 0) ||
           n.issues.push({
             origin: typeof n.value,
             code: `not_multiple_of`,
@@ -559,14 +1750,14 @@ const ct = (e) => {
           })
       })
   }),
-  vt = r(`$ZodCheckNumberFormat`, (e, t) => {
-    w.init(e, t), (t.format = t.format || `float64`)
+  rn = S(`$ZodCheckNumberFormat`, (e, t) => {
+    j.init(e, t), (t.format = t.format || `float64`)
     let n = t.format?.includes(`int`),
       r = n ? `int` : `number`,
-      [i, a] = ue[t.format]
+      [i, a] = Ke[t.format]
     e._zod.onattach.push((e) => {
       let r = e._zod.bag
-      ;(r.format = t.format), (r.minimum = i), (r.maximum = a), n && (r.pattern = lt)
+      ;(r.format = t.format), (r.minimum = i), (r.maximum = a), n && (r.pattern = Jt)
     }),
       (e._zod.check = (o) => {
         let s = o.value
@@ -622,13 +1813,13 @@ const ct = (e) => {
             })
       })
   }),
-  yt = r(`$ZodCheckMaxLength`, (e, t) => {
+  an = S(`$ZodCheckMaxLength`, (e, t) => {
     var n
-    w.init(e, t),
+    j.init(e, t),
       (n = e._zod.def).when ??
         (n.when = (e) => {
           let t = e.value
-          return !ee(t) && t.length !== void 0
+          return !Ne(t) && t.length !== void 0
         }),
       e._zod.onattach.push((e) => {
         let n = e._zod.bag.maximum ?? 1 / 0
@@ -637,7 +1828,7 @@ const ct = (e) => {
       (e._zod.check = (n) => {
         let r = n.value
         if (r.length <= t.maximum) return
-        let i = ye(r)
+        let i = rt(r)
         n.issues.push({
           origin: i,
           code: `too_big`,
@@ -649,13 +1840,13 @@ const ct = (e) => {
         })
       })
   }),
-  bt = r(`$ZodCheckMinLength`, (e, t) => {
+  on = S(`$ZodCheckMinLength`, (e, t) => {
     var n
-    w.init(e, t),
+    j.init(e, t),
       (n = e._zod.def).when ??
         (n.when = (e) => {
           let t = e.value
-          return !ee(t) && t.length !== void 0
+          return !Ne(t) && t.length !== void 0
         }),
       e._zod.onattach.push((e) => {
         let n = e._zod.bag.minimum ?? -1 / 0
@@ -664,7 +1855,7 @@ const ct = (e) => {
       (e._zod.check = (n) => {
         let r = n.value
         if (r.length >= t.minimum) return
-        let i = ye(r)
+        let i = rt(r)
         n.issues.push({
           origin: i,
           code: `too_small`,
@@ -676,13 +1867,13 @@ const ct = (e) => {
         })
       })
   }),
-  xt = r(`$ZodCheckLengthEquals`, (e, t) => {
+  sn = S(`$ZodCheckLengthEquals`, (e, t) => {
     var n
-    w.init(e, t),
+    j.init(e, t),
       (n = e._zod.def).when ??
         (n.when = (e) => {
           let t = e.value
-          return !ee(t) && t.length !== void 0
+          return !Ne(t) && t.length !== void 0
         }),
       e._zod.onattach.push((e) => {
         let n = e._zod.bag
@@ -692,7 +1883,7 @@ const ct = (e) => {
         let r = n.value,
           i = r.length
         if (i === t.length) return
-        let a = ye(r),
+        let a = rt(r),
           o = i > t.length
         n.issues.push({
           origin: a,
@@ -705,9 +1896,9 @@ const ct = (e) => {
         })
       })
   }),
-  St = r(`$ZodCheckStringFormat`, (e, t) => {
+  cn = S(`$ZodCheckStringFormat`, (e, t) => {
     var n, r
-    w.init(e, t),
+    j.init(e, t),
       e._zod.onattach.push((e) => {
         let n = e._zod.bag
         ;(n.format = t.format), t.pattern && ((n.patterns ??= new Set()), n.patterns.add(t.pattern))
@@ -729,8 +1920,8 @@ const ct = (e) => {
           }))
         : ((r = e._zod).check ?? (r.check = () => {}))
   }),
-  Ct = r(`$ZodCheckRegex`, (e, t) => {
-    St.init(e, t),
+  ln = S(`$ZodCheckRegex`, (e, t) => {
+    cn.init(e, t),
       (e._zod.check = (n) => {
         ;(t.pattern.lastIndex = 0),
           !t.pattern.test(n.value) &&
@@ -745,15 +1936,15 @@ const ct = (e) => {
             })
       })
   }),
-  wt = r(`$ZodCheckLowerCase`, (e, t) => {
-    ;(t.pattern ??= ft), St.init(e, t)
+  un = S(`$ZodCheckLowerCase`, (e, t) => {
+    ;(t.pattern ??= Zt), cn.init(e, t)
   }),
-  Tt = r(`$ZodCheckUpperCase`, (e, t) => {
-    ;(t.pattern ??= pt), St.init(e, t)
+  dn = S(`$ZodCheckUpperCase`, (e, t) => {
+    ;(t.pattern ??= Qt), cn.init(e, t)
   }),
-  Et = r(`$ZodCheckIncludes`, (e, t) => {
-    w.init(e, t)
-    let n = _(t.includes),
+  fn = S(`$ZodCheckIncludes`, (e, t) => {
+    j.init(e, t)
+    let n = We(t.includes),
       r = new RegExp(typeof t.position == `number` ? `^.{${t.position}}${n}` : n)
     ;(t.pattern = r),
       e._zod.onattach.push((e) => {
@@ -773,9 +1964,9 @@ const ct = (e) => {
           })
       })
   }),
-  Dt = r(`$ZodCheckStartsWith`, (e, t) => {
-    w.init(e, t)
-    let n = RegExp(`^${_(t.prefix)}.*`)
+  pn = S(`$ZodCheckStartsWith`, (e, t) => {
+    j.init(e, t)
+    let n = RegExp(`^${We(t.prefix)}.*`)
     ;(t.pattern ??= n),
       e._zod.onattach.push((e) => {
         let t = e._zod.bag
@@ -794,9 +1985,9 @@ const ct = (e) => {
           })
       })
   }),
-  Ot = r(`$ZodCheckEndsWith`, (e, t) => {
-    w.init(e, t)
-    let n = RegExp(`.*${_(t.suffix)}$`)
+  mn = S(`$ZodCheckEndsWith`, (e, t) => {
+    j.init(e, t)
+    let n = RegExp(`.*${We(t.suffix)}$`)
     ;(t.pattern ??= n),
       e._zod.onattach.push((e) => {
         let t = e._zod.bag
@@ -815,13 +2006,13 @@ const ct = (e) => {
           })
       })
   }),
-  kt = r(`$ZodCheckOverwrite`, (e, t) => {
-    w.init(e, t),
+  hn = S(`$ZodCheckOverwrite`, (e, t) => {
+    j.init(e, t),
       (e._zod.check = (e) => {
         e.value = t.tx(e.value)
       })
   })
-var At = class {
+var gn = class {
   constructor(e = []) {
     ;(this.content = []), (this.indent = 0), this && (this.args = e)
   }
@@ -852,10 +2043,10 @@ var At = class {
     )
   }
 }
-const jt = { major: 4, minor: 3, patch: 6 },
-  T = r(`$ZodType`, (e, t) => {
+const _n = { major: 4, minor: 3, patch: 6 },
+  M = S(`$ZodType`, (e, t) => {
     var n
-    ;(e ??= {}), (e._zod.def = t), (e._zod.bag = e._zod.bag || {}), (e._zod.version = jt)
+    ;(e ??= {}), (e._zod.def = t), (e._zod.bag = e._zod.bag || {}), (e._zod.version = _n)
     let r = [...(e._zod.def.checks ?? [])]
     e._zod.traits.has(`$ZodCheck`) && r.unshift(e)
     for (let t of r) for (let n of t._zod.onattach) n(e)
@@ -866,65 +2057,65 @@ const jt = { major: 4, minor: 3, patch: 6 },
         })
     else {
       let t = (e, t, n) => {
-          let r = b(e),
-            a
-          for (let o of t) {
-            if (o._zod.def.when) {
-              if (!o._zod.def.when(e)) continue
+          let r = et(e),
+            i
+          for (let a of t) {
+            if (a._zod.def.when) {
+              if (!a._zod.def.when(e)) continue
             } else if (r) continue
             let t = e.issues.length,
-              s = o._zod.check(e)
-            if (s instanceof Promise && n?.async === !1) throw new i()
-            if (a || s instanceof Promise)
-              a = (a ?? Promise.resolve()).then(async () => {
-                await s, e.issues.length !== t && (r ||= b(e, t))
+              o = a._zod.check(e)
+            if (o instanceof Promise && n?.async === !1) throw new De()
+            if (i || o instanceof Promise)
+              i = (i ?? Promise.resolve()).then(async () => {
+                await o, e.issues.length !== t && (r ||= et(e, t))
               })
             else {
               if (e.issues.length === t) continue
-              r ||= b(e, t)
+              r ||= et(e, t)
             }
           }
-          return a ? a.then(() => e) : e
+          return i ? i.then(() => e) : e
         },
-        n = (n, a, o) => {
-          if (b(n)) return (n.aborted = !0), n
-          let s = t(a, r, o)
-          if (s instanceof Promise) {
-            if (o.async === !1) throw new i()
-            return s.then((t) => e._zod.parse(t, o))
+        n = (n, i, a) => {
+          if (et(n)) return (n.aborted = !0), n
+          let o = t(i, r, a)
+          if (o instanceof Promise) {
+            if (a.async === !1) throw new De()
+            return o.then((t) => e._zod.parse(t, a))
           }
-          return e._zod.parse(s, o)
+          return e._zod.parse(o, a)
         }
-      e._zod.run = (a, o) => {
-        if (o.skipChecks) return e._zod.parse(a, o)
-        if (o.direction === `backward`) {
-          let t = e._zod.parse({ value: a.value, issues: [] }, { ...o, skipChecks: !0 })
-          return t instanceof Promise ? t.then((e) => n(e, a, o)) : n(t, a, o)
+      e._zod.run = (i, a) => {
+        if (a.skipChecks) return e._zod.parse(i, a)
+        if (a.direction === `backward`) {
+          let t = e._zod.parse({ value: i.value, issues: [] }, { ...a, skipChecks: !0 })
+          return t instanceof Promise ? t.then((e) => n(e, i, a)) : n(t, i, a)
         }
-        let s = e._zod.parse(a, o)
-        if (s instanceof Promise) {
-          if (o.async === !1) throw new i()
-          return s.then((e) => t(e, r, o))
+        let o = e._zod.parse(i, a)
+        if (o instanceof Promise) {
+          if (a.async === !1) throw new De()
+          return o.then((e) => t(e, r, a))
         }
-        return t(s, r, o)
+        return t(o, r, a)
       }
     }
-    f(e, `~standard`, () => ({
+    w(e, `~standard`, () => ({
       validate: (t) => {
         try {
-          let n = Oe(e, t)
+          let n = pt(e, t)
           return n.success ? { value: n.data } : { issues: n.error?.issues }
         } catch {
-          return Ae(e, t).then((e) => (e.success ? { value: e.data } : { issues: e.error?.issues }))
+          return ht(e, t).then((e) => (e.success ? { value: e.data } : { issues: e.error?.issues }))
         }
       },
       vendor: `zod`,
       version: 1
     }))
   }),
-  Mt = r(`$ZodString`, (e, t) => {
-    T.init(e, t),
-      (e._zod.pattern = [...(e?._zod.bag?.patterns ?? [])].pop() ?? ct(e._zod.bag)),
+  vn = S(`$ZodString`, (e, t) => {
+    M.init(e, t),
+      (e._zod.pattern = [...(e?._zod.bag?.patterns ?? [])].pop() ?? qt(e._zod.bag)),
       (e._zod.parse = (n, r) => {
         if (t.coerce)
           try {
@@ -937,25 +2128,25 @@ const jt = { major: 4, minor: 3, patch: 6 },
         )
       })
   }),
-  E = r(`$ZodStringFormat`, (e, t) => {
-    St.init(e, t), Mt.init(e, t)
+  N = S(`$ZodStringFormat`, (e, t) => {
+    cn.init(e, t), vn.init(e, t)
   }),
-  Nt = r(`$ZodGUID`, (e, t) => {
-    ;(t.pattern ??= Ke), E.init(e, t)
+  yn = S(`$ZodGUID`, (e, t) => {
+    ;(t.pattern ??= jt), N.init(e, t)
   }),
-  Pt = r(`$ZodUUID`, (e, t) => {
+  bn = S(`$ZodUUID`, (e, t) => {
     if (t.version) {
       let e = { v1: 1, v2: 2, v3: 3, v4: 4, v5: 5, v6: 6, v7: 7, v8: 8 }[t.version]
       if (e === void 0) throw Error(`Invalid UUID version: "${t.version}"`)
-      t.pattern ??= qe(e)
-    } else t.pattern ??= qe()
-    E.init(e, t)
+      t.pattern ??= Mt(e)
+    } else t.pattern ??= Mt()
+    N.init(e, t)
   }),
-  Ft = r(`$ZodEmail`, (e, t) => {
-    ;(t.pattern ??= Je), E.init(e, t)
+  xn = S(`$ZodEmail`, (e, t) => {
+    ;(t.pattern ??= Nt), N.init(e, t)
   }),
-  It = r(`$ZodURL`, (e, t) => {
-    E.init(e, t),
+  Sn = S(`$ZodURL`, (e, t) => {
+    N.init(e, t),
       (e._zod.check = (n) => {
         try {
           let r = n.value.trim(),
@@ -991,45 +2182,45 @@ const jt = { major: 4, minor: 3, patch: 6 },
         }
       })
   }),
-  Lt = r(`$ZodEmoji`, (e, t) => {
-    ;(t.pattern ??= Ye()), E.init(e, t)
+  Cn = S(`$ZodEmoji`, (e, t) => {
+    ;(t.pattern ??= Pt()), N.init(e, t)
   }),
-  Rt = r(`$ZodNanoID`, (e, t) => {
-    ;(t.pattern ??= We), E.init(e, t)
+  wn = S(`$ZodNanoID`, (e, t) => {
+    ;(t.pattern ??= kt), N.init(e, t)
   }),
-  zt = r(`$ZodCUID`, (e, t) => {
-    ;(t.pattern ??= ze), E.init(e, t)
+  Tn = S(`$ZodCUID`, (e, t) => {
+    ;(t.pattern ??= wt), N.init(e, t)
   }),
-  Bt = r(`$ZodCUID2`, (e, t) => {
-    ;(t.pattern ??= Be), E.init(e, t)
+  En = S(`$ZodCUID2`, (e, t) => {
+    ;(t.pattern ??= Tt), N.init(e, t)
   }),
-  Vt = r(`$ZodULID`, (e, t) => {
-    ;(t.pattern ??= Ve), E.init(e, t)
+  Dn = S(`$ZodULID`, (e, t) => {
+    ;(t.pattern ??= Et), N.init(e, t)
   }),
-  Ht = r(`$ZodXID`, (e, t) => {
-    ;(t.pattern ??= He), E.init(e, t)
+  On = S(`$ZodXID`, (e, t) => {
+    ;(t.pattern ??= Dt), N.init(e, t)
   }),
-  Ut = r(`$ZodKSUID`, (e, t) => {
-    ;(t.pattern ??= Ue), E.init(e, t)
+  kn = S(`$ZodKSUID`, (e, t) => {
+    ;(t.pattern ??= Ot), N.init(e, t)
   }),
-  Wt = r(`$ZodISODateTime`, (e, t) => {
-    ;(t.pattern ??= st(t)), E.init(e, t)
+  An = S(`$ZodISODateTime`, (e, t) => {
+    ;(t.pattern ??= Kt(t)), N.init(e, t)
   }),
-  Gt = r(`$ZodISODate`, (e, t) => {
-    ;(t.pattern ??= it), E.init(e, t)
+  jn = S(`$ZodISODate`, (e, t) => {
+    ;(t.pattern ??= Ut), N.init(e, t)
   }),
-  Kt = r(`$ZodISOTime`, (e, t) => {
-    ;(t.pattern ??= ot(t)), E.init(e, t)
+  Mn = S(`$ZodISOTime`, (e, t) => {
+    ;(t.pattern ??= Gt(t)), N.init(e, t)
   }),
-  qt = r(`$ZodISODuration`, (e, t) => {
-    ;(t.pattern ??= Ge), E.init(e, t)
+  Nn = S(`$ZodISODuration`, (e, t) => {
+    ;(t.pattern ??= At), N.init(e, t)
   }),
-  Jt = r(`$ZodIPv4`, (e, t) => {
-    ;(t.pattern ??= Xe), E.init(e, t), (e._zod.bag.format = `ipv4`)
+  Pn = S(`$ZodIPv4`, (e, t) => {
+    ;(t.pattern ??= Ft), N.init(e, t), (e._zod.bag.format = `ipv4`)
   }),
-  Yt = r(`$ZodIPv6`, (e, t) => {
-    ;(t.pattern ??= Ze),
-      E.init(e, t),
+  Fn = S(`$ZodIPv6`, (e, t) => {
+    ;(t.pattern ??= It),
+      N.init(e, t),
       (e._zod.bag.format = `ipv6`),
       (e._zod.check = (n) => {
         try {
@@ -1039,12 +2230,12 @@ const jt = { major: 4, minor: 3, patch: 6 },
         }
       })
   }),
-  Xt = r(`$ZodCIDRv4`, (e, t) => {
-    ;(t.pattern ??= Qe), E.init(e, t)
+  In = S(`$ZodCIDRv4`, (e, t) => {
+    ;(t.pattern ??= Lt), N.init(e, t)
   }),
-  Zt = r(`$ZodCIDRv6`, (e, t) => {
-    ;(t.pattern ??= $e),
-      E.init(e, t),
+  Ln = S(`$ZodCIDRv6`, (e, t) => {
+    ;(t.pattern ??= Rt),
+      N.init(e, t),
       (e._zod.check = (n) => {
         let r = n.value.split(`/`)
         try {
@@ -1059,7 +2250,7 @@ const jt = { major: 4, minor: 3, patch: 6 },
         }
       })
   })
-function Qt(e) {
+function Rn(e) {
   if (e === ``) return !0
   if (e.length % 4 != 0) return !1
   try {
@@ -1068,33 +2259,33 @@ function Qt(e) {
     return !1
   }
 }
-const $t = r(`$ZodBase64`, (e, t) => {
-  ;(t.pattern ??= et),
-    E.init(e, t),
+const zn = S(`$ZodBase64`, (e, t) => {
+  ;(t.pattern ??= zt),
+    N.init(e, t),
     (e._zod.bag.contentEncoding = `base64`),
     (e._zod.check = (n) => {
-      Qt(n.value) ||
+      Rn(n.value) ||
         n.issues.push({ code: `invalid_format`, format: `base64`, input: n.value, inst: e, continue: !t.abort })
     })
 })
-function en(e) {
-  if (!tt.test(e)) return !1
+function Bn(e) {
+  if (!Bt.test(e)) return !1
   let t = e.replace(/[-_]/g, (e) => (e === `-` ? `+` : `/`))
-  return Qt(t.padEnd(Math.ceil(t.length / 4) * 4, `=`))
+  return Rn(t.padEnd(Math.ceil(t.length / 4) * 4, `=`))
 }
-const tn = r(`$ZodBase64URL`, (e, t) => {
-    ;(t.pattern ??= tt),
-      E.init(e, t),
+const Vn = S(`$ZodBase64URL`, (e, t) => {
+    ;(t.pattern ??= Bt),
+      N.init(e, t),
       (e._zod.bag.contentEncoding = `base64url`),
       (e._zod.check = (n) => {
-        en(n.value) ||
+        Bn(n.value) ||
           n.issues.push({ code: `invalid_format`, format: `base64url`, input: n.value, inst: e, continue: !t.abort })
       })
   }),
-  nn = r(`$ZodE164`, (e, t) => {
-    ;(t.pattern ??= nt), E.init(e, t)
+  Hn = S(`$ZodE164`, (e, t) => {
+    ;(t.pattern ??= Vt), N.init(e, t)
   })
-function rn(e, t = null) {
+function Un(e, t = null) {
   try {
     let n = e.split(`.`)
     if (n.length !== 3) return !1
@@ -1106,16 +2297,16 @@ function rn(e, t = null) {
     return !1
   }
 }
-const an = r(`$ZodJWT`, (e, t) => {
-    E.init(e, t),
+const Wn = S(`$ZodJWT`, (e, t) => {
+    N.init(e, t),
       (e._zod.check = (n) => {
-        rn(n.value, t.alg) ||
+        Un(n.value, t.alg) ||
           n.issues.push({ code: `invalid_format`, format: `jwt`, input: n.value, inst: e, continue: !t.abort })
       })
   }),
-  on = r(`$ZodNumber`, (e, t) => {
-    T.init(e, t),
-      (e._zod.pattern = e._zod.bag.pattern ?? ut),
+  Gn = S(`$ZodNumber`, (e, t) => {
+    M.init(e, t),
+      (e._zod.pattern = e._zod.bag.pattern ?? Yt),
       (e._zod.parse = (n, r) => {
         if (t.coerce)
           try {
@@ -1130,12 +2321,12 @@ const an = r(`$ZodJWT`, (e, t) => {
         )
       })
   }),
-  sn = r(`$ZodNumberFormat`, (e, t) => {
-    vt.init(e, t), on.init(e, t)
+  Kn = S(`$ZodNumberFormat`, (e, t) => {
+    rn.init(e, t), Gn.init(e, t)
   }),
-  cn = r(`$ZodBoolean`, (e, t) => {
-    T.init(e, t),
-      (e._zod.pattern = dt),
+  qn = S(`$ZodBoolean`, (e, t) => {
+    M.init(e, t),
+      (e._zod.pattern = Xt),
       (e._zod.parse = (n, r) => {
         if (t.coerce)
           try {
@@ -1147,20 +2338,20 @@ const an = r(`$ZodJWT`, (e, t) => {
         )
       })
   }),
-  ln = r(`$ZodUnknown`, (e, t) => {
-    T.init(e, t), (e._zod.parse = (e) => e)
+  Jn = S(`$ZodUnknown`, (e, t) => {
+    M.init(e, t), (e._zod.parse = (e) => e)
   }),
-  un = r(`$ZodNever`, (e, t) => {
-    T.init(e, t),
+  Yn = S(`$ZodNever`, (e, t) => {
+    M.init(e, t),
       (e._zod.parse = (t, n) => (
         t.issues.push({ expected: `never`, code: `invalid_type`, input: t.value, inst: e }), t
       ))
   })
-function dn(e, t, n) {
-  e.issues.length && t.issues.push(...x(n, e.issues)), (t.value[n] = e.value)
+function Xn(e, t, n) {
+  e.issues.length && t.issues.push(...tt(n, e.issues)), (t.value[n] = e.value)
 }
-const fn = r(`$ZodArray`, (e, t) => {
-  T.init(e, t),
+const Zn = S(`$ZodArray`, (e, t) => {
+  M.init(e, t),
     (e._zod.parse = (n, r) => {
       let i = n.value
       if (!Array.isArray(i)) return n.issues.push({ expected: `array`, code: `invalid_type`, input: i, inst: e }), n
@@ -1169,27 +2360,27 @@ const fn = r(`$ZodArray`, (e, t) => {
       for (let e = 0; e < i.length; e++) {
         let o = i[e],
           s = t.element._zod.run({ value: o, issues: [] }, r)
-        s instanceof Promise ? a.push(s.then((t) => dn(t, n, e))) : dn(s, n, e)
+        s instanceof Promise ? a.push(s.then((t) => Xn(t, n, e))) : Xn(s, n, e)
       }
       return a.length ? Promise.all(a).then(() => n) : n
     })
 })
-function pn(e, t, n, r, i) {
+function Qn(e, t, n, r, i) {
   if (e.issues.length) {
     if (i && !(n in r)) return
-    t.issues.push(...x(n, e.issues))
+    t.issues.push(...tt(n, e.issues))
   }
   e.value === void 0 ? n in r && (t.value[n] = void 0) : (t.value[n] = e.value)
 }
-function mn(e) {
+function $n(e) {
   let t = Object.keys(e.shape)
   for (let n of t)
     if (!e.shape?.[n]?._zod?.traits?.has(`$ZodType`))
       throw Error(`Invalid element at key "${n}": expected a Zod schema`)
-  let n = le(e.shape)
+  let n = Ge(e.shape)
   return { ...e, keys: t, keySet: new Set(t), numKeys: t.length, optionalKeys: new Set(n) }
 }
-function hn(e, t, n, r, i, a) {
+function er(e, t, n, r, i, a) {
   let o = [],
     s = i.keySet,
     c = i.catchall._zod,
@@ -1202,15 +2393,15 @@ function hn(e, t, n, r, i, a) {
       continue
     }
     let a = c.run({ value: t[i], issues: [] }, r)
-    a instanceof Promise ? e.push(a.then((e) => pn(e, n, i, t, u))) : pn(a, n, i, t, u)
+    a instanceof Promise ? e.push(a.then((e) => Qn(e, n, i, t, u))) : Qn(a, n, i, t, u)
   }
   return (
     o.length && n.issues.push({ code: `unrecognized_keys`, keys: o, input: t, inst: a }),
     e.length ? Promise.all(e).then(() => n) : n
   )
 }
-const gn = r(`$ZodObject`, (e, t) => {
-    if ((T.init(e, t), !Object.getOwnPropertyDescriptor(t, `shape`)?.get)) {
+const tr = S(`$ZodObject`, (e, t) => {
+    if ((M.init(e, t), !Object.getOwnPropertyDescriptor(t, `shape`)?.get)) {
       let e = t.shape
       Object.defineProperty(t, `shape`, {
         get: () => {
@@ -1219,8 +2410,8 @@ const gn = r(`$ZodObject`, (e, t) => {
         }
       })
     }
-    let n = u(() => mn(t))
-    f(e._zod, `propValues`, () => {
+    let n = Me(() => $n(t))
+    w(e._zod, `propValues`, () => {
       let e = t.shape,
         n = {}
       for (let t in e) {
@@ -1232,7 +2423,7 @@ const gn = r(`$ZodObject`, (e, t) => {
       }
       return n
     })
-    let r = h,
+    let r = Be,
       i = t.catchall,
       a
     e._zod.parse = (t, o) => {
@@ -1246,20 +2437,20 @@ const gn = r(`$ZodObject`, (e, t) => {
         let n = l[e],
           r = n._zod.optout === `optional`,
           i = n._zod.run({ value: s[e], issues: [] }, o)
-        i instanceof Promise ? c.push(i.then((n) => pn(n, t, e, s, r))) : pn(i, t, e, s, r)
+        i instanceof Promise ? c.push(i.then((n) => Qn(n, t, e, s, r))) : Qn(i, t, e, s, r)
       }
-      return i ? hn(c, s, t, o, n.value, e) : c.length ? Promise.all(c).then(() => t) : t
+      return i ? er(c, s, t, o, n.value, e) : c.length ? Promise.all(c).then(() => t) : t
     }
   }),
-  _n = r(`$ZodObjectJIT`, (e, t) => {
-    gn.init(e, t)
+  nr = S(`$ZodObjectJIT`, (e, t) => {
+    tr.init(e, t)
     let n = e._zod.parse,
-      r = u(() => mn(t)),
+      r = Me(() => $n(t)),
       i = (e) => {
-        let t = new At([`shape`, `payload`, `ctx`]),
+        let t = new gn([`shape`, `payload`, `ctx`]),
           n = r.value,
           i = (e) => {
-            let t = re(e)
+            let t = Le(e)
             return `shape[${t}]._zod.run({ value: input[${t}], issues: [] }, ctx)`
           }
         t.write(`const input = payload.value;`)
@@ -1269,7 +2460,7 @@ const gn = r(`$ZodObject`, (e, t) => {
         t.write(`const newResult = {};`)
         for (let r of n.keys) {
           let n = a[r],
-            o = re(r),
+            o = Le(r),
             s = e[r]?._zod?.optout === `optional`
           t.write(`const ${n} = ${i(r)};`),
             s
@@ -1315,45 +2506,45 @@ const gn = r(`$ZodObject`, (e, t) => {
         return (t, n) => s(e, t, n)
       },
       a,
-      s = h,
-      c = !o.jitless,
-      l = c && oe.value,
-      ee = t.catchall,
-      d
-    e._zod.parse = (o, u) => {
-      d ??= r.value
-      let te = o.value
-      return s(te)
-        ? c && l && u?.async === !1 && u.jitless !== !0
-          ? ((a ||= i(t.shape)), (o = a(o, u)), ee ? hn([], te, o, u, d, e) : o)
-          : n(o, u)
-        : (o.issues.push({ expected: `object`, code: `invalid_type`, input: te, inst: e }), o)
+      o = Be,
+      s = !ke.jitless,
+      c = s && Ve.value,
+      l = t.catchall,
+      u
+    e._zod.parse = (d, f) => {
+      u ??= r.value
+      let p = d.value
+      return o(p)
+        ? s && c && f?.async === !1 && f.jitless !== !0
+          ? ((a ||= i(t.shape)), (d = a(d, f)), l ? er([], p, d, f, u, e) : d)
+          : n(d, f)
+        : (d.issues.push({ expected: `object`, code: `invalid_type`, input: p, inst: e }), d)
     }
   })
-function vn(e, t, n, r) {
+function rr(e, t, n, r) {
   for (let n of e) if (n.issues.length === 0) return (t.value = n.value), t
-  let i = e.filter((e) => !b(e))
+  let i = e.filter((e) => !et(e))
   return i.length === 1
     ? ((t.value = i[0].value), i[0])
     : (t.issues.push({
         code: `invalid_union`,
         input: t.value,
         inst: n,
-        errors: e.map((e) => e.issues.map((e) => S(e, r, s())))
+        errors: e.map((e) => e.issues.map((e) => A(e, r, C())))
       }),
       t)
 }
-const yn = r(`$ZodUnion`, (e, t) => {
-    T.init(e, t),
-      f(e._zod, `optin`, () => (t.options.some((e) => e._zod.optin === `optional`) ? `optional` : void 0)),
-      f(e._zod, `optout`, () => (t.options.some((e) => e._zod.optout === `optional`) ? `optional` : void 0)),
-      f(e._zod, `values`, () => {
+const ir = S(`$ZodUnion`, (e, t) => {
+    M.init(e, t),
+      w(e._zod, `optin`, () => (t.options.some((e) => e._zod.optin === `optional`) ? `optional` : void 0)),
+      w(e._zod, `optout`, () => (t.options.some((e) => e._zod.optout === `optional`) ? `optional` : void 0)),
+      w(e._zod, `values`, () => {
         if (t.options.every((e) => e._zod.values)) return new Set(t.options.flatMap((e) => Array.from(e._zod.values)))
       }),
-      f(e._zod, `pattern`, () => {
+      w(e._zod, `pattern`, () => {
         if (t.options.every((e) => e._zod.pattern)) {
           let e = t.options.map((e) => e._zod.pattern)
-          return RegExp(`^(${e.map((e) => d(e.source)).join(`|`)})$`)
+          return RegExp(`^(${e.map((e) => Pe(e.source)).join(`|`)})$`)
         }
       })
     let n = t.options.length === 1,
@@ -1370,13 +2561,13 @@ const yn = r(`$ZodUnion`, (e, t) => {
           s.push(t)
         }
       }
-      return o ? Promise.all(s).then((t) => vn(t, i, e, a)) : vn(s, i, e, a)
+      return o ? Promise.all(s).then((t) => rr(t, i, e, a)) : rr(s, i, e, a)
     }
   }),
-  bn = r(`$ZodDiscriminatedUnion`, (e, t) => {
-    ;(t.inclusive = !1), yn.init(e, t)
+  ar = S(`$ZodDiscriminatedUnion`, (e, t) => {
+    ;(t.inclusive = !1), ir.init(e, t)
     let n = e._zod.parse
-    f(e._zod, `propValues`, () => {
+    w(e._zod, `propValues`, () => {
       let e = {}
       for (let n of t.options) {
         let r = n._zod.propValues
@@ -1389,7 +2580,7 @@ const yn = r(`$ZodUnion`, (e, t) => {
       }
       return e
     })
-    let r = u(() => {
+    let r = Me(() => {
       let e = t.options,
         n = new Map()
       for (let r of e) {
@@ -1404,7 +2595,7 @@ const yn = r(`$ZodUnion`, (e, t) => {
     })
     e._zod.parse = (i, a) => {
       let o = i.value
-      if (!h(o)) return i.issues.push({ code: `invalid_type`, expected: `object`, input: o, inst: e }), i
+      if (!Be(o)) return i.issues.push({ code: `invalid_type`, expected: `object`, input: o, inst: e }), i
       let s = r.value.get(o?.[t.discriminator])
       return s
         ? s._zod.run(i, a)
@@ -1422,25 +2613,25 @@ const yn = r(`$ZodUnion`, (e, t) => {
             i)
     }
   }),
-  xn = r(`$ZodIntersection`, (e, t) => {
-    T.init(e, t),
+  or = S(`$ZodIntersection`, (e, t) => {
+    M.init(e, t),
       (e._zod.parse = (e, n) => {
         let r = e.value,
           i = t.left._zod.run({ value: r, issues: [] }, n),
           a = t.right._zod.run({ value: r, issues: [] }, n)
         return i instanceof Promise || a instanceof Promise
-          ? Promise.all([i, a]).then(([t, n]) => Cn(e, t, n))
-          : Cn(e, i, a)
+          ? Promise.all([i, a]).then(([t, n]) => cr(e, t, n))
+          : cr(e, i, a)
       })
   })
-function Sn(e, t) {
+function sr(e, t) {
   if (e === t || (e instanceof Date && t instanceof Date && +e == +t)) return { valid: !0, data: e }
-  if (g(e) && g(t)) {
+  if (D(e) && D(t)) {
     let n = Object.keys(t),
       r = Object.keys(e).filter((e) => n.indexOf(e) !== -1),
       i = { ...e, ...t }
     for (let n of r) {
-      let r = Sn(e[n], t[n])
+      let r = sr(e[n], t[n])
       if (!r.valid) return { valid: !1, mergeErrorPath: [n, ...r.mergeErrorPath] }
       i[n] = r.data
     }
@@ -1452,7 +2643,7 @@ function Sn(e, t) {
     for (let r = 0; r < e.length; r++) {
       let i = e[r],
         a = t[r],
-        o = Sn(i, a)
+        o = sr(i, a)
       if (!o.valid) return { valid: !1, mergeErrorPath: [r, ...o.mergeErrorPath] }
       n.push(o.data)
     }
@@ -1460,7 +2651,7 @@ function Sn(e, t) {
   }
   return { valid: !1, mergeErrorPath: [] }
 }
-function Cn(e, t, n) {
+function cr(e, t, n) {
   let r = new Map(),
     i
   for (let n of t.issues)
@@ -1472,16 +2663,16 @@ function Cn(e, t, n) {
     if (t.code === `unrecognized_keys`) for (let e of t.keys) r.has(e) || r.set(e, {}), (r.get(e).r = !0)
     else e.issues.push(t)
   let a = [...r].filter(([, e]) => e.l && e.r).map(([e]) => e)
-  if ((a.length && i && e.issues.push({ ...i, keys: a }), b(e))) return e
-  let o = Sn(t.value, n.value)
+  if ((a.length && i && e.issues.push({ ...i, keys: a }), et(e))) return e
+  let o = sr(t.value, n.value)
   if (!o.valid) throw Error(`Unmergable intersection. Error path: ${JSON.stringify(o.mergeErrorPath)}`)
   return (e.value = o.data), e
 }
-const wn = r(`$ZodRecord`, (e, t) => {
-    T.init(e, t),
+const lr = S(`$ZodRecord`, (e, t) => {
+    M.init(e, t),
       (e._zod.parse = (n, r) => {
         let i = n.value
-        if (!g(i)) return n.issues.push({ expected: `record`, code: `invalid_type`, input: i, inst: e }), n
+        if (!D(i)) return n.issues.push({ expected: `record`, code: `invalid_type`, input: i, inst: e }), n
         let a = [],
           o = t.keyType._zod.values
         if (o) {
@@ -1494,10 +2685,10 @@ const wn = r(`$ZodRecord`, (e, t) => {
               o instanceof Promise
                 ? a.push(
                     o.then((t) => {
-                      t.issues.length && n.issues.push(...x(e, t.issues)), (n.value[e] = t.value)
+                      t.issues.length && n.issues.push(...tt(e, t.issues)), (n.value[e] = t.value)
                     })
                   )
-                : (o.issues.length && n.issues.push(...x(e, o.issues)), (n.value[e] = o.value))
+                : (o.issues.length && n.issues.push(...tt(e, o.issues)), (n.value[e] = o.value))
             }
           let c
           for (let e in i) s.has(e) || ((c ??= []), c.push(e))
@@ -1506,48 +2697,48 @@ const wn = r(`$ZodRecord`, (e, t) => {
           n.value = {}
           for (let o of Reflect.ownKeys(i)) {
             if (o === `__proto__`) continue
-            let c = t.keyType._zod.run({ value: o, issues: [] }, r)
-            if (c instanceof Promise) throw Error(`Async schemas not supported in object keys currently`)
-            if (typeof o == `string` && ut.test(o) && c.issues.length) {
+            let s = t.keyType._zod.run({ value: o, issues: [] }, r)
+            if (s instanceof Promise) throw Error(`Async schemas not supported in object keys currently`)
+            if (typeof o == `string` && Yt.test(o) && s.issues.length) {
               let e = t.keyType._zod.run({ value: Number(o), issues: [] }, r)
               if (e instanceof Promise) throw Error(`Async schemas not supported in object keys currently`)
-              e.issues.length === 0 && (c = e)
+              e.issues.length === 0 && (s = e)
             }
-            if (c.issues.length) {
+            if (s.issues.length) {
               t.mode === `loose`
                 ? (n.value[o] = i[o])
                 : n.issues.push({
                     code: `invalid_key`,
                     origin: `record`,
-                    issues: c.issues.map((e) => S(e, r, s())),
+                    issues: s.issues.map((e) => A(e, r, C())),
                     input: o,
                     path: [o],
                     inst: e
                   })
               continue
             }
-            let l = t.valueType._zod.run({ value: i[o], issues: [] }, r)
-            l instanceof Promise
+            let c = t.valueType._zod.run({ value: i[o], issues: [] }, r)
+            c instanceof Promise
               ? a.push(
-                  l.then((e) => {
-                    e.issues.length && n.issues.push(...x(o, e.issues)), (n.value[c.value] = e.value)
+                  c.then((e) => {
+                    e.issues.length && n.issues.push(...tt(o, e.issues)), (n.value[s.value] = e.value)
                   })
                 )
-              : (l.issues.length && n.issues.push(...x(o, l.issues)), (n.value[c.value] = l.value))
+              : (c.issues.length && n.issues.push(...tt(o, c.issues)), (n.value[s.value] = c.value))
           }
         }
         return a.length ? Promise.all(a).then(() => n) : n
       })
   }),
-  Tn = r(`$ZodEnum`, (e, t) => {
-    T.init(e, t)
-    let n = c(t.entries),
+  ur = S(`$ZodEnum`, (e, t) => {
+    M.init(e, t)
+    let n = Ae(t.entries),
       r = new Set(n)
     ;(e._zod.values = r),
       (e._zod.pattern = RegExp(
         `^(${n
-          .filter((e) => ce.has(typeof e))
-          .map((e) => (typeof e == `string` ? _(e) : e.toString()))
+          .filter((e) => Ue.has(typeof e))
+          .map((e) => (typeof e == `string` ? We(e) : e.toString()))
           .join(`|`)})$`
       )),
       (e._zod.parse = (t, i) => {
@@ -1555,99 +2746,99 @@ const wn = r(`$ZodRecord`, (e, t) => {
         return r.has(a) || t.issues.push({ code: `invalid_value`, values: n, input: a, inst: e }), t
       })
   }),
-  En = r(`$ZodLiteral`, (e, t) => {
-    if ((T.init(e, t), t.values.length === 0)) throw Error(`Cannot create literal schema with no valid values`)
+  dr = S(`$ZodLiteral`, (e, t) => {
+    if ((M.init(e, t), t.values.length === 0)) throw Error(`Cannot create literal schema with no valid values`)
     let n = new Set(t.values)
     ;(e._zod.values = n),
       (e._zod.pattern = RegExp(
-        `^(${t.values.map((e) => (typeof e == `string` ? _(e) : e ? _(e.toString()) : String(e))).join(`|`)})$`
+        `^(${t.values.map((e) => (typeof e == `string` ? We(e) : e ? We(e.toString()) : String(e))).join(`|`)})$`
       )),
       (e._zod.parse = (r, i) => {
         let a = r.value
         return n.has(a) || r.issues.push({ code: `invalid_value`, values: t.values, input: a, inst: e }), r
       })
   }),
-  Dn = r(`$ZodTransform`, (e, t) => {
-    T.init(e, t),
+  fr = S(`$ZodTransform`, (e, t) => {
+    M.init(e, t),
       (e._zod.parse = (n, r) => {
-        if (r.direction === `backward`) throw new a(e.constructor.name)
-        let o = t.transform(n.value, n)
-        if (r.async) return (o instanceof Promise ? o : Promise.resolve(o)).then((e) => ((n.value = e), n))
-        if (o instanceof Promise) throw new i()
-        return (n.value = o), n
+        if (r.direction === `backward`) throw new Oe(e.constructor.name)
+        let i = t.transform(n.value, n)
+        if (r.async) return (i instanceof Promise ? i : Promise.resolve(i)).then((e) => ((n.value = e), n))
+        if (i instanceof Promise) throw new De()
+        return (n.value = i), n
       })
   })
-function On(e, t) {
+function pr(e, t) {
   return e.issues.length && t === void 0 ? { issues: [], value: void 0 } : e
 }
-const kn = r(`$ZodOptional`, (e, t) => {
-    T.init(e, t),
+const mr = S(`$ZodOptional`, (e, t) => {
+    M.init(e, t),
       (e._zod.optin = `optional`),
       (e._zod.optout = `optional`),
-      f(e._zod, `values`, () => (t.innerType._zod.values ? new Set([...t.innerType._zod.values, void 0]) : void 0)),
-      f(e._zod, `pattern`, () => {
+      w(e._zod, `values`, () => (t.innerType._zod.values ? new Set([...t.innerType._zod.values, void 0]) : void 0)),
+      w(e._zod, `pattern`, () => {
         let e = t.innerType._zod.pattern
-        return e ? RegExp(`^(${d(e.source)})?$`) : void 0
+        return e ? RegExp(`^(${Pe(e.source)})?$`) : void 0
       }),
       (e._zod.parse = (e, n) => {
         if (t.innerType._zod.optin === `optional`) {
           let r = t.innerType._zod.run(e, n)
-          return r instanceof Promise ? r.then((t) => On(t, e.value)) : On(r, e.value)
+          return r instanceof Promise ? r.then((t) => pr(t, e.value)) : pr(r, e.value)
         }
         return e.value === void 0 ? e : t.innerType._zod.run(e, n)
       })
   }),
-  An = r(`$ZodExactOptional`, (e, t) => {
-    kn.init(e, t),
-      f(e._zod, `values`, () => t.innerType._zod.values),
-      f(e._zod, `pattern`, () => t.innerType._zod.pattern),
+  hr = S(`$ZodExactOptional`, (e, t) => {
+    mr.init(e, t),
+      w(e._zod, `values`, () => t.innerType._zod.values),
+      w(e._zod, `pattern`, () => t.innerType._zod.pattern),
       (e._zod.parse = (e, n) => t.innerType._zod.run(e, n))
   }),
-  jn = r(`$ZodNullable`, (e, t) => {
-    T.init(e, t),
-      f(e._zod, `optin`, () => t.innerType._zod.optin),
-      f(e._zod, `optout`, () => t.innerType._zod.optout),
-      f(e._zod, `pattern`, () => {
+  gr = S(`$ZodNullable`, (e, t) => {
+    M.init(e, t),
+      w(e._zod, `optin`, () => t.innerType._zod.optin),
+      w(e._zod, `optout`, () => t.innerType._zod.optout),
+      w(e._zod, `pattern`, () => {
         let e = t.innerType._zod.pattern
-        return e ? RegExp(`^(${d(e.source)}|null)$`) : void 0
+        return e ? RegExp(`^(${Pe(e.source)}|null)$`) : void 0
       }),
-      f(e._zod, `values`, () => (t.innerType._zod.values ? new Set([...t.innerType._zod.values, null]) : void 0)),
+      w(e._zod, `values`, () => (t.innerType._zod.values ? new Set([...t.innerType._zod.values, null]) : void 0)),
       (e._zod.parse = (e, n) => (e.value === null ? e : t.innerType._zod.run(e, n)))
   }),
-  Mn = r(`$ZodDefault`, (e, t) => {
-    T.init(e, t),
+  _r = S(`$ZodDefault`, (e, t) => {
+    M.init(e, t),
       (e._zod.optin = `optional`),
-      f(e._zod, `values`, () => t.innerType._zod.values),
+      w(e._zod, `values`, () => t.innerType._zod.values),
       (e._zod.parse = (e, n) => {
         if (n.direction === `backward`) return t.innerType._zod.run(e, n)
         if (e.value === void 0) return (e.value = t.defaultValue), e
         let r = t.innerType._zod.run(e, n)
-        return r instanceof Promise ? r.then((e) => Nn(e, t)) : Nn(r, t)
+        return r instanceof Promise ? r.then((e) => vr(e, t)) : vr(r, t)
       })
   })
-function Nn(e, t) {
+function vr(e, t) {
   return e.value === void 0 && (e.value = t.defaultValue), e
 }
-const Pn = r(`$ZodPrefault`, (e, t) => {
-    T.init(e, t),
+const yr = S(`$ZodPrefault`, (e, t) => {
+    M.init(e, t),
       (e._zod.optin = `optional`),
-      f(e._zod, `values`, () => t.innerType._zod.values),
+      w(e._zod, `values`, () => t.innerType._zod.values),
       (e._zod.parse = (e, n) => (
         n.direction === `backward` || (e.value === void 0 && (e.value = t.defaultValue)), t.innerType._zod.run(e, n)
       ))
   }),
-  Fn = r(`$ZodNonOptional`, (e, t) => {
-    T.init(e, t),
-      f(e._zod, `values`, () => {
+  br = S(`$ZodNonOptional`, (e, t) => {
+    M.init(e, t),
+      w(e._zod, `values`, () => {
         let e = t.innerType._zod.values
         return e ? new Set([...e].filter((e) => e !== void 0)) : void 0
       }),
       (e._zod.parse = (n, r) => {
         let i = t.innerType._zod.run(n, r)
-        return i instanceof Promise ? i.then((t) => In(t, e)) : In(i, e)
+        return i instanceof Promise ? i.then((t) => xr(t, e)) : xr(i, e)
       })
   })
-function In(e, t) {
+function xr(e, t) {
   return (
     !e.issues.length &&
       e.value === void 0 &&
@@ -1655,11 +2846,11 @@ function In(e, t) {
     e
   )
 }
-const Ln = r(`$ZodCatch`, (e, t) => {
-    T.init(e, t),
-      f(e._zod, `optin`, () => t.innerType._zod.optin),
-      f(e._zod, `optout`, () => t.innerType._zod.optout),
-      f(e._zod, `values`, () => t.innerType._zod.values),
+const Sr = S(`$ZodCatch`, (e, t) => {
+    M.init(e, t),
+      w(e._zod, `optin`, () => t.innerType._zod.optin),
+      w(e._zod, `optout`, () => t.innerType._zod.optout),
+      w(e._zod, `values`, () => t.innerType._zod.values),
       (e._zod.parse = (e, n) => {
         if (n.direction === `backward`) return t.innerType._zod.run(e, n)
         let r = t.innerType._zod.run(e, n)
@@ -1670,7 +2861,7 @@ const Ln = r(`$ZodCatch`, (e, t) => {
                 r.issues.length &&
                   ((e.value = t.catchValue({
                     ...e,
-                    error: { issues: r.issues.map((e) => S(e, n, s())) },
+                    error: { issues: r.issues.map((e) => A(e, n, C())) },
                     input: e.value
                   })),
                   (e.issues = [])),
@@ -1679,63 +2870,63 @@ const Ln = r(`$ZodCatch`, (e, t) => {
             )
           : ((e.value = r.value),
             r.issues.length &&
-              ((e.value = t.catchValue({ ...e, error: { issues: r.issues.map((e) => S(e, n, s())) }, input: e.value })),
+              ((e.value = t.catchValue({ ...e, error: { issues: r.issues.map((e) => A(e, n, C())) }, input: e.value })),
               (e.issues = [])),
             e)
       })
   }),
-  Rn = r(`$ZodPipe`, (e, t) => {
-    T.init(e, t),
-      f(e._zod, `values`, () => t.in._zod.values),
-      f(e._zod, `optin`, () => t.in._zod.optin),
-      f(e._zod, `optout`, () => t.out._zod.optout),
-      f(e._zod, `propValues`, () => t.in._zod.propValues),
+  Cr = S(`$ZodPipe`, (e, t) => {
+    M.init(e, t),
+      w(e._zod, `values`, () => t.in._zod.values),
+      w(e._zod, `optin`, () => t.in._zod.optin),
+      w(e._zod, `optout`, () => t.out._zod.optout),
+      w(e._zod, `propValues`, () => t.in._zod.propValues),
       (e._zod.parse = (e, n) => {
         if (n.direction === `backward`) {
           let r = t.out._zod.run(e, n)
-          return r instanceof Promise ? r.then((e) => D(e, t.in, n)) : D(r, t.in, n)
+          return r instanceof Promise ? r.then((e) => wr(e, t.in, n)) : wr(r, t.in, n)
         }
         let r = t.in._zod.run(e, n)
-        return r instanceof Promise ? r.then((e) => D(e, t.out, n)) : D(r, t.out, n)
+        return r instanceof Promise ? r.then((e) => wr(e, t.out, n)) : wr(r, t.out, n)
       })
   })
-function D(e, t, n) {
+function wr(e, t, n) {
   return e.issues.length ? ((e.aborted = !0), e) : t._zod.run({ value: e.value, issues: e.issues }, n)
 }
-const zn = r(`$ZodReadonly`, (e, t) => {
-  T.init(e, t),
-    f(e._zod, `propValues`, () => t.innerType._zod.propValues),
-    f(e._zod, `values`, () => t.innerType._zod.values),
-    f(e._zod, `optin`, () => t.innerType?._zod?.optin),
-    f(e._zod, `optout`, () => t.innerType?._zod?.optout),
+const Tr = S(`$ZodReadonly`, (e, t) => {
+  M.init(e, t),
+    w(e._zod, `propValues`, () => t.innerType._zod.propValues),
+    w(e._zod, `values`, () => t.innerType._zod.values),
+    w(e._zod, `optin`, () => t.innerType?._zod?.optin),
+    w(e._zod, `optout`, () => t.innerType?._zod?.optout),
     (e._zod.parse = (e, n) => {
       if (n.direction === `backward`) return t.innerType._zod.run(e, n)
       let r = t.innerType._zod.run(e, n)
-      return r instanceof Promise ? r.then(Bn) : Bn(r)
+      return r instanceof Promise ? r.then(Er) : Er(r)
     })
 })
-function Bn(e) {
+function Er(e) {
   return (e.value = Object.freeze(e.value)), e
 }
-const Vn = r(`$ZodCustom`, (e, t) => {
-  w.init(e, t),
-    T.init(e, t),
+const Dr = S(`$ZodCustom`, (e, t) => {
+  j.init(e, t),
+    M.init(e, t),
     (e._zod.parse = (e, t) => e),
     (e._zod.check = (n) => {
       let r = n.value,
         i = t.fn(r)
-      if (i instanceof Promise) return i.then((t) => Hn(t, n, r, e))
-      Hn(i, n, r, e)
+      if (i instanceof Promise) return i.then((t) => Or(t, n, r, e))
+      Or(i, n, r, e)
     })
 })
-function Hn(e, t, n, r) {
+function Or(e, t, n, r) {
   if (!e) {
     let e = { code: `custom`, input: n, inst: r, path: [...(r._zod.def.path ?? [])], continue: !r._zod.def.abort }
-    r._zod.def.params && (e.params = r._zod.def.params), t.issues.push(C(e))
+    r._zod.def.params && (e.params = r._zod.def.params), t.issues.push(it(e))
   }
 }
-var Un,
-  Wn = class {
+var kr,
+  Ar = class {
     constructor() {
       ;(this._map = new WeakMap()), (this._idmap = new Map())
     }
@@ -1764,81 +2955,81 @@ var Un,
       return this._map.has(e)
     }
   }
-function Gn() {
-  return new Wn()
+function jr() {
+  return new Ar()
 }
-;(Un = globalThis).__zod_globalRegistry ?? (Un.__zod_globalRegistry = Gn())
-const O = globalThis.__zod_globalRegistry
-function Kn(e, t) {
-  return new e({ type: `string`, ...y(t) })
+;(kr = globalThis).__zod_globalRegistry ?? (kr.__zod_globalRegistry = jr())
+const Mr = globalThis.__zod_globalRegistry
+function Nr(e, t) {
+  return new e({ type: `string`, ...k(t) })
 }
-function qn(e, t) {
-  return new e({ type: `string`, format: `email`, check: `string_format`, abort: !1, ...y(t) })
+function Pr(e, t) {
+  return new e({ type: `string`, format: `email`, check: `string_format`, abort: !1, ...k(t) })
 }
-function Jn(e, t) {
-  return new e({ type: `string`, format: `guid`, check: `string_format`, abort: !1, ...y(t) })
+function Fr(e, t) {
+  return new e({ type: `string`, format: `guid`, check: `string_format`, abort: !1, ...k(t) })
 }
-function Yn(e, t) {
-  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, ...y(t) })
+function Ir(e, t) {
+  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, ...k(t) })
 }
-function Xn(e, t) {
-  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v4`, ...y(t) })
+function Lr(e, t) {
+  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v4`, ...k(t) })
 }
-function Zn(e, t) {
-  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v6`, ...y(t) })
+function Rr(e, t) {
+  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v6`, ...k(t) })
 }
-function Qn(e, t) {
-  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v7`, ...y(t) })
+function zr(e, t) {
+  return new e({ type: `string`, format: `uuid`, check: `string_format`, abort: !1, version: `v7`, ...k(t) })
 }
-function $n(e, t) {
-  return new e({ type: `string`, format: `url`, check: `string_format`, abort: !1, ...y(t) })
+function Br(e, t) {
+  return new e({ type: `string`, format: `url`, check: `string_format`, abort: !1, ...k(t) })
 }
-function er(e, t) {
-  return new e({ type: `string`, format: `emoji`, check: `string_format`, abort: !1, ...y(t) })
+function Vr(e, t) {
+  return new e({ type: `string`, format: `emoji`, check: `string_format`, abort: !1, ...k(t) })
 }
-function tr(e, t) {
-  return new e({ type: `string`, format: `nanoid`, check: `string_format`, abort: !1, ...y(t) })
+function Hr(e, t) {
+  return new e({ type: `string`, format: `nanoid`, check: `string_format`, abort: !1, ...k(t) })
 }
-function nr(e, t) {
-  return new e({ type: `string`, format: `cuid`, check: `string_format`, abort: !1, ...y(t) })
+function Ur(e, t) {
+  return new e({ type: `string`, format: `cuid`, check: `string_format`, abort: !1, ...k(t) })
 }
-function rr(e, t) {
-  return new e({ type: `string`, format: `cuid2`, check: `string_format`, abort: !1, ...y(t) })
+function Wr(e, t) {
+  return new e({ type: `string`, format: `cuid2`, check: `string_format`, abort: !1, ...k(t) })
 }
-function ir(e, t) {
-  return new e({ type: `string`, format: `ulid`, check: `string_format`, abort: !1, ...y(t) })
+function Gr(e, t) {
+  return new e({ type: `string`, format: `ulid`, check: `string_format`, abort: !1, ...k(t) })
 }
-function ar(e, t) {
-  return new e({ type: `string`, format: `xid`, check: `string_format`, abort: !1, ...y(t) })
+function Kr(e, t) {
+  return new e({ type: `string`, format: `xid`, check: `string_format`, abort: !1, ...k(t) })
 }
-function or(e, t) {
-  return new e({ type: `string`, format: `ksuid`, check: `string_format`, abort: !1, ...y(t) })
+function qr(e, t) {
+  return new e({ type: `string`, format: `ksuid`, check: `string_format`, abort: !1, ...k(t) })
 }
-function sr(e, t) {
-  return new e({ type: `string`, format: `ipv4`, check: `string_format`, abort: !1, ...y(t) })
+function Jr(e, t) {
+  return new e({ type: `string`, format: `ipv4`, check: `string_format`, abort: !1, ...k(t) })
 }
-function cr(e, t) {
-  return new e({ type: `string`, format: `ipv6`, check: `string_format`, abort: !1, ...y(t) })
+function Yr(e, t) {
+  return new e({ type: `string`, format: `ipv6`, check: `string_format`, abort: !1, ...k(t) })
 }
-function lr(e, t) {
-  return new e({ type: `string`, format: `cidrv4`, check: `string_format`, abort: !1, ...y(t) })
+function Xr(e, t) {
+  return new e({ type: `string`, format: `cidrv4`, check: `string_format`, abort: !1, ...k(t) })
 }
-function ur(e, t) {
-  return new e({ type: `string`, format: `cidrv6`, check: `string_format`, abort: !1, ...y(t) })
+function Zr(e, t) {
+  return new e({ type: `string`, format: `cidrv6`, check: `string_format`, abort: !1, ...k(t) })
 }
-function dr(e, t) {
-  return new e({ type: `string`, format: `base64`, check: `string_format`, abort: !1, ...y(t) })
+function Qr(e, t) {
+  return new e({ type: `string`, format: `base64`, check: `string_format`, abort: !1, ...k(t) })
 }
-function fr(e, t) {
-  return new e({ type: `string`, format: `base64url`, check: `string_format`, abort: !1, ...y(t) })
+function $r(e, t) {
+  return new e({ type: `string`, format: `base64url`, check: `string_format`, abort: !1, ...k(t) })
 }
-function pr(e, t) {
-  return new e({ type: `string`, format: `e164`, check: `string_format`, abort: !1, ...y(t) })
+function ei(e, t) {
+  return new e({ type: `string`, format: `e164`, check: `string_format`, abort: !1, ...k(t) })
 }
-function mr(e, t) {
-  return new e({ type: `string`, format: `jwt`, check: `string_format`, abort: !1, ...y(t) })
+function ti(e, t) {
+  return new e({ type: `string`, format: `jwt`, check: `string_format`, abort: !1, ...k(t) })
 }
-function hr(e, t) {
+function ni(e, t) {
   return new e({
     type: `string`,
     format: `datetime`,
@@ -1846,104 +3037,104 @@ function hr(e, t) {
     offset: !1,
     local: !1,
     precision: null,
-    ...y(t)
+    ...k(t)
   })
 }
-function gr(e, t) {
-  return new e({ type: `string`, format: `date`, check: `string_format`, ...y(t) })
+function ri(e, t) {
+  return new e({ type: `string`, format: `date`, check: `string_format`, ...k(t) })
 }
-function _r(e, t) {
-  return new e({ type: `string`, format: `time`, check: `string_format`, precision: null, ...y(t) })
+function ii(e, t) {
+  return new e({ type: `string`, format: `time`, check: `string_format`, precision: null, ...k(t) })
 }
-function vr(e, t) {
-  return new e({ type: `string`, format: `duration`, check: `string_format`, ...y(t) })
+function ai(e, t) {
+  return new e({ type: `string`, format: `duration`, check: `string_format`, ...k(t) })
 }
-function yr(e, t) {
-  return new e({ type: `number`, checks: [], ...y(t) })
+function oi(e, t) {
+  return new e({ type: `number`, checks: [], ...k(t) })
 }
-function br(e, t) {
-  return new e({ type: `number`, check: `number_format`, abort: !1, format: `safeint`, ...y(t) })
+function si(e, t) {
+  return new e({ type: `number`, check: `number_format`, abort: !1, format: `safeint`, ...k(t) })
 }
-function xr(e, t) {
-  return new e({ type: `boolean`, ...y(t) })
+function ci(e, t) {
+  return new e({ type: `boolean`, ...k(t) })
 }
-function Sr(e) {
+function li(e) {
   return new e({ type: `unknown` })
 }
-function Cr(e, t) {
-  return new e({ type: `never`, ...y(t) })
+function ui(e, t) {
+  return new e({ type: `never`, ...k(t) })
 }
-function wr(e, t) {
-  return new ht({ check: `less_than`, ...y(t), value: e, inclusive: !1 })
+function di(e, t) {
+  return new en({ check: `less_than`, ...k(t), value: e, inclusive: !1 })
 }
-function Tr(e, t) {
-  return new ht({ check: `less_than`, ...y(t), value: e, inclusive: !0 })
+function fi(e, t) {
+  return new en({ check: `less_than`, ...k(t), value: e, inclusive: !0 })
 }
-function Er(e, t) {
-  return new gt({ check: `greater_than`, ...y(t), value: e, inclusive: !1 })
+function pi(e, t) {
+  return new tn({ check: `greater_than`, ...k(t), value: e, inclusive: !1 })
 }
-function Dr(e, t) {
-  return new gt({ check: `greater_than`, ...y(t), value: e, inclusive: !0 })
+function mi(e, t) {
+  return new tn({ check: `greater_than`, ...k(t), value: e, inclusive: !0 })
 }
-function Or(e, t) {
-  return new _t({ check: `multiple_of`, ...y(t), value: e })
+function hi(e, t) {
+  return new nn({ check: `multiple_of`, ...k(t), value: e })
 }
-function kr(e, t) {
-  return new yt({ check: `max_length`, ...y(t), maximum: e })
+function gi(e, t) {
+  return new an({ check: `max_length`, ...k(t), maximum: e })
 }
-function Ar(e, t) {
-  return new bt({ check: `min_length`, ...y(t), minimum: e })
+function _i(e, t) {
+  return new on({ check: `min_length`, ...k(t), minimum: e })
 }
-function jr(e, t) {
-  return new xt({ check: `length_equals`, ...y(t), length: e })
+function vi(e, t) {
+  return new sn({ check: `length_equals`, ...k(t), length: e })
 }
-function Mr(e, t) {
-  return new Ct({ check: `string_format`, format: `regex`, ...y(t), pattern: e })
+function yi(e, t) {
+  return new ln({ check: `string_format`, format: `regex`, ...k(t), pattern: e })
 }
-function Nr(e) {
-  return new wt({ check: `string_format`, format: `lowercase`, ...y(e) })
+function bi(e) {
+  return new un({ check: `string_format`, format: `lowercase`, ...k(e) })
 }
-function Pr(e) {
-  return new Tt({ check: `string_format`, format: `uppercase`, ...y(e) })
+function xi(e) {
+  return new dn({ check: `string_format`, format: `uppercase`, ...k(e) })
 }
-function Fr(e, t) {
-  return new Et({ check: `string_format`, format: `includes`, ...y(t), includes: e })
+function Si(e, t) {
+  return new fn({ check: `string_format`, format: `includes`, ...k(t), includes: e })
 }
-function Ir(e, t) {
-  return new Dt({ check: `string_format`, format: `starts_with`, ...y(t), prefix: e })
+function Ci(e, t) {
+  return new pn({ check: `string_format`, format: `starts_with`, ...k(t), prefix: e })
 }
-function Lr(e, t) {
-  return new Ot({ check: `string_format`, format: `ends_with`, ...y(t), suffix: e })
+function wi(e, t) {
+  return new mn({ check: `string_format`, format: `ends_with`, ...k(t), suffix: e })
 }
-function k(e) {
-  return new kt({ check: `overwrite`, tx: e })
+function P(e) {
+  return new hn({ check: `overwrite`, tx: e })
 }
-function Rr(e) {
-  return k((t) => t.normalize(e))
+function Ti(e) {
+  return P((t) => t.normalize(e))
 }
-function zr() {
-  return k((e) => e.trim())
+function Ei() {
+  return P((e) => e.trim())
 }
-function Br() {
-  return k((e) => e.toLowerCase())
+function Di() {
+  return P((e) => e.toLowerCase())
 }
-function Vr() {
-  return k((e) => e.toUpperCase())
+function Oi() {
+  return P((e) => e.toUpperCase())
 }
-function Hr() {
-  return k((e) => ie(e))
+function ki() {
+  return P((e) => Re(e))
 }
-function Ur(e, t, n) {
-  return new e({ type: `array`, element: t, ...y(n) })
+function Ai(e, t, n) {
+  return new e({ type: `array`, element: t, ...k(n) })
 }
-function Wr(e, t, n) {
-  return new e({ type: `custom`, check: `custom`, fn: t, ...y(n) })
+function ji(e, t, n) {
+  return new e({ type: `custom`, check: `custom`, fn: t, ...k(n) })
 }
-function Gr(e) {
-  let t = Kr(
+function Mi(e) {
+  let t = Ni(
     (n) => (
       (n.addIssue = (e) => {
-        if (typeof e == `string`) n.issues.push(C(e, n.value, t._zod.def))
+        if (typeof e == `string`) n.issues.push(it(e, n.value, t._zod.def))
         else {
           let r = e
           r.fatal && (r.continue = !1),
@@ -1951,7 +3142,7 @@ function Gr(e) {
             (r.input ??= n.value),
             (r.inst ??= t),
             (r.continue ??= !t._zod.def.abort),
-            n.issues.push(C(r))
+            n.issues.push(it(r))
         }
       }),
       e(n.value, n)
@@ -1959,18 +3150,18 @@ function Gr(e) {
   )
   return t
 }
-function Kr(e, t) {
-  let n = new w({ check: `custom`, ...y(t) })
+function Ni(e, t) {
+  let n = new j({ check: `custom`, ...k(t) })
   return (n._zod.check = e), n
 }
-function qr(e) {
+function Pi(e) {
   let t = e?.target ?? `draft-2020-12`
   return (
     t === `draft-4` && (t = `draft-04`),
     t === `draft-7` && (t = `draft-07`),
     {
       processors: e.processors ?? {},
-      metadataRegistry: e?.metadata ?? O,
+      metadataRegistry: e?.metadata ?? Mr,
       target: t,
       unrepresentable: e?.unrepresentable ?? `throw`,
       override: e?.override ?? (() => {}),
@@ -1983,7 +3174,7 @@ function qr(e) {
     }
   )
 }
-function A(e, t, n = { path: [], schemaPath: [] }) {
+function F(e, t, n = { path: [], schemaPath: [] }) {
   var r
   let i = e._zod.def,
     a = t.seen.get(e)
@@ -2002,18 +3193,18 @@ function A(e, t, n = { path: [], schemaPath: [] }) {
       a(e, t, n, r)
     }
     let a = e._zod.parent
-    a && ((o.ref ||= a), A(a, t, r), (t.seen.get(a).isParent = !0))
+    a && ((o.ref ||= a), F(a, t, r), (t.seen.get(a).isParent = !0))
   }
   let c = t.metadataRegistry.get(e)
   return (
     c && Object.assign(o.schema, c),
-    t.io === `input` && j(e) && (delete o.schema.examples, delete o.schema.default),
+    t.io === `input` && I(e) && (delete o.schema.examples, delete o.schema.default),
     t.io === `input` && o.schema._prefault && ((r = o.schema).default ?? (r.default = o.schema._prefault)),
     delete o.schema._prefault,
     t.seen.get(e).schema
   )
 }
-function Jr(e, t) {
+function Fi(e, t) {
   let n = e.seen.get(t)
   if (!n) throw Error(`Unprocessed schema. This is a bug in Zod.`)
   let r = new Map()
@@ -2086,7 +3277,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   }
 }
-function Yr(e, t) {
+function Ii(e, t) {
   let n = e.seen.get(t)
   if (!n) throw Error(`Unprocessed schema. This is a bug in Zod.`)
   let r = (t) => {
@@ -2154,7 +3345,7 @@ function Yr(e, t) {
       Object.defineProperty(n, `~standard`, {
         value: {
           ...t[`~standard`],
-          jsonSchema: { input: Zr(t, `input`, e.processors), output: Zr(t, `output`, e.processors) }
+          jsonSchema: { input: Ri(t, `input`, e.processors), output: Ri(t, `output`, e.processors) }
         },
         enumerable: !1,
         writable: !1
@@ -2165,15 +3356,15 @@ function Yr(e, t) {
     throw Error(`Error converting schema to JSON.`)
   }
 }
-function j(e, t) {
+function I(e, t) {
   let n = t ?? { seen: new Set() }
   if (n.seen.has(e)) return !1
   n.seen.add(e)
   let r = e._zod.def
   if (r.type === `transform`) return !0
-  if (r.type === `array`) return j(r.element, n)
-  if (r.type === `set`) return j(r.valueType, n)
-  if (r.type === `lazy`) return j(r.getter(), n)
+  if (r.type === `array`) return I(r.element, n)
+  if (r.type === `set`) return I(r.valueType, n)
+  if (r.type === `lazy`) return I(r.getter(), n)
   if (
     r.type === `promise` ||
     r.type === `optional` ||
@@ -2183,46 +3374,46 @@ function j(e, t) {
     r.type === `default` ||
     r.type === `prefault`
   )
-    return j(r.innerType, n)
-  if (r.type === `intersection`) return j(r.left, n) || j(r.right, n)
-  if (r.type === `record` || r.type === `map`) return j(r.keyType, n) || j(r.valueType, n)
-  if (r.type === `pipe`) return j(r.in, n) || j(r.out, n)
+    return I(r.innerType, n)
+  if (r.type === `intersection`) return I(r.left, n) || I(r.right, n)
+  if (r.type === `record` || r.type === `map`) return I(r.keyType, n) || I(r.valueType, n)
+  if (r.type === `pipe`) return I(r.in, n) || I(r.out, n)
   if (r.type === `object`) {
-    for (let e in r.shape) if (j(r.shape[e], n)) return !0
+    for (let e in r.shape) if (I(r.shape[e], n)) return !0
     return !1
   }
   if (r.type === `union`) {
-    for (let e of r.options) if (j(e, n)) return !0
+    for (let e of r.options) if (I(e, n)) return !0
     return !1
   }
   if (r.type === `tuple`) {
-    for (let e of r.items) if (j(e, n)) return !0
-    return !!(r.rest && j(r.rest, n))
+    for (let e of r.items) if (I(e, n)) return !0
+    return !!(r.rest && I(r.rest, n))
   }
   return !1
 }
-const Xr =
+const Li =
     (e, t = {}) =>
     (n) => {
-      let r = qr({ ...n, processors: t })
-      return A(e, r), Jr(r, e), Yr(r, e)
+      let r = Pi({ ...n, processors: t })
+      return F(e, r), Fi(r, e), Ii(r, e)
     },
-  Zr =
+  Ri =
     (e, t, n = {}) =>
     (r) => {
       let { libraryOptions: i, target: a } = r ?? {},
-        o = qr({ ...(i ?? {}), target: a, io: t, processors: n })
-      return A(e, o), Jr(o, e), Yr(o, e)
+        o = Pi({ ...(i ?? {}), target: a, io: t, processors: n })
+      return F(e, o), Fi(o, e), Ii(o, e)
     },
-  Qr = { guid: `uuid`, url: `uri`, datetime: `date-time`, json_string: `json-string`, regex: `` },
-  $r = (e, t, n, r) => {
+  zi = { guid: `uuid`, url: `uri`, datetime: `date-time`, json_string: `json-string`, regex: `` },
+  Bi = (e, t, n, r) => {
     let i = n
     i.type = `string`
     let { minimum: a, maximum: o, format: s, patterns: c, contentEncoding: l } = e._zod.bag
     if (
       (typeof a == `number` && (i.minLength = a),
       typeof o == `number` && (i.maxLength = o),
-      s && ((i.format = Qr[s] ?? s), i.format === `` && delete i.format, s === `time` && delete i.format),
+      s && ((i.format = zi[s] ?? s), i.format === `` && delete i.format, s === `time` && delete i.format),
       l && (i.contentEncoding = l),
       c && c.size > 0)
     ) {
@@ -2240,7 +3431,7 @@ const Xr =
           ])
     }
   },
-  ei = (e, t, n, r) => {
+  Vi = (e, t, n, r) => {
     let i = n,
       { minimum: a, maximum: o, format: s, multipleOf: c, exclusiveMaximum: l, exclusiveMinimum: u } = e._zod.bag
     typeof s == `string` && s.includes(`int`) ? (i.type = `integer`) : (i.type = `number`),
@@ -2260,20 +3451,20 @@ const Xr =
         typeof l == `number` && t.target !== `draft-04` && (l <= o ? delete i.maximum : delete i.exclusiveMaximum)),
       typeof c == `number` && (i.multipleOf = c)
   },
-  ti = (e, t, n, r) => {
+  Hi = (e, t, n, r) => {
     n.type = `boolean`
   },
-  ni = (e, t, n, r) => {
+  Ui = (e, t, n, r) => {
     n.not = {}
   },
-  ri = (e, t, n, r) => {
+  Wi = (e, t, n, r) => {
     let i = e._zod.def,
-      a = c(i.entries)
+      a = Ae(i.entries)
     a.every((e) => typeof e == `number`) && (n.type = `number`),
       a.every((e) => typeof e == `string`) && (n.type = `string`),
       (n.enum = a)
   },
-  ii = (e, t, n, r) => {
+  Gi = (e, t, n, r) => {
     let i = e._zod.def,
       a = []
     for (let e of i.values)
@@ -2295,27 +3486,27 @@ const Xr =
           a.every((e) => e === null) && (n.type = `null`),
           (n.enum = a)
   },
-  ai = (e, t, n, r) => {
+  Ki = (e, t, n, r) => {
     if (t.unrepresentable === `throw`) throw Error(`Custom types cannot be represented in JSON Schema`)
   },
-  oi = (e, t, n, r) => {
+  qi = (e, t, n, r) => {
     if (t.unrepresentable === `throw`) throw Error(`Transforms cannot be represented in JSON Schema`)
   },
-  si = (e, t, n, r) => {
+  Ji = (e, t, n, r) => {
     let i = n,
       a = e._zod.def,
       { minimum: o, maximum: s } = e._zod.bag
     typeof o == `number` && (i.minItems = o),
       typeof s == `number` && (i.maxItems = s),
       (i.type = `array`),
-      (i.items = A(a.element, t, { ...r, path: [...r.path, `items`] }))
+      (i.items = F(a.element, t, { ...r, path: [...r.path, `items`] }))
   },
-  ci = (e, t, n, r) => {
+  Yi = (e, t, n, r) => {
     let i = n,
       a = e._zod.def
     ;(i.type = `object`), (i.properties = {})
     let o = a.shape
-    for (let e in o) i.properties[e] = A(o[e], t, { ...r, path: [...r.path, `properties`, e] })
+    for (let e in o) i.properties[e] = F(o[e], t, { ...r, path: [...r.path, `properties`, e] })
     let s = new Set(Object.keys(o)),
       c = new Set(
         [...s].filter((e) => {
@@ -2328,69 +3519,69 @@ const Xr =
         ? (i.additionalProperties = !1)
         : a.catchall
           ? a.catchall &&
-            (i.additionalProperties = A(a.catchall, t, { ...r, path: [...r.path, `additionalProperties`] }))
+            (i.additionalProperties = F(a.catchall, t, { ...r, path: [...r.path, `additionalProperties`] }))
           : t.io === `output` && (i.additionalProperties = !1)
   },
-  li = (e, t, n, r) => {
+  Xi = (e, t, n, r) => {
     let i = e._zod.def,
       a = i.inclusive === !1,
-      o = i.options.map((e, n) => A(e, t, { ...r, path: [...r.path, a ? `oneOf` : `anyOf`, n] }))
+      o = i.options.map((e, n) => F(e, t, { ...r, path: [...r.path, a ? `oneOf` : `anyOf`, n] }))
     a ? (n.oneOf = o) : (n.anyOf = o)
   },
-  ui = (e, t, n, r) => {
+  Zi = (e, t, n, r) => {
     let i = e._zod.def,
-      a = A(i.left, t, { ...r, path: [...r.path, `allOf`, 0] }),
-      o = A(i.right, t, { ...r, path: [...r.path, `allOf`, 1] }),
+      a = F(i.left, t, { ...r, path: [...r.path, `allOf`, 0] }),
+      o = F(i.right, t, { ...r, path: [...r.path, `allOf`, 1] }),
       s = (e) => `allOf` in e && Object.keys(e).length === 1
     n.allOf = [...(s(a) ? a.allOf : [a]), ...(s(o) ? o.allOf : [o])]
   },
-  di = (e, t, n, r) => {
+  Qi = (e, t, n, r) => {
     let i = n,
       a = e._zod.def
     i.type = `object`
     let o = a.keyType,
       s = o._zod.bag?.patterns
     if (a.mode === `loose` && s && s.size > 0) {
-      let e = A(a.valueType, t, { ...r, path: [...r.path, `patternProperties`, `*`] })
+      let e = F(a.valueType, t, { ...r, path: [...r.path, `patternProperties`, `*`] })
       i.patternProperties = {}
       for (let t of s) i.patternProperties[t.source] = e
     } else
       (t.target === `draft-07` || t.target === `draft-2020-12`) &&
-        (i.propertyNames = A(a.keyType, t, { ...r, path: [...r.path, `propertyNames`] })),
-        (i.additionalProperties = A(a.valueType, t, { ...r, path: [...r.path, `additionalProperties`] }))
+        (i.propertyNames = F(a.keyType, t, { ...r, path: [...r.path, `propertyNames`] })),
+        (i.additionalProperties = F(a.valueType, t, { ...r, path: [...r.path, `additionalProperties`] }))
     let c = o._zod.values
     if (c) {
       let e = [...c].filter((e) => typeof e == `string` || typeof e == `number`)
       e.length > 0 && (i.required = e)
     }
   },
-  fi = (e, t, n, r) => {
+  $i = (e, t, n, r) => {
     let i = e._zod.def,
-      a = A(i.innerType, t, r),
+      a = F(i.innerType, t, r),
       o = t.seen.get(e)
     t.target === `openapi-3.0` ? ((o.ref = i.innerType), (n.nullable = !0)) : (n.anyOf = [a, { type: `null` }])
   },
-  pi = (e, t, n, r) => {
+  ea = (e, t, n, r) => {
     let i = e._zod.def
-    A(i.innerType, t, r)
+    F(i.innerType, t, r)
     let a = t.seen.get(e)
     a.ref = i.innerType
   },
-  mi = (e, t, n, r) => {
+  ta = (e, t, n, r) => {
     let i = e._zod.def
-    A(i.innerType, t, r)
+    F(i.innerType, t, r)
     let a = t.seen.get(e)
     ;(a.ref = i.innerType), (n.default = JSON.parse(JSON.stringify(i.defaultValue)))
   },
-  hi = (e, t, n, r) => {
+  na = (e, t, n, r) => {
     let i = e._zod.def
-    A(i.innerType, t, r)
+    F(i.innerType, t, r)
     let a = t.seen.get(e)
     ;(a.ref = i.innerType), t.io === `input` && (n._prefault = JSON.parse(JSON.stringify(i.defaultValue)))
   },
-  gi = (e, t, n, r) => {
+  ra = (e, t, n, r) => {
     let i = e._zod.def
-    A(i.innerType, t, r)
+    F(i.innerType, t, r)
     let a = t.seen.get(e)
     a.ref = i.innerType
     let o
@@ -2401,63 +3592,63 @@ const Xr =
     }
     n.default = o
   },
-  _i = (e, t, n, r) => {
+  ia = (e, t, n, r) => {
     let i = e._zod.def,
       a = t.io === `input` ? (i.in._zod.def.type === `transform` ? i.out : i.in) : i.out
-    A(a, t, r)
+    F(a, t, r)
     let o = t.seen.get(e)
     o.ref = a
   },
-  vi = (e, t, n, r) => {
+  aa = (e, t, n, r) => {
     let i = e._zod.def
-    A(i.innerType, t, r)
+    F(i.innerType, t, r)
     let a = t.seen.get(e)
     ;(a.ref = i.innerType), (n.readOnly = !0)
   },
-  yi = (e, t, n, r) => {
+  oa = (e, t, n, r) => {
     let i = e._zod.def
-    A(i.innerType, t, r)
+    F(i.innerType, t, r)
     let a = t.seen.get(e)
     a.ref = i.innerType
   },
-  bi = r(`ZodISODateTime`, (e, t) => {
-    Wt.init(e, t), F.init(e, t)
+  sa = S(`ZodISODateTime`, (e, t) => {
+    An.init(e, t), B.init(e, t)
   })
-function xi(e) {
-  return hr(bi, e)
+function ca(e) {
+  return ni(sa, e)
 }
-const Si = r(`ZodISODate`, (e, t) => {
-  Gt.init(e, t), F.init(e, t)
+const la = S(`ZodISODate`, (e, t) => {
+  jn.init(e, t), B.init(e, t)
 })
-function Ci(e) {
-  return gr(Si, e)
+function ua(e) {
+  return ri(la, e)
 }
-const wi = r(`ZodISOTime`, (e, t) => {
-  Kt.init(e, t), F.init(e, t)
+const da = S(`ZodISOTime`, (e, t) => {
+  Mn.init(e, t), B.init(e, t)
 })
-function Ti(e) {
-  return _r(wi, e)
+function fa(e) {
+  return ii(da, e)
 }
-const Ei = r(`ZodISODuration`, (e, t) => {
-  qt.init(e, t), F.init(e, t)
+const pa = S(`ZodISODuration`, (e, t) => {
+  Nn.init(e, t), B.init(e, t)
 })
-function Di(e) {
-  return vr(Ei, e)
+function ma(e) {
+  return ai(pa, e)
 }
-const Oi = (e, t) => {
-  xe.init(e, t),
+const ha = (e, t) => {
+  ot.init(e, t),
     (e.name = `ZodError`),
     Object.defineProperties(e, {
-      format: { value: (t) => we(e, t) },
-      flatten: { value: (t) => Ce(e, t) },
+      format: { value: (t) => lt(e, t) },
+      flatten: { value: (t) => ct(e, t) },
       addIssue: {
         value: (t) => {
-          e.issues.push(t), (e.message = JSON.stringify(e.issues, l, 2))
+          e.issues.push(t), (e.message = JSON.stringify(e.issues, je, 2))
         }
       },
       addIssues: {
         value: (t) => {
-          e.issues.push(...t), (e.message = JSON.stringify(e.issues, l, 2))
+          e.issues.push(...t), (e.message = JSON.stringify(e.issues, je, 2))
         }
       },
       isEmpty: {
@@ -2467,32 +3658,32 @@ const Oi = (e, t) => {
       }
     })
 }
-r(`ZodError`, Oi)
-const M = r(`ZodError`, Oi, { Parent: Error }),
-  ki = Te(M),
-  Ai = Ee(M),
-  ji = De(M),
-  Mi = ke(M),
-  Ni = je(M),
-  Pi = Me(M),
-  Fi = Ne(M),
-  Ii = Pe(M),
-  Li = Fe(M),
-  Ri = Ie(M),
-  zi = Le(M),
-  Bi = Re(M),
-  N = r(
+S(`ZodError`, ha)
+const L = S(`ZodError`, ha, { Parent: Error }),
+  ga = ut(L),
+  _a = dt(L),
+  va = ft(L),
+  ya = mt(L),
+  ba = gt(L),
+  xa = _t(L),
+  Sa = vt(L),
+  Ca = yt(L),
+  wa = bt(L),
+  Ta = xt(L),
+  Ea = St(L),
+  Da = Ct(L),
+  R = S(
     `ZodType`,
     (e, t) => (
-      T.init(e, t),
-      Object.assign(e[`~standard`], { jsonSchema: { input: Zr(e, `input`), output: Zr(e, `output`) } }),
-      (e.toJSONSchema = Xr(e, {})),
+      M.init(e, t),
+      Object.assign(e[`~standard`], { jsonSchema: { input: Ri(e, `input`), output: Ri(e, `output`) } }),
+      (e.toJSONSchema = Li(e, {})),
       (e.def = t),
       (e.type = t.type),
       Object.defineProperty(e, `_def`, { value: t }),
       (e.check = (...n) =>
         e.clone(
-          m(t, {
+          E(t, {
             checks: [
               ...(t.checks ?? []),
               ...n.map((e) =>
@@ -2503,53 +3694,53 @@ const M = r(`ZodError`, Oi, { Parent: Error }),
           { parent: !0 }
         )),
       (e.with = e.check),
-      (e.clone = (t, n) => v(e, t, n)),
+      (e.clone = (t, n) => O(e, t, n)),
       (e.brand = () => e),
       (e.register = (t, n) => (t.add(e, n), e)),
-      (e.parse = (t, n) => ki(e, t, n, { callee: e.parse })),
-      (e.safeParse = (t, n) => ji(e, t, n)),
-      (e.parseAsync = async (t, n) => Ai(e, t, n, { callee: e.parseAsync })),
-      (e.safeParseAsync = async (t, n) => Mi(e, t, n)),
+      (e.parse = (t, n) => ga(e, t, n, { callee: e.parse })),
+      (e.safeParse = (t, n) => va(e, t, n)),
+      (e.parseAsync = async (t, n) => _a(e, t, n, { callee: e.parseAsync })),
+      (e.safeParseAsync = async (t, n) => ya(e, t, n)),
       (e.spa = e.safeParseAsync),
-      (e.encode = (t, n) => Ni(e, t, n)),
-      (e.decode = (t, n) => Pi(e, t, n)),
-      (e.encodeAsync = async (t, n) => Fi(e, t, n)),
-      (e.decodeAsync = async (t, n) => Ii(e, t, n)),
-      (e.safeEncode = (t, n) => Li(e, t, n)),
-      (e.safeDecode = (t, n) => Ri(e, t, n)),
-      (e.safeEncodeAsync = async (t, n) => zi(e, t, n)),
-      (e.safeDecodeAsync = async (t, n) => Bi(e, t, n)),
-      (e.refine = (t, n) => e.check(Ka(t, n))),
-      (e.superRefine = (t) => e.check(qa(t))),
-      (e.overwrite = (t) => e.check(k(t))),
-      (e.optional = () => Oa(e)),
-      (e.exactOptional = () => Aa(e)),
-      (e.nullable = () => Ma(e)),
-      (e.nullish = () => Oa(Ma(e))),
-      (e.nonoptional = (t) => Ra(e, t)),
-      (e.array = () => V(e)),
-      (e.or = (t) => _a([e, t])),
-      (e.and = (t) => ba(e, t)),
-      (e.transform = (t) => Ha(e, Ea(t))),
-      (e.default = (t) => Pa(e, t)),
-      (e.prefault = (t) => Ia(e, t)),
-      (e.catch = (t) => Ba(e, t)),
-      (e.pipe = (t) => Ha(e, t)),
-      (e.readonly = () => Wa(e)),
+      (e.encode = (t, n) => ba(e, t, n)),
+      (e.decode = (t, n) => xa(e, t, n)),
+      (e.encodeAsync = async (t, n) => Sa(e, t, n)),
+      (e.decodeAsync = async (t, n) => Ca(e, t, n)),
+      (e.safeEncode = (t, n) => wa(e, t, n)),
+      (e.safeDecode = (t, n) => Ta(e, t, n)),
+      (e.safeEncodeAsync = async (t, n) => Ea(e, t, n)),
+      (e.safeDecodeAsync = async (t, n) => Da(e, t, n)),
+      (e.refine = (t, n) => e.check(Lo(t, n))),
+      (e.superRefine = (t) => e.check(Ro(t))),
+      (e.overwrite = (t) => e.check(P(t))),
+      (e.optional = () => yo(e)),
+      (e.exactOptional = () => xo(e)),
+      (e.nullable = () => Co(e)),
+      (e.nullish = () => yo(Co(e))),
+      (e.nonoptional = (t) => ko(e, t)),
+      (e.array = () => W(e)),
+      (e.or = (t) => oo([e, t])),
+      (e.and = (t) => lo(e, t)),
+      (e.transform = (t) => No(e, _o(t))),
+      (e.default = (t) => To(e, t)),
+      (e.prefault = (t) => Do(e, t)),
+      (e.catch = (t) => jo(e, t)),
+      (e.pipe = (t) => No(e, t)),
+      (e.readonly = () => Fo(e)),
       (e.describe = (t) => {
         let n = e.clone()
-        return O.add(n, { description: t }), n
+        return Mr.add(n, { description: t }), n
       }),
       Object.defineProperty(e, `description`, {
         get() {
-          return O.get(e)?.description
+          return Mr.get(e)?.description
         },
         configurable: !0
       }),
       (e.meta = (...t) => {
-        if (t.length === 0) return O.get(e)
+        if (t.length === 0) return Mr.get(e)
         let n = e.clone()
-        return O.add(n, t[0]), n
+        return Mr.add(n, t[0]), n
       }),
       (e.isOptional = () => e.safeParse(void 0).success),
       (e.isNullable = () => e.safeParse(null).success),
@@ -2557,143 +3748,143 @@ const M = r(`ZodError`, Oi, { Parent: Error }),
       e
     )
   ),
-  Vi = r(`_ZodString`, (e, t) => {
-    Mt.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => $r(e, t, n, r))
+  Oa = S(`_ZodString`, (e, t) => {
+    vn.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Bi(e, t, n, r))
     let n = e._zod.bag
     ;(e.format = n.format ?? null),
       (e.minLength = n.minimum ?? null),
       (e.maxLength = n.maximum ?? null),
-      (e.regex = (...t) => e.check(Mr(...t))),
-      (e.includes = (...t) => e.check(Fr(...t))),
-      (e.startsWith = (...t) => e.check(Ir(...t))),
-      (e.endsWith = (...t) => e.check(Lr(...t))),
-      (e.min = (...t) => e.check(Ar(...t))),
-      (e.max = (...t) => e.check(kr(...t))),
-      (e.length = (...t) => e.check(jr(...t))),
-      (e.nonempty = (...t) => e.check(Ar(1, ...t))),
-      (e.lowercase = (t) => e.check(Nr(t))),
-      (e.uppercase = (t) => e.check(Pr(t))),
-      (e.trim = () => e.check(zr())),
-      (e.normalize = (...t) => e.check(Rr(...t))),
-      (e.toLowerCase = () => e.check(Br())),
-      (e.toUpperCase = () => e.check(Vr())),
-      (e.slugify = () => e.check(Hr()))
+      (e.regex = (...t) => e.check(yi(...t))),
+      (e.includes = (...t) => e.check(Si(...t))),
+      (e.startsWith = (...t) => e.check(Ci(...t))),
+      (e.endsWith = (...t) => e.check(wi(...t))),
+      (e.min = (...t) => e.check(_i(...t))),
+      (e.max = (...t) => e.check(gi(...t))),
+      (e.length = (...t) => e.check(vi(...t))),
+      (e.nonempty = (...t) => e.check(_i(1, ...t))),
+      (e.lowercase = (t) => e.check(bi(t))),
+      (e.uppercase = (t) => e.check(xi(t))),
+      (e.trim = () => e.check(Ei())),
+      (e.normalize = (...t) => e.check(Ti(...t))),
+      (e.toLowerCase = () => e.check(Di())),
+      (e.toUpperCase = () => e.check(Oi())),
+      (e.slugify = () => e.check(ki()))
   }),
-  Hi = r(`ZodString`, (e, t) => {
-    Mt.init(e, t),
-      Vi.init(e, t),
-      (e.email = (t) => e.check(qn(Ui, t))),
-      (e.url = (t) => e.check($n(Gi, t))),
-      (e.jwt = (t) => e.check(mr(oa, t))),
-      (e.emoji = (t) => e.check(er(Ki, t))),
-      (e.guid = (t) => e.check(Jn(Wi, t))),
-      (e.uuid = (t) => e.check(Yn(I, t))),
-      (e.uuidv4 = (t) => e.check(Xn(I, t))),
-      (e.uuidv6 = (t) => e.check(Zn(I, t))),
-      (e.uuidv7 = (t) => e.check(Qn(I, t))),
-      (e.nanoid = (t) => e.check(tr(qi, t))),
-      (e.guid = (t) => e.check(Jn(Wi, t))),
-      (e.cuid = (t) => e.check(nr(Ji, t))),
-      (e.cuid2 = (t) => e.check(rr(Yi, t))),
-      (e.ulid = (t) => e.check(ir(Xi, t))),
-      (e.base64 = (t) => e.check(dr(ra, t))),
-      (e.base64url = (t) => e.check(fr(ia, t))),
-      (e.xid = (t) => e.check(ar(Zi, t))),
-      (e.ksuid = (t) => e.check(or(Qi, t))),
-      (e.ipv4 = (t) => e.check(sr($i, t))),
-      (e.ipv6 = (t) => e.check(cr(ea, t))),
-      (e.cidrv4 = (t) => e.check(lr(ta, t))),
-      (e.cidrv6 = (t) => e.check(ur(na, t))),
-      (e.e164 = (t) => e.check(pr(aa, t))),
-      (e.datetime = (t) => e.check(xi(t))),
-      (e.date = (t) => e.check(Ci(t))),
-      (e.time = (t) => e.check(Ti(t))),
-      (e.duration = (t) => e.check(Di(t)))
+  ka = S(`ZodString`, (e, t) => {
+    vn.init(e, t),
+      Oa.init(e, t),
+      (e.email = (t) => e.check(Pr(Aa, t))),
+      (e.url = (t) => e.check(Br(Na, t))),
+      (e.jwt = (t) => e.check(ti(Ja, t))),
+      (e.emoji = (t) => e.check(Vr(Pa, t))),
+      (e.guid = (t) => e.check(Fr(ja, t))),
+      (e.uuid = (t) => e.check(Ir(Ma, t))),
+      (e.uuidv4 = (t) => e.check(Lr(Ma, t))),
+      (e.uuidv6 = (t) => e.check(Rr(Ma, t))),
+      (e.uuidv7 = (t) => e.check(zr(Ma, t))),
+      (e.nanoid = (t) => e.check(Hr(Fa, t))),
+      (e.guid = (t) => e.check(Fr(ja, t))),
+      (e.cuid = (t) => e.check(Ur(Ia, t))),
+      (e.cuid2 = (t) => e.check(Wr(La, t))),
+      (e.ulid = (t) => e.check(Gr(Ra, t))),
+      (e.base64 = (t) => e.check(Qr(Ga, t))),
+      (e.base64url = (t) => e.check($r(Ka, t))),
+      (e.xid = (t) => e.check(Kr(za, t))),
+      (e.ksuid = (t) => e.check(qr(Ba, t))),
+      (e.ipv4 = (t) => e.check(Jr(Va, t))),
+      (e.ipv6 = (t) => e.check(Yr(Ha, t))),
+      (e.cidrv4 = (t) => e.check(Xr(Ua, t))),
+      (e.cidrv6 = (t) => e.check(Zr(Wa, t))),
+      (e.e164 = (t) => e.check(ei(qa, t))),
+      (e.datetime = (t) => e.check(ca(t))),
+      (e.date = (t) => e.check(ua(t))),
+      (e.time = (t) => e.check(fa(t))),
+      (e.duration = (t) => e.check(ma(t)))
   })
-function P(e) {
-  return Kn(Hi, e)
+function z(e) {
+  return Nr(ka, e)
 }
-const F = r(`ZodStringFormat`, (e, t) => {
-    E.init(e, t), Vi.init(e, t)
+const B = S(`ZodStringFormat`, (e, t) => {
+    N.init(e, t), Oa.init(e, t)
   }),
-  Ui = r(`ZodEmail`, (e, t) => {
-    Ft.init(e, t), F.init(e, t)
+  Aa = S(`ZodEmail`, (e, t) => {
+    xn.init(e, t), B.init(e, t)
   }),
-  Wi = r(`ZodGUID`, (e, t) => {
-    Nt.init(e, t), F.init(e, t)
+  ja = S(`ZodGUID`, (e, t) => {
+    yn.init(e, t), B.init(e, t)
   }),
-  I = r(`ZodUUID`, (e, t) => {
-    Pt.init(e, t), F.init(e, t)
+  Ma = S(`ZodUUID`, (e, t) => {
+    bn.init(e, t), B.init(e, t)
   }),
-  Gi = r(`ZodURL`, (e, t) => {
-    It.init(e, t), F.init(e, t)
+  Na = S(`ZodURL`, (e, t) => {
+    Sn.init(e, t), B.init(e, t)
   })
-function L(e) {
-  return $n(Gi, e)
+function V(e) {
+  return Br(Na, e)
 }
-const Ki = r(`ZodEmoji`, (e, t) => {
-    Lt.init(e, t), F.init(e, t)
+const Pa = S(`ZodEmoji`, (e, t) => {
+    Cn.init(e, t), B.init(e, t)
   }),
-  qi = r(`ZodNanoID`, (e, t) => {
-    Rt.init(e, t), F.init(e, t)
+  Fa = S(`ZodNanoID`, (e, t) => {
+    wn.init(e, t), B.init(e, t)
   }),
-  Ji = r(`ZodCUID`, (e, t) => {
-    zt.init(e, t), F.init(e, t)
+  Ia = S(`ZodCUID`, (e, t) => {
+    Tn.init(e, t), B.init(e, t)
   }),
-  Yi = r(`ZodCUID2`, (e, t) => {
-    Bt.init(e, t), F.init(e, t)
+  La = S(`ZodCUID2`, (e, t) => {
+    En.init(e, t), B.init(e, t)
   }),
-  Xi = r(`ZodULID`, (e, t) => {
-    Vt.init(e, t), F.init(e, t)
+  Ra = S(`ZodULID`, (e, t) => {
+    Dn.init(e, t), B.init(e, t)
   }),
-  Zi = r(`ZodXID`, (e, t) => {
-    Ht.init(e, t), F.init(e, t)
+  za = S(`ZodXID`, (e, t) => {
+    On.init(e, t), B.init(e, t)
   }),
-  Qi = r(`ZodKSUID`, (e, t) => {
-    Ut.init(e, t), F.init(e, t)
+  Ba = S(`ZodKSUID`, (e, t) => {
+    kn.init(e, t), B.init(e, t)
   }),
-  $i = r(`ZodIPv4`, (e, t) => {
-    Jt.init(e, t), F.init(e, t)
+  Va = S(`ZodIPv4`, (e, t) => {
+    Pn.init(e, t), B.init(e, t)
   }),
-  ea = r(`ZodIPv6`, (e, t) => {
-    Yt.init(e, t), F.init(e, t)
+  Ha = S(`ZodIPv6`, (e, t) => {
+    Fn.init(e, t), B.init(e, t)
   }),
-  ta = r(`ZodCIDRv4`, (e, t) => {
-    Xt.init(e, t), F.init(e, t)
+  Ua = S(`ZodCIDRv4`, (e, t) => {
+    In.init(e, t), B.init(e, t)
   }),
-  na = r(`ZodCIDRv6`, (e, t) => {
-    Zt.init(e, t), F.init(e, t)
+  Wa = S(`ZodCIDRv6`, (e, t) => {
+    Ln.init(e, t), B.init(e, t)
   }),
-  ra = r(`ZodBase64`, (e, t) => {
-    $t.init(e, t), F.init(e, t)
+  Ga = S(`ZodBase64`, (e, t) => {
+    zn.init(e, t), B.init(e, t)
   }),
-  ia = r(`ZodBase64URL`, (e, t) => {
-    tn.init(e, t), F.init(e, t)
+  Ka = S(`ZodBase64URL`, (e, t) => {
+    Vn.init(e, t), B.init(e, t)
   }),
-  aa = r(`ZodE164`, (e, t) => {
-    nn.init(e, t), F.init(e, t)
+  qa = S(`ZodE164`, (e, t) => {
+    Hn.init(e, t), B.init(e, t)
   }),
-  oa = r(`ZodJWT`, (e, t) => {
-    an.init(e, t), F.init(e, t)
+  Ja = S(`ZodJWT`, (e, t) => {
+    Wn.init(e, t), B.init(e, t)
   }),
-  sa = r(`ZodNumber`, (e, t) => {
-    on.init(e, t),
-      N.init(e, t),
-      (e._zod.processJSONSchema = (t, n, r) => ei(e, t, n, r)),
-      (e.gt = (t, n) => e.check(Er(t, n))),
-      (e.gte = (t, n) => e.check(Dr(t, n))),
-      (e.min = (t, n) => e.check(Dr(t, n))),
-      (e.lt = (t, n) => e.check(wr(t, n))),
-      (e.lte = (t, n) => e.check(Tr(t, n))),
-      (e.max = (t, n) => e.check(Tr(t, n))),
-      (e.int = (t) => e.check(la(t))),
-      (e.safe = (t) => e.check(la(t))),
-      (e.positive = (t) => e.check(Er(0, t))),
-      (e.nonnegative = (t) => e.check(Dr(0, t))),
-      (e.negative = (t) => e.check(wr(0, t))),
-      (e.nonpositive = (t) => e.check(Tr(0, t))),
-      (e.multipleOf = (t, n) => e.check(Or(t, n))),
-      (e.step = (t, n) => e.check(Or(t, n))),
+  Ya = S(`ZodNumber`, (e, t) => {
+    Gn.init(e, t),
+      R.init(e, t),
+      (e._zod.processJSONSchema = (t, n, r) => Vi(e, t, n, r)),
+      (e.gt = (t, n) => e.check(pi(t, n))),
+      (e.gte = (t, n) => e.check(mi(t, n))),
+      (e.min = (t, n) => e.check(mi(t, n))),
+      (e.lt = (t, n) => e.check(di(t, n))),
+      (e.lte = (t, n) => e.check(fi(t, n))),
+      (e.max = (t, n) => e.check(fi(t, n))),
+      (e.int = (t) => e.check(Za(t))),
+      (e.safe = (t) => e.check(Za(t))),
+      (e.positive = (t) => e.check(pi(0, t))),
+      (e.nonnegative = (t) => e.check(mi(0, t))),
+      (e.negative = (t) => e.check(di(0, t))),
+      (e.nonpositive = (t) => e.check(fi(0, t))),
+      (e.multipleOf = (t, n) => e.check(hi(t, n))),
+      (e.step = (t, n) => e.check(hi(t, n))),
       (e.finite = () => e)
     let n = e._zod.bag
     ;(e.minValue = Math.max(n.minimum ?? -1 / 0, n.exclusiveMinimum ?? -1 / 0) ?? null),
@@ -2702,105 +3893,105 @@ const Ki = r(`ZodEmoji`, (e, t) => {
       (e.isFinite = !0),
       (e.format = n.format ?? null)
   })
-function R(e) {
-  return yr(sa, e)
+function H(e) {
+  return oi(Ya, e)
 }
-const ca = r(`ZodNumberFormat`, (e, t) => {
-  sn.init(e, t), sa.init(e, t)
+const Xa = S(`ZodNumberFormat`, (e, t) => {
+  Kn.init(e, t), Ya.init(e, t)
 })
-function la(e) {
-  return br(ca, e)
+function Za(e) {
+  return si(Xa, e)
 }
-const ua = r(`ZodBoolean`, (e, t) => {
-  cn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ti(e, t, n, r))
+const Qa = S(`ZodBoolean`, (e, t) => {
+  qn.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Hi(e, t, n, r))
 })
-function z(e) {
-  return xr(ua, e)
+function U(e) {
+  return ci(Qa, e)
 }
-const da = r(`ZodUnknown`, (e, t) => {
-  ln.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (e, t, n) => void 0)
+const $a = S(`ZodUnknown`, (e, t) => {
+  Jn.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (e, t, n) => void 0)
 })
-function B() {
-  return Sr(da)
+function eo() {
+  return li($a)
 }
-const fa = r(`ZodNever`, (e, t) => {
-  un.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ni(e, t, n, r))
+const to = S(`ZodNever`, (e, t) => {
+  Yn.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Ui(e, t, n, r))
 })
-function pa(e) {
-  return Cr(fa, e)
+function no(e) {
+  return ui(to, e)
 }
-const ma = r(`ZodArray`, (e, t) => {
-  fn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => si(e, t, n, r)),
+const ro = S(`ZodArray`, (e, t) => {
+  Zn.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => Ji(e, t, n, r)),
     (e.element = t.element),
-    (e.min = (t, n) => e.check(Ar(t, n))),
-    (e.nonempty = (t) => e.check(Ar(1, t))),
-    (e.max = (t, n) => e.check(kr(t, n))),
-    (e.length = (t, n) => e.check(jr(t, n))),
+    (e.min = (t, n) => e.check(_i(t, n))),
+    (e.nonempty = (t) => e.check(_i(1, t))),
+    (e.max = (t, n) => e.check(gi(t, n))),
+    (e.length = (t, n) => e.check(vi(t, n))),
     (e.unwrap = () => e.element)
 })
-function V(e, t) {
-  return Ur(ma, e, t)
+function W(e, t) {
+  return Ai(ro, e, t)
 }
-const ha = r(`ZodObject`, (e, t) => {
-  _n.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => ci(e, t, n, r)),
-    f(e, `shape`, () => t.shape),
-    (e.keyof = () => G(Object.keys(e._zod.def.shape))),
+const io = S(`ZodObject`, (e, t) => {
+  nr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => Yi(e, t, n, r)),
+    w(e, `shape`, () => t.shape),
+    (e.keyof = () => q(Object.keys(e._zod.def.shape))),
     (e.catchall = (t) => e.clone({ ...e._zod.def, catchall: t })),
-    (e.passthrough = () => e.clone({ ...e._zod.def, catchall: B() })),
-    (e.loose = () => e.clone({ ...e._zod.def, catchall: B() })),
-    (e.strict = () => e.clone({ ...e._zod.def, catchall: pa() })),
+    (e.passthrough = () => e.clone({ ...e._zod.def, catchall: eo() })),
+    (e.loose = () => e.clone({ ...e._zod.def, catchall: eo() })),
+    (e.strict = () => e.clone({ ...e._zod.def, catchall: no() })),
     (e.strip = () => e.clone({ ...e._zod.def, catchall: void 0 })),
-    (e.extend = (t) => pe(e, t)),
-    (e.safeExtend = (t) => me(e, t)),
-    (e.merge = (t) => he(e, t)),
-    (e.pick = (t) => de(e, t)),
-    (e.omit = (t) => fe(e, t)),
-    (e.partial = (...t) => ge(Da, e, t[0])),
-    (e.required = (...t) => _e(La, e, t[0]))
+    (e.extend = (t) => Ye(e, t)),
+    (e.safeExtend = (t) => Xe(e, t)),
+    (e.merge = (t) => Ze(e, t)),
+    (e.pick = (t) => qe(e, t)),
+    (e.omit = (t) => Je(e, t)),
+    (e.partial = (...t) => Qe(vo, e, t[0])),
+    (e.required = (...t) => $e(Oo, e, t[0]))
 })
-function H(e, t) {
-  return new ha({ type: `object`, shape: e ?? {}, ...y(t) })
+function G(e, t) {
+  return new io({ type: `object`, shape: e ?? {}, ...k(t) })
 }
-const ga = r(`ZodUnion`, (e, t) => {
-  yn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => li(e, t, n, r)), (e.options = t.options)
+const ao = S(`ZodUnion`, (e, t) => {
+  ir.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Xi(e, t, n, r)), (e.options = t.options)
 })
-function _a(e, t) {
-  return new ga({ type: `union`, options: e, ...y(t) })
+function oo(e, t) {
+  return new ao({ type: `union`, options: e, ...k(t) })
 }
-const va = r(`ZodDiscriminatedUnion`, (e, t) => {
-  ga.init(e, t), bn.init(e, t)
+const so = S(`ZodDiscriminatedUnion`, (e, t) => {
+  ao.init(e, t), ar.init(e, t)
 })
-function U(e, t, n) {
-  return new va({ type: `union`, options: t, discriminator: e, ...y(n) })
+function K(e, t, n) {
+  return new so({ type: `union`, options: t, discriminator: e, ...k(n) })
 }
-const ya = r(`ZodIntersection`, (e, t) => {
-  xn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ui(e, t, n, r))
+const co = S(`ZodIntersection`, (e, t) => {
+  or.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Zi(e, t, n, r))
 })
-function ba(e, t) {
-  return new ya({ type: `intersection`, left: e, right: t })
+function lo(e, t) {
+  return new co({ type: `intersection`, left: e, right: t })
 }
-const xa = r(`ZodRecord`, (e, t) => {
-  wn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => di(e, t, n, r)),
+const uo = S(`ZodRecord`, (e, t) => {
+  lr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => Qi(e, t, n, r)),
     (e.keyType = t.keyType),
     (e.valueType = t.valueType)
 })
-function Sa(e, t, n) {
-  return new xa({ type: `record`, keyType: e, valueType: t, ...y(n) })
+function fo(e, t, n) {
+  return new uo({ type: `record`, keyType: e, valueType: t, ...k(n) })
 }
-function W(e, t, n) {
-  let r = v(e)
-  return (r._zod.values = void 0), new xa({ type: `record`, keyType: r, valueType: t, ...y(n) })
+function po(e, t, n) {
+  let r = O(e)
+  return (r._zod.values = void 0), new uo({ type: `record`, keyType: r, valueType: t, ...k(n) })
 }
-const Ca = r(`ZodEnum`, (e, t) => {
-  Tn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => ri(e, t, n, r)),
+const mo = S(`ZodEnum`, (e, t) => {
+  ur.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => Wi(e, t, n, r)),
     (e.enum = t.entries),
     (e.options = Object.values(t.entries))
   let n = new Set(Object.keys(t.entries))
@@ -2809,23 +4000,23 @@ const Ca = r(`ZodEnum`, (e, t) => {
     for (let r of e)
       if (n.has(r)) i[r] = t.entries[r]
       else throw Error(`Key ${r} not found in enum`)
-    return new Ca({ ...t, checks: [], ...y(r), entries: i })
+    return new mo({ ...t, checks: [], ...k(r), entries: i })
   }),
     (e.exclude = (e, r) => {
       let i = { ...t.entries }
       for (let t of e)
         if (n.has(t)) delete i[t]
         else throw Error(`Key ${t} not found in enum`)
-      return new Ca({ ...t, checks: [], ...y(r), entries: i })
+      return new mo({ ...t, checks: [], ...k(r), entries: i })
     })
 })
-function G(e, t) {
-  return new Ca({ type: `enum`, entries: Array.isArray(e) ? Object.fromEntries(e.map((e) => [e, e])) : e, ...y(t) })
+function q(e, t) {
+  return new mo({ type: `enum`, entries: Array.isArray(e) ? Object.fromEntries(e.map((e) => [e, e])) : e, ...k(t) })
 }
-const wa = r(`ZodLiteral`, (e, t) => {
-  En.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => ii(e, t, n, r)),
+const ho = S(`ZodLiteral`, (e, t) => {
+  dr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => Gi(e, t, n, r)),
     (e.values = new Set(t.values)),
     Object.defineProperty(e, `value`, {
       get() {
@@ -2835,135 +4026,136 @@ const wa = r(`ZodLiteral`, (e, t) => {
       }
     })
 })
-function K(e, t) {
-  return new wa({ type: `literal`, values: Array.isArray(e) ? e : [e], ...y(t) })
+function J(e, t) {
+  return new ho({ type: `literal`, values: Array.isArray(e) ? e : [e], ...k(t) })
 }
-const Ta = r(`ZodTransform`, (e, t) => {
-  Dn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => oi(e, t, n, r)),
+const go = S(`ZodTransform`, (e, t) => {
+  fr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => qi(e, t, n, r)),
     (e._zod.parse = (n, r) => {
-      if (r.direction === `backward`) throw new a(e.constructor.name)
+      if (r.direction === `backward`) throw new Oe(e.constructor.name)
       n.addIssue = (r) => {
-        if (typeof r == `string`) n.issues.push(C(r, n.value, t))
+        if (typeof r == `string`) n.issues.push(it(r, n.value, t))
         else {
           let t = r
           t.fatal && (t.continue = !1),
             (t.code ??= `custom`),
             (t.input ??= n.value),
             (t.inst ??= e),
-            n.issues.push(C(t))
+            n.issues.push(it(t))
         }
       }
       let i = t.transform(n.value, n)
       return i instanceof Promise ? i.then((e) => ((n.value = e), n)) : ((n.value = i), n)
     })
 })
-function Ea(e) {
-  return new Ta({ type: `transform`, transform: e })
+function _o(e) {
+  return new go({ type: `transform`, transform: e })
 }
-const Da = r(`ZodOptional`, (e, t) => {
-  kn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => yi(e, t, n, r)),
+const vo = S(`ZodOptional`, (e, t) => {
+  mr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => oa(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Oa(e) {
-  return new Da({ type: `optional`, innerType: e })
+function yo(e) {
+  return new vo({ type: `optional`, innerType: e })
 }
-const ka = r(`ZodExactOptional`, (e, t) => {
-  An.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => yi(e, t, n, r)),
+const bo = S(`ZodExactOptional`, (e, t) => {
+  hr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => oa(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Aa(e) {
-  return new ka({ type: `optional`, innerType: e })
+function xo(e) {
+  return new bo({ type: `optional`, innerType: e })
 }
-const ja = r(`ZodNullable`, (e, t) => {
-  jn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => fi(e, t, n, r)),
+const So = S(`ZodNullable`, (e, t) => {
+  gr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => $i(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Ma(e) {
-  return new ja({ type: `nullable`, innerType: e })
+function Co(e) {
+  return new So({ type: `nullable`, innerType: e })
 }
-const Na = r(`ZodDefault`, (e, t) => {
-  Mn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => mi(e, t, n, r)),
+const wo = S(`ZodDefault`, (e, t) => {
+  _r.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => ta(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType),
     (e.removeDefault = e.unwrap)
 })
-function Pa(e, t) {
-  return new Na({
+function To(e, t) {
+  return new wo({
     type: `default`,
     innerType: e,
     get defaultValue() {
-      return typeof t == `function` ? t() : se(t)
+      return typeof t == `function` ? t() : He(t)
     }
   })
 }
-const Fa = r(`ZodPrefault`, (e, t) => {
-  Pn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => hi(e, t, n, r)),
+const Eo = S(`ZodPrefault`, (e, t) => {
+  yr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => na(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Ia(e, t) {
-  return new Fa({
+function Do(e, t) {
+  return new Eo({
     type: `prefault`,
     innerType: e,
     get defaultValue() {
-      return typeof t == `function` ? t() : se(t)
+      return typeof t == `function` ? t() : He(t)
     }
   })
 }
-const La = r(`ZodNonOptional`, (e, t) => {
-  Fn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => pi(e, t, n, r)),
+const Oo = S(`ZodNonOptional`, (e, t) => {
+  br.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => ea(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Ra(e, t) {
-  return new La({ type: `nonoptional`, innerType: e, ...y(t) })
+function ko(e, t) {
+  return new Oo({ type: `nonoptional`, innerType: e, ...k(t) })
 }
-const za = r(`ZodCatch`, (e, t) => {
-  Ln.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => gi(e, t, n, r)),
+const Ao = S(`ZodCatch`, (e, t) => {
+  Sr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => ra(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType),
     (e.removeCatch = e.unwrap)
 })
-function Ba(e, t) {
-  return new za({ type: `catch`, innerType: e, catchValue: typeof t == `function` ? t : () => t })
+function jo(e, t) {
+  return new Ao({ type: `catch`, innerType: e, catchValue: typeof t == `function` ? t : () => t })
 }
-const Va = r(`ZodPipe`, (e, t) => {
-  Rn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => _i(e, t, n, r)), (e.in = t.in), (e.out = t.out)
+const Mo = S(`ZodPipe`, (e, t) => {
+  Cr.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ia(e, t, n, r)), (e.in = t.in), (e.out = t.out)
 })
-function Ha(e, t) {
-  return new Va({ type: `pipe`, in: e, out: t })
+function No(e, t) {
+  return new Mo({ type: `pipe`, in: e, out: t })
 }
-const Ua = r(`ZodReadonly`, (e, t) => {
-  zn.init(e, t),
-    N.init(e, t),
-    (e._zod.processJSONSchema = (t, n, r) => vi(e, t, n, r)),
+const Po = S(`ZodReadonly`, (e, t) => {
+  Tr.init(e, t),
+    R.init(e, t),
+    (e._zod.processJSONSchema = (t, n, r) => aa(e, t, n, r)),
     (e.unwrap = () => e._zod.def.innerType)
 })
-function Wa(e) {
-  return new Ua({ type: `readonly`, innerType: e })
+function Fo(e) {
+  return new Po({ type: `readonly`, innerType: e })
 }
-const Ga = r(`ZodCustom`, (e, t) => {
-  Vn.init(e, t), N.init(e, t), (e._zod.processJSONSchema = (t, n, r) => ai(e, t, n, r))
+const Io = S(`ZodCustom`, (e, t) => {
+  Dr.init(e, t), R.init(e, t), (e._zod.processJSONSchema = (t, n, r) => Ki(e, t, n, r))
 })
-function Ka(e, t = {}) {
-  return Wr(Ga, e, t)
+function Lo(e, t = {}) {
+  return ji(Io, e, t)
 }
-function qa(e) {
-  return Gr(e)
+function Ro(e) {
+  return Mi(e)
 }
-const q = {
+Ee()
+const Y = {
     ANTHROPIC_MESSAGES: `anthropic-messages`,
     GOOGLE_GENERATE_CONTENT: `google-generate-content`,
     JINA_RERANK: `jina-rerank`,
@@ -2980,7 +4172,7 @@ const q = {
     OPENAI_TEXT_TO_SPEECH: `openai-text-to-speech`,
     OPENAI_VIDEO_GENERATION: `openai-video-generation`
   },
-  Ja = {
+  zo = {
     FUNCTION_CALL: `function-call`,
     REASONING: `reasoning`,
     IMAGE_RECOGNITION: `image-recognition`,
@@ -2998,9 +4190,9 @@ const q = {
     FILE_SEARCH: `file-search`,
     COMPUTER_USE: `computer-use`
   },
-  Ya = { WEB_SEARCH: `web-search`, URL_CONTEXT: `url-context` },
-  Xa = { ALL_CHAT_MODELS: `all-chat-models`, MODEL_DEPENDENT: `model-dependent` },
-  J = {
+  Bo = { WEB_SEARCH: `web-search`, URL_CONTEXT: `url-context` },
+  Vo = { ALL_CHAT_MODELS: `all-chat-models`, MODEL_DEPENDENT: `model-dependent` },
+  Ho = {
     ADD_WATERMARK: `addWatermark`,
     ASPECT_RATIO: `aspectRatio`,
     BACKGROUND: `background`,
@@ -3046,9 +4238,9 @@ const q = {
     TOP_SCALE: `topScale`,
     UPSCALE_FACTOR: `upscaleFactor`
   },
-  Za = { TEXT: `text`, IMAGE: `image`, AUDIO: `audio`, VIDEO: `video`, VECTOR: `vector` },
-  Qa = { USD: `USD`, CNY: `CNY` },
-  $a = {
+  Uo = { TEXT: `text`, IMAGE: `image`, AUDIO: `audio`, VIDEO: `video`, VECTOR: `vector` },
+  Wo = { USD: `USD`, CNY: `CNY` },
+  Go = {
     NONE: `none`,
     MINIMAL: `minimal`,
     LOW: `low`,
@@ -3059,19 +4251,19 @@ const q = {
     ULTRA: `ultra`,
     AUTO: `auto`
   }
-function Y(e) {
+function X(e) {
   return Object.values(e)
 }
-const eo = P().min(1),
-  to = P().min(1),
-  no = P().min(1),
-  ro = H({ min: R(), max: R() }).refine((e) => e.min <= e.max, { message: `min must be less than or equal to max` })
-H({ min: P(), max: P() })
-const io = G(Y(Qa)).optional(),
-  X = H({ perMillionTokens: R().nonnegative().nullable(), currency: io }),
-  ao = Sa(P(), B()).optional()
-function Z(e, { min: t } = {}) {
-  let n = V(B()).transform((t) =>
+const Ko = z().min(1),
+  qo = z().min(1),
+  Jo = z().min(1),
+  Yo = G({ min: H(), max: H() }).refine((e) => e.min <= e.max, { message: `min must be less than or equal to max` })
+G({ min: z(), max: z() })
+const Xo = q(X(Wo)).optional(),
+  Z = G({ perMillionTokens: H().nonnegative().nullable(), currency: Xo }),
+  Zo = fo(z(), eo()).optional()
+function Q(e, { min: t } = {}) {
+  let n = W(eo()).transform((t) =>
     t.reduce((t, n) => {
       let r = e.safeParse(n)
       return r.success && t.push(r.data), t
@@ -3079,23 +4271,184 @@ function Z(e, { min: t } = {}) {
   )
   return t === void 0 ? n : n.refine((e) => e.length >= t, { message: `expected at least ${t} recognized value(s)` })
 }
-const oo = G(Y(Za)),
-  so = G(Y(Ja)),
-  co = G(Y(J)),
-  lo = H({ min: R().nonnegative().optional(), max: R().positive().optional(), default: R().nonnegative().optional() })
+const Qo = {
+    anthropic: /^(?:anthropic\.)?claude/i,
+    gemini: /^(?:gemini|palm|veo|imagen|learnlm|lyria)/i,
+    gemma: /^gemma(?:[-:\d]|$)/i,
+    grok: /^grok/i,
+    openai: /\bgpt\b|^o[134]|^chatgpt|^codex|^davinci|^babbage|^dall-e|^text-moderation|^text-embedding-(?:3|ada)/i,
+    qwen: /^qwen|^qwq|^qvq|^tongyi/i,
+    doubao: /^(?:doubao|skylark|seed|seedance|seedream|ep-)/i,
+    hunyuan: /^(?:hunyuan|hy-|hy\d)/i,
+    kimi: /^(?:kimi|moonshot|k3(?:[-_.]|$))/i,
+    deepseek: /^deepseek/i,
+    perplexity: /^sonar/i,
+    baichuan: /^baichuan/i,
+    mimo: /^mimo-/i,
+    ling: /^(?:ling|ring)-/i,
+    minimax: /^(?:minimax|abab)/i,
+    step: /^step-/i,
+    zhipu: /^(?:glm|chatglm|cogview|cogvideo|codegeex)/i,
+    mistral: /^(?:open-|labs-)?(?:mistral|pixtral|codestral|ministral|voxtral|devstral|mixtral|magistral)/i
+  },
+  $o = q(
+    `reasoningEffort,reasoningSummary,reasoning_effort,reasoning.effort,reasoning.enabled,reasoning.exclude,reasoning.max_tokens,thinking.type,thinking.budget_tokens,thinking.budgetTokens,thinking.display,effort,sendReasoning,enable_thinking,thinking_budget,incremental_output,disable_reasoning,reasoning_budget,chat_template_kwargs.enable_thinking,chat_template_kwargs.thinking,chat_template_kwargs.thinking_mode,chat_template_kwargs.thinking_budget,extra_body.google.thinking_config.thinking_budget,extra_body.google.thinking_config.include_thoughts,extra_body.thinking.type,extra_body.thinking_budget,extra_body.reasoning_effort,thinkingConfig.includeThoughts,thinkingConfig.thinkingBudget,thinkingConfig.thinkingLevel,reasoningConfig.type,reasoningConfig.budgetTokens,reasoningConfig.maxReasoningEffort,think`.split(
+      `,`
+    )
+  ),
+  es = q(X(Go)),
+  ts = G({
+    target: $o,
+    value: K(`source`, [
+      G({ source: J(`literal`), value: oo([z(), H(), U()]) }),
+      G({ source: J(`effort`) }),
+      G({ source: J(`budget`) }),
+      G({ source: J(`assistant-summary`) })
+    ])
+  }),
+  ns = G({
+    target: $o,
+    value: K(`source`, [
+      G({ source: J(`literal`), value: oo([z(), H(), U()]) }),
+      G({ source: J(`effort`) }),
+      G({ source: J(`assistant-summary`) })
+    ])
+  }),
+  rs = G({
+    min: H().nonnegative().optional(),
+    autoValue: H().optional(),
+    clampToMaxTokens: U().optional(),
+    missing: K(`type`, [
+      G({ type: J(`omit-value`) }),
+      G({ type: J(`omit-mode`) }),
+      G({ type: J(`fallback`), value: H() })
+    ])
+  }),
+  is = po(es, es).optional(),
+  as = oo([
+    G({ operations: W(ns).min(1), effortMap: is }),
+    G({
+      operations: W(ts)
+        .min(1)
+        .refine((e) => e.some((e) => e.value.source === `budget`), {
+          message: `reasoning budget mode must contain a budget operation`
+        }),
+      effortMap: is,
+      budget: rs
+    })
+  ]),
+  os = G({
+    disabled: J(!0).optional(),
+    default: as.optional(),
+    off: as.optional(),
+    auto: as.optional(),
+    effort: as.optional()
+  }).refine((e) => e.disabled === !0 || e.default || e.off || e.auto || e.effort, {
+    message: `reasoning wire profile must declare a mode or be disabled`
+  })
+G({ wire: os, budgetWire: os.optional() })
+const ss = q(X(Y)),
+  cs = X(Y),
+  ls = q([`global`, `cn`]),
+  us = q([`openai-priority`, `claude-code`]),
+  ds = q([`standard`, `auto`, `fast`, `flex`]),
+  fs = W(ds)
+    .min(1)
+    .refine((e) => new Set(e).size === e.length, { message: `service tier options must be unique` })
+    .refine((e) => e.includes(`standard`), { message: `service tier options must include standard` }),
+  ps = G({
+    default: ds,
+    options: fs,
+    wire: G({
+      delivery: K(`type`, [
+        G({ type: J(`provider-option`), key: z().min(1) }),
+        G({ type: J(`request-body`), key: z().min(1) })
+      ]),
+      values: po(ds, z().min(1))
+    })
+  }).superRefine((e, t) => {
+    e.options.includes(e.default) ||
+      t.addIssue({ code: `custom`, message: `service tier default must be one of its options`, path: [`default`] })
+    for (let n of e.options)
+      e.wire.values[n] ||
+        t.addIssue({
+          code: `custom`,
+          message: `service tier option '${n}' must have a wire value`,
+          path: [`wire`, `values`, n]
+        })
+  }),
+  ms = G({
+    id: q(X(Bo)),
+    modelScope: q(X(Vo)).default(Vo.MODEL_DEPENDENT),
+    endpointTypes: Q(ss).optional(),
+    vendors: Q(q(Object.keys(Qo))).optional()
+  }),
+  $ = (e) => G({ type: J(e), wire: os.optional() }),
+  hs = K(`type`, [$(`openai-chat`), $(`openai-responses`), $(`anthropic`), $(`gemini`), $(`ollama`), $(`none`)])
+hs.options.map((e) => e.shape.type.value)
+const gs = G({
+    website: G({ official: V().optional(), docs: V().optional(), apiKey: V().optional(), models: V().optional() })
+  }),
+  _s = G({ streamOptions: U().optional(), developerRole: U().optional(), reasoningSummary: U().optional() }),
+  vs = G({
+    baseUrl: V().optional(),
+    modelsApiUrls: G({
+      default: V().optional(),
+      embedding: V().optional(),
+      image: V().optional(),
+      reranker: V().optional()
+    }).optional(),
+    reasoningFormat: hs.optional(),
+    adapterFamily: z().optional(),
+    dialect: _s.optional(),
+    requestControls: G({ serviceTier: ps.optional() }).optional()
+  }),
+  ys = G({
+    version: Jo,
+    providers: Q(
+      G({
+        id: qo,
+        presetProviderId: qo.optional(),
+        name: z(),
+        availableInEditions: Q(ls, { min: 1 }).optional(),
+        description: z().optional(),
+        endpointConfigs: fo(
+          z().refine((e) => cs.includes(e), {
+            message: `Invalid endpoint type key, must be one of: ${X(Y).join(`, `)}`
+          }),
+          vs
+        ).optional(),
+        defaultChatEndpoint: ss.nullable().default(null),
+        modelListSource: q([`api`, `registry`]).default(`api`),
+        authMethods: Q(q([`api-key`, `oauth`, `external-cli`])).optional(),
+        authOptional: U().default(!1),
+        serverTools: Q(ms).default([]),
+        reportsActualCost: U().default(!1),
+        reportedCostCurrency: Xo,
+        fastMode: G({ transport: us, serviceTier: z().optional() }).optional(),
+        metadata: Zo.and(gs)
+      }).refine((e) => (e.endpointConfigs && e.defaultChatEndpoint ? e.defaultChatEndpoint in e.endpointConfigs : !0), {
+        message: `defaultChatEndpoint must exist as a key in endpointConfigs`
+      })
+    )
+  }),
+  bs = q(X(Uo)),
+  xs = q(X(zo)),
+  Ss = q(X(Ho)),
+  Cs = G({ min: H().nonnegative().optional(), max: H().positive().optional(), default: H().nonnegative().optional() })
     .refine((e) => (e.min == null) == (e.max == null), { message: `min and max must be both present or both absent` })
     .refine((e) => e.min == null || e.max == null || e.min <= e.max, {
       message: `min must be less than or equal to max`
     }),
-  Q = G(Y($a)),
-  uo = U(`kind`, [
-    H({ kind: K(`effort`), values: Z(Q, { min: 1 }), default: Q.optional() }),
-    H({ kind: K(`budget`), min: R().nonnegative(), max: R().positive(), default: R().nonnegative().optional() }),
-    H({ kind: K(`toggle`), default: z().optional() })
+  ws = q(X(Go)),
+  Ts = K(`kind`, [
+    G({ kind: J(`effort`), values: Q(ws, { min: 1 }), default: ws.optional() }),
+    G({ kind: J(`budget`), min: H().nonnegative(), max: H().positive(), default: H().nonnegative().optional() }),
+    G({ kind: J(`toggle`), default: U().optional() })
   ]),
-  fo = G([`effort`, `budget`])
-H({
-  pattern: P().refine(
+  Es = q([`effort`, `budget`])
+G({
+  pattern: z().refine(
     (e) => {
       try {
         return new RegExp(e, `i`), !0
@@ -3105,24 +4458,24 @@ H({
     },
     { message: `pattern must be a valid regular expression` }
   ),
-  effort: Z(Q, { min: 1 }).optional(),
-  toggle: z().optional(),
-  budget: H({ min: R().nonnegative(), max: R().positive() })
+  effort: Q(ws, { min: 1 }).optional(),
+  toggle: U().optional(),
+  budget: G({ min: H().nonnegative(), max: H().positive() })
     .refine((e) => e.min <= e.max, { message: `budget min must be <= max` })
     .optional(),
-  template: K(!0).optional(),
-  wireDialect: fo.optional()
+  template: J(!0).optional(),
+  wireDialect: Es.optional()
 }).refine(
   (e) =>
     e.template !== !0 || e.effort !== void 0 || e.toggle !== void 0 || e.budget !== void 0 || e.wireDialect !== void 0,
   { message: `a template rule with no knobs declares nothing — drop it or make it a profile` }
 )
-const po = H({
-    controls: Z(uo).optional(),
-    thinkingTokenLimits: lo.optional(),
-    supportedEfforts: Z(Q).optional(),
-    defaultEffort: Q.optional(),
-    wireDialect: fo.optional()
+const Ds = G({
+    controls: Q(Ts).optional(),
+    thinkingTokenLimits: Cs.optional(),
+    supportedEfforts: Q(ws).optional(),
+    defaultEffort: ws.optional(),
+    wireDialect: Es.optional()
   }).superRefine((e, t) => {
     let n = (e.controls ?? []).map((e) => e.kind)
     new Set(n).size !== n.length && t.addIssue({ code: `custom`, message: `at most one reasoning control per kind` })
@@ -3135,86 +4488,86 @@ const po = H({
           (n.min > n.max || (n.default != null && (n.default < n.min || n.default > n.max))) &&
           t.addIssue({ code: `custom`, message: `budget range must satisfy min <= default <= max` })
   }),
-  mo = G([`generate`, `edit`, `remix`, `upscale`, `merge`]),
-  ho = H({ type: K(`switch`), default: z().optional() }),
-  go = H({
-    type: K(`enum`),
-    options: V(P()).min(1),
-    default: P().optional(),
-    render: G([`select`, `chips`]).optional(),
-    columns: R().int().positive().optional()
+  Os = q([`generate`, `edit`, `remix`, `upscale`, `merge`]),
+  ks = G({ type: J(`switch`), default: U().optional() }),
+  As = G({
+    type: J(`enum`),
+    options: W(z()).min(1),
+    default: z().optional(),
+    render: q([`select`, `chips`]).optional(),
+    columns: H().int().positive().optional()
   }),
-  _o = H({ type: K(`range`), min: R(), max: R(), default: R().optional(), step: R().optional() }).refine(
+  js = G({ type: J(`range`), min: H(), max: H(), default: H().optional(), step: H().optional() }).refine(
     (e) => e.min <= e.max,
     { message: `min must be ≤ max` }
   ),
-  vo = H({
-    type: K(`range`),
-    min: R().int(),
-    max: R().int(),
-    default: R().int().optional(),
-    step: R().int().positive().default(1)
+  Ms = G({
+    type: J(`range`),
+    min: H().int(),
+    max: H().int(),
+    default: H().int().optional(),
+    step: H().int().positive().default(1)
   }).refine((e) => e.min <= e.max, { message: `min must be ≤ max` }),
-  yo = U(`type`, [
-    ho,
-    go,
-    _o,
-    H({ type: K(`size`), minSide: R(), maxSide: R(), pairedEnumKey: P().optional() }),
-    H({ type: K(`text`), multiline: z().optional() })
+  Ns = K(`type`, [
+    ks,
+    As,
+    js,
+    G({ type: J(`size`), minSide: H(), maxSide: H(), pairedEnumKey: z().optional() }),
+    G({ type: J(`text`), multiline: U().optional() })
   ]),
-  bo = [J.NUM_IMAGES, J.MAX_IMAGES, J.NUM_INFERENCE_STEPS, J.SAFETY_TOLERANCE, J.OUTPUT_COMPRESSION],
-  xo = H({
-    modes: W(
-      mo,
-      H({
-        supports: W(co, yo).transform((e, t) => {
+  Ps = [Ho.NUM_IMAGES, Ho.MAX_IMAGES, Ho.NUM_INFERENCE_STEPS, Ho.SAFETY_TOLERANCE, Ho.OUTPUT_COMPRESSION],
+  Fs = G({
+    modes: po(
+      Os,
+      G({
+        supports: po(Ss, Ns).transform((e, t) => {
           let n = { ...e }
-          for (let r of bo) {
+          for (let r of Ps) {
             let i = e[r]
             if (i === void 0) continue
-            let a = vo.safeParse(i)
+            let a = Ms.safeParse(i)
             if (a.success) n[r] = a.data
             else for (let e of a.error.issues) t.addIssue({ ...e, path: [r, ...e.path] })
           }
           return n
         }),
-        maxInputImages: R().int().positive().optional(),
-        vendorTransport: H({
-          endpoint: P().regex(/^\/(?!\/)/, `vendor transport endpoint must be a root-relative path, not a URL`),
-          isSync: z().optional()
+        maxInputImages: H().int().positive().optional(),
+        vendorTransport: G({
+          endpoint: z().regex(/^\/(?!\/)/, `vendor transport endpoint must be a root-relative path, not a URL`),
+          isSync: U().optional()
         }).optional(),
-        requirePrompt: z().optional()
+        requirePrompt: U().optional()
       })
     )
   }),
-  So = H({
-    temperature: H({ supported: z(), range: ro.optional() }).default({ supported: !0 }),
-    topP: H({ supported: z(), range: ro.optional() }).default({ supported: !0 }),
-    topK: H({ supported: z(), range: ro.optional() }).default({ supported: !1 }),
-    frequencyPenalty: z().default(!0),
-    presencePenalty: z().default(!0),
-    maxTokens: z().default(!0),
-    stopSequences: z().default(!0),
-    systemMessage: z().default(!0)
+  Is = G({
+    temperature: G({ supported: U(), range: Yo.optional() }).default({ supported: !0 }),
+    topP: G({ supported: U(), range: Yo.optional() }).default({ supported: !0 }),
+    topK: G({ supported: U(), range: Yo.optional() }).default({ supported: !1 }),
+    frequencyPenalty: U().default(!0),
+    presencePenalty: U().default(!0),
+    maxTokens: U().default(!0),
+    stopSequences: U().default(!0),
+    systemMessage: U().default(!0)
   }),
-  Co = H({
-    input: X,
-    output: X,
-    cacheRead: X.optional(),
-    cacheWrite: X.optional(),
-    inputTokenTiers: V(
-      H({
-        minInputTokens: R().int().positive().refine(Number.isSafeInteger),
-        input: X,
-        output: X,
-        cacheRead: X.optional(),
-        cacheWrite: X.optional()
+  Ls = G({
+    input: Z,
+    output: Z,
+    cacheRead: Z.optional(),
+    cacheWrite: Z.optional(),
+    inputTokenTiers: W(
+      G({
+        minInputTokens: H().int().positive().refine(Number.isSafeInteger),
+        input: Z,
+        output: Z,
+        cacheRead: Z.optional(),
+        cacheWrite: Z.optional()
       })
     ).optional(),
-    perImage: H({ price: R(), currency: io, unit: G([`image`, `pixel`]).optional() }).optional(),
-    perMinute: H({ price: R(), currency: io }).optional()
+    perImage: G({ price: H(), currency: Xo, unit: q([`image`, `pixel`]).optional() }).optional(),
+    perMinute: G({ price: H(), currency: Xo }).optional()
   })
-function wo(e, t) {
+function Rs(e, t) {
   for (let n = 1; n < (e.inputTokenTiers?.length ?? 0); n++)
     e.inputTokenTiers[n].minInputTokens <= e.inputTokenTiers[n - 1].minInputTokens &&
       t.addIssue({
@@ -3235,278 +4588,118 @@ function wo(e, t) {
         ...(e.cacheWrite ? [{ rate: e.cacheWrite, path: [`inputTokenTiers`, t, `cacheWrite`] }] : [])
       ])
     ],
-    r = n[0]?.rate.currency ?? Qa.USD
+    r = n[0]?.rate.currency ?? Wo.USD
   for (let { rate: e, path: i } of n)
-    (e.currency ?? Qa.USD) !== r &&
+    (e.currency ?? Wo.USD) !== r &&
       t.addIssue({ code: `custom`, path: [...i, `currency`], message: `pricing currencies must match` })
 }
-const To = Co.superRefine(wo),
-  Eo = Co.partial().superRefine(wo),
-  Do = H({
-    version: no,
-    models: Z(
-      H({
-        id: eo,
-        name: P(),
-        description: P().optional(),
-        capabilities: Z(so)
+const zs = Ls.superRefine(Rs),
+  Bs = Ls.partial().superRefine(Rs),
+  Vs = G({
+    version: Jo,
+    models: Q(
+      G({
+        id: Ko,
+        name: z(),
+        description: z().optional(),
+        capabilities: Q(xs)
           .refine((e) => new Set(e).size === e.length, { message: `Capabilities must be unique` })
           .optional(),
-        inputModalities: Z(oo)
+        inputModalities: Q(bs)
           .refine((e) => new Set(e).size === e.length, { message: `Input modalities must be unique` })
           .optional(),
-        outputModalities: Z(oo)
+        outputModalities: Q(bs)
           .refine((e) => new Set(e).size === e.length, { message: `Output modalities must be unique` })
           .optional(),
-        contextWindow: R().optional(),
-        maxOutputTokens: R().optional(),
-        maxInputTokens: R().optional(),
-        pricing: To.optional(),
-        reasoning: po.optional(),
-        parameterSupport: So.optional(),
-        imageGeneration: xo.optional(),
-        family: P().optional(),
-        ownedBy: P().optional(),
-        openWeights: z().optional(),
-        metadata: ao
+        endpointTypes: Q(ss).optional(),
+        contextWindow: H().optional(),
+        maxOutputTokens: H().optional(),
+        maxInputTokens: H().optional(),
+        pricing: zs.optional(),
+        reasoning: Ds.optional(),
+        parameterSupport: Is.optional(),
+        imageGeneration: Fs.optional(),
+        family: z().optional(),
+        ownedBy: z().optional(),
+        openWeights: U().optional(),
+        metadata: Zo
       })
     )
   }),
-  Oo = {
-    anthropic: /^(?:anthropic\.)?claude/i,
-    gemini: /^(?:gemini|palm|veo|imagen|learnlm|lyria)/i,
-    gemma: /^gemma(?:[-:\d]|$)/i,
-    grok: /^grok/i,
-    openai: /\bgpt\b|^o[134]|^chatgpt|^codex|^davinci|^babbage|^dall-e|^text-moderation|^text-embedding-(?:3|ada)/i,
-    qwen: /^qwen|^qwq|^qvq|^tongyi/i,
-    doubao: /^(?:doubao|skylark|seed|seedance|seedream|ep-)/i,
-    hunyuan: /^(?:hunyuan|hy-|hy\d)/i,
-    kimi: /^(?:kimi|moonshot|k3(?:[-_.]|$))/i,
-    deepseek: /^deepseek/i,
-    perplexity: /^sonar/i,
-    baichuan: /^baichuan/i,
-    mimo: /^mimo-/i,
-    ling: /^(?:ling|ring)-/i,
-    minimax: /^(?:minimax|abab)/i,
-    step: /^step-/i,
-    zhipu: /^(?:glm|chatglm|cogview|cogvideo|codegeex)/i,
-    mistral: /^(?:open-|labs-)?(?:mistral|pixtral|codestral|ministral|voxtral|devstral|mixtral|magistral)/i
-  },
-  ko = G(
-    `reasoningEffort,reasoningSummary,reasoning_effort,reasoning.effort,reasoning.enabled,reasoning.exclude,reasoning.max_tokens,thinking.type,thinking.budget_tokens,thinking.budgetTokens,thinking.display,effort,sendReasoning,enable_thinking,thinking_budget,incremental_output,disable_reasoning,reasoning_budget,chat_template_kwargs.enable_thinking,chat_template_kwargs.thinking,chat_template_kwargs.thinking_mode,chat_template_kwargs.thinking_budget,extra_body.google.thinking_config.thinking_budget,extra_body.google.thinking_config.include_thoughts,extra_body.thinking.type,extra_body.thinking_budget,extra_body.reasoning_effort,thinkingConfig.includeThoughts,thinkingConfig.thinkingBudget,thinkingConfig.thinkingLevel,reasoningConfig.type,reasoningConfig.budgetTokens,reasoningConfig.maxReasoningEffort,think`.split(
-      `,`
-    )
-  ),
-  Ao = G(Y($a)),
-  jo = H({
-    target: ko,
-    value: U(`source`, [
-      H({ source: K(`literal`), value: _a([P(), R(), z()]) }),
-      H({ source: K(`effort`) }),
-      H({ source: K(`budget`) }),
-      H({ source: K(`assistant-summary`) })
-    ])
-  }),
-  Mo = H({
-    target: ko,
-    value: U(`source`, [
-      H({ source: K(`literal`), value: _a([P(), R(), z()]) }),
-      H({ source: K(`effort`) }),
-      H({ source: K(`assistant-summary`) })
-    ])
-  }),
-  No = H({
-    min: R().nonnegative().optional(),
-    autoValue: R().optional(),
-    clampToMaxTokens: z().optional(),
-    missing: U(`type`, [
-      H({ type: K(`omit-value`) }),
-      H({ type: K(`omit-mode`) }),
-      H({ type: K(`fallback`), value: R() })
-    ])
-  }),
-  Po = W(Ao, Ao).optional(),
-  Fo = _a([
-    H({ operations: V(Mo).min(1), effortMap: Po }),
-    H({
-      operations: V(jo)
-        .min(1)
-        .refine((e) => e.some((e) => e.value.source === `budget`), {
-          message: `reasoning budget mode must contain a budget operation`
-        }),
-      effortMap: Po,
-      budget: No
-    })
+  Hs = G({ add: Q(xs).optional(), remove: Q(xs).optional(), force: Q(xs).optional() }),
+  Us = q([
+    Y.OPENAI_RESPONSES,
+    Y.OPENAI_CHAT_COMPLETIONS,
+    Y.ANTHROPIC_MESSAGES,
+    Y.GOOGLE_GENERATE_CONTENT,
+    Y.OLLAMA_CHAT,
+    Y.OLLAMA_GENERATE,
+    Y.OPENAI_TEXT_COMPLETIONS
   ]),
-  Io = H({
-    disabled: K(!0).optional(),
-    default: Fo.optional(),
-    off: Fo.optional(),
-    auto: Fo.optional(),
-    effort: Fo.optional()
-  }).refine((e) => e.disabled === !0 || e.default || e.off || e.auto || e.effort, {
-    message: `reasoning wire profile must declare a mode or be disabled`
-  })
-H({ wire: Io, budgetWire: Io.optional() })
-const Lo = G(Y(q)),
-  Ro = Y(q),
-  zo = G([`global`, `cn`]),
-  Bo = G([`openai-priority`, `claude-code`]),
-  Vo = G([`standard`, `auto`, `fast`, `flex`]),
-  Ho = V(Vo)
-    .min(1)
-    .refine((e) => new Set(e).size === e.length, { message: `service tier options must be unique` })
-    .refine((e) => e.includes(`standard`), { message: `service tier options must include standard` }),
-  Uo = H({
-    default: Vo,
-    options: Ho,
-    wire: H({
-      delivery: U(`type`, [
-        H({ type: K(`provider-option`), key: P().min(1) }),
-        H({ type: K(`request-body`), key: P().min(1) })
-      ]),
-      values: W(Vo, P().min(1))
-    })
-  }).superRefine((e, t) => {
-    e.options.includes(e.default) ||
-      t.addIssue({ code: `custom`, message: `service tier default must be one of its options`, path: [`default`] })
-    for (let n of e.options)
-      e.wire.values[n] ||
-        t.addIssue({
-          code: `custom`,
-          message: `service tier option '${n}' must have a wire value`,
-          path: [`wire`, `values`, n]
-        })
-  }),
-  Wo = H({
-    id: G(Y(Ya)),
-    modelScope: G(Y(Xa)).default(Xa.MODEL_DEPENDENT),
-    endpointTypes: Z(Lo).optional(),
-    vendors: Z(G(Object.keys(Oo))).optional()
-  }),
-  $ = (e) => H({ type: K(e), wire: Io.optional() }),
-  Go = U(`type`, [$(`openai-chat`), $(`openai-responses`), $(`anthropic`), $(`gemini`), $(`ollama`), $(`none`)])
-Go.options.map((e) => e.shape.type.value)
-const Ko = H({
-    website: H({ official: L().optional(), docs: L().optional(), apiKey: L().optional(), models: L().optional() })
-  }),
-  qo = H({ streamOptions: z().optional(), developerRole: z().optional(), reasoningSummary: z().optional() }),
-  Jo = H({
-    baseUrl: L().optional(),
-    modelsApiUrls: H({
-      default: L().optional(),
-      embedding: L().optional(),
-      image: L().optional(),
-      reranker: L().optional()
-    }).optional(),
-    reasoningFormat: Go.optional(),
-    adapterFamily: P().optional(),
-    dialect: qo.optional(),
-    requestControls: H({ serviceTier: Uo.optional() }).optional()
-  }),
-  Yo = H({
-    version: no,
-    providers: Z(
-      H({
-        id: to,
-        presetProviderId: to.optional(),
-        name: P(),
-        availableInEditions: Z(zo, { min: 1 }).optional(),
-        description: P().optional(),
-        endpointConfigs: Sa(
-          P().refine((e) => Ro.includes(e), {
-            message: `Invalid endpoint type key, must be one of: ${Y(q).join(`, `)}`
-          }),
-          Jo
-        ).optional(),
-        defaultChatEndpoint: Lo.nullable().default(null),
-        modelListSource: G([`api`, `registry`]).default(`api`),
-        authMethods: Z(G([`api-key`, `oauth`, `external-cli`])).optional(),
-        authOptional: z().default(!1),
-        serverTools: Z(Wo).default([]),
-        reportsActualCost: z().default(!1),
-        reportedCostCurrency: io,
-        fastMode: H({ transport: Bo, serviceTier: P().optional() }).optional(),
-        metadata: ao.and(Ko)
-      }).refine((e) => (e.endpointConfigs && e.defaultChatEndpoint ? e.defaultChatEndpoint in e.endpointConfigs : !0), {
-        message: `defaultChatEndpoint must exist as a key in endpointConfigs`
-      })
-    )
-  }),
-  Xo = H({ add: Z(so).optional(), remove: Z(so).optional(), force: Z(so).optional() }),
-  Zo = G([
-    q.OPENAI_RESPONSES,
-    q.OPENAI_CHAT_COMPLETIONS,
-    q.ANTHROPIC_MESSAGES,
-    q.GOOGLE_GENERATE_CONTENT,
-    q.OLLAMA_CHAT,
-    q.OLLAMA_GENERATE,
-    q.OPENAI_TEXT_COMPLETIONS
-  ]),
-  Qo = H({ support: po.optional(), wire: Io.optional() }).refine((e) => e.support || e.wire, {
+  Ws = G({ support: Ds.optional(), wire: os.optional() }).refine((e) => e.support || e.wire, {
     message: `provider-model reasoning contract must declare support or wire`
   }),
-  $o = H({
-    version: no,
-    overrides: Z(
-      H({
-        providerId: to,
-        modelId: eo,
-        apiModelId: P().optional(),
-        modelVariants: V(P().min(1)).optional(),
-        capabilities: Xo.optional(),
-        limits: H({
-          contextWindow: R().optional(),
-          maxOutputTokens: R().optional(),
-          maxInputTokens: R().optional()
+  Gs = G({
+    version: Jo,
+    overrides: Q(
+      G({
+        providerId: qo,
+        modelId: Ko,
+        apiModelId: z().optional(),
+        modelVariants: W(z().min(1)).optional(),
+        capabilities: Hs.optional(),
+        limits: G({
+          contextWindow: H().optional(),
+          maxOutputTokens: H().optional(),
+          maxInputTokens: H().optional()
         }).optional(),
-        pricing: Eo.optional(),
-        reasoningContracts: W(Zo, Qo).optional(),
-        supportsFastMode: z().optional(),
-        requestControls: H({ serviceTier: H({ options: Ho }).optional() }).optional(),
-        parameterSupport: So.partial().optional(),
-        endpointTypes: Z(Lo).optional(),
-        inputModalities: Z(oo).optional(),
-        outputModalities: Z(oo).optional(),
-        name: P().optional(),
-        description: P().optional(),
-        family: P().optional(),
-        ownedBy: P().optional(),
-        imageGeneration: xo.optional(),
-        disabled: z().optional(),
-        replaceWith: eo.optional(),
-        reason: P().optional()
+        pricing: Bs.optional(),
+        reasoningContracts: po(Us, Ws).optional(),
+        supportsFastMode: U().optional(),
+        requestControls: G({ serviceTier: G({ options: fs }).optional() }).optional(),
+        parameterSupport: Is.partial().optional(),
+        endpointTypes: Q(ss).optional(),
+        inputModalities: Q(bs).optional(),
+        outputModalities: Q(bs).optional(),
+        name: z().optional(),
+        description: z().optional(),
+        family: z().optional(),
+        ownedBy: z().optional(),
+        imageGeneration: Fs.optional(),
+        disabled: U().optional(),
+        replaceWith: Ko.optional(),
+        reason: z().optional()
       })
     )
   }),
-  es = `anthropic|amazon|meta|google|mistralai|cohere|openai|ai21|microsoft|nvidia`
-;`${es}`, `${es}`
-const ts = [`models.json`, `providers.json`, `provider-models.json`]
-H({
-  minAppVersion: P().min(1),
-  sourceAppVersion: P().min(1),
-  revision: R().int().nonnegative(),
-  schemaVersion: R().int(),
-  files: Sa(P(), P())
+  Ks = `anthropic|amazon|meta|google|mistralai|cohere|openai|ai21|microsoft|nvidia`
+;`${Ks}`, `${Ks}`
+const qs = [`models.json`, `providers.json`, `provider-models.json`]
+G({
+  minAppVersion: z().min(1),
+  sourceAppVersion: z().min(1),
+  revision: H().int().nonnegative(),
+  schemaVersion: H().int(),
+  files: fo(z(), z())
 })
-const ns = { 'models.json': Do, 'providers.json': Yo, 'provider-models.json': $o },
-  rs = 2
-function is(e) {
+const Js = { 'models.json': Vs, 'providers.json': ys, 'provider-models.json': Gs },
+  Ys = 2
+function Xs(e) {
   return e && typeof e == `object` && `issues` in e
     ? JSON.stringify(e.issues)
     : e instanceof Error
       ? e.message
       : String(e)
 }
-function as(e, t) {
-  ns[e].parse(t)
+function Zs(e, t) {
+  Js[e].parse(t)
 }
-function os(n) {
-  for (let r of ts)
+function Qs(n) {
+  for (let r of qs)
     try {
-      as(r, JSON.parse(e(t.join(n, r), `utf8`)))
+      Zs(r, JSON.parse(e(t.join(n, r), `utf8`)))
     } catch (e) {
-      throw Error(`${r} is not compatible with registry schema v2: ${is(e)}`)
+      throw Error(`${r} is not compatible with registry schema v2: ${Xs(e)}`)
     }
 }
 if (process.argv[1] && t.resolve(process.argv[1]) === n(import.meta.url)) {
@@ -3514,9 +4707,9 @@ if (process.argv[1] && t.resolve(process.argv[1]) === n(import.meta.url)) {
   if (!e) console.error(`Usage: node vN-validator.mjs <catalog-data-directory>`), (process.exitCode = 1)
   else
     try {
-      os(t.resolve(e)), console.log(`Catalog is compatible with frozen registry schema v2`)
+      Qs(t.resolve(e)), console.log(`Catalog is compatible with frozen registry schema v2`)
     } catch (e) {
       console.error(e instanceof Error ? e.message : e), (process.exitCode = 1)
     }
 }
-export { rs as schemaVersion, os as validateCatalogDirectory, as as validateCatalogFile }
+export { Ys as schemaVersion, Qs as validateCatalogDirectory, Zs as validateCatalogFile }

--- a/packages/provider-registry/scripts/createCompatibilityBaseline.ts
+++ b/packages/provider-registry/scripts/createCompatibilityBaseline.ts
@@ -35,7 +35,7 @@ async function createCompatibilityBaseline(): Promise<void> {
       dts: false,
       report: false,
       tsconfig: false,
-      noExternal: [/^zod(?:\/|$)/]
+      noExternal: () => true
     })
 
     const bundle = readFileSync(path.join(outputDirectory, targetName), 'utf8').replace(/[ \t]+$/gm, '')
@@ -47,6 +47,14 @@ async function createCompatibilityBaseline(): Promise<void> {
       cwd: repositoryRoot,
       stdio: 'inherit'
     })
+    // CI runs the baseline with bare `node` against a checkout that has no node_modules.
+    const leaked = [...readFileSync(targetPath, 'utf8').matchAll(/^import\b.*?['"]([^'"]+)['"]/gm)]
+      .map(([, id]) => id)
+      .filter((id) => !id.startsWith('node:'))
+    if (leaked.length > 0) {
+      rmSync(targetPath)
+      throw new Error(`Baseline is not dependency-free, it imports ${leaked.join(', ')}`)
+    }
     console.log(`Created frozen registry compatibility baseline ${path.relative(packageRoot, targetPath)}`)
   } finally {
     rmSync(outputDirectory, { recursive: true, force: true })

--- a/scripts/__tests__/publishRegistryCatalog.test.ts
+++ b/scripts/__tests__/publishRegistryCatalog.test.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { publishRegistryCatalog } from '../publishRegistryCatalog'
+
+const COMPAT_DIRECTORY = path.resolve(__dirname, '../../packages/provider-registry/compat')
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+function makeDirectories() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-publish-'))
+  temporaryDirectories.push(root)
+  const sourceDirectory = path.join(root, 'data')
+  const destinationDirectory = path.join(root, 'pub')
+  fs.mkdirSync(sourceDirectory)
+  fs.mkdirSync(destinationDirectory)
+  return { sourceDirectory, destinationDirectory }
+}
+
+/** A v1-shaped override carrying `ultra`, the effort v1's frozen enum does not know. */
+function writeCatalog(sourceDirectory: string, override: Record<string, unknown>) {
+  fs.writeFileSync(path.join(sourceDirectory, 'models.json'), JSON.stringify({ version: 'm1', models: [] }))
+  fs.writeFileSync(path.join(sourceDirectory, 'providers.json'), JSON.stringify({ version: 'p1', providers: [] }))
+  fs.writeFileSync(
+    path.join(sourceDirectory, 'provider-models.json'),
+    JSON.stringify({ version: 'pm1', overrides: [override] })
+  )
+}
+
+const OVERRIDE_WITH_UNKNOWN_EFFORT = {
+  providerId: 'openai-codex',
+  modelId: 'gpt-6-astra',
+  reasoningContracts: {
+    'openai-responses': {
+      support: { controls: [{ default: 'low', kind: 'effort', values: ['low', 'max', 'ultra'] }], defaultEffort: 'low' }
+    }
+  }
+}
+
+const publishOptions = {
+  compatDirectory: COMPAT_DIRECTORY,
+  currentVersion: 2,
+  minAppVersion: '2.0.13',
+  sourceAppVersion: '2.0.12',
+  revision: 41
+}
+
+describe('publishRegistryCatalog', () => {
+  it('keeps a model reaching an older schema by dropping only what it cannot represent', async () => {
+    const { sourceDirectory, destinationDirectory } = makeDirectories()
+    writeCatalog(sourceDirectory, OVERRIDE_WITH_UNKNOWN_EFFORT)
+
+    const published = await publishRegistryCatalog({ ...publishOptions, sourceDirectory, destinationDirectory })
+
+    expect(published).toEqual(['v1', 'v2'])
+    const v1 = JSON.parse(fs.readFileSync(path.join(destinationDirectory, 'v1/provider-models.json'), 'utf8'))
+    expect(v1.overrides).toHaveLength(1)
+    expect(v1.overrides[0].reasoningContracts['openai-responses'].support.controls[0].values).toEqual(['low', 'max'])
+
+    const { validateCatalogFile } = await import(path.join(COMPAT_DIRECTORY, 'v1-validator.mjs'))
+    expect(() => validateCatalogFile('provider-models.json', v1)).not.toThrow()
+  })
+
+  it('publishes the current version untouched', async () => {
+    const { sourceDirectory, destinationDirectory } = makeDirectories()
+    writeCatalog(sourceDirectory, OVERRIDE_WITH_UNKNOWN_EFFORT)
+
+    await publishRegistryCatalog({ ...publishOptions, sourceDirectory, destinationDirectory })
+
+    const v2 = JSON.parse(fs.readFileSync(path.join(destinationDirectory, 'v2/provider-models.json'), 'utf8'))
+    expect(v2.overrides[0].reasoningContracts['openai-responses'].support.controls[0].values).toEqual([
+      'low',
+      'max',
+      'ultra'
+    ])
+  })
+
+  it('leaves an older dir untouched when its break cannot be dropped', async () => {
+    const { sourceDirectory, destinationDirectory } = makeDirectories()
+    writeCatalog(sourceDirectory, OVERRIDE_WITH_UNKNOWN_EFFORT)
+    fs.writeFileSync(path.join(sourceDirectory, 'models.json'), JSON.stringify({ version: 'm1', models: 'retyped' }))
+    fs.mkdirSync(path.join(destinationDirectory, 'v1'))
+    fs.writeFileSync(path.join(destinationDirectory, 'v1/models.json'), 'previous snapshot')
+
+    const published = await publishRegistryCatalog({ ...publishOptions, sourceDirectory, destinationDirectory })
+
+    expect(published).toEqual(['v2'])
+    expect(fs.readFileSync(path.join(destinationDirectory, 'v1/models.json'), 'utf8')).toBe('previous snapshot')
+  })
+
+  it('keeps an older stream on the semantic floor it was published with', async () => {
+    const { sourceDirectory, destinationDirectory } = makeDirectories()
+    writeCatalog(sourceDirectory, OVERRIDE_WITH_UNKNOWN_EFFORT)
+    fs.mkdirSync(path.join(destinationDirectory, 'v1'))
+    fs.writeFileSync(
+      path.join(destinationDirectory, 'v1/manifest.json'),
+      JSON.stringify({ minAppVersion: '2.0.9', sourceAppVersion: '2.0.12', revision: 35, schemaVersion: 1, files: {} })
+    )
+
+    await publishRegistryCatalog({ ...publishOptions, sourceDirectory, destinationDirectory })
+
+    const v1 = JSON.parse(fs.readFileSync(path.join(destinationDirectory, 'v1/manifest.json'), 'utf8'))
+    const v2 = JSON.parse(fs.readFileSync(path.join(destinationDirectory, 'v2/manifest.json'), 'utf8'))
+    expect(v1).toMatchObject({ minAppVersion: '2.0.9', schemaVersion: 1, revision: 41 })
+    expect(v2).toMatchObject({ minAppVersion: '2.0.13', schemaVersion: 2 })
+    expect(v1.files).toEqual({ 'models.json': 'm1', 'providers.json': 'p1', 'provider-models.json': 'pm1' })
+  })
+})

--- a/scripts/publishRegistryCatalog.js
+++ b/scripts/publishRegistryCatalog.js
@@ -1,0 +1,155 @@
+/**
+ * Stage the catalog into every published schema-version dir of the
+ * `x-files/provider-registry` branch, one manifest each.
+ *
+ * The current version gets the catalog verbatim. An older version gets it
+ * down-converted: its own frozen `compat/vN-validator.mjs` is the oracle, and
+ * whatever it cannot represent is dropped — the same degradation a v2+ client
+ * applies at read time (`schemas/forwardCompat.ts`), moved to publish time for
+ * clients too old to do it themselves. A version whose break cannot be dropped
+ * (a renamed or retyped field) stops receiving updates instead of failing the run.
+ */
+const fs = require('node:fs')
+const path = require('node:path')
+const { pathToFileURL } = require('node:url')
+
+const CATALOG_FILES = ['models.json', 'providers.json', 'provider-models.json']
+
+/** Published schema versions, oldest first: every frozen baseline up to the current one. */
+function listSchemaVersions(compatDirectory, currentVersion) {
+  return fs
+    .readdirSync(compatDirectory)
+    .map((entry) => /^v(\d+)-validator\.mjs$/.exec(entry))
+    .filter(Boolean)
+    .map((match) => Number(match[1]))
+    .filter((version) => version <= currentVersion)
+    .sort((a, b) => a - b)
+}
+
+// Descending path order: an index is spliced only after every deeper or later
+// sibling issue, so no not-yet-applied path shifts underneath us.
+function comparePathsDescending(a, b) {
+  for (let index = 0; index < Math.min(a.length, b.length); index += 1) {
+    if (a[index] === b[index]) continue
+    return a[index] < b[index] ? 1 : -1
+  }
+  return b.length - a.length
+}
+
+function dropIssuePaths(document, issuePaths) {
+  let dropped = 0
+  for (const issuePath of issuePaths) {
+    let container = document
+    for (const key of issuePath.slice(0, -1)) container = container?.[key]
+    const last = issuePath[issuePath.length - 1]
+    if (!Array.isArray(container) || typeof last !== 'number') continue
+    container.splice(last, 1)
+    dropped += 1
+  }
+  return dropped
+}
+
+/** Prune until the frozen validator accepts, or `null` when a break is not droppable. */
+function downconvert(validateCatalogFile, file, document) {
+  let dropped = 0
+  for (;;) {
+    try {
+      validateCatalogFile(file, document)
+      return { document, dropped }
+    } catch (error) {
+      const issues = error && typeof error === 'object' ? error.issues : null
+      if (!Array.isArray(issues) || issues.length === 0) return null
+      const pruned = dropIssuePaths(document, issues.map((issue) => issue.path).sort(comparePathsDescending))
+      if (pruned === 0) return null
+      dropped += pruned
+    }
+  }
+}
+
+function readPublishedMinAppVersion(manifestPath) {
+  try {
+    const minAppVersion = JSON.parse(fs.readFileSync(manifestPath, 'utf8')).minAppVersion
+    return typeof minAppVersion === 'string' && minAppVersion ? minAppVersion : null
+  } catch {
+    return null
+  }
+}
+
+async function publishRegistryCatalog({
+  sourceDirectory,
+  compatDirectory,
+  destinationDirectory,
+  currentVersion,
+  minAppVersion,
+  sourceAppVersion,
+  revision
+}) {
+  const published = []
+
+  for (const version of listSchemaVersions(compatDirectory, currentVersion)) {
+    const { validateCatalogFile } = await import(
+      pathToFileURL(path.join(compatDirectory, `v${version}-validator.mjs`)).href
+    )
+
+    const contents = {}
+    for (const file of CATALOG_FILES) {
+      const original = fs.readFileSync(path.join(sourceDirectory, file))
+      if (version === currentVersion) {
+        contents[file] = original
+        continue
+      }
+      const result = downconvert(validateCatalogFile, file, JSON.parse(original))
+      if (!result) {
+        console.error(`v${version}: ${file} has a break that cannot be dropped, leaving the dir untouched`)
+        break
+      }
+      // Re-serialize only what actually changed, so an untouched file stays byte-identical.
+      contents[file] = result.dropped === 0 ? original : Buffer.from(`${JSON.stringify(result.document, null, 2)}\n`)
+    }
+    if (Object.keys(contents).length !== CATALOG_FILES.length) continue
+
+    const destination = path.join(destinationDirectory, `v${version}`)
+    const manifestPath = path.join(destination, 'manifest.json')
+    // An older dir keeps the semantic floor it was published with; only the
+    // current version tracks REGISTRY_MIN_APP_VERSION.
+    const floor = (version === currentVersion ? null : readPublishedMinAppVersion(manifestPath)) ?? minAppVersion
+    const manifest = {
+      minAppVersion: floor,
+      sourceAppVersion,
+      revision,
+      schemaVersion: version,
+      files: Object.fromEntries(CATALOG_FILES.map((file) => [file, JSON.parse(contents[file]).version]))
+    }
+
+    fs.mkdirSync(destination, { recursive: true })
+    for (const file of CATALOG_FILES) fs.writeFileSync(path.join(destination, file), contents[file])
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    published.push(`v${version}`)
+  }
+
+  return published
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+async function main() {
+  const published = await publishRegistryCatalog({
+    sourceDirectory: requiredEnvironment('REGISTRY_PUBLISH_SOURCE'),
+    compatDirectory: requiredEnvironment('REGISTRY_PUBLISH_COMPAT'),
+    destinationDirectory: requiredEnvironment('REGISTRY_PUBLISH_DEST'),
+    currentVersion: Number(requiredEnvironment('REGISTRY_PUBLISH_CURRENT_VERSION')),
+    minAppVersion: requiredEnvironment('REGISTRY_PUBLISH_MIN_APP_VERSION'),
+    sourceAppVersion: requiredEnvironment('REGISTRY_PUBLISH_SOURCE_APP_VERSION'),
+    revision: Number(requiredEnvironment('REGISTRY_PUBLISH_REVISION'))
+  })
+
+  console.log(published.join(' '))
+}
+
+if (require.main === module) main()
+
+exports.publishRegistryCatalog = publishRegistryCatalog

--- a/scripts/publishRegistryCatalog.js
+++ b/scripts/publishRegistryCatalog.js
@@ -150,6 +150,6 @@ async function main() {
   console.log(published.join(' '))
 }
 
-if (require.main === module) main()
+if (require.main === module) void main()
 
 exports.publishRegistryCatalog = publishRegistryCatalog


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Two defects kept the provider-registry catalog from reaching users. First, `Sync provider-registry data` has failed on every run since #20056 bumped the schema to v2: the frozen `compat/v2-validator.mjs` externalizes `semver` (reached through `registry-loader.ts`), so the workflow's bare `node` invocation died with `ERR_MODULE_NOT_FOUND` and `v2/` was never published. Second, the workflow only ever refreshes the *current* `v{N}/` dir, so the moment the schema bumped, every shipped client on schema v1 (2.0.9–2.0.12) silently stopped receiving catalog updates, with no recovery date.

After this PR:

The job installs `semver` into the checkout before running any baseline, so the publish job works again without touching the immutable v2 bundle; the baseline generator now inlines every dependency and asserts the emitted bundle imports only `node:` builtins, so v3 onward will not need that step. Every published `v{N}/` is refreshed rather than just the current one: an older dir gets the catalog down-converted against its own frozen validator, dropping only the values that schema cannot represent — the same degradation `schemas/forwardCompat.ts` performs inside a v2+ client, moved to publish time for clients too old to do it themselves. Verified end to end against the real catalog and the real published `v1/manifest.json`: both dirs are accepted by their own frozen validator, `v2/` is byte-identical to source, and `v1/` keeps all 1442 overrides with only the unknown `ultra` effort removed, so 2.0.9–2.0.12 users get `gpt-6-astra` without waiting for a release.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The frozen validator is the only authority on what a given schema version can parse, so it is used as the oracle: prune the array element each reported `issue.path` points at, revalidate, repeat. A break that is not an array element (a renamed or retyped field) cannot be pruned, and that version simply stops being refreshed instead of failing the run — the v1 stream then ends on its own, with no manual policy to maintain. An older dir keeps the `minAppVersion` recorded in its already-published manifest, so no new source of truth is introduced.

The following tradeoffs were made:

- The v1 stream keeps its published semantic floor of `2.0.9`, so 2.0.9–2.0.12 can receive rows whose newest semantics their runtime renders imperfectly (Astra's tiered pricing, for example). This was chosen over an indefinite update freeze for every currently released user.
- The `semver` install stays in the workflow for as long as v2 is published, because a frozen baseline cannot be repaired in place. It is scoped to a scratch prefix and copied in as a single package, so it never reifies this repo's dependency tree.

The following alternatives were considered:

- Regenerating `compat/v2-validator.mjs` so it is dependency-free — implemented first, then reverted: `compat:policy` compares baselines byte-for-byte against the base ref and rejects any modification, and that guard is right even though `v2/` has never been published.
- Leaving `v1/` frozen and relying on shipping 2.0.13 — rejected because it strands every currently released user with no recovery date.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

None. The `v2/` publish window stays closed until 2.0.13 is released (`minAppVersion` 2.0.13 exceeds `sourceAppVersion` 2.0.12), at which point the existing `release: published` trigger reopens it; `v1/` resumes updating immediately.

### Special notes for your reviewer

<!-- optional -->

- No frozen artifact is touched: `packages/provider-registry/compat/` is absent from the diff.
- The changed paths are now in the workflow's `paths:` filter, but please still dispatch `sync-registry-data.yml` manually after merge to confirm the first `v2/` publish.
- Gates run locally: `compat:policy` against `origin/main`, `actionlint 1.7.12` with `SHELLCHECK_OPTS=--severity=error` (same version as CI), `oxlint --deny-warnings`, eslint, biome, `changeset status`, and 29 vitest tests across `publishRegistryCatalog`, `buildRegistrySyncRequest` and the provider-registry compat suite.
- The publish path was rehearsed in a simulated runner layout: without the install step it reproduces the exact `ERR_MODULE_NOT_FOUND: semver` from the failing runs, and with it both dirs publish and validate.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
