### PR TITLE
fix(pi): preserve OpenCode session headers

### DIFF
--- a/src/main/ai/runtime/pi/modelInjection.test.ts
+++ b/src/main/ai/runtime/pi/modelInjection.test.ts
@@ -3,7 +3,7 @@ import type * as AgentApiGateway from '@main/ai/runtime/agentApiGateway'
 import { CHERRY_CLOUD_MODEL_GROUP, CHERRY_CLOUD_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const serviceMocks = vi.hoisted(() => ({
   getByProviderId: vi.fn(),
@@ -554,6 +554,83 @@ describe('buildPiProviderInjection', () => {
     })
 
     expect(() => buildPiProviderInjection(provider, makeModel({}), '')).toThrow(PiUnsupportedProviderError)
+  })
+})
+
+describe('OpenCode Pi session headers', () => {
+  beforeEach(() => {
+    serviceMocks.resolveApiKey.mockReturnValue({ value: REAL_KEY })
+  })
+  afterEach(() => {
+    serviceMocks.resolveApiKey.mockReset()
+  })
+
+  const provider = makeProvider({
+    id: 'opencode',
+    defaultChatEndpoint: 'openai-chat-completions',
+    endpointConfigs: {
+      'openai-chat-completions': { adapterFamily: 'openai-compatible', baseUrl: 'https://opencode.ai/zen/v1' },
+      'openai-responses': { adapterFamily: 'openai', baseUrl: 'https://opencode.ai/zen/v1' }
+    }
+  })
+
+  it.each(['openai-chat-completions', 'openai-responses'] as const)(
+    'keeps the session header stable and isolates sessions for %s',
+    async (endpoint) => {
+      const selectedProvider = { ...provider, defaultChatEndpoint: endpoint }
+      const model = makeModel({ providerId: provider.id, endpointTypes: [endpoint] })
+      const first = await resolvePiProviderInjectionForSession('session-1', selectedProvider, model)
+      const repeated = await resolvePiProviderInjectionForSession('session-1', selectedProvider, model)
+      const second = await resolvePiProviderInjectionForSession('session-2', selectedProvider, model)
+
+      expect(first.api).toBe(endpoint === 'openai-responses' ? 'openai-responses' : 'openai-completions')
+      expect(first.providerConfig.headers).toEqual({ 'x-opencode-session': 'session-1' })
+      expect(repeated.providerConfig.headers).toEqual(first.providerConfig.headers)
+      expect(second.providerConfig.headers).toEqual({ 'x-opencode-session': 'session-2' })
+    }
+  )
+
+  it('recognizes providers created from the OpenCode preset', async () => {
+    const customProvider = { ...provider, id: 'my-console', presetProviderId: 'opencode' }
+    const injection = await resolvePiProviderInjectionForSession('session-1', customProvider, makeModel({}))
+
+    expect(injection.providerConfig.headers).toEqual({ 'x-opencode-session': 'session-1' })
+  })
+
+  it('preserves an explicit session header regardless of its casing', async () => {
+    const configured = {
+      ...provider,
+      settings: { extraHeaders: { 'X-OpenCode-Session': 'chosen-session', 'x-tenant': 'tenant-1' } }
+    }
+    const injection = await resolvePiProviderInjectionForSession('session-1', configured, makeModel({}))
+
+    expect(injection.providerConfig.headers).toEqual({
+      'X-OpenCode-Session': 'chosen-session',
+      'x-tenant': 'tenant-1'
+    })
+  })
+
+  it('keeps session and custom header values literal for Pi', async () => {
+    const { AuthStorage, ModelRegistry } = await import('@earendil-works/pi-coding-agent')
+    const configured = { ...provider, settings: { extraHeaders: { 'x-tenant': 'a$b' } } }
+    const injection = await resolvePiProviderInjectionForSession('!session$1', configured, makeModel({}))
+    const authStorage = AuthStorage.inMemory()
+    authStorage.setRuntimeApiKey(provider.id, injection.apiKey)
+    const registry = ModelRegistry.inMemory(authStorage)
+    registry.registerProvider(provider.id, injection.providerConfig)
+    const auth = await registry.getApiKeyAndHeaders(registry.find(provider.id, injection.modelId)!)
+
+    expect(auth).toMatchObject({
+      ok: true,
+      headers: { 'x-opencode-session': '!session$1', 'x-tenant': 'a$b' }
+    })
+  })
+
+  it('does not add an OpenCode session header to unrelated providers', async () => {
+    const otherProvider = { ...provider, id: 'other', settings: { extraHeaders: { 'x-tenant': 'tenant-1' } } }
+    const injection = await resolvePiProviderInjectionForSession('session-1', otherProvider, makeModel({}))
+
+    expect(injection.providerConfig.headers).toEqual({ 'x-tenant': 'tenant-1' })
   })
 })
 

