### PR TITLE
fix(obsidian-export): serialize note front matter as YAML

### DIFF
--- a/src/renderer/components/ObsidianExportDialog.tsx
+++ b/src/renderer/components/ObsidianExportDialog.tsx
@@ -35,6 +35,7 @@ import type { ExportableMessage } from '@renderer/types/messageExport'
 import type { Topic } from '@renderer/types/topic'
 import { XIcon } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
+import { parse, stringify } from 'yaml'
 
 const logger = loggerService.withContext('ObsidianExportDialog')
 
@@ -49,6 +50,29 @@ const ObsidianProcessingMethod = {
   PREPEND: '2',
   NEW_OR_OVERWRITE: '3'
 } as const
+
+// Separator from Obsidian Web Clipper's `multitext` parsing (obsidianmd/obsidian-clipper, src/utils/shared.ts, MIT).
+const multitextSeparator = /,(?![^[]*\]\])/
+
+const parseTags = (input: string): string[] => {
+  const value = input.trim()
+  const bare = value.replace(/^\[|\]$/g, '')
+  let items: string[]
+  if (value.startsWith('[') && value.endsWith(']')) {
+    try {
+      const parsed: unknown = parse(value)
+      items =
+        Array.isArray(parsed) && parsed.every((item) => typeof item === 'string')
+          ? parsed
+          : bare.split(multitextSeparator)
+    } catch {
+      items = bare.split(multitextSeparator)
+    }
+  } else {
+    items = bare.split(multitextSeparator)
+  }
+  return items.map((item) => item.trim().replace(/^#/, '')).filter((item) => item !== '')
+}
 
 interface PopupContainerProps {
   title: string
@@ -280,7 +304,11 @@ const PopupContainer: React.FC<PopupContainerProps> = ({
       if (state.processingMethod !== ObsidianProcessingMethod.NEW_OR_OVERWRITE) {
         content = `\n---\n${markdown}`
       } else {
-        content = `---\ntitle: ${state.title}\ncreated: ${state.createdAt}\nsource: ${state.source}\ntags: ${state.tags}\n---\n${markdown}`
+        const frontMatter = stringify(
+          { title: state.title, created: state.createdAt, source: state.source, tags: parseTags(state.tags) },
+          { lineWidth: 0 }
+        )
+        content = `---\n${frontMatter}---\n${markdown}`
       }
       if (content === '') {
         toast.error(i18n.t('chat.topics.export.obsidian_export_failed'))

--- a/src/renderer/components/__tests__/ObsidianExportDialog.test.tsx
+++ b/src/renderer/components/__tests__/ObsidianExportDialog.test.tsx
@@ -1,0 +1,117 @@
+// The front-matter contract is the subject; real @cherrystudio/ui primitives are rendered
+// because the global stand-in has no TreeSelect and nothing here depends on primitive behavior.
+vi.mock('@cherrystudio/ui', async (importOriginal) => await importOriginal())
+
+const { ipcRequest, exportMarkdownToObsidian } = vi.hoisted(() => ({
+  ipcRequest: vi.fn(),
+  exportMarkdownToObsidian: vi.fn()
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: ipcRequest, on: vi.fn(() => () => {}) }
+}))
+
+vi.mock('@renderer/services/ExportService', () => ({
+  exportMarkdownToObsidian,
+  messagesToMarkdown: vi.fn(),
+  messageToMarkdown: vi.fn(),
+  messageToMarkdownWithReasoning: vi.fn(),
+  topicToMarkdown: vi.fn()
+}))
+
+import { ObsidianProcessingMethod, PopupContainer } from '@renderer/components/ObsidianExportDialog'
+import i18n from '@renderer/i18n/resolver'
+import { mockUsePreference } from '@test-mocks/renderer/usePreference'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import matter from 'gray-matter'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const body = '# Body\n\nHello from the chat.'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // The vault-loading effect depends on a stable preference setter.
+  mockUsePreference.mockReturnValue(['', vi.fn()])
+  ipcRequest.mockImplementation(async (route: string) => {
+    if (route === 'export.obsidian.get_vaults') return [{ name: 'Notes', path: '/vaults/Notes' }]
+    if (route === 'export.obsidian.get_files') return []
+    return undefined
+  })
+  exportMarkdownToObsidian.mockResolvedValue(true)
+})
+
+afterEach(cleanup)
+
+const exportNewNote = async (title: string, tags: string) => {
+  const user = userEvent.setup()
+  render(
+    <PopupContainer
+      title={title}
+      obsidianTags={tags}
+      processingMethod={ObsidianProcessingMethod.NEW_OR_OVERWRITE}
+      open
+      resolve={vi.fn()}
+      rawContent={body}
+    />
+  )
+
+  const confirm = await screen.findByRole('button', { name: i18n.t('chat.topics.export.obsidian_btn') })
+  await waitFor(() => expect(confirm).toBeEnabled())
+  await user.click(confirm)
+  await waitFor(() => expect(exportMarkdownToObsidian).toHaveBeenCalled())
+
+  return matter(await navigator.clipboard.readText())
+}
+
+describe('ObsidianExportDialog front matter', () => {
+  it('keeps a ": " title and turns comma-separated "#" tags into a plain tag list', async () => {
+    const note = await exportNewNote('Meeting: sprint planning', '#work, notes')
+
+    expect(note.data.title).toBe('Meeting: sprint planning')
+    expect(note.data.tags).toEqual(['work', 'notes'])
+    expect(note.content.trim()).toBe(body)
+  })
+
+  it('keeps a title starting with "#" instead of turning it into a YAML comment', async () => {
+    const note = await exportNewNote('# Draft', '')
+
+    expect(note.data.title).toBe('# Draft')
+  })
+
+  it.each(['["work", "notes"]', "['work', 'notes']", '[ "work", "notes" ]'])(
+    'parses the quoted tag list %s without keeping the quotes',
+    async (input) => {
+      const note = await exportNewNote('Weekly sync', input)
+
+      expect(note.data.tags).toEqual(['work', 'notes'])
+    }
+  )
+
+  it('turns a bare bracketed list like [work, notes] into two clean tags', async () => {
+    const note = await exportNewNote('Weekly sync', '[work, notes]')
+
+    expect(note.data.tags).toEqual(['work', 'notes'])
+  })
+
+  it('keeps an empty list from becoming a literal tag', async () => {
+    const note = await exportNewNote('Weekly sync', '[]')
+
+    expect(note.data.tags).toEqual([])
+  })
+
+  it('falls back to comma splitting when a hash makes the list invalid YAML', async () => {
+    const note = await exportNewNote('Weekly sync', '[work, #notes]')
+
+    expect(note.data.tags).toEqual(['work', 'notes'])
+  })
+
+  it('keeps a long title on a single front matter line', async () => {
+    const longTitle =
+      'Meeting: sprint planning retrospective for the payments team covering incident review and roadmap alignment'
+    const note = await exportNewNote(longTitle, '')
+
+    expect(note.data.title).toBe(longTitle)
+    expect(note.matter.split('\n').some((line) => line.includes(longTitle))).toBe(true)
+  })
+})


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The Obsidian export dialog built the note's front matter by string interpolation. A title containing `: ` (for example `Meeting: sprint planning`) produced invalid YAML, a title starting with `#` turned into a YAML comment and the title was lost, and the tags field was written as one raw string instead of a list.

After this PR:

Front matter properties are serialized with the `yaml` package, one line per property, so any title round-trips intact. The tags input is normalized into a YAML list: comma-separated values, bracketed lists (`[work, notes]`, `["work", "notes"]`, `['work', 'notes']`) and an empty list are all accepted, and a leading `#` is dropped because Obsidian rewrites tag properties without it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Serialize with the `yaml` package (already a renderer dependency) instead of hand-escaping values, and pass `lineWidth: 0` so long titles are not folded across lines.
- Export tags as a YAML list because the Obsidian Properties documentation requires the `tags` property to be a list.
- Drop a leading `#` from tag values; Obsidian deprecated `#tag` in properties and rewrites it to `tag`.
- The comma separator regex is taken from Obsidian Web Clipper's `multitext` parsing (MIT), credited in a code comment.

The following alternatives were considered:

- Wrapping each value with `JSON.stringify`: fixes the quoting but keeps tags as a single string.
- Porting the Web Clipper parser verbatim: it only accepts the strict JSON form, so `[work, notes]` would export as two bracketed tags.

Links to places where the discussion took place: None

### Breaking changes

None. An empty tags field now exports `tags: []` instead of a bare `tags:`; Obsidian renders both as an empty property.

### Special notes for your reviewer

- The test renders the real `@cherrystudio/ui` primitives because the global stand-in has no `TreeSelect`; nothing in the test depends on primitive behavior.
- The test pins a stable `usePreference` setter. The shared mock returns a new setter on every render, which loops the dialog's vault-loading effect under the mock only.
- No user-guide change is needed: the tags field keeps its comma-separated input contract, only the exported result changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Obsidian export writing invalid or lossy front matter when the note title contains ": " or starts with "#", and export tags as a proper YAML list.
```
