### PR TITLE
feat(cherry-cloud)!: bind cloud sessions to the current machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "sharp": "0.35.3",
     "smol-toml": "^1.7.0",
     "sqlite-vec": "npm:@aiany/sqlite-vec@0.1.10-alpha.4.aiany.2",
+    "systeminformation": "5.33.8",
     "tar": "^7.5.11",
     "tesseract.js": "6.0.1",
     "turndown": "7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       sqlite-vec:
         specifier: npm:@aiany/sqlite-vec@0.1.10-alpha.4.aiany.2
         version: '@aiany/sqlite-vec@0.1.10-alpha.4.aiany.2'
+      systeminformation:
+        specifier: 5.33.8
+        version: 5.33.8
       tar:
         specifier: 7.5.19
         version: 7.5.19
@@ -14925,6 +14928,12 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  systeminformation@5.33.8:
+    resolution: {integrity: sha512-v4F6OGYGh7wDvV68YmjOmZwGixV9A/GQ7d2b84t0UF4CaOy9jipNWIJDkHqYDYiTPuiojqlwVQd0hfUKOUN7tQ==}
+    engines: {node: '>=10.0.0'}
+    os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
+    hasBin: true
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -30896,6 +30905,8 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.3)
 
   symbol-tree@3.2.4: {}
+
+  systeminformation@5.33.8: {}
 
   tagged-tag@1.0.0: {}
 

--- a/src/main/services/cherryCloud/CherryCloudService.ts
+++ b/src/main/services/cherryCloud/CherryCloudService.ts
@@ -26,6 +26,7 @@ import {
   refreshProductSessionResponseSchema
 } from './contracts'
 import { createAuthorizationSecrets, createDeviceKeyPair, createDeviceSignature, createIdempotencyKey } from './crypto'
+import { getMachineCode } from './machineCode'
 
 const logger = loggerService.withContext('CherryCloudService')
 const DEVELOPMENT_API_ORIGIN = 'http://127.0.0.1:8084'
