### PR TITLE
fix(chat): ignore orphaned attachments in text-only requests

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/AssistantFileToolsServer.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/AssistantFileToolsServer.test.ts
@@ -51,6 +51,50 @@ function message(fileEntryId: string, filename: string) {
   }
 }
 
+function messageWithComposerAttachments() {
+  return {
+    id: 'message-managed-files',
+    role: 'user',
+    data: {
+      parts: [
+        {
+          type: 'text',
+          text: 'attachments',
+          providerMetadata: {
+            cherry: {
+              composer: {
+                version: 1,
+                tokens: [{ id: 'file:live-source', kind: 'file', label: 'live.txt', index: 0, textOffset: 0 }]
+              }
+            }
+          }
+        },
+        {
+          type: 'file',
+          url: 'file:///tmp/live.txt',
+          mediaType: 'text/plain',
+          filename: 'live.txt',
+          providerMetadata: { cherry: { fileEntryId: 'entry-live', fileTokenSourceId: 'live-source' } }
+        },
+        {
+          type: 'file',
+          url: 'file:///tmp/stale.txt',
+          mediaType: 'text/plain',
+          filename: 'stale.txt',
+          providerMetadata: { cherry: { fileEntryId: 'entry-stale', fileTokenSourceId: 'stale-source' } }
+        },
+        {
+          type: 'file',
+          url: 'file:///tmp/legacy.txt',
+          mediaType: 'text/plain',
+          filename: 'legacy.txt',
+          providerMetadata: { cherry: { fileEntryId: 'entry-legacy' } }
+        }
+      ]
+    }
+  }
+}
+
 function handlers(server: InstanceType<typeof AssistantFileToolsServer>) {
   return (server.mcpServer.server as any)._requestHandlers
 }
@@ -104,6 +148,30 @@ describe('AssistantFileToolsServer', () => {
     expect(second.content[0].text).toBe('(none)')
     expect(mocks.listSessionMessages).toHaveBeenCalledTimes(2)
     expect(JSON.stringify(first)).not.toContain(entryId)
+  })
+
+  it('does not expose orphaned managed attachments to read_file', async () => {
+    mocks.listSessionMessages.mockReturnValue({ items: [messageWithComposerAttachments()], nextCursor: undefined })
+    mocks.readFile.mockImplementation(async (_input, context) => ({
+      text: context.attachments.map((attachment: { displayName: string }) => attachment.displayName).join(',')
+    }))
+    const server = new AssistantFileToolsServer({ sessionId: 'session-1', workspacePath: '/workspace' })
+
+    const result = await callTool(server, 'read_file', {
+      filename: createAssistantFileAttachmentHandle('entry-live')
+    })
+
+    expect(result.content[0].text).toBe('live.txt,legacy.txt')
+    expect(mocks.readFile).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        attachments: [
+          expect.objectContaining({ fileEntryId: 'entry-live', displayName: 'live.txt' }),
+          expect.objectContaining({ fileEntryId: 'entry-legacy', displayName: 'legacy.txt' })
+        ]
+      },
+      expect.any(AbortSignal)
+    )
   })
 
   it('resolves attachments only when save_attachment is invoked', async () => {

--- a/src/main/ai/messages/__tests__/assistantFileAttachments.test.ts
+++ b/src/main/ai/messages/__tests__/assistantFileAttachments.test.ts
@@ -3,13 +3,34 @@ import { describe, expect, it } from 'vitest'
 
 import { collectAssistantFileAttachments, createAssistantFileAttachmentHandle } from '../assistantFileAttachments'
 
-function filePart(fileEntryId: string, filename?: string): CherryMessagePart {
+function filePart(fileEntryId: string, filename?: string, fileTokenSourceId?: string): CherryMessagePart {
   return {
     type: 'file',
     url: 'file:///attachment',
     mediaType: 'application/octet-stream',
     filename,
-    providerMetadata: { cherry: { fileEntryId } }
+    providerMetadata: { cherry: { fileEntryId, ...(fileTokenSourceId ? { fileTokenSourceId } : {}) } }
+  } as CherryMessagePart
+}
+
+function composerText(...fileTokenSourceIds: string[]): CherryMessagePart {
+  return {
+    type: 'text',
+    text: 'attachments',
+    providerMetadata: {
+      cherry: {
+        composer: {
+          version: 1,
+          tokens: fileTokenSourceIds.map((sourceId, index) => ({
+            id: `file:${sourceId}`,
+            kind: 'file',
+            label: `${sourceId}.txt`,
+            index,
+            textOffset: 0
+          }))
+        }
+      }
+    }
   } as CherryMessagePart
 }
 
@@ -43,6 +64,30 @@ describe('assistantFileAttachments', () => {
         fileEntryId: 'entry-2',
         handle: createAssistantFileAttachmentHandle('entry-2'),
         displayName: 'file'
+      }
+    ])
+  })
+
+  it('ignores orphaned modern file parts but keeps matching and legacy attachments', () => {
+    const attachments = collectAssistantFileAttachments([
+      message('message-1', [
+        composerText('live-source'),
+        filePart('entry-live', 'live.txt', 'live-source'),
+        filePart('entry-stale', 'stale.txt', 'stale-source'),
+        filePart('entry-legacy', 'legacy.txt')
+      ])
+    ])
+
+    expect(attachments).toEqual([
+      {
+        fileEntryId: 'entry-live',
+        handle: createAssistantFileAttachmentHandle('entry-live'),
+        displayName: 'live.txt'
+      },
+      {
+        fileEntryId: 'entry-legacy',
+        handle: createAssistantFileAttachmentHandle('entry-legacy'),
+        displayName: 'legacy.txt'
       }
     ])
   })

