### PR TITLE
fix(export): await the Notion body write and report its failure

### DIFF
--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -952,7 +952,12 @@ const executeNotionExport = async (title: string, allBlocks: any[]): Promise<boo
         }
       }
     })
-    toast.loading({ title: i18n.t('message.loading.notion.preparing'), promise: responsePromise })
+    const preparingToastKey = 'notion-export:preparing'
+    toast.loading({
+      key: preparingToastKey,
+      title: i18n.t('message.loading.notion.preparing'),
+      promise: responsePromise.finally(() => toast.closeToast(preparingToastKey)).catch(() => undefined)
+    })
     const response = await responsePromise
 
     const exportPromise = appendBlocks({
@@ -960,7 +965,20 @@ const executeNotionExport = async (title: string, allBlocks: any[]): Promise<boo
       children: allBlocks,
       client: notion
     })
-    toast.loading({ title: i18n.t('message.loading.notion.exporting_progress'), promise: exportPromise })
+    const exportingToastKey = 'notion-export:exporting'
+    toast.loading({
+      key: exportingToastKey,
+      title: i18n.t('message.loading.notion.exporting_progress'),
+      promise: exportPromise.finally(() => toast.closeToast(exportingToastKey)).catch(() => undefined)
+    })
+    const result = await exportPromise
+    if ('error' in result || ('apiResponses' in result && result.apiResponses === null)) {
+      throw new Error(
+        'error' in result && typeof result.error === 'string' && result.error
+          ? result.error
+          : i18n.t('message.error.notion.export')
+      )
+    }
 
     toast.success(i18n.t('message.success.notion.export'))
     return true

