### PR TITLE
feat(provider-registry): add DeepSeek V4.1 Flash Expires-On model

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -7628,6 +7628,42 @@
       }
     },
     {
+      "capabilities": ["function-call", "image-recognition", "reasoning", "structured-output"],
+      "contextWindow": 1000000,
+      "family": "deepseek-flash",
+      "id": "deepseek-v4-1-flash-expires-on",
+      "inputModalities": ["text", "image"],
+      "maxOutputTokens": 393216,
+      "metadata": {},
+      "name": "DeepSeek V4.1 Flash Expires-On-0910",
+      "openWeights": true,
+      "outputModalities": ["text"],
+      "ownedBy": "deepseek",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.014
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.44
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.32
+        }
+      },
+      "reasoning": {
+        "controls": [
+          {
+            "kind": "effort",
+            "values": ["none", "low", "high", "max"]
+          }
+        ],
+        "supportedEfforts": ["none", "low", "high", "max"]
+      }
+    },
+    {
       "capabilities": ["function-call", "reasoning", "structured-output"],
       "contextWindow": 1048576,
       "family": "deepseek-flash",

--- a/packages/provider-registry/src/creators/deepseek.ts
+++ b/packages/provider-registry/src/creators/deepseek.ts
@@ -49,6 +49,19 @@ export default defineCreator({
       openWeights: true
     },
     {
+      id: 'deepseek-v4.1-flash-expires-on-0910',
+      name: 'DeepSeek V4.1 Flash Expires-On-0910',
+      family: 'deepseek-flash',
+      capabilities: ['function-call', 'image-recognition', 'reasoning', 'structured-output'],
+      contextWindow: 1000000,
+      maxOutputTokens: 393216,
+      inputModalities: ['text', 'image'],
+      outputModalities: ['text'],
+      pricing: v4FlashPeakPricing,
+      reasoning: { controls: [{ kind: 'effort', values: ['none', 'low', 'high', 'max'] }] },
+      openWeights: true
+    },
+    {
       id: 'deepseek-v4-pro',
       name: 'DeepSeek V4 Pro',
       family: 'deepseek-thinking',


### PR DESCRIPTION
### What this PR does

Before this PR: the DeepSeek catalog exposes `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`, and `deepseek-v4-pro`, but not the `deepseek-v4.1-flash-expires-on-0910` variant.

After this PR: adds `deepseek-v4.1-flash-expires-on-0910` as a vision model (text + image input) to the DeepSeek creator, so it appears in the model catalog. It mirrors the existing `deepseek-v4-flash-vision-exp` entry (same `deepseek-flash` family, peak pricing, and effort reasoning controls).

Fixes #

### Why we need it and why it was done in this way

The new variant is a text + image model, so it is modeled after the existing V4 Flash Vision Exp entry rather than the text-only `deepseek-v4-flash`. Since it is an experimental/expiring SKU not present in models.dev/OpenRouter, it is declared by hand in `src/creators/deepseek.ts` with full metadata.

The following tradeoffs were made:

- The registry id is canonicalized at build/runtime (`deepseek-v4.1-flash-expires-on-0910` → `deepseek-v4-1-flash-expires-on`; the dot becomes a hyphen and the trailing `-0910` is stripped as a date suffix). The display `name` keeps the original `DeepSeek V4.1 Flash Expires-On-0910`.

The following alternatives were considered:

- Adding `imagePixelBudget` / `imageMaxBytes` as new schema fields. Not done: neither field exists anywhere in the registry schema (`ModelConfigSchema`) or the runtime `Model` type, and `metadata` is reset to `{}` by the generator. Vision support is instead expressed through `inputModalities: ['text', 'image']` plus the `image-recognition` capability.
- Adding a provider override in `src/providers/deepseek.ts` so the model is served by the DeepSeek endpoint. Out of scope for this change (the attached file was the creator only); can be added separately with an `apiModelId` mapping back to the dotted wire id.

Links to places where the discussion took place: <!-- optional -->

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

- Only the new model row is added to `data/models.json`. A full `pnpm generate` right now pulls a large amount of unrelated upstream drift from models.dev/OpenRouter (Microsoft image-model display-name change, OpenCode model pins) that breaks two unrelated `catalog-invariants` cases; that drift is unrelated to this model, so it was deliberately not included.
- Verified with the provider-registry test suite: `catalog-source-sync`, `catalog-invariants`, schema/compatibility validators, and `normalize` all pass (the single `checkCatalogCompatibility` timeout observed is a cold-transform 5s default, not a real failure — it passes in ~500ms warm).

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
A new DeepSeek V4.1 Flash Expires-On-0910 vision model is now available in the model catalog.
```