--- a/src/main/ai/runtime/pi/modelInjection.ts
+++ b/src/main/ai/runtime/pi/modelInjection.ts
@@ -33,7 +33,8 @@ import type { ApiKeyEntry, Provider } from '@shared/data/types/provider'
 import { formatApiHost, withoutTrailingApiVersion } from '@shared/utils/api'
 import { formatGatewayModelId } from '@shared/utils/apiGateway'
 import { getRawModelId } from '@shared/utils/model'
-import { isLoginBasedProvider, resolveEndpointDialect } from '@shared/utils/provider'
+import { isLoginBasedProvider, matchesPreset, resolveEndpointDialect } from '@shared/utils/provider'
+import { SystemProviderIds } from '@shared/utils/systemProviderId'
 
 import { resolveEffectiveEndpoint } from '../../provider/endpoint'
 import { getProviderTransportAdapter, type ProviderTransportAdapter } from '../../provider/runtimeTransport'
@@ -324,7 +325,15 @@ export async function resolvePiProviderInjectionForSession(
   enabledApiKeys?: readonly ApiKeyEntry[]
 ): Promise<PiProviderInjection> {
   if (!usesPiGateway(provider)) {
-    return resolvePiProviderInjectionFromSnapshot(provider, model, enabledApiKeys)
+    const injection = resolvePiProviderInjectionFromSnapshot(provider, model, enabledApiKeys)
+    const headers = injection.providerConfig.headers
+    if (
+      matchesPreset(provider, SystemProviderIds.opencode) &&
+      !Object.keys(headers ?? {}).some((name) => name.toLowerCase() === 'x-opencode-session')
+    ) {
+      injection.providerConfig.headers = { ...headers, ...toPiHeaders({ 'x-opencode-session': sessionId }) }
+    }
+    return injection
   }
 
   const gateway = await resolveApiGatewayRuntime(sessionId)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Pi agents connecting directly to OpenCode did not send `x-opencode-session`, even though Cherry already had an agent session ID. OpenCode could reject these requests with `MissingSessionID`.

After this PR:
The Pi session resolver supplies a stable header for that session. OpenCode preset-derived providers are covered, and explicit user headers keep precedence regardless of casing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20250

### Why we need it and why it was done in this way

The following tradeoffs were made:
The default belongs to the session-bound resolver, which already owns the session ID. The provider mapping stays independent of any invented session identity. Existing Pi literal-header escaping also applies to the default value.

The following alternatives were considered:
A random provider-global ID would not preserve per-session affinity. The AI SDK chat path already supplies its conversation header; changing it would not cover Pi direct connections.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20250#issuecomment-5595533047

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Validation on macOS arm64 with Node 24.15.0 and pnpm 11.8.0:

- `pnpm test:main src/main/ai/runtime/pi/modelInjection.test.ts`: 48 tests passed. Against the original production code, the same tests produced 4 failures for missing session headers and 44 passes.
- `pnpm lint`: passed, including Node, renderer and AI core type checks, i18n checks, and formatting.
- `git diff --check`: passed.

The regressions cover Chat Completions, Responses, session isolation, explicit headers, preset-derived providers, and actual Pi registry header resolution. Windows application execution and a live OpenCode account request were not performed.

No user-guide changes are needed for this correction to the existing provider connection behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Pi agents] Fix OpenCode Go/Zen requests failing with MissingSessionID by preserving the agent session header.
```