@@ -103,6 +104,7 @@ class CherryCloudSessionRequiredError extends Error {
 @ServicePhase(Phase.WhenReady)
 export class CherryCloudService extends BaseService {
   private cloudState = emptyState()
+  private machineCode: string | null = null
   private lifecycleGeneration = 0
   private authorizationOperation: AuthorizationOperation | null = null
   private loginPromise: Promise<CherryCloudStatus> | null = null
@@ -155,6 +157,7 @@ export class CherryCloudService extends BaseService {
     this.clearSessionExpiryTimer()
     if (this.cloudState.session) this.sessionGeneration += 1
     this.cloudState = emptyState()
+    this.machineCode = null
   }
 
   public async getStatus(): Promise<CherryCloudStatus> {
@@ -212,6 +215,10 @@ export class CherryCloudService extends BaseService {
     this.assertAuthorizationOperation(operation)
     if (current.phase !== 'signed-out') return current
 
+    const machineCode = await getMachineCode()
+    this.assertLifecycleGeneration(lifecycleGeneration)
+    this.assertAuthorizationOperation(operation)
+    this.machineCode = machineCode
     const device = this.getOrCreateDevice()
     const secrets = createAuthorizationSecrets()
     const loopbackCallback = await this.openLoopbackCallback(lifecycleGeneration, operation)
@@ -230,6 +237,7 @@ export class CherryCloudService extends BaseService {
           code_challenge: secrets.codeChallenge,
           code_challenge_method: 'S256',
           device_public_key: device.publicKey,
+          machine_code: machineCode,
           platform: platformName(),
           client_version: app.getVersion().replace(/^v/, ''),
           ...(loopbackCallback ? { callback_port: loopbackCallback.port } : {})
@@ -893,11 +901,15 @@ export class CherryCloudService extends BaseService {
   ): Promise<Response> {
     const device = this.cloudState.device
     if (!device) throw new Error('Cherry Cloud device credentials are unavailable')
+    const machineCode = this.machineCode ?? (await getMachineCode())
+    if (this.cloudState.device !== device) throw new Error('Cherry Cloud device credentials changed')
+    this.machineCode = machineCode
     const method = (init?.method ?? 'GET').toUpperCase()
     const body = Buffer.from(init?.body ?? '', 'utf8')
     const headers = new Headers(init?.headers)
     for (const name of [
       'Cherry-Device-ID',
+      'Cherry-Machine-Code',
       'Cherry-Request-ID',
       'Cherry-Timestamp',
       'Cherry-Body-SHA256',
@@ -914,6 +926,7 @@ export class CherryCloudService extends BaseService {
     const requestTarget = `${url.pathname}${url.search}`
     const signature = createDeviceSignature({
       privateKey: device.privateKey,
+      machineCode,
       method,
       requestTarget,
       body,

--- a/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
+++ b/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
@@ -25,6 +25,10 @@ const mocks = vi.hoisted(() => ({
   showMainWindow: vi.fn()
 }))
 
+vi.mock('systeminformation', () => ({
+  uuid: vi.fn(async () => ({ os: 'abcdef12123456789abc1234567890ab', hardware: '', macs: [] }))
+}))
+
 vi.mock('@data/dataApiDataChange', () => ({
   notifyDataApiDataChange: mocks.notifyDataChange
 }))
@@ -98,6 +102,7 @@ vi.mock('../CherryCloudLoopbackCallback', () => ({
 }))
 
 import { providerRegistryService } from '@data/services/ProviderRegistryService'
+import { uuid } from 'systeminformation'
 
 import { CherryCloudLoginUnavailableError, CherryCloudService } from '../CherryCloudService'
 
@@ -397,6 +402,60 @@ describe('CherryCloudService', () => {
 
     const createBody = authorizationRequestBody()
     expect(createBody.device_public_key).toBe(firstDevicePublicKey)
+  })
+
+  it('uses the current computer when restoring copied credentials and requires login after rejection', async () => {
+    const original = await createSignedInService()
+    mockCloudRoute('/v1/models', jsonResponse({ data: [] }))
+    await original.authenticatedFetch('/v1/models')
+    const originalCode = new Headers(requestCalls('/v1/models')[0][1].headers).get('Cherry-Machine-Code')
+    expect(originalCode).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    const originalDevice = structuredClone(mocks.savedDevice)
+    mocks.netFetch.mockClear()
+    vi.mocked(uuid).mockResolvedValueOnce({ os: '12345678123456789abc1234567890ab', hardware: '', macs: [] })
+    let restoredCode: string | null = null
+    mockCloudRoute('/api/v1/product-sessions/refresh', (init) => {
+      restoredCode = new Headers(init.headers).get('Cherry-Machine-Code')
+      return restoredCode === originalCode
+        ? jsonResponse(refreshedTokenSet())
+        : jsonResponse({ error: { code: 'REAUTH_REQUIRED' } }, 401)
+    })
+    CherryCloudService.resetInstances()
+    const copied = await createService()
+    await vi.waitFor(async () => {
+      expect(await copied.getStatus()).toEqual({ phase: 'signed-out', displayName: null })
+    })
+    expect(restoredCode).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(restoredCode).not.toBe(originalCode)
+    expect(mocks.savedSession).toBeNull()
+    expect(mocks.savedDevice).toEqual(originalDevice)
+  })
+
+  it('sends the same machine code after local credentials are deleted and a new device key is generated', async () => {
+    const service = await createService()
+    mockCloudRoute('/api/v1/desktop/authorizations', jsonResponse(authorizationResponse(), 201))
+    await service.startLogin()
+    const first = authorizationRequestBody()
+    await service._doStop()
+    CherryCloudService.resetInstances()
+    mocks.savedDevice = null
+    mocks.savedSession = null
+    mocks.netFetch.mockClear()
+    const restarted = await createService()
+    mockCloudRoute('/api/v1/desktop/authorizations', jsonResponse(authorizationResponse(), 201))
+    await restarted.startLogin()
+    const second = authorizationRequestBody()
+    expect(second.device_public_key).not.toBe(first.device_public_key)
+    expect(second.machine_code).toBe(first.machine_code)
+    expect(second.machine_code).toMatch(/^[A-Za-z0-9_-]{43}$/)
+  })
+
+  it('does not start cloud authorization when the system machine ID is missing', async () => {
+    vi.mocked(uuid).mockResolvedValueOnce({ os: '', hardware: '', macs: [] })
+    const service = await createService()
+    await expect(service.startLogin()).rejects.toThrow('valid system machine ID is required')
+    expect(mocks.netFetch).not.toHaveBeenCalled()
+    expect(mocks.savedDevice).toBeNull()
   })
 
   it('keeps the Session when automatic Gateway startup fails', async () => {

--- a/src/main/services/cherryCloud/__tests__/crypto.test.ts
+++ b/src/main/services/cherryCloud/__tests__/crypto.test.ts
@@ -38,6 +38,7 @@ describe('Cherry Cloud device request signing', () => {
     expect(
       createDeviceSignature({
         privateKey,
+        machineCode: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8',
         method: 'POST',
         requestTarget: '/v1/messages',
         body,
@@ -49,8 +50,9 @@ describe('Cherry Cloud device request signing', () => {
       'Cherry-Request-ID': '018f47a2-7d3b-7c91-b8f5-8b3f4c6d2a10',
       'Cherry-Timestamp': '1710000000',
       'Cherry-Body-SHA256': '862ece927adfbee83d138acac6f093c1d67272618334e96886fb8c11a62097ff',
-      'Cherry-Signature-Version': '1',
-      'Cherry-Signature': '68XKbmorIHWYnCZAKXGbDVzRzM3qSKTRBx2Kj6xuGnZtOUyWtoLbN7JNAAJGc93-QDagy_OrmxfqKyrpdEwfCQ'
+      'Cherry-Signature-Version': '2',
+      'Cherry-Machine-Code': 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8',
+      'Cherry-Signature': 'KLBGmwxKvF2sGoRzNxN_xOMX3gYL864mZp32sZKUITjEEpKm9i661GVtkdPJ6rrvSO4RlCtylFJXKCtjISduCw'
     })
   })
 })

--- a/src/main/services/cherryCloud/__tests__/machineCode.test.ts
+++ b/src/main/services/cherryCloud/__tests__/machineCode.test.ts
@@ -1,0 +1,34 @@
+import { uuid } from 'systeminformation'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { getMachineCode } from '../machineCode'
+
+vi.mock('systeminformation', () => ({ uuid: vi.fn() }))
+afterEach(() => vi.resetAllMocks())
+
+function systemIdentity(os: string) {
+  return { os, hardware: 'unused-serial', macs: ['00:11:22:33:44:55'] }
+}
+
+it('normalizes equivalent system IDs into the same machine code', async () => {
+  vi.mocked(uuid).mockResolvedValueOnce(systemIdentity('ABCDEF12-1234-5678-9ABC-1234567890AB'))
+  const first = await getMachineCode()
+  vi.mocked(uuid).mockResolvedValueOnce(systemIdentity('abcdef12123456789abc1234567890ab\n'))
+  expect(await getMachineCode()).toBe(first)
+  expect(first).toMatch(/^[A-Za-z0-9_-]{43}$/)
+})
+
+it('distinguishes different system machine IDs', async () => {
+  vi.mocked(uuid).mockResolvedValueOnce(systemIdentity('abcdef12123456789abc1234567890ab'))
+  const first = await getMachineCode()
+  vi.mocked(uuid).mockResolvedValueOnce(systemIdentity('abcdef12123456789abc1234567890ac'))
+  expect(await getMachineCode()).not.toBe(first)
+})
+
+it.each(['', 'unknown', 'hostname', '0'.repeat(32), 'f'.repeat(32), '00000000-0000-0000-0000-000000000000'])(
+  'rejects unavailable or placeholder machine IDs rather than generating an identity: %s',
+  async (os) => {
+    vi.mocked(uuid).mockResolvedValue(systemIdentity(os))
+    await expect(getMachineCode()).rejects.toThrow('valid system machine ID is required')
+  }
+)

--- a/src/main/services/cherryCloud/crypto.ts
+++ b/src/main/services/cherryCloud/crypto.ts
@@ -28,6 +28,7 @@ export function createIdempotencyKey(): string {
 
 export function createDeviceSignature(input: {
   privateKey: string
+  machineCode: string
   method: string
   requestTarget: string
   body: Uint8Array
@@ -39,13 +40,14 @@ export function createDeviceSignature(input: {
   const requestId = input.requestId ?? randomUUID()
   const bodyHash = createHash('sha256').update(input.body).digest('hex')
   const canonical = [
-    'cherry-device-signature-v1',
+    'cherry-device-signature-v2',
     input.method.toUpperCase(),
     input.requestTarget,
     timestamp,
     requestId,
     bodyHash,
-    input.idempotencyKey ?? ''
+    input.idempotencyKey ?? '',
+    input.machineCode
   ].join('\n')
   const privateKey = createPrivateKey({
     key: Buffer.from(input.privateKey, 'base64'),
@@ -57,7 +59,8 @@ export function createDeviceSignature(input: {
     'Cherry-Request-ID': requestId,
     'Cherry-Timestamp': timestamp,
     'Cherry-Body-SHA256': bodyHash,
-    'Cherry-Signature-Version': '1',
+    'Cherry-Signature-Version': '2',
+    'Cherry-Machine-Code': input.machineCode,
     'Cherry-Signature': sign(null, Buffer.from(canonical, 'utf8'), privateKey).toString('base64url')
   }
 }

--- a/src/main/services/cherryCloud/machineCode.ts
+++ b/src/main/services/cherryCloud/machineCode.ts
@@ -1,0 +1,21 @@
+import { createHmac } from 'node:crypto'
+
+import { uuid } from 'systeminformation'
+
+export async function getMachineCode(): Promise<string> {
+  const identity = await uuid()
+  const machineID = identity.os.trim().toLowerCase()
+  if (
+    !/^(?:[0-9a-f]{32}|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})$/.test(machineID) ||
+    /^(?:0+|f+)$/.test(machineID.replaceAll('-', ''))
+  ) {
+    throw new Error('A valid system machine ID is required for Cherry Cloud login')
+  }
+
+  // Domain separation avoids exposing the system-wide ID to the cloud.
+  return createHmac('sha256', 'cherry-studio:cloud-machine-code:v1')
+    .update(process.platform)
+    .update('\0')
+    .update(machineID.replaceAll('-', ''))
+    .digest('base64url')
+}

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-machine-code.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-machine-code.md
@@ -2,7 +2,7 @@
 title: Cloud sessions are bound to the current computer
 category: changed
 severity: breaking
-introduced_in_pr: TBD
+introduced_in_pr: '#20222'
 date: 2026-09-08
 ---
 

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-machine-code.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-machine-code.md
@@ -1,0 +1,23 @@
+---
+title: Cloud sessions are bound to the current computer
+category: changed
+severity: breaking
+introduced_in_pr: TBD
+date: 2026-09-08
+---
+
+## What changed
+
+Cloud login and signed requests now include an application-specific digest of the operating system's machine ID separately from the signing public key. Copying credentials to another computer requires a new login; resetting application data or generating a new signing key does not change the machine code. Credential storage stays in its original location.
+
+## Why this matters to the user
+
+When the server's same-machine free-entitlement policy is enforced, later accounts on a computer that already received an automatic free grant are not given another one. The server records the computer at grant time: signing in on another computer does not consume that computer's grant eligibility. Changing signing keys does not reset grant history. Registration and login remain allowed, and existing entitlements are retained. A missing or invalid system ID prevents new cloud login instead of creating a random device identity.
+
+## What the user should do
+
+Upgrade to matching client and server versions, then sign in again. Old sessions without a machine binding and signature v1 requests are no longer accepted. Moving the data directory within the same computer preserves the session if its credentials are retained.
+
+## Notes for release manager
+
+Apply the Cloud API schema migrations before the coordinated server and client rollout. Signature v2 covers the current machine code, which must match the session's immutable machine binding; re-login replaces only the same account, machine and client-key session. Existing entitlements without a recorded grant machine are retained; their origin is not inferred from login history. Machine IDs are OS-provided identifiers, not tamper-proof hardware attestation; OS reinstallation or cloning can change or duplicate them. Modified clients can still submit fabricated machine codes. No raw machine ID is transmitted, and it is never used to derive a signing private key.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Cloud requests used signature v1 and identified the client only by its signing key. Resetting credentials changed that identity, and copied credentials did not identify the current computer.

After this PR:

- Read the operating system's machine ID through pinned `systeminformation`, normalize it, and produce an application-specific digest without transmitting the raw ID.
- Submit `machine_code` during cloud login and include `Cherry-Machine-Code` in signature v2 for every signed request, including refresh.
- Keep random Ed25519 keys and credential storage unchanged. Re-read the current computer's identity after restart; reject missing or placeholder IDs without a random fallback.
- Cover credential resets, copied credentials, ID normalization, unavailable IDs, and the server-compatible signature fixture with regression tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: None.

### Why we need it and why it was done in this way

The server must recognize the same computer after local credentials are cleared, without confusing signing-key identity with machine identity. This completes the desktop side of the merged Cloud API change.

The following tradeoffs were made:

OS-provided machine IDs can change after OS reinstallation or be duplicated by cloning. The digest is cached only in memory, not copied with credentials. No key derivation or credential-storage migration is introduced.

The following alternatives were considered:

Public-key hashes alone do not survive key regeneration. Moving credential files does not identify the computer. Deriving signing secrets from a machine ID would conflate identification with private-key security.

Links to places where the discussion took place: https://github.com/CherryInternal/cherry-studio-cloud-api/pull/62 (merged companion API change; repository access required).

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

Cloud API and desktop versions must both support machine codes and signature v2. Existing sessions without a machine binding require a new login. Copying credentials to another computer also requires a new login. Registration, normal login, and existing entitlements remain available; automatic repeated free grants are controlled by the server's existing enforcement policy.

Upgrade details: [breaking-change note](https://github.com/CherryHQ/cherry-studio/blob/zhibisora/block-fork-cloud-login/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-machine-code.md).

### Special notes for your reviewer

<!-- optional -->

- Scope: desktop changes only; the companion server PR is already merged. No deployment is performed by this PR.
- This is machine identification for ordinary clients, not official-package attestation or protection against modified clients fabricating machine codes.
- After rebasing onto `main`: 65 targeted main-process tests, `pnpm lint`, `pnpm test:lint`, and `pnpm docs:check` passed. Existing lint warnings remain; no new UI components or manual UI test are involved.
- Refactor checklist item: N/A; this is a focused behavior change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Cherry Cloud] Bind cloud sessions to the current computer and preserve same-computer free-grant history across local credential resets. action required: upgrade to a compatible client/server version and sign in again; copied credentials require a new login on another computer.
```
