### PR TITLE
fix(model-selector): merge and prioritize CherryAI models

### DIFF
--- a/src/renderer/components/ModelSelector/__tests__/useModelSelectorData.test.ts
+++ b/src/renderer/components/ModelSelector/__tests__/useModelSelectorData.test.ts
@@ -1,4 +1,4 @@
-import { CHERRY_CLOUD_PROVIDER_ID } from '@shared/data/presets/cherryai'
+import { CHERRY_CLOUD_PROVIDER_ID, CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import { LOCAL_EMBEDDING_PROVIDER_ID } from '@shared/data/presets/localEmbedding'
 import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
@@ -109,6 +109,44 @@ beforeEach(() => {
 })
 
 describe('useModelSelectorData', () => {
+  it('merges Qwen and Cloud into the first provider group without changing model routing', () => {
+    const qwen = makeModel('qwen', CHERRYAI_PROVIDER_ID, { name: 'Shared name' })
+    const cloud = makeModel('cloud-model', CHERRY_CLOUD_PROVIDER_ID, { name: 'Shared name' })
+    wireDeps({
+      providers: [
+        makeProvider('openai'),
+        makeProvider(CHERRY_CLOUD_PROVIDER_ID),
+        makeProvider('custom', { name: 'CherryAI' }),
+        makeProvider(CHERRYAI_PROVIDER_ID)
+      ],
+      models: [makeModel('gpt-4', 'openai'), cloud, makeModel('custom-model', 'custom'), qwen]
+    })
+
+    const { result, rerender } = renderHook(({ searchText }) => useModelSelectorData({ searchText }), {
+      initialProps: { searchText: '' }
+    })
+
+    expect(result.current.listItems.filter((item) => item.type === 'group').map((item) => item.key)).toEqual([
+      'provider-cherryai',
+      'provider-openai',
+      'provider-custom'
+    ])
+    expect(result.current.modelItems.slice(0, 2).map((item) => item.model)).toEqual([qwen, cloud])
+    expect(result.current.modelItems.slice(0, 2).map((item) => item.provider.id)).toEqual([
+      CHERRYAI_PROVIDER_ID,
+      CHERRY_CLOUD_PROVIDER_ID
+    ])
+    expect(result.current.modelItems.slice(0, 2).every((item) => item.showIdentifier)).toBe(true)
+
+    rerender({ searchText: 'cloud-model' })
+
+    expect(result.current.listItems.filter((item) => item.type === 'group').map((item) => item.key)).toEqual([
+      'provider-cherryai'
+    ])
+    expect(result.current.modelItems.map((item) => item.model)).toEqual([cloud])
+    expect(result.current.modelItems[0].showIdentifier).toBe(false)
+  })
+
   it('passes the selector activation state to every catalog query', () => {
     wireDeps({
       providers: [makeProvider('openai')],

--- a/src/renderer/components/ModelSelector/useModelSelectorData.ts
+++ b/src/renderer/components/ModelSelector/useModelSelectorData.ts
@@ -5,6 +5,11 @@ import { useProviders } from '@renderer/hooks/useProvider'
 import { getAppEdition } from '@renderer/utils/appEdition'
 import { getSearchMatchScore } from '@renderer/utils/model'
 import { isProviderSettingsListVisibleProvider } from '@renderer/utils/providerSettings'
+import {
+  CHERRY_CLOUD_PROVIDER_ID,
+  CHERRYAI_PROVIDER_ID,
+  isManagedCherryProviderId
+} from '@shared/data/presets/cherryai'
 import { isUniqueModelId, type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { isAgentOnlyProvider } from '@shared/utils/provider'
@@ -54,12 +59,8 @@ function getModelIdentifier(model: Model) {
 }
 
 function sortProvidersByPriority(providers: Provider[], prioritizedProviderIds: readonly string[]) {
-  if (prioritizedProviderIds.length === 0) {
-    return providers
-  }
-
   const providerById = new Map(providers.map((provider) => [provider.id, provider]))
-  const prioritized = prioritizedProviderIds
+  const prioritized = [...new Set([CHERRYAI_PROVIDER_ID, CHERRY_CLOUD_PROVIDER_ID, ...prioritizedProviderIds])]
     .map((providerId) => providerById.get(providerId))
     .filter((provider): provider is Provider => Boolean(provider))
   const prioritizedIds = new Set(prioritized.map((provider) => provider.id))
@@ -252,6 +253,16 @@ export function useModelSelectorData({
     const duplicateModelNamesByProvider = new Map(
       [...tagFilteredModelsByProvider].map(([providerId, models]) => [providerId, getDuplicateModelNames(models)])
     )
+    const duplicateCherryModelNames = getDuplicateModelNames(
+      [...tagFilteredModelsByProvider].flatMap(([providerId, models]) =>
+        isManagedCherryProviderId(providerId) ? models : []
+      )
+    )
+    for (const provider of sortedProviders) {
+      if (isManagedCherryProviderId(provider.id)) {
+        duplicateModelNamesByProvider.set(provider.id, duplicateCherryModelNames)
+      }
+    }
 
     if (searchText.length === 0 && showPinnedModels && pinnedIdSet.size > 0) {
       const pinnedItems = pinnedIds.flatMap((modelId) => {
@@ -283,6 +294,7 @@ export function useModelSelectorData({
       }
     }
 
+    const displayedGroupIds = new Set<string>()
     sortedProviders.forEach((provider) => {
       const filteredModels = (tagFilteredModelsByProvider.get(provider.id) ?? []).filter(
         (model) => !showPinnedModels || searchText.length > 0 || !pinnedIdSet.has(model.id)
@@ -292,14 +304,18 @@ export function useModelSelectorData({
         return
       }
 
-      items.push({
-        key: `provider-${provider.id}`,
-        type: 'group',
-        title: getProviderDisplayName(provider),
-        groupKind: 'provider',
-        provider,
-        canNavigateToSettings: isProviderSettingsListVisibleProvider(provider)
-      })
+      const groupId = isManagedCherryProviderId(provider.id) ? CHERRYAI_PROVIDER_ID : provider.id
+      if (!displayedGroupIds.has(groupId)) {
+        displayedGroupIds.add(groupId)
+        items.push({
+          key: `provider-${groupId}`,
+          type: 'group',
+          title: getProviderDisplayName(provider),
+          groupKind: 'provider',
+          provider,
+          canNavigateToSettings: isProviderSettingsListVisibleProvider(provider)
+        })
+      }
 
       items.push(
         ...filteredModels.map((model) =>

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-09-cherryai-selector-first.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-09-cherryai-selector-first.md
@@ -2,7 +2,7 @@
 title: CherryAI appears first in the model selector
 category: changed
 severity: notice
-introduced_in_pr: TBD
+introduced_in_pr: '#20270'
 date: 2026-09-09
 ---
 

--- a/v2-refactor-temp/docs/breaking-changes/2026-09-09-cherryai-selector-first.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-09-09-cherryai-selector-first.md
@@ -1,0 +1,19 @@
+---
+title: CherryAI appears first in the model selector
+category: changed
+severity: notice
+introduced_in_pr: TBD
+date: 2026-09-09
+---
+
+## What changed
+
+CherryAI Qwen and Cloud models now appear together under a single CherryAI group before other provider groups in the model selector, with Qwen followed by Cloud. The pinned models section remains above provider groups.
+
+## Why this matters to the user
+
+CherryAI models are easier to find without scrolling through other providers. Existing model filters and the relative order of other providers are unchanged.
+
+## What the user should do
+
+Nothing — automatic.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Qwen and Cloud appeared in separate CherryAI groups among other providers.

After this PR:

One leading CherryAI display group contains Qwen then Cloud. The selector computes duplicate-name disambiguation and its title once per display group while preserving each model’s original provider routing, filters, and the pinned section above it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

A selector-local display rule declares Qwen and Cloud as one ordered group; separate managed provider identities are retained on every model row

The following alternatives were considered:

Database provider merge — unnecessary routing and migration changes

Links to places where the discussion took place: None <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None

### Special notes for your reviewer

<!-- optional -->

Validation: 64 ModelSelector tests, `pnpm lint`, and a real-window selector check passed; the local profile has Qwen but no Cherry Cloud entitlement models.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Show Qwen and Cloud models together in a single CherryAI group before other providers, while preserving pinned models and model routing.
```