--- a/src/main/ai/messages/__tests__/attachmentRouting.test.ts
+++ b/src/main/ai/messages/__tests__/attachmentRouting.test.ts
@@ -34,13 +34,38 @@ const ALL: NativeFileSupport = { image: true, pdf: true, audio: true, video: tru
 function userMessage(parts: CherryMessagePart[]): CherryUIMessage {
   return { id: 'm1', role: 'user', parts } as CherryUIMessage
 }
-const fileWithEntry = (id: string, filename: string, mediaType: string): CherryMessagePart =>
+const fileWithEntry = (
+  id: string,
+  filename: string,
+  mediaType: string,
+  fileTokenSourceId?: string
+): CherryMessagePart =>
   ({
     type: 'file',
     url: `file:///x/${filename}`,
     mediaType,
     filename,
-    providerMetadata: { cherry: { fileEntryId: id } }
+    providerMetadata: { cherry: { fileEntryId: id, ...(fileTokenSourceId ? { fileTokenSourceId } : {}) } }
+  }) as CherryMessagePart
+
+const composerText = (text: string, ...fileTokenSourceIds: string[]): CherryMessagePart =>
+  ({
+    type: 'text',
+    text,
+    providerMetadata: {
+      cherry: {
+        composer: {
+          version: 1,
+          tokens: fileTokenSourceIds.map((sourceId, index) => ({
+            id: `file:${sourceId}`,
+            kind: 'file',
+            label: `${sourceId}.png`,
+            index,
+            textOffset: 0
+          }))
+        }
+      }
+    }
   }) as CherryMessagePart
 
 /** One token per character, so a test's `cap` reads directly as a character cap. */
@@ -90,12 +115,50 @@ describe('prepareChatMessages — routing', () => {
     expect(extractMock).not.toHaveBeenCalled()
   })
 
-  it('OCRs a non-vision image into inline text', async () => {
+  it('OCRs a legacy non-vision image without composer source metadata', async () => {
     getByIdMock.mockResolvedValueOnce({ ext: 'png' })
     ocrMock.mockResolvedValueOnce('ocr body')
     const [out] = await run([fileWithEntry('e1', 'a.png', 'image/png')], NONE)
     expect(out.parts.filter((p) => p.type === 'file')).toHaveLength(0)
     expect(textOf(out.parts)[0]).toBe('Attached file "a.png":\nocr body')
+  })
+
+  it('OCRs a modern non-vision image whose composer token matches its source id', async () => {
+    getByIdMock.mockResolvedValueOnce({ ext: 'png' })
+    ocrMock.mockResolvedValueOnce('ocr body')
+
+    const [out] = await run(
+      [composerText('attached', 'source-1'), fileWithEntry('e1', 'a.png', 'image/png', 'source-1')],
+      NONE
+    )
+
+    expect(textOf(out.parts)).toEqual(['attached', 'Attached file "a.png":\nocr body'])
+    expect(ocrMock).toHaveBeenCalledOnce()
+  })
+
+  it('ignores a modern managed image whose composer token no longer references its source id', async () => {
+    const [out] = await run(
+      [composerText('text only', 'different-source'), fileWithEntry('e1', 'stale.png', 'image/png', 'stale-source')],
+      NONE
+    )
+
+    expect(out.parts).toEqual([composerText('text only', 'different-source')])
+    expect(getByIdMock).not.toHaveBeenCalled()
+    expect(ocrMock).not.toHaveBeenCalled()
+  })
+
+  it('does not OCR a stale retained attachment when the effective messages are text-only', async () => {
+    const message = userMessage([{ type: 'text', text: 'text only' } as CherryMessagePart])
+
+    const out = await prepareChatMessages([message] as UIMessage[], {
+      attachments: [{ fileEntryId: 'stale-entry', handle: 'stale.png', displayName: 'stale.png' }],
+      nativeSupport: NONE,
+      isToolCapable: true
+    })
+
+    expect(out).toEqual([message])
+    expect(getByIdMock).not.toHaveBeenCalled()
+    expect(ocrMock).not.toHaveBeenCalled()
   })
 
   it('rejects before native materialization when OCR finds no text', async () => {
@@ -350,5 +413,21 @@ describe('collectFileAttachments', () => {
   it('ignores file parts without a fileEntryId', () => {
     const legacy = { type: 'file', url: 'file:///x/legacy.pdf', mediaType: 'application/pdf' } as CherryMessagePart
     expect(collectFileAttachments([userMessage([legacy])] as UIMessage[])).toEqual([])
+  })
+
+  it('ignores orphaned modern file parts but keeps matching and legacy attachments', () => {
+    const messages = [
+      userMessage([
+        composerText('attached', 'live-source'),
+        fileWithEntry('live', 'live.png', 'image/png', 'live-source'),
+        fileWithEntry('stale', 'stale.png', 'image/png', 'stale-source'),
+        fileWithEntry('legacy', 'legacy.png', 'image/png')
+      ])
+    ] as UIMessage[]
+
+    expect(collectFileAttachments(messages)).toEqual([
+      { fileEntryId: 'live', handle: 'live.png', displayName: 'live.png' },
+      { fileEntryId: 'legacy', handle: 'legacy.png', displayName: 'legacy.png' }
+    ])
   })
 })

--- a/src/main/ai/messages/assistantFileAttachments.ts
+++ b/src/main/ai/messages/assistantFileAttachments.ts
@@ -4,6 +4,8 @@ import type { FileAttachmentRef } from '@main/ai/messages/attachmentTypes'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import type { UIMessage } from 'ai'
 
+import { collectComposerFileTokenIds, isActiveManagedFilePart } from './composerFileParts'
+
 export function createAssistantFileAttachmentHandle(fileEntryId: string): string {
   const digest = createHash('sha256').update(fileEntryId).digest('hex').slice(0, 16)
   return `file_${digest}`
@@ -13,10 +15,12 @@ export function collectAssistantFileAttachments(messages: UIMessage[] | undefine
   const attachments = new Map<string, FileAttachmentRef>()
 
   for (const message of messages ?? []) {
+    const composerFileTokenIds = collectComposerFileTokenIds(message)
     for (const part of message.parts ?? []) {
       if (part.type !== 'file') continue
       const fileEntryId = readCherryMeta(part)?.fileEntryId
       if (!fileEntryId || attachments.has(fileEntryId)) continue
+      if (!isActiveManagedFilePart(part, composerFileTokenIds)) continue
 
       attachments.set(fileEntryId, {
         fileEntryId,

--- a/src/main/ai/messages/attachmentRouting.ts
+++ b/src/main/ai/messages/attachmentRouting.ts
@@ -64,6 +64,22 @@ function uniqueHandle(base: string, used: Set<string>): string {
   return candidate
 }
 
+function collectComposerFileTokenIds(message: UIMessage): Set<string> {
+  const tokenIds = new Set<string>()
+  for (const part of message.parts ?? []) {
+    if (part.type !== 'text') continue
+    for (const token of readCherryMeta(part)?.composer?.tokens ?? []) {
+      if (token.kind === 'file') tokenIds.add(token.id)
+    }
+  }
+  return tokenIds
+}
+
+function isActiveManagedFilePart(part: FileUIPart, composerFileTokenIds: ReadonlySet<string>): boolean {
+  const sourceId = readCherryMeta(part)?.fileTokenSourceId
+  return !sourceId || composerFileTokenIds.has(`file:${sourceId}`)
+}
+
 /**
  * Flat allow-list of fileEntry-backed attachments across all messages. Each gets
  * a **unique** model-facing `handle` (normalized + deduped) plus the original
@@ -73,10 +89,12 @@ export function collectFileAttachments(messages: UIMessage[] | undefined): FileA
   const refs: FileAttachmentRef[] = []
   const used = new Set<string>()
   for (const message of messages ?? []) {
+    const composerFileTokenIds = collectComposerFileTokenIds(message)
     for (const part of message.parts ?? []) {
       if (part.type !== 'file') continue
       const fileEntryId = readCherryMeta(part)?.fileEntryId
       if (!fileEntryId) continue
+      if (!isActiveManagedFilePart(part, composerFileTokenIds)) continue
       const displayName = part.filename ?? 'file'
       const handle = uniqueHandle(displayName.trim() || 'file', used)
       refs.push({ fileEntryId, handle, displayName })
@@ -172,6 +190,7 @@ async function prepareChatMessage<T extends UIMessage>(
   if (!message.parts?.length) return message
 
   const kept: UIMessage['parts'] = []
+  const composerFileTokenIds = collectComposerFileTokenIds(message)
   const inlineNative = async (part: FileUIPart): Promise<boolean> => {
     const inlined = await materializeNativeFilePart(part)
     if (!inlined) return false
@@ -208,6 +227,15 @@ async function prepareChatMessage<T extends UIMessage>(
       continue
     }
 
+    if (!isActiveManagedFilePart(part, composerFileTokenIds)) {
+      logger.warn('Ignoring orphaned managed file part', {
+        messageId: message.id,
+        displayName: part.filename ?? 'file',
+        fileEntryId
+      })
+      continue
+    }
+
     // This is the eager (every-turn, whole-history) path, so any failure here —
     // missing/deleted entry, parse error, failed native
     // materialization — must degrade to a model-visible note rather than reject
@@ -232,7 +260,14 @@ async function prepareChatMessage<T extends UIMessage>(
       // provider request. Gateway-backed models can explicitly enable Vision.
       if (fileType === FILE_TYPE.IMAGE) {
         const ocrText = await ocrNonVisionImage(fileEntryId, ctx.signal)
-        if (ocrText === null) throw new NonVisionImageOcrError()
+        if (ocrText === null) {
+          logger.warn('Non-vision image OCR produced no readable text', {
+            messageId: message.id,
+            displayName,
+            fileEntryId
+          })
+          throw new NonVisionImageOcrError()
+        }
         defer(kept, pending, handle, ocrText)
         continue
       }

--- a/src/main/ai/messages/attachmentRouting.ts
+++ b/src/main/ai/messages/attachmentRouting.ts
@@ -39,6 +39,7 @@ import type { UIMessage } from 'ai'
 
 import { allocateInlineCaps, type AttachmentBudget } from './attachmentBudget'
 import { extractDocumentText, noExtractableTextNote } from './attachmentTextExtraction'
+import { collectComposerFileTokenIds, isActiveManagedFilePart } from './composerFileParts'
 import { materializeNativeFilePart } from './fileProcessor'
 
 const logger = loggerService.withContext('ai:attachmentRouting')
@@ -62,22 +63,6 @@ function uniqueHandle(base: string, used: Set<string>): string {
   for (let n = 2; used.has(candidate); n++) candidate = `${base} (${n})`
   used.add(candidate)
   return candidate
-}
-
-function collectComposerFileTokenIds(message: UIMessage): Set<string> {
-  const tokenIds = new Set<string>()
-  for (const part of message.parts ?? []) {
-    if (part.type !== 'text') continue
-    for (const token of readCherryMeta(part)?.composer?.tokens ?? []) {
-      if (token.kind === 'file') tokenIds.add(token.id)
-    }
-  }
-  return tokenIds
-}
-
-function isActiveManagedFilePart(part: FileUIPart, composerFileTokenIds: ReadonlySet<string>): boolean {
-  const sourceId = readCherryMeta(part)?.fileTokenSourceId
-  return !sourceId || composerFileTokenIds.has(`file:${sourceId}`)
 }
 
 /**

--- a/src/main/ai/messages/composerFileParts.ts
+++ b/src/main/ai/messages/composerFileParts.ts
@@ -1,0 +1,19 @@
+import type { FileUIPart } from '@shared/data/types/message'
+import { readCherryMeta } from '@shared/data/types/uiParts'
+import type { UIMessage } from 'ai'
+
+export function collectComposerFileTokenIds(message: UIMessage): Set<string> {
+  const tokenIds = new Set<string>()
+  for (const part of message.parts ?? []) {
+    if (part.type !== 'text') continue
+    for (const token of readCherryMeta(part)?.composer?.tokens ?? []) {
+      if (token.kind === 'file') tokenIds.add(token.id)
+    }
+  }
+  return tokenIds
+}
+
+export function isActiveManagedFilePart(part: FileUIPart, composerFileTokenIds: ReadonlySet<string>): boolean {
+  const sourceId = readCherryMeta(part)?.fileTokenSourceId
+  return !sourceId || composerFileTokenIds.has(`file:${sourceId}`)
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Text-only continuation turns could retain an orphaned modern image file part after its composer token was removed. Attachment routing treated that stale part as active and could fail the request in the non-vision OCR path.

After this PR:

Modern managed file parts are routed only when their `fileTokenSourceId` matches a file token in the same message's composer snapshot. Legacy migrated attachments without a source ID keep their existing routing behavior, and OCR failures now log the triggering message and attachment identifiers.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20126

### Why we need it and why it was done in this way

The composer snapshot is the persisted source of truth for which modern attachments remain active in a message. A shared message-local predicate now filters both the `read_file` allow-list and provider message preparation, preventing the two paths from disagreeing.

The following tradeoffs were made:

Attachments without `fileTokenSourceId` remain active for v1-to-v2 migration compatibility because migrated historical messages do not have composer association metadata.

The following alternatives were considered:

Filtering only the retained attachment allow-list was rejected because direct provider message preparation would still process the stale file part. Filtering all attachments without matching tokens was rejected because it would drop migrated historical attachments.

Links to places where the discussion took place: #20126

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This changes backend attachment routing only and has no visual output change. No Electron instance or UI screenshot was produced; regression coverage exercises matching modern attachments, orphaned modern attachments, migrated legacy attachments, and text-only retained context.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed text-only continuation turns incorrectly processing stale image attachments and failing before the response starts.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core chat attachment routing and tool allow-lists; behavior shifts for modern managed files but is scoped by composer token matching with legacy fallbacks.
> 
> **Overview**
> Fixes text-only follow-up turns that could still hit **stale modern file parts** left in message history after their composer token was removed, which could trigger non-vision image OCR and fail the request before the model runs.
> 
> Adds shared helpers in `composerFileParts.ts` that treat the composer snapshot as the source of truth: file parts with `fileTokenSourceId` are included only when `file:{sourceId}` appears in the same message’s composer tokens. **Legacy** parts without that metadata keep the previous behavior for migration compatibility.
> 
> That predicate is applied consistently when building attachment allow-lists (`collectFileAttachments`, `collectAssistantFileAttachments`), when preparing provider messages (orphaned parts are dropped with a warning), and in assistant `read_file` context. Non-vision OCR failures now log the message and attachment identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde65a0d939b6b9c8275e1db5e2211cc35480d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- pr-20210-agent-session-followup -->
### Current-head follow-up

The Agent Session `read_file` allow-list now applies the same message-local composer token association as normal chat: matching modern attachments and legacy attachments remain available, while a managed file part with a mismatched `fileTokenSourceId` is excluded.

Regression evidence on Node 24.14.0: the new collector contract failed before the fix by returning `live + stale + legacy`; the focused main suites now pass 41/41, and `pnpm lint`, `pnpm test:lint`, Biome checks, and `git diff --check` pass. Commit `bde65a0d93` is signed, DCO-signed off, and GitHub reports it Verified.

This is backend attachment routing with no visual change. No Electron instance was started and no UI screenshot is applicable.