--- a/src/renderer/services/__tests__/ExportService.test.ts
+++ b/src/renderer/services/__tests__/ExportService.test.ts
@@ -317,13 +317,99 @@ describe('ExportService', () => {
     await preferenceService.set('data.integration.notion.database_id', 'database-id')
     await preferenceService.set('data.integration.notion.page_name_key', 'Name')
     notionMocks.createPage.mockResolvedValue({ id: 'page-id' })
-    notionMocks.appendBlocks.mockResolvedValue(undefined)
+    notionMocks.appendBlocks.mockResolvedValue({ apiResponses: [{ results: [{ id: 'block-id' }] }], apiCallCount: 1 })
 
     await expect(exportMessageToNotion('First', 'First export')).resolves.toBe(true)
     expect(notionMocks.moduleLoads).toEqual(loaded)
 
     await expect(exportMessageToNotion('Second', 'Second export')).resolves.toBe(true)
     expect(notionMocks.moduleLoads).toEqual(loaded)
+  })
+
+  describe.each([
+    ['single message', () => exportMessageToNotion('Message', 'Body')],
+    ['multiple messages', () => exportMessagesToNotion('Topic', [createExportView([{ type: 'text', text: 'Body' }])])]
+  ])('Notion write completion (%s)', (_name, exportToNotion) => {
+    const success = { apiResponses: [{ results: [{ id: 'block-id' }] }], apiCallCount: 1 }
+
+    beforeEach(async () => {
+      await preferenceService.set('data.integration.notion.api_key', 'notion-key')
+      await preferenceService.set('data.integration.notion.database_id', 'database-id')
+      notionMocks.createPage.mockResolvedValue({ id: 'page-id' })
+      notionMocks.appendBlocks.mockResolvedValue(success)
+    })
+
+    afterEach(async () => {
+      await preferenceService.set('data.integration.notion.api_key', '')
+      await preferenceService.set('data.integration.notion.database_id', '')
+    })
+
+    it('keeps the export pending and blocks another export until the body is written', async () => {
+      let finishWrite!: (result: object) => void
+      notionMocks.appendBlocks.mockReturnValueOnce(new Promise<object>((resolve) => (finishWrite = resolve)))
+      let settled = false
+      const exportPromise = exportToNotion().then((result) => {
+        settled = true
+        return result
+      })
+
+      try {
+        await vi.waitFor(() =>
+          expect(toast.loading).toHaveBeenCalledWith(
+            expect.objectContaining({ title: 'message.loading.notion.exporting_progress' })
+          )
+        )
+        expect(settled).toBe(false)
+        expect(toast.success).not.toHaveBeenCalled()
+        await expect(exportToNotion()).resolves.toBe(false)
+        expect(toast.warning).toHaveBeenCalledWith('message.warn.export.exporting')
+        expect(notionMocks.createPage).toHaveBeenCalledTimes(1)
+        expect(toast.closeToast).toHaveBeenCalledWith('notion-export:preparing')
+        expect(toast.closeToast).not.toHaveBeenCalledWith('notion-export:exporting')
+      } finally {
+        finishWrite(success)
+        await exportPromise
+      }
+
+      await expect(exportPromise).resolves.toBe(true)
+      expect(toast.success).toHaveBeenCalledExactlyOnceWith('message.success.notion.export')
+      expect(toast.closeToast).toHaveBeenCalledWith('notion-export:exporting')
+      await expect(exportToNotion()).resolves.toBe(true)
+    })
+
+    it.each([
+      ['first request failure', { apiResponses: null, apiCallCount: 1, error: 'Permission denied' }],
+      ['later chunk failure', { apiResponses: null, apiCallCount: 2, error: 'Rate limited' }],
+      ['empty error message', { apiResponses: null, apiCallCount: 1, error: '' }],
+      ['missing error message', { apiResponses: null, apiCallCount: 1 }],
+      ['error field alone', { error: 'Write failed' }]
+    ])('reports %s as failure and allows a subsequent export', async (_case, result) => {
+      notionMocks.appendBlocks.mockResolvedValueOnce(result)
+
+      await expect(exportToNotion()).resolves.toBe(false)
+      expect(toast.success).not.toHaveBeenCalled()
+      expect(toast.error).toHaveBeenCalledExactlyOnceWith('message.error.notion.export')
+      expect(toast.closeToast).toHaveBeenCalledWith('notion-export:exporting')
+      await expect(exportToNotion()).resolves.toBe(true)
+    })
+
+    it.each(['createPage', 'appendBlocks'] as const)(
+      'reports a rejected %s and releases the export lock',
+      async (step) => {
+        notionMocks[step].mockRejectedValueOnce(new Error('Network failure'))
+
+        await expect(exportToNotion()).resolves.toBe(false)
+        expect(toast.success).not.toHaveBeenCalled()
+        expect(toast.error).toHaveBeenCalledExactlyOnceWith('message.error.notion.export')
+        if (step === 'createPage') {
+          expect(notionMocks.appendBlocks).not.toHaveBeenCalled()
+          expect(toast.closeToast).toHaveBeenCalledWith('notion-export:preparing')
+        } else {
+          expect(toast.closeToast).toHaveBeenCalledWith('notion-export:exporting')
+        }
+        await expect(exportToNotion()).resolves.toBe(true)
+      }
+    )
   })
 
   describe('exportMessagesToNotion', () => {
@@ -333,7 +419,7 @@ describe('ExportService', () => {
       await preferenceService.set('data.integration.notion.page_name_key', 'Name')
       await preferenceService.set('data.integration.notion.export_reasoning', true)
       notionMocks.createPage.mockResolvedValue({ id: 'page-id' })
-      notionMocks.appendBlocks.mockResolvedValue(undefined)
+      notionMocks.appendBlocks.mockResolvedValue({ apiResponses: [{ results: [{ id: 'block-id' }] }], apiCallCount: 1 })
     })
 
     afterEach(async () => {
@@ -1204,7 +1290,7 @@ describe('Notion export alert callout wiring', () => {
     await preferenceService.set('data.integration.notion.database_id', 'database-id')
     await preferenceService.set('data.integration.notion.page_name_key', 'Name')
     notionMocks.createPage.mockResolvedValue({ id: 'page-id' })
-    notionMocks.appendBlocks.mockResolvedValue(undefined)
+    notionMocks.appendBlocks.mockResolvedValue({ apiResponses: [{ results: [{ id: 'block-id' }] }], apiCallCount: 1 })
     notionMocks.markdownToBlocks.mockImplementation((markdown: string): any[] =>
       typeof markdown === 'string' && markdown.includes('[!WARNING]')
         ? [alertQuoteBlock('[!WARNING]', 'Do not commit secrets')]


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`notion-helper`'s `appendBlocks` never rejects. On failure it resolves with `apiResponses: null` and an `error` string. `executeNotionExport` handed that promise to the loading toast and never awaited it, so the export returned `true`, showed the success toast, and released the export mutex while the body was still being written. A failed body write was reported as a successful export, and a second export could start mid-write.

After this PR:

- The body write is awaited and the export mutex is held until it settles.
- The resolved failure shape (`apiResponses: null` or an `error` field) is treated as an error: the export returns `false`, logs the library message, and shows the existing generic export error toast.
- Both loading toasts ("Preparing" and "Exporting") get a fixed key and close themselves when their promise settles, following the pattern already used by the topic and session image export toasts. One result toast is shown per export instead of the auto-transitioned duplicate.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The library's raw error message is only logged, not shown. The user sees the existing generic `message.error.notion.export` toast, which keeps the failure UI consistent with the page-creation failure path.
- Static toast keys are used because `executeNotionExport` is already guarded by the single export-in-progress mutex, so two Notion exports never overlap.

The following alternatives were considered:

- Wrapping `appendBlocks` in a `.then` that throws on the failure shape and passing that promise to the loading toast. This surfaced the failure but produced two error toasts (the auto-transitioned loading toast plus the generic one), so it was replaced with the close-on-settle pattern.
- Letting the loading toast auto-transition to success. Its title cannot change, so the user would see "Exporting to Notion ..." with a check mark instead of the real success message.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The 16 new test cases (8 each for single-message and multi-message export) fail against the pre-fix source and pass after it. Scoped checks run locally: `vitest` on the test file (70/70), `oxlint --deny-warnings`, `biome check`, and `tsgo --noEmit -p tsconfig.web.json --composite false`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Export] Notion export now waits for the page body to be written and reports a failed write as an error instead of success. The progress toast closes on its own and a single result toast is shown.
```
