### PR TITLE
fix(chat): preserve grouped replies when deleting context response

### DIFF
--- a/docs/references/chat/message-tree.md
+++ b/docs/references/chat/message-tree.md
@@ -101,7 +101,7 @@ papered over).
 | Target | Behavior |
 |---|---|
 | Virtual root | **Rejected** (`INVALID_OPERATION`), regardless of `cascade`. Deleting it would orphan first-turn children (unique-index violation) or leave a rootless topic. |
-| Content message, `cascade = false` | Splice the node out: reparent its children onto its parent (their grandparent), then delete it. A child carries its `siblingsGroupId` (relative to its old parent), so each distinct non-zero moved group is **rebased** to a fresh id above any group already at the destination — it can't merge into an unrelated group there. |
+| Content message, `cascade = false` | For a grouped assistant reply on the active path with the default parent strategy, transfer children to the next live reply in the same group (previous at the end), ordered by creation time then ID. Otherwise reparent children onto the deleted node's parent. Clear descendant context anchors when deleting a grouped context reply, including when no sibling remains. Preserve an active descendant; if the deleted node itself is active, select the successor or fall back to the parent. A child carries its `siblingsGroupId` (relative to its old parent), so each distinct non-zero moved group is **rebased** to a fresh id above any group already at the destination — it can't merge into an unrelated group there. |
 | Content message, `cascade = true` | Delete the message and its whole subtree. |
 | "Clear all messages" | `clearTopicMessages(topicId)` (`DELETE /topics/:topicId/messages`) — deletes every non-root row of the topic in one statement and clears `activeNodeId`; the content-less virtual root stays. The structural replacement for the old "delete the root to clear the topic" (now rejected). |
 

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -46,7 +46,7 @@ import {
 import type { UniqueModelId } from '@shared/data/types/model'
 import { hasClearContextPart, isBlankUserTurn, readCherryMeta } from '@shared/data/types/uiParts'
 import { isToolUIPart } from 'ai'
-import { and, eq, gte, inArray, isNotNull, isNull, lte, ne, or, type SQL, sql } from 'drizzle-orm'
+import { and, asc, eq, gte, inArray, isNotNull, isNull, lte, ne, or, type SQL, sql } from 'drizzle-orm'
 
 import { aiUsageRecordService, mergeMessageRuntimeStats } from './AiUsageRecordService'
 import { getDataService, registerDataService } from './dataServiceRegistry'
@@ -1677,31 +1677,7 @@ export class MessageService {
         ...(row.data?.turnOptions ? { turnOptions: row.data.turnOptions } : {})
       }
       const descendantIds = this.getDescendantIdsTx(tx, id)
-      for (let offset = 0; offset < descendantIds.length; offset += SQLITE_INARRAY_CHUNK) {
-        const chunk = descendantIds.slice(offset, offset + SQLITE_INARRAY_CHUNK)
-        const descendants = tx
-          .select({
-            id: messageTable.id,
-            stats: messageTable.stats,
-            updatedAt: messageTable.updatedAt
-          })
-          .from(messageTable)
-          .where(inArray(messageTable.id, chunk))
-          .all()
-        for (const descendant of descendants) {
-          if (descendant.stats?.contextTokens === undefined) continue
-          const descendantStats = { ...descendant.stats }
-          delete descendantStats.contextTokens
-          tx.update(messageTable)
-            .set({ stats: descendantStats, updatedAt: descendant.updatedAt })
-            .where(eq(messageTable.id, descendant.id))
-            .run()
-        }
-        tx.update(messageTable)
-          .set({ compactionSummary: null, updatedAt: messageTable.updatedAt })
-          .where(inArray(messageTable.id, chunk))
-          .run()
-      }
+      this.clearContextAnchorsTx(tx, descendantIds)
       const [updated] = tx
         .update(messageTable)
         .set({ data, status: 'pending', stats, compactionSummary: null, updatedAt: row.updatedAt })
@@ -1931,11 +1907,12 @@ export class MessageService {
    *
    * Supports two modes:
    * - cascade=true: Delete the message and all its descendants
-   * - cascade=false: Delete only this message, reparent children to grandparent
+   * - cascade=false: Delete only this message. An active grouped reply hands context
+   *   and children to its next sibling (previous at the end); otherwise splice onto the parent.
    *
    * When the deleted message(s) include the topic's activeNodeId, it will be
    * automatically updated based on activeNodeStrategy:
-   * - 'parent' (default): Sets activeNodeId to the deleted message's parent
+   * - 'parent' (default): Use the remaining context reply, falling back to the parent
    * - 'clear': Sets activeNodeId to null
    *
    * All operations are performed within a transaction for consistency.
@@ -2013,14 +1990,41 @@ export class MessageService {
 
         logger.info('Cascade deleted messages', { rootId: id, count: deletedIds.length })
       } else {
-        // Splice this node out: reparent its children onto its parent (their grandparent).
-        reparentedIds = this.reparentChildrenTx(tx, [message])
+        // Only the active context reply may hand its continuation to another member.
+        // Resolve the successor from persisted membership, including hidden regenerations.
+        const isContextReply =
+          activeNodeStrategy === 'parent' &&
+          message.role === 'assistant' &&
+          message.siblingsGroupId !== 0 &&
+          topic.activeNodeId !== null &&
+          this.getPathRowsToNodeTx(tx, topic.activeNodeId, { topicId: message.topicId }).some((row) => row.id === id)
+        const group = isContextReply
+          ? tx
+              .select({ id: messageTable.id })
+              .from(messageTable)
+              .where(
+                and(
+                  eq(messageTable.topicId, message.topicId),
+                  eq(messageTable.parentId, message.parentId),
+                  eq(messageTable.role, 'assistant'),
+                  eq(messageTable.siblingsGroupId, message.siblingsGroupId),
+                  isNull(messageTable.deletedAt)
+                )
+              )
+              .orderBy(asc(messageTable.createdAt), asc(messageTable.id))
+              .all()
+          : []
+        // Match the displayed chronological order: next, or previous at the end.
+        const contextIndex = group.findIndex((member) => member.id === id)
+        const successor = contextIndex < 0 ? undefined : (group[contextIndex + 1] ?? group[contextIndex - 1])
+        if (isContextReply) this.clearContextAnchorsTx(tx, this.getDescendantIdsTx(tx, id))
+        reparentedIds = this.reparentChildrenTx(tx, [message], successor?.id)
 
         deletedIds = [id]
 
         // Check if activeNodeId is affected
         if (topic.activeNodeId === id) {
-          newActiveNodeId = activeNodeStrategy === 'clear' ? null : parentFallback
+          newActiveNodeId = activeNodeStrategy === 'clear' ? null : (successor?.id ?? parentFallback)
         }
 
         // Hard delete this message
@@ -2074,6 +2078,35 @@ export class MessageService {
     return response
   }
 
+  /** Clear derived context after changing message ancestry or content. */
+  private clearContextAnchorsTx(tx: DbOrTx, messageIds: string[]): void {
+    for (let offset = 0; offset < messageIds.length; offset += SQLITE_INARRAY_CHUNK) {
+      const chunk = messageIds.slice(offset, offset + SQLITE_INARRAY_CHUNK)
+      const descendants = tx
+        .select({
+          id: messageTable.id,
+          stats: messageTable.stats,
+          updatedAt: messageTable.updatedAt
+        })
+        .from(messageTable)
+        .where(inArray(messageTable.id, chunk))
+        .all()
+      for (const descendant of descendants) {
+        if (descendant.stats?.contextTokens === undefined) continue
+        const descendantStats = { ...descendant.stats }
+        delete descendantStats.contextTokens
+        tx.update(messageTable)
+          .set({ stats: descendantStats, updatedAt: descendant.updatedAt })
+          .where(eq(messageTable.id, descendant.id))
+          .run()
+      }
+      tx.update(messageTable)
+        .set({ compactionSummary: null, updatedAt: messageTable.updatedAt })
+        .where(inArray(messageTable.id, chunk))
+        .run()
+    }
+  }
+
   private resolveActiveNodeFallbackTx(tx: DbOrTx, parentId: string | null): string | null {
     if (!parentId) return null
 
@@ -2087,9 +2120,13 @@ export class MessageService {
     return !parent || parent.role === 'root' ? null : parentId
   }
 
-  private reparentChildrenTx(tx: DbOrTx, targets: Array<Pick<MessageRow, 'id' | 'parentId'>>): string[] {
+  private reparentChildrenTx(
+    tx: DbOrTx,
+    targets: Array<Pick<MessageRow, 'id' | 'parentId'>>,
+    destinationParentId?: string
+  ): string[] {
     const targetIds = targets.map((target) => target.id)
-    const newParentId = targets[0]?.parentId ?? null
+    const newParentId = destinationParentId ?? targets[0]?.parentId ?? null
     const children = tx
       .select({
         id: messageTable.id,

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -1965,6 +1965,7 @@ export class MessageService {
       const descendantIds = cascade ? this.getDescendantIdsTx(tx, id) : []
       let deletedIds: string[]
       let reparentedIds: string[] | undefined
+      let contextChangedIds: string[] = []
       let newActiveNodeId: string | null | undefined
 
       // The virtual root is structural and never a valid active node.
@@ -2017,7 +2018,10 @@ export class MessageService {
         // Match the displayed chronological order: next, or previous at the end.
         const contextIndex = group.findIndex((member) => member.id === id)
         const successor = contextIndex < 0 ? undefined : (group[contextIndex + 1] ?? group[contextIndex - 1])
-        if (isContextReply) this.clearContextAnchorsTx(tx, this.getDescendantIdsTx(tx, id))
+        if (isContextReply) {
+          contextChangedIds = this.getDescendantIdsTx(tx, id)
+          this.clearContextAnchorsTx(tx, contextChangedIds)
+        }
         reparentedIds = this.reparentChildrenTx(tx, [message], successor?.id)
 
         deletedIds = [id]
@@ -2053,12 +2057,13 @@ export class MessageService {
       return {
         topicId: message.topicId,
         deletedIds,
+        contextChangedIds,
         reparentedIds: reparentedIds?.length ? reparentedIds : undefined,
         newActiveNodeId
       }
     })
-    const { topicId, ...response } = result
-    const changedIds = [...response.deletedIds, ...(response.reparentedIds ?? [])]
+    const { topicId, contextChangedIds, ...response } = result
+    const changedIds = [...new Set([...response.deletedIds, ...(response.reparentedIds ?? []), ...contextChangedIds])]
     notifyDataApiDataChange([
       {
         endpoint: '/topics/:topicId/messages',
@@ -2067,7 +2072,7 @@ export class MessageService {
         entityIds: changedIds
       },
       { endpoint: '/topics/:topicId/tree', routeParams: { topicId }, entityIds: changedIds },
-      { endpoint: '/messages/:id', entityIds: response.deletedIds },
+      { endpoint: '/messages/:id', entityIds: changedIds },
       ...(response.newActiveNodeId !== undefined
         ? ([
             { endpoint: '/topics', kind: 'projection', entityIds: [topicId] },

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -699,6 +699,141 @@ describe('MessageService', () => {
     })
   })
 
+  describe('delete — context reply inheritance', () => {
+    it.each([
+      ['m-a1', 'm-a2'],
+      ['m-a2', 'm-a3'],
+      ['m-a3', 'm-a2']
+    ])('hands context from %s to its visual neighbour %s', async (targetId, expectedId) => {
+      await seedMultiModelTree()
+      const source = dbh.db.select().from(messageTable).where(eq(messageTable.id, 'm-a1')).get()!
+      const { ftsRowid: _ftsRowid, ...sibling } = source
+      void _ftsRowid
+      dbh.db
+        .insert(messageTable)
+        .values({ ...sibling, id: 'm-a3', createdAt: 220 })
+        .run()
+      topicService.setActiveNode('topic-1', targetId)
+      expect(messageService.delete(targetId, false).newActiveNodeId).toBe(expectedId)
+      expect(messageService.getBranchMessages('topic-1').items.at(-1)?.message.id).toBe(expectedId)
+    })
+
+    it('chooses the previous live neighbour deterministically and clears obsolete context summaries', async () => {
+      await seedMultiModelTree()
+      const source = dbh.db.select().from(messageTable).where(eq(messageTable.id, 'm-a1')).get()!
+      const { ftsRowid: _ftsRowid, ...sibling } = source
+      void _ftsRowid
+      dbh.db
+        .insert(messageTable)
+        .values([
+          { ...sibling, id: 'm-a0', createdAt: 200 },
+          { ...sibling, id: 'm-deleted', createdAt: 150, deletedAt: 160 },
+          { ...sibling, id: 'm-other-group', siblingsGroupId: 2, createdAt: 100 }
+        ])
+        .run()
+      dbh.db
+        .update(messageTable)
+        .set({ compactionSummary: 'old context', stats: { contextTokens: 99, totalTokens: 120 } })
+        .where(eq(messageTable.id, 'm-follow'))
+        .run()
+      messageService.delete('m-a2', false)
+      expect(messageService.getById('m-follow')).toMatchObject({
+        parentId: 'm-a1',
+        compactionSummary: null,
+        stats: { totalTokens: 120 }
+      })
+      expect(messageService.getById('m-follow').stats).not.toHaveProperty('contextTokens')
+      expect(messageService.getPathToNode('m-follow').map((message) => message.id)).toEqual([
+        'm-root',
+        'm-a1',
+        'm-follow'
+      ])
+    })
+
+    it('clears descendant context when deleting the final inherited reply', async () => {
+      await seedMultiModelTree()
+      messageService.delete('m-a2', false)
+      dbh.db
+        .update(messageTable)
+        .set({ compactionSummary: 'context from remaining reply', stats: { contextTokens: 99, totalTokens: 120 } })
+        .where(eq(messageTable.id, 'm-follow'))
+        .run()
+
+      messageService.delete('m-a1', false)
+
+      expect(messageService.getById('m-follow')).toMatchObject({
+        parentId: 'm-root',
+        compactionSummary: null,
+        stats: { totalTokens: 120 }
+      })
+      expect(messageService.getById('m-follow').stats).not.toHaveProperty('contextTokens')
+      const branch = messageService.getBranchMessages('topic-1')
+      expect(branch.activeNodeId).toBe('m-follow')
+      expect(branch.items.map((item) => item.message.id)).toEqual(['m-root', 'm-follow'])
+    })
+
+    it.each([0, 2])('does not inherit from an ungrouped or unrelated reply (group=%s)', async (group) => {
+      await seedMultiModelTree()
+      dbh.db.update(messageTable).set({ siblingsGroupId: group }).where(eq(messageTable.id, 'm-a1')).run()
+      topicService.setActiveNode('topic-1', 'm-a2')
+      expect(messageService.delete('m-a2', false).newActiveNodeId).toBe('m-root')
+      expect(messageService.getById('m-follow').parentId).toBe('m-root')
+    })
+
+    it('preserves explicit clear semantics', async () => {
+      await seedMultiModelTree()
+      topicService.setActiveNode('topic-1', 'm-a2')
+      expect(messageService.delete('m-a2', false, 'clear').newActiveNodeId).toBeNull()
+      expect(messageService.getById('m-follow').parentId).toBe('m-root')
+      expect(messageService.getById('m-a1').id).toBe('m-a1')
+    })
+
+    it('preserves the successor existing children and avoids group collisions', async () => {
+      await seedMultiModelTree()
+      dbh.db
+        .insert(messageTable)
+        .values({
+          id: 'other-follow',
+          topicId: 'topic-1',
+          parentId: 'm-a1',
+          role: 'user',
+          data: mainText('other branch'),
+          status: 'success',
+          siblingsGroupId: 3
+        })
+        .run()
+      dbh.db.update(messageTable).set({ siblingsGroupId: 3 }).where(eq(messageTable.id, 'm-follow')).run()
+      messageService.delete('m-a2', false)
+      expect(messageService.getById('other-follow').parentId).toBe('m-a1')
+      expect(messageService.getById('m-follow').parentId).toBe('m-a1')
+      expect(messageService.getById('m-follow').siblingsGroupId).not.toBe(3)
+      expect(messageService.getBranchMessages('topic-1').activeNodeId).toBe('m-follow')
+    })
+
+    it.each([false, true])('retains the group and context with descendants=%s', async (withDescendants) => {
+      await seedMultiModelTree()
+      topicService.setActiveNode('topic-1', withDescendants ? 'm-follow' : 'm-a2')
+      const result = messageService.delete('m-a2', false)
+      expect(result.deletedIds).toEqual(['m-a2'])
+      expect(messageService.getById('m-follow').parentId).toBe('m-a1')
+      const branch = messageService.getBranchMessages('topic-1', { includeSiblings: true })
+      expect(branch.items.map((item) => item.message.id)).toEqual(
+        withDescendants ? ['m-root', 'm-a1', 'm-follow'] : ['m-root', 'm-a1']
+      )
+      expect(branch.activeNodeId).toBe(withDescendants ? 'm-follow' : 'm-a1')
+    })
+
+    it('does not change the active branch when deleting another reply', async () => {
+      await seedMultiModelTree()
+      messageService.delete('m-a1', false)
+      expect(messageService.getBranchMessages('topic-1').items.map((item) => item.message.id)).toEqual([
+        'm-root',
+        'm-a2',
+        'm-follow'
+      ])
+    })
+  })
+
   describe('getBranchMessages — regression for raw SQL casing bug', () => {
     it('returns camelCase fields (parentId, siblingsGroupId) for path messages', async () => {
       await seedMultiModelTree()
@@ -2377,8 +2512,9 @@ describe('MessageService', () => {
       expect(byId.get('m-follow-a1')?.siblingsGroupId).not.toBe(byId.get('m-follow')?.siblingsGroupId)
     })
 
-    it('non-cascade delete reparents children to the real parent (linear splice)', async () => {
+    it('non-cascade delete without a remaining group member reparents children to the real parent', async () => {
       await seedMultiModelTree()
+      messageService.delete('m-a1', false)
 
       // m-a2 is mid-conversation (parent = m-root); its child m-follow reparents to m-root.
       const result = messageService.delete('m-a2', false)

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -750,6 +750,34 @@ describe('MessageService', () => {
       ])
     })
 
+    it('publishes by-ID changes for all descendants whose context was cleared', async () => {
+      await seedMultiModelTree()
+      dbh.db
+        .insert(messageTable)
+        .values({
+          id: 'm-deep',
+          topicId: 'topic-1',
+          parentId: 'm-follow',
+          role: 'assistant',
+          data: mainText('deep reply'),
+          status: 'success',
+          siblingsGroupId: 0,
+          compactionSummary: 'obsolete',
+          stats: { contextTokens: 42 }
+        })
+        .run()
+      notifyDataApiDataChangeMock.mockClear()
+
+      messageService.delete('m-a2', false)
+
+      expect(messageService.getById('m-deep').compactionSummary).toBeNull()
+      expect(messageService.getById('m-deep').stats).not.toHaveProperty('contextTokens')
+      const effects = notifyDataApiDataChangeMock.mock.calls.flatMap(([batch]) => batch)
+      expect(effects.find((effect) => effect.endpoint === '/messages/:id')?.entityIds).toEqual(
+        expect.arrayContaining(['m-a2', 'm-follow', 'm-deep'])
+      )
+    })
+
     it('clears descendant context when deleting the final inherited reply', async () => {
       await seedMultiModelTree()
       messageService.delete('m-a2', false)

--- a/src/renderer/components/chat/flow/TopicMessageFlowNode.tsx
+++ b/src/renderer/components/chat/flow/TopicMessageFlowNode.tsx
@@ -1,5 +1,5 @@
 import { Popover, PopoverAnchor, PopoverContent } from '@cherrystudio/ui'
-import { useQuery } from '@data/hooks/useDataApi'
+import { useDataChange, useQuery } from '@data/hooks/useDataApi'
 import MessageContent from '@renderer/components/chat/messages/frame/MessageContent'
 import { MessageContentProvider } from '@renderer/components/chat/messages/MessageContentProvider'
 import { toMessageListItem } from '@renderer/components/chat/messages/utils/messageListItem'
@@ -92,10 +92,16 @@ function TopicMessageFlowNodePreviewCard({
   const {
     data: message,
     error,
-    isLoading
+    isLoading,
+    mutate
   } = useQuery('/messages/:id', {
     enabled: open,
     params: { id: messageId }
+  })
+  useDataChange('/messages/:id', (effects) => {
+    if (open && effects.some((effect) => !effect.entityIds || effect.entityIds.includes(messageId))) {
+      void mutate()
+    }
   })
   const uiMessage = useMemo(() => (message ? sharedMessageToUIMessage(message) : null), [message])
   const messageItems = useMemo(

--- a/src/renderer/components/chat/flow/__tests__/TopicMessageFlowNode.dataChange.test.tsx
+++ b/src/renderer/components/chat/flow/__tests__/TopicMessageFlowNode.dataChange.test.tsx
@@ -1,0 +1,78 @@
+import { dataApiService } from '@data/DataApiService'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ComponentProps, ReactNode } from 'react'
+import { SWRConfig } from 'swr'
+import { beforeEach, expect, it, vi } from 'vitest'
+
+vi.unmock('@data/hooks/useDataApi')
+vi.mock('@xyflow/react', () => ({ Handle: () => null, Position: { Bottom: 'bottom', Top: 'top' } }))
+vi.mock('@cherrystudio/ui', async () => {
+  const React = await import('react')
+  const Context = React.createContext(false)
+  return {
+    Popover: ({ children, open }: { children: ReactNode; open: boolean }) => <Context value={open}>{children}</Context>,
+    PopoverAnchor: ({ children }: { children: ReactNode }) => children,
+    PopoverContent: ({ children }: { children: ReactNode }) => (React.use(Context) ? <div>{children}</div> : null)
+  }
+})
+vi.mock('@renderer/components/chat/messages/MessageContentProvider', () => ({
+  MessageContentProvider: ({ children }: { children: ReactNode }) => children
+}))
+vi.mock('@renderer/components/chat/messages/frame/MessageContent', () => ({
+  default: ({ message }: { message: { stats?: { contextTokens?: number } } }) => (
+    <div>Context tokens: {message.stats?.contextTokens ?? 'unknown'}</div>
+  )
+}))
+
+import TopicMessageFlowNode from '../TopicMessageFlowNode'
+
+const service = dataApiService as typeof dataApiService & {
+  _resetMockState: () => void
+  _emitDataChange: (effects: Array<{ endpoint: '/messages/:id'; entityIds: string[] }>) => void
+}
+
+beforeEach(() => service._resetMockState())
+
+it('refreshes an open by-ID preview after its ancestor deletion changes context', async () => {
+  let stats: { contextTokens?: number } = { contextTokens: 42 }
+  vi.mocked(dataApiService.get).mockImplementation(
+    async () =>
+      ({
+        id: 'follow',
+        topicId: 'topic',
+        parentId: 'reply',
+        role: 'assistant',
+        data: { parts: [{ type: 'text', text: 'Follow-up' }] },
+        status: 'success',
+        siblingsGroupId: 0,
+        stats,
+        createdAt: '2026-09-08T00:00:00Z',
+        updatedAt: '2026-09-08T00:00:00Z'
+      }) as never
+  )
+  const props = {
+    id: 'follow',
+    data: {
+      messageId: 'follow',
+      preview: 'Follow-up',
+      role: 'assistant',
+      status: 'success',
+      createdAt: '2026-09-08T00:00:00Z',
+      isActive: true,
+      isOnActivePath: true,
+      isInactiveBranch: false
+    }
+  } as ComponentProps<typeof TopicMessageFlowNode>
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <TopicMessageFlowNode {...props} />
+    </SWRConfig>
+  )
+  fireEvent.mouseEnter(screen.getByText('Follow-up').closest('[data-message-id]')!)
+  await screen.findByText('Context tokens: 42')
+  stats = {}
+  await act(async () => service._emitDataChange([{ endpoint: '/messages/:id', entityIds: ['unrelated'] }]))
+  expect(screen.getByText('Context tokens: 42')).toBeInTheDocument()
+  await act(async () => service._emitDataChange([{ endpoint: '/messages/:id', entityIds: ['reply', 'follow'] }]))
+  await waitFor(() => expect(screen.getByText('Context tokens: unknown')).toBeInTheDocument())
+})

--- a/src/renderer/components/chat/flow/__tests__/TopicMessageFlowNode.test.tsx
+++ b/src/renderer/components/chat/flow/__tests__/TopicMessageFlowNode.test.tsx
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@data/hooks/useDataApi', () => ({
-  useQuery: mocks.useQuery
+  useQuery: mocks.useQuery,
+  useDataChange: vi.fn()
 }))
 
 vi.mock('@xyflow/react', () => ({

--- a/src/renderer/hooks/__tests__/useTopicMessages.test.ts
+++ b/src/renderer/hooks/__tests__/useTopicMessages.test.ts
@@ -190,6 +190,43 @@ describe('useTopicMessages', () => {
     expect(mutate).toHaveBeenCalledWith()
   })
 
+  it('keeps tied single-model siblings in ID order when the active reply changes', () => {
+    const replies = ['reply-a', 'reply-b', 'reply-c'].map((id) =>
+      createAssistantMessage(id, 'provider::model', '2026-01-01T00:00:01.000Z')
+    )
+    let active = replies[1]
+    mockUseInfiniteQuery.mockImplementation(
+      () =>
+        ({
+          pages: [
+            {
+              items: [{ message: active, siblingsGroup: replies.filter((reply) => reply.id !== active.id).reverse() }],
+              activeNodeId: active.id
+            }
+          ],
+          isLoading: false,
+          isRefreshing: false,
+          hasNext: false,
+          loadNext: vi.fn(),
+          refresh: vi.fn(),
+          reset: vi.fn(),
+          mutate: vi.fn()
+        }) as never
+    )
+    const { result, rerender } = renderHook(() => useTopicMessages('topic-1'))
+
+    for (const reply of [replies[1], replies[2], replies[0]]) {
+      active = reply
+      rerender()
+      expect(result.current.uiMessages.map((message) => message.id)).toEqual([active.id])
+      expect(result.current.siblingsMap[active.id].map((message) => message.id)).toEqual([
+        'reply-a',
+        'reply-b',
+        'reply-c'
+      ])
+    }
+  })
+
   it('uses one group classification for multi-model display and single-model navigation', () => {
     const firstModelReply = createAssistantMessage('reply-a-1', 'provider-a::model-a', '2026-01-01T00:00:01.000Z')
     const otherModelReply = createAssistantMessage('reply-b-1', 'provider-b::model-b', '2026-01-01T00:00:02.000Z')

--- a/src/renderer/hooks/useTopicMessages.ts
+++ b/src/renderer/hooks/useTopicMessages.ts
@@ -114,7 +114,7 @@ function projectBranchMessages(items: BranchMessage[]): BranchProjection {
     const message = pickDisplayMember(bucket, item.message.id)
     displayMessages.push({ message, isActiveBranch: message.id === item.message.id })
     if (bucket.length < 2) continue
-    bucket.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    bucket.sort(compareMessageOrder)
     for (const member of bucket) siblingsMap[member.id] = bucket
   }
   return { displayMessages, siblingsMap }

--- a/src/renderer/pages/home/hooks/useChatWriteActions.ts
+++ b/src/renderer/pages/home/hooks/useChatWriteActions.ts
@@ -219,9 +219,8 @@ export function useChatWriteActions(params: Params): Result {
         throw new Error('Message deletion is unavailable')
       }
 
-      const optimisticIds = new Set([id])
-      await seedOptimisticBranch((prev) => branchWithoutIds(prev, optimisticIds))
-
+      // Main owns context inheritance and reparenting; wait for its authoritative
+      // refresh to preserve the surviving replies in the group.
       try {
         await deleteMessageTrigger({ params: { id }, query: { cascade: false } })
         invalidateCachedMessageUiStates([id])
@@ -231,7 +230,7 @@ export function useChatWriteActions(params: Params): Result {
       }
       logger.info('Deleted message', { id })
     },
-    [branchWithoutIds, deleteMessageTrigger, getMessageDeleteAvailability, rollbackBranch, seedOptimisticBranch]
+    [deleteMessageTrigger, getMessageDeleteAvailability, rollbackBranch]
   )
 
   const handleDeleteMessageGroup = useCallback<ChatWriteActions['deleteMessageGroup']>(

--- a/src/shared/data/api/schemas/messages.ts
+++ b/src/shared/data/api/schemas/messages.ts
@@ -271,8 +271,10 @@ export type MessageSchemas = {
     /**
      * Delete a message
      * - cascade=true: deletes message and all descendants
-     * - cascade=false: reparents children to grandparent
-     * - activeNodeStrategy='parent' (default): sets activeNodeId to parent if affected
+     * - cascade=false: an active grouped reply transfers children to the next live sibling
+     *   (previous at the end); otherwise reparents children to the parent.
+     * - activeNodeStrategy='parent' (default): uses that sibling, or the parent, if the active node is deleted.
+     *   Surviving descendants retain their active node; grouped context deletion clears their context anchors.
      * - activeNodeStrategy='clear': sets activeNodeId to null if affected
      * - awaitingInputOnly=true: rejects unless the target is an awaiting-input user leaf
      */

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-08-context-reply-deletion.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-08-context-reply-deletion.md
@@ -1,0 +1,23 @@
+---
+title: Remaining replies inherit context when the selected reply is deleted
+category: changed
+severity: notice
+introduced_in_pr: TBD
+date: 2026-09-08
+---
+
+## What changed
+
+Deleting the reply selected for context now selects its next neighbour in the same group's display order, or its previous neighbour when deleting the last reply. The order is creation time followed by message ID. Existing follow-up messages continue under that reply, and the remaining group stays visible.
+
+## Why this matters to the user
+
+Deleting one selected reply no longer makes the entire reply group disappear. Future requests use the replacement reply as context.
+
+## What the user should do
+
+Nothing — automatic. Select a different remaining reply if another response should supply context.
+
+## Notes for release manager
+
+Fixes issue #20219. Deleting an entire reply group retains its existing behavior.

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-08-context-reply-deletion.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-08-context-reply-deletion.md
@@ -2,7 +2,7 @@
 title: Remaining replies inherit context when the selected reply is deleted
 category: changed
 severity: notice
-introduced_in_pr: TBD
+introduced_in_pr: '#20233'
 date: 2026-09-08
 ---
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Deleting the response selected for context could hide the entire response group and detach its follow-up messages from the remaining responses.

<img width="1552" height="1244" alt="PixPin_2026-09-08_19-32-12" src="https://github.com/user-attachments/assets/2ac77851-cafe-46ee-95e9-95cc2b11911d" />

After this PR:
Only the selected response is deleted. Context and follow-up messages move to the next response in display order, or the previous response when deleting the last item. Deleting the final context response clears obsolete descendant context summaries while preserving the continuation. Whole-group deletion remains a separate action.

<img width="1550" height="1236" alt="PixPin_2026-09-08_19-28-56" src="https://github.com/user-attachments/assets/2fa70b07-90e9-4984-8705-03b3122b5cdb" />

Fixes #20219

### Why we need it and why it was done in this way

The following tradeoffs were made:
The main-process transaction owns successor selection and reparenting from persisted group membership. Single-message deletion waits for the authoritative refresh so the renderer does not remove the surviving group prematurely.

The following alternatives were considered:
Selecting the first remaining response was rejected in favor of visual adjacency. Reimplementing inheritance in the renderer would duplicate the main-process rule and depend on partially loaded data.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20219

### Breaking changes

No API or schema changes. Deleting a context response now automatically selects an adjacent remaining response; no user action is required.

### Special notes for your reviewer

- 156 focused tests passed: 126 MessageService tests with real SQLite and 30 renderer deletion-action tests.
- Main and renderer TypeScript checks, scoped oxlint --deny-warnings, ESLint, Biome and git diff --check passed.
- Electron mouse interactions verified next/previous inheritance, retained follow-ups and persistence after reload. The final-response summary cleanup is covered by a SQLite regression that failed before the fix.
- Independent Standards, Spec and project reviews completed on the final local diff.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Deleting a response selected for context now preserves the other replies and transfers context and follow-up messages to an adjacent reply.
```

