### PR TITLE
fix(cherry-cloud): explain client upgrade requirements

### DIFF
--- a/src/main/ipc/handlers/__tests__/cherryCloud.test.ts
+++ b/src/main/ipc/handlers/__tests__/cherryCloud.test.ts
@@ -13,7 +13,10 @@ vi.mock('@application', () => ({
   }
 }))
 
-import { CherryCloudLoginUnavailableError } from '@main/services/cherryCloud/CherryCloudService'
+import {
+  CherryCloudLoginUnavailableError,
+  CherryCloudUpgradeRequiredError
+} from '@main/services/cherryCloud/CherryCloudService'
 import { cherryCloudErrorCodes } from '@shared/ipc/errors/cherryCloud'
 import { IpcError } from '@shared/ipc/errors/IpcError'
 
@@ -22,14 +25,17 @@ import { cherryCloudHandlers } from '../cherryCloud'
 describe('cherryCloudHandlers', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('maps an unavailable login service to a stable IPC error', async () => {
-    service.startLogin.mockRejectedValueOnce(new CherryCloudLoginUnavailableError())
+  it.each([
+    [new CherryCloudLoginUnavailableError(), cherryCloudErrorCodes.LOGIN_SERVICE_UNAVAILABLE],
+    [new CherryCloudUpgradeRequiredError(), cherryCloudErrorCodes.UPGRADE_REQUIRED]
+  ])('preserves the login error code %s across IPC', async (failure, code) => {
+    service.startLogin.mockRejectedValueOnce(failure)
 
     const error = await cherryCloudHandlers['cherry_cloud.login.start'](undefined, { senderId: 'w1' }).catch(
       (caught: unknown) => caught
     )
 
     expect(error).toBeInstanceOf(IpcError)
-    expect(error).toHaveProperty('code', cherryCloudErrorCodes.LOGIN_SERVICE_UNAVAILABLE)
+    expect(error).toHaveProperty('code', code)
   })
 })

--- a/src/main/ipc/handlers/cherryCloud.ts
+++ b/src/main/ipc/handlers/cherryCloud.ts
@@ -1,5 +1,8 @@
 import { application } from '@application'
-import { CherryCloudLoginUnavailableError } from '@main/services/cherryCloud/CherryCloudService'
+import {
+  CherryCloudLoginUnavailableError,
+  CherryCloudUpgradeRequiredError
+} from '@main/services/cherryCloud/CherryCloudService'
 import { cherryCloudErrorCodes } from '@shared/ipc/errors/cherryCloud'
 import { IpcError } from '@shared/ipc/errors/IpcError'
 import type { cherryCloudRequestSchemas } from '@shared/ipc/schemas/cherryCloud'
@@ -9,6 +12,9 @@ async function startLogin() {
   try {
     return await application.get('CherryCloudService').startLogin()
   } catch (error) {
+    if (error instanceof CherryCloudUpgradeRequiredError) {
+      throw new IpcError(cherryCloudErrorCodes.UPGRADE_REQUIRED, error.message)
+    }
     if (error instanceof CherryCloudLoginUnavailableError) {
       throw new IpcError(cherryCloudErrorCodes.LOGIN_SERVICE_UNAVAILABLE, error.message)
     }

--- a/src/main/services/cherryCloud/CherryCloudService.ts
+++ b/src/main/services/cherryCloud/CherryCloudService.ts
@@ -93,6 +93,13 @@ export class CherryCloudLoginUnavailableError extends Error {
   }
 }
 
+export class CherryCloudUpgradeRequiredError extends Error {
+  constructor() {
+    super('Update Cherry Studio to sign in to Cherry Cloud')
+    this.name = 'CherryCloudUpgradeRequiredError'
+  }
+}
+
 class CherryCloudSessionRequiredError extends Error {
   constructor() {
     super('Cherry Cloud account is not signed in')
@@ -1013,6 +1020,7 @@ export class CherryCloudService extends BaseService {
       })
       throw new CherryCloudLoginUnavailableError()
     }
+    if (response.status === 426) throw new CherryCloudUpgradeRequiredError()
     if (response.status === 404 || response.status >= 500) {
       logger.warn('Cherry Cloud login service returned an unavailable response', { path, status: response.status })
       throw new CherryCloudLoginUnavailableError()

--- a/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
+++ b/src/main/services/cherryCloud/__tests__/CherryCloudService.test.ts
@@ -628,6 +628,19 @@ describe('CherryCloudService', () => {
     expect(newReceiver.dispose).toHaveBeenCalledOnce()
   })
 
+  it('reports an upgrade requirement without opening a browser or leaving login pending', async () => {
+    mockCloudRoute('/api/v1/desktop/authorizations', jsonResponse({ error: { code: 'CLIENT_UPGRADE_REQUIRED' } }, 426))
+    const service = await createService()
+
+    await expect(service.startLogin()).rejects.toHaveProperty('name', 'CherryCloudUpgradeRequiredError')
+    expect(await service.getStatus()).toEqual({ phase: 'signed-out', displayName: null })
+    expect(mocks.openExternal).not.toHaveBeenCalled()
+    expect(mocks.loopbackReceiver.dispose).toHaveBeenCalled()
+
+    mockCloudRoute('/api/v1/desktop/authorizations', jsonResponse(authorizationResponse(), 201))
+    await expect(service.startLogin()).resolves.toEqual({ phase: 'authorizing', displayName: null })
+  })
+
   it('reports an unavailable login service when the backend cannot be reached', async () => {
     mockCloudRoute('/api/v1/desktop/authorizations', () => Promise.reject(new TypeError('fetch failed')))
     const service = await createService()

--- a/src/renderer/hooks/__tests__/useCherryAccountSession.test.ts
+++ b/src/renderer/hooks/__tests__/useCherryAccountSession.test.ts
@@ -84,6 +84,8 @@ describe('useCherryAccountSession', () => {
 
   it.each([
     ['login', new IpcError(cherryCloudErrorCodes.LOGIN_SERVICE_UNAVAILABLE), 'error.http.503'],
+    ['login', new IpcError('CHERRY_CLOUD_UPGRADE_REQUIRED'), 'settings.provider.cherry_cloud.upgrade_required'],
+    ['login', new Error('Cherry Cloud login request failed (400)'), 'settings.provider.cherry_cloud.sign_in_failed'],
     ['cancelLogin', new Error('cancel failed'), 'settings.provider.cherry_cloud.sign_in_failed'],
     ['revokeSession', new Error('revoke failed'), 'settings.provider.cherry_cloud.logout_failed']
   ] as const)('translates %s failures', async (action, error, message) => {
@@ -94,5 +96,7 @@ describe('useCherryAccountSession', () => {
     await act(() => result.current[action]())
 
     expect(mocks.toastError).toHaveBeenCalledWith(message)
+    expect(result.current.isStartingLogin).toBe(false)
+    expect(result.current.status).toEqual(signedOut)
   })
 })

--- a/src/renderer/hooks/useCherryAccountSession.ts
+++ b/src/renderer/hooks/useCherryAccountSession.ts
@@ -62,14 +62,18 @@ export function useCherryAccountSession(enabled = true) {
         if (requestId === requestRef.current) applyStatus(nextStatus)
       } catch (error) {
         if (requestId !== requestRef.current) return
-        const message =
+        let message = t(
           action === 'revoke'
-            ? t('settings.provider.cherry_cloud.logout_failed')
-            : action === 'login' &&
-                error instanceof IpcError &&
-                error.code === cherryCloudErrorCodes.LOGIN_SERVICE_UNAVAILABLE
-              ? t('error.http.503')
-              : t('settings.provider.cherry_cloud.sign_in_failed')
+            ? 'settings.provider.cherry_cloud.logout_failed'
+            : 'settings.provider.cherry_cloud.sign_in_failed'
+        )
+        if (action === 'login' && error instanceof IpcError) {
+          if (error.code === cherryCloudErrorCodes.UPGRADE_REQUIRED) {
+            message = t('settings.provider.cherry_cloud.upgrade_required')
+          } else if (error.code === cherryCloudErrorCodes.LOGIN_SERVICE_UNAVAILABLE) {
+            message = t('error.http.503')
+          }
+        }
         toast.error(message)
       } finally {
         setPendingAction((current) => (current === action ? null : current))

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Abmeldung fehlgeschlagen. Bitte erneut versuchen.",
   "settings.provider.cherry_cloud.sign_in_failed": "Anmeldung fehlgeschlagen. Bitte erneut versuchen.",
   "settings.provider.cherry_cloud.signing_in": "Warten auf Browser-Autorisierung…",
+  "settings.provider.cherry_cloud.upgrade_required": "Diese Version von Cherry Studio wird nicht mehr unterstützt. Bitte aktualisieren Sie Cherry Studio, bevor Sie sich anmelden.",
   "settings.provider.cherryin.api_host.acceleration": "Beschleunigungsdomäne",
   "settings.provider.cherryin.api_host.international": "Internationale Domäne",
   "settings.provider.claude_code.agent_only_note": "Der Claude Code-Provider ist nur für Agents verfügbar – er kann nicht in Chat oder Assistenten verwendet werden.",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Δεν ήταν δυνατή η αποσύνδεση. Δοκιμάστε ξανά.",
   "settings.provider.cherry_cloud.sign_in_failed": "Η σύνδεση απέτυχε. Δοκιμάστε ξανά.",
   "settings.provider.cherry_cloud.signing_in": "Αναμονή εξουσιοδότησης στο πρόγραμμα περιήγησης…",
+  "settings.provider.cherry_cloud.upgrade_required": "Η έκδοση του Cherry Studio που χρησιμοποιείτε δεν υποστηρίζεται πλέον. Ενημερώστε το Cherry Studio πριν συνδεθείτε.",
   "settings.provider.cherryin.api_host.acceleration": "Τομέας επιτάχυνσης",
   "settings.provider.cherryin.api_host.international": "Διεθνής τομέας",
   "settings.provider.claude_code.agent_only_note": "Ο πάροχος Claude Code είναι διαθέσιμος μόνο για Πράκτορες — δεν μπορεί να χρησιμοποιηθεί σε συνομιλίες ή βοηθούς.",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Could not log out. Please try again.",
   "settings.provider.cherry_cloud.sign_in_failed": "Sign-in failed. Please try again.",
   "settings.provider.cherry_cloud.signing_in": "Waiting for browser authorization…",
+  "settings.provider.cherry_cloud.upgrade_required": "Your Cherry Studio version is no longer supported. Please update Cherry Studio before signing in.",
   "settings.provider.cherryin.api_host.acceleration": "Acceleration domain",
   "settings.provider.cherryin.api_host.international": "International domain",
   "settings.provider.claude_code.agent_only_note": "The Claude Code provider is available to Agents only — it can't be used in chat or assistants.",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "No se pudo cerrar sesión. Inténtalo de nuevo.",
   "settings.provider.cherry_cloud.sign_in_failed": "Error al iniciar sesión. Inténtalo de nuevo.",
   "settings.provider.cherry_cloud.signing_in": "Esperando la autorización del navegador…",
+  "settings.provider.cherry_cloud.upgrade_required": "Tu versión de Cherry Studio ya no es compatible. Actualiza Cherry Studio antes de iniciar sesión.",
   "settings.provider.cherryin.api_host.acceleration": "Dominio de aceleración",
   "settings.provider.cherryin.api_host.international": "Dominio internacional",
   "settings.provider.claude_code.agent_only_note": "El proveedor de Claude Code está disponible solo para Agentes: no se puede usar en chat o asistentes.",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Impossible de se déconnecter. Réessayez.",
   "settings.provider.cherry_cloud.sign_in_failed": "Échec de la connexion. Réessayez.",
   "settings.provider.cherry_cloud.signing_in": "En attente de l’autorisation du navigateur…",
+  "settings.provider.cherry_cloud.upgrade_required": "Votre version de Cherry Studio n’est plus prise en charge. Veuillez mettre à jour Cherry Studio avant de vous connecter.",
   "settings.provider.cherryin.api_host.acceleration": "Domaine d'accélération",
   "settings.provider.cherryin.api_host.international": "Domaine international",
   "settings.provider.claude_code.agent_only_note": "Le fournisseur Claude Code n'est disponible que pour les Agents — il ne peut pas être utilisé dans les chats ou les assistants.",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "ログアウトできませんでした。もう一度お試しください。",
   "settings.provider.cherry_cloud.sign_in_failed": "ログインに失敗しました。もう一度お試しください。",
   "settings.provider.cherry_cloud.signing_in": "ブラウザでの認証を待っています…",
+  "settings.provider.cherry_cloud.upgrade_required": "このバージョンの Cherry Studio はサポートされていません。ログインする前に Cherry Studio を更新してください。",
   "settings.provider.cherryin.api_host.acceleration": "加速度領域",
   "settings.provider.cherryin.api_host.international": "国際ドメイン",
   "settings.provider.claude_code.agent_only_note": "Claude Codeプロバイダーはエージェントのみで利用可能です — チャットやアシスタントでは使用できません。",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Não foi possível terminar sessão. Tente novamente.",
   "settings.provider.cherry_cloud.sign_in_failed": "Falha ao iniciar sessão. Tente novamente.",
   "settings.provider.cherry_cloud.signing_in": "A aguardar autorização no navegador…",
+  "settings.provider.cherry_cloud.upgrade_required": "A sua versão do Cherry Studio já não é suportada. Atualize o Cherry Studio antes de iniciar sessão.",
   "settings.provider.cherryin.api_host.acceleration": "Domínio de aceleração",
   "settings.provider.cherryin.api_host.international": "Domínio internacional",
   "settings.provider.claude_code.agent_only_note": "O fornecedor Claude Code está disponível apenas para Agentes — não pode ser usado em chats ou assistentes.",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Nu s-a putut realiza deconectarea. Încercați din nou.",
   "settings.provider.cherry_cloud.sign_in_failed": "Conectarea a eșuat. Încercați din nou.",
   "settings.provider.cherry_cloud.signing_in": "Se așteaptă autorizarea în browser…",
+  "settings.provider.cherry_cloud.upgrade_required": "Versiunea dvs. de Cherry Studio nu mai este acceptată. Actualizați Cherry Studio înainte de a vă conecta.",
   "settings.provider.cherryin.api_host.acceleration": "Domeniu de accelerație",
   "settings.provider.cherryin.api_host.international": "Domeniu internațional",
   "settings.provider.claude_code.agent_only_note": "Furnizorul Claude Code este disponibil doar pentru Agenți — nu poate fi utilizat în chat sau asistenți.",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Не удалось выйти. Повторите попытку.",
   "settings.provider.cherry_cloud.sign_in_failed": "Не удалось войти. Повторите попытку.",
   "settings.provider.cherry_cloud.signing_in": "Ожидание авторизации в браузере…",
+  "settings.provider.cherry_cloud.upgrade_required": "Ваша версия Cherry Studio больше не поддерживается. Обновите Cherry Studio перед входом.",
   "settings.provider.cherryin.api_host.acceleration": "Домен ускорения",
   "settings.provider.cherryin.api_host.international": "Международный домен",
   "settings.provider.claude_code.agent_only_note": "Провайдер Claude Code доступен только для Агентов — его нельзя использовать в чате или ассистентах.",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Oturum kapatılamadı. Lütfen tekrar deneyin.",
   "settings.provider.cherry_cloud.sign_in_failed": "Oturum açılamadı. Lütfen tekrar deneyin.",
   "settings.provider.cherry_cloud.signing_in": "Tarayıcı yetkilendirmesi bekleniyor…",
+  "settings.provider.cherry_cloud.upgrade_required": "Cherry Studio sürümünüz artık desteklenmiyor. Oturum açmadan önce Cherry Studio’yu güncelleyin.",
   "settings.provider.cherryin.api_host.acceleration": "Hızlandırma alan adı",
   "settings.provider.cherryin.api_host.international": "Uluslararası alan adı",
   "settings.provider.claude_code.agent_only_note": "Claude Code sağlayıcısı yalnızca ajanlar tarafından kullanılabilir — sohbetlerde veya asistanlarda kullanılamaz.",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "Không thể đăng xuất. Vui lòng thử lại.",
   "settings.provider.cherry_cloud.sign_in_failed": "Đăng nhập thất bại. Vui lòng thử lại.",
   "settings.provider.cherry_cloud.signing_in": "Đang chờ xác thực trên trình duyệt…",
+  "settings.provider.cherry_cloud.upgrade_required": "Phiên bản Cherry Studio của bạn không còn được hỗ trợ. Vui lòng cập nhật Cherry Studio trước khi đăng nhập.",
   "settings.provider.cherryin.api_host.acceleration": "Miền gia tốc",
   "settings.provider.cherryin.api_host.international": "Tên miền quốc tế",
   "settings.provider.claude_code.agent_only_note": "Nhà cung cấp Claude Code chỉ khả dụng cho Agent, không thể dùng trong trò chuyện hoặc trợ lý.",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "退出登录失败，请重试。",
   "settings.provider.cherry_cloud.sign_in_failed": "登录失败，请重试。",
   "settings.provider.cherry_cloud.signing_in": "等待浏览器授权…",
+  "settings.provider.cherry_cloud.upgrade_required": "当前 Cherry Studio 版本已不受支持，请升级 Cherry Studio 后再登录。",
   "settings.provider.cherryin.api_host.acceleration": "加速域名",
   "settings.provider.cherryin.api_host.international": "国际域名",
   "settings.provider.claude_code.agent_only_note": "Claude Code 提供商仅供 Agent 使用，无法在聊天或助手中使用。",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -4545,6 +4545,7 @@
   "settings.provider.cherry_cloud.logout_failed": "無法登出，請重試。",
   "settings.provider.cherry_cloud.sign_in_failed": "登入失敗，請重試。",
   "settings.provider.cherry_cloud.signing_in": "等待瀏覽器授權…",
+  "settings.provider.cherry_cloud.upgrade_required": "目前的 Cherry Studio 版本已不受支援，請升級 Cherry Studio 後再登入。",
   "settings.provider.cherryin.api_host.acceleration": "加速網域",
   "settings.provider.cherryin.api_host.international": "國際網域",
   "settings.provider.claude_code.agent_only_note": "Claude Code 供應商僅供 Agent 使用 — 無法在聊天或助理中使用。",

--- a/src/shared/ipc/errors/cherryCloud.ts
+++ b/src/shared/ipc/errors/cherryCloud.ts
@@ -1,4 +1,5 @@
 /** Cherry Cloud domain IpcApi error codes. Import directly on both sides of the IPC boundary. */
 export const cherryCloudErrorCodes = {
-  LOGIN_SERVICE_UNAVAILABLE: 'CHERRY_CLOUD_LOGIN_SERVICE_UNAVAILABLE'
+  LOGIN_SERVICE_UNAVAILABLE: 'CHERRY_CLOUD_LOGIN_SERVICE_UNAVAILABLE',
+  UPGRADE_REQUIRED: 'CHERRY_CLOUD_UPGRADE_REQUIRED'
 } as const

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-login-upgrade-message.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-login-upgrade-message.md
@@ -2,7 +2,7 @@
 title: Cloud login explains when Cherry Studio needs an update
 category: changed
 severity: notice
-introduced_in_pr: TBD
+introduced_in_pr: "#20229"
 date: 2026-09-08
 ---
 

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-login-upgrade-message.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-login-upgrade-message.md
@@ -1,0 +1,23 @@
+---
+title: Cloud login explains when Cherry Studio needs an update
+category: changed
+severity: notice
+introduced_in_pr: TBD
+date: 2026-09-08
+---
+
+## What changed
+
+When Cherry Cloud rejects an unsupported client version, the login prompt now asks the user to update Cherry Studio instead of retrying the same login.
+
+## Why this matters to the user
+
+Retrying cannot resolve a minimum-version requirement. The prompt now distinguishes this condition from a temporary service failure.
+
+## What the user should do
+
+Update Cherry Studio before signing in again.
+
+## Notes for release manager
+
+This change only handles the upgrade-required response. It does not change the server's minimum version or add machine-bound signature v2 support.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A Cloud login rejected with HTTP 426 was shown as a generic sign-in failure asking the user to retry.

After this PR:

The client preserves the upgrade-required error across IPC and asks the user to update Cherry Studio before signing in. Existing service-unavailable and other login errors retain their behavior. All 13 UI locales are translated.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: None.

### Why we need it and why it was done in this way

The following tradeoffs were made:

Reuse the existing login request and toast flow; no additional preflight request, automatic updater flow, or server configuration change.

The following alternatives were considered:

Fetching client-config before login was deferred to keep this fix small and avoid an extra network dependency.

Links to places where the discussion took place: None (local investigation).

### Breaking changes

<!-- optional -->

None. This PR does not introduce machine codes or signature v2; those changes are already on main.

### Special notes for your reviewer

<!-- optional -->

- Regression tests first reproduced the missing upgrade handling.
- Targeted Cloud service, IPC, and renderer tests pass after rebasing onto current main.
- `pnpm lint` (including typecheck and i18n), `pnpm docs:check`, and `git diff --check` passed before rebase; only the targeted tests were repeated after the clean rebase.
- User-facing change is documented in `v2-refactor-temp/docs/breaking-changes/2026-09-08-cloud-login-upgrade-message.md`; a separate user-guide update is not required.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Cherry Cloud] Unsupported client versions now show an update-required message instead of asking users to retry login.
```
