### PR TITLE
fix(composer): hide focus shortcut hint from layout when editor is focused

### DIFF
--- a/src/renderer/components/composer/ComposerFocusShortcut.tsx
+++ b/src/renderer/components/composer/ComposerFocusShortcut.tsx
@@ -12,7 +12,7 @@ export function ComposerFocusShortcut({ focus, editable = true }: { focus: () =>
   if (!editable || !shortcutLabel) return null
 
   return (
-    <span className="pointer-events-none z-1 mt-2 mr-8 flex h-5 shrink-0 select-none items-center gap-1 self-start text-foreground-tertiary text-xs group-has-[:focus]/composer-editor:invisible [[data-composer-presentation=compact]_&]:mt-0 [[data-composer-presentation=compact]_&]:self-center">
+    <span className="pointer-events-none z-1 mt-2 mr-8 flex h-5 shrink-0 select-none items-center gap-1 self-start text-foreground-tertiary text-xs group-has-[:focus]/composer-editor:hidden [[data-composer-presentation=compact]_&]:mt-0 [[data-composer-presentation=compact]_&]:self-center">
       <CommandShortcut
         command="chat.input.focus"
         className="h-5 rounded-md bg-muted/50 px-1.5 font-normal text-foreground-tertiary"

--- a/src/renderer/components/composer/__tests__/useCompactComposerPresentation.test.tsx
+++ b/src/renderer/components/composer/__tests__/useCompactComposerPresentation.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { useCompactComposerPresentation } from '../useCompactComposerPresentation'
@@ -105,20 +105,75 @@ describe('useCompactComposerPresentation', () => {
     dims.scrollHeight = 60
     editorObserver().trigger(500)
     await waitFor(() => expect(result.current.isCompact).toBe(false))
+    // Widening back to the regular width is the flip's own echo; the browser
+    // delivers it right after the settled re-render, so consume it before the
+    // next entry models a real external change.
+    editorObserver().trigger(600)
+    await Promise.resolve()
+    expect(result.current.isCompact).toBe(false)
 
     // Refocus: the hint leaves the layout, the text fits on one line again.
     dims.scrollHeight = 20
-    editorObserver().trigger(600)
+    editorObserver().trigger(700)
     await waitFor(() => expect(result.current.isCompact).toBe(true))
+    editorObserver().trigger(520)
+    await Promise.resolve()
+    expect(result.current.isCompact).toBe(true)
 
     // The transition must keep working on repetition, not just once.
     dims.scrollHeight = 60
     editorObserver().trigger(500)
     await waitFor(() => expect(result.current.isCompact).toBe(false))
-
-    // An unchanged width must not schedule a measurement (no resize cycle).
-    editorObserver().trigger(500)
+    editorObserver().trigger(600)
     await Promise.resolve()
     expect(result.current.isCompact).toBe(false)
+
+    // An unchanged width must not schedule a measurement (no resize cycle).
+    editorObserver().trigger(600)
+    await Promise.resolve()
+    expect(result.current.isCompact).toBe(false)
+  })
+
+  it('does not toggle repeatedly when compact content stays overflowing', async () => {
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+    const { frame } = buildComposerFrame()
+    const frameRef = { current: frame }
+    const dims = { clientHeight: 20, scrollHeight: 20 }
+    const paintedPresentations: boolean[] = []
+
+    const { result } = renderHook(() => {
+      const hook = useCompactComposerPresentation({
+        enabled: true,
+        frameRef,
+        isComposing: () => false
+      })
+      paintedPresentations.push(hook.isCompact)
+      return hook
+    })
+    const editorElement = appendEditorElement(frame, dims)
+
+    // Single line fits: compact.
+    await waitFor(() => expect(result.current.isCompact).toBe(true))
+    const editorObserver = () => FakeResizeObserver.forElement(editorElement)
+    const paintCount = () => paintedPresentations.length
+
+    // Blur narrows the editor and the now-longer text overflows: regular.
+    dims.scrollHeight = 60
+    editorObserver().trigger(500)
+    await waitFor(() => expect(result.current.isCompact).toBe(false))
+    const settledPaints = paintCount()
+
+    // Widening back to the regular width is the flip's own echo, not a user
+    // layout change — it must be consumed instead of re-entering the
+    // measure -> flip -> resize loop, so no new paint may happen.
+    editorObserver().trigger(600)
+    await act(async () => {})
+    expect(result.current.isCompact).toBe(false)
+    expect(paintCount()).toBe(settledPaints)
+
+    // A real external narrowing must still remeasure.
+    dims.scrollHeight = 20
+    editorObserver().trigger(500)
+    await waitFor(() => expect(result.current.isCompact).toBe(true))
   })
 })

--- a/src/renderer/components/composer/__tests__/useCompactComposerPresentation.test.tsx
+++ b/src/renderer/components/composer/__tests__/useCompactComposerPresentation.test.tsx
@@ -22,7 +22,7 @@ class FakeResizeObserver {
   disconnect() {}
 
   trigger(width: number) {
-    this.callback([{ contentRect: { width } }] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver)
+    this.callback([{ contentRect: { width } }] as unknown as ResizeObserverEntry[], this)
   }
 
   static forElement(element: Element): FakeResizeObserver {

--- a/src/renderer/components/composer/__tests__/useCompactComposerPresentation.test.tsx
+++ b/src/renderer/components/composer/__tests__/useCompactComposerPresentation.test.tsx
@@ -1,7 +1,36 @@
 import { renderHook, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { useCompactComposerPresentation } from '../useCompactComposerPresentation'
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+
+  private callback: ResizeObserverCallback
+  readonly observed: Element[] = []
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    FakeResizeObserver.instances.push(this)
+  }
+
+  observe(element: Element) {
+    this.observed.push(element)
+  }
+
+  unobserve() {}
+  disconnect() {}
+
+  trigger(width: number) {
+    this.callback([{ contentRect: { width } }] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+
+  static forElement(element: Element): FakeResizeObserver {
+    const instance = FakeResizeObserver.instances.find((candidate) => candidate.observed.includes(element))
+    if (!instance) throw new Error('No FakeResizeObserver observed the element')
+    return instance
+  }
+}
 
 function buildComposerFrame() {
   const inputbar = document.createElement('div')
@@ -17,12 +46,14 @@ function buildComposerFrame() {
   return { frame, inputbar }
 }
 
-function appendEditorElement(frame: HTMLElement, { clientHeight, scrollHeight }: Record<string, number>) {
+function appendEditorElement(frame: HTMLElement, dims: { clientHeight: number; scrollHeight: number }) {
   const editorElement = document.createElement('div')
   editorElement.className = 'composer-tiptap'
+  // Getters (not snapshots) so a test can move the dimensions after mount to
+  // emulate text rewrapping when the focus hint takes/releases layout space.
   Object.defineProperties(editorElement, {
-    clientHeight: { configurable: true, get: () => clientHeight },
-    scrollHeight: { configurable: true, get: () => scrollHeight }
+    clientHeight: { configurable: true, get: () => dims.clientHeight },
+    scrollHeight: { configurable: true, get: () => dims.scrollHeight }
   })
   frame.appendChild(editorElement)
 
@@ -31,6 +62,8 @@ function appendEditorElement(frame: HTMLElement, { clientHeight, scrollHeight }:
 
 describe('useCompactComposerPresentation', () => {
   afterEach(() => {
+    vi.unstubAllGlobals()
+    FakeResizeObserver.instances = []
     document.body.innerHTML = ''
   })
 
@@ -50,5 +83,42 @@ describe('useCompactComposerPresentation', () => {
     appendEditorElement(frame, { clientHeight: 20, scrollHeight: 60 })
 
     await waitFor(() => expect(result.current.isCompact).toBe(false))
+  })
+
+  it('remeasures when the editor width changes, across repeated focus/blur transitions', async () => {
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+    const { frame } = buildComposerFrame()
+    const frameRef = { current: frame }
+    const dims = { clientHeight: 20, scrollHeight: 20 }
+
+    const { result } = renderHook(() =>
+      useCompactComposerPresentation({ enabled: true, frameRef, isComposing: () => false })
+    )
+    const editorElement = appendEditorElement(frame, dims)
+
+    // Single line fits: compact.
+    await waitFor(() => expect(result.current.isCompact).toBe(true))
+    const editorObserver = () => FakeResizeObserver.forElement(editorElement)
+
+    // Blur: the focus hint re-enters the layout, the editor loses width, and
+    // the text wraps onto a clipped second line — the composer must expand.
+    dims.scrollHeight = 60
+    editorObserver().trigger(500)
+    await waitFor(() => expect(result.current.isCompact).toBe(false))
+
+    // Refocus: the hint leaves the layout, the text fits on one line again.
+    dims.scrollHeight = 20
+    editorObserver().trigger(600)
+    await waitFor(() => expect(result.current.isCompact).toBe(true))
+
+    // The transition must keep working on repetition, not just once.
+    dims.scrollHeight = 60
+    editorObserver().trigger(500)
+    await waitFor(() => expect(result.current.isCompact).toBe(false))
+
+    // An unchanged width must not schedule a measurement (no resize cycle).
+    editorObserver().trigger(500)
+    await Promise.resolve()
+    expect(result.current.isCompact).toBe(false)
   })
 })

--- a/src/renderer/components/composer/useCompactComposerPresentation.ts
+++ b/src/renderer/components/composer/useCompactComposerPresentation.ts
@@ -85,12 +85,46 @@ export function useCompactComposerPresentation({ enabled, frameRef, isComposing 
     // that mounts already enabled. Watching the frame catches both the editor's
     // insertion and its later content edits, and the measurement below reruns
     // off the resulting revision bump.
-    const mutationObserver = new MutationObserver(requestMeasurement)
+    const mutationObserver = new MutationObserver(() => {
+      attachEditorResizeObserver()
+      requestMeasurement()
+    })
     mutationObserver.observe(frame, {
       characterData: true,
       childList: true,
       subtree: true
     })
+
+    // Focus-driven affordances (the focus shortcut hint leaving the layout
+    // while the editor is focused) change the editor's inline size without
+    // touching the inputbar's outer width or the content, so neither observer
+    // above would notice: text that fit while focused can wrap on blur and get
+    // clipped by the fixed-height compact frame. Watch the editor width itself
+    // and remeasure on change; the width-equality guard keeps presentation
+    // flips from re-requesting in a cycle.
+    let observedEditorElement: HTMLElement | null = null
+    let lastEditorWidth = 0
+    let editorResizeObserver: ResizeObserver | null = null
+    const composerFrame: HTMLElement = frame
+
+    function attachEditorResizeObserver() {
+      if (typeof ResizeObserver === 'undefined') return
+      const editorElement = composerFrame.querySelector<HTMLElement>('.composer-tiptap')
+      if (!editorElement || editorElement === observedEditorElement) return
+
+      editorResizeObserver?.disconnect()
+      observedEditorElement = editorElement
+      lastEditorWidth = editorElement.getBoundingClientRect().width
+      editorResizeObserver = new ResizeObserver((entries) => {
+        const nextEditorWidth = entries[0]?.contentRect.width ?? editorElement.getBoundingClientRect().width
+        if (nextEditorWidth === lastEditorWidth) return
+
+        lastEditorWidth = nextEditorWidth
+        requestMeasurement()
+      })
+      editorResizeObserver.observe(editorElement)
+    }
+    attachEditorResizeObserver()
 
     let lastInputbarWidth = inputbarElement.getBoundingClientRect().width
     const resizeObserver =
@@ -108,6 +142,7 @@ export function useCompactComposerPresentation({ enabled, frameRef, isComposing 
     return () => {
       mutationObserver.disconnect()
       resizeObserver?.disconnect()
+      editorResizeObserver?.disconnect()
     }
   }, [enabled, frameRef, requestMeasurement])
 

--- a/src/renderer/components/composer/useCompactComposerPresentation.ts
+++ b/src/renderer/components/composer/useCompactComposerPresentation.ts
@@ -23,6 +23,10 @@ export function useCompactComposerPresentation({ enabled, frameRef, isComposing 
   const measurementScheduledRef = useRef(false)
   const mountedRef = useRef(true)
   const wasEnabledRef = useRef(enabled)
+  // Mirrors the isCompact value the current render actually painted, so the
+  // editor ResizeObserver below can tell a width change caused by a
+  // presentation flip apart from an external layout change.
+  const renderedIsCompactRef = useRef(enabled)
 
   const requestMeasurement = useCallback(() => {
     if (!enabled || isComposing() || measurementScheduledRef.current) return
@@ -100,10 +104,10 @@ export function useCompactComposerPresentation({ enabled, frameRef, isComposing 
     // touching the inputbar's outer width or the content, so neither observer
     // above would notice: text that fit while focused can wrap on blur and get
     // clipped by the fixed-height compact frame. Watch the editor width itself
-    // and remeasure on change; the width-equality guard keeps presentation
-    // flips from re-requesting in a cycle.
+    // and remeasure on change.
     let observedEditorElement: HTMLElement | null = null
     let lastEditorWidth = 0
+    let lastSeenRenderedCompact = true
     let editorResizeObserver: ResizeObserver | null = null
     const composerFrame: HTMLElement = frame
 
@@ -115,11 +119,23 @@ export function useCompactComposerPresentation({ enabled, frameRef, isComposing 
       editorResizeObserver?.disconnect()
       observedEditorElement = editorElement
       lastEditorWidth = editorElement.getBoundingClientRect().width
+      lastSeenRenderedCompact = renderedIsCompactRef.current
       editorResizeObserver = new ResizeObserver((entries) => {
         const nextEditorWidth = entries[0]?.contentRect.width ?? editorElement.getBoundingClientRect().width
         if (nextEditorWidth === lastEditorWidth) return
 
         lastEditorWidth = nextEditorWidth
+        // A presentation flip (the optimistic compact render while a
+        // measurement is pending, or the settled re-render afterwards) changes
+        // the editor width on its own. Feeding that echo back into a new
+        // measurement would toggle compact and regular forever while the
+        // compact content keeps overflowing, so consume it here and only
+        // remeasure for width changes that happen in a steady presentation.
+        const renderedCompactNow = renderedIsCompactRef.current
+        const flipDrivenWidthChange = renderedCompactNow !== lastSeenRenderedCompact
+        lastSeenRenderedCompact = renderedCompactNow
+        if (flipDrivenWidthChange) return
+
         requestMeasurement()
       })
       editorResizeObserver.observe(editorElement)
@@ -147,9 +163,11 @@ export function useCompactComposerPresentation({ enabled, frameRef, isComposing 
   }, [enabled, frameRef, requestMeasurement])
 
   const measurementPending = measurement.revision !== requestedRevision
+  const isCompact = enabled && (measurementPending || measurement.presentation === 'compact')
+  renderedIsCompactRef.current = isCompact
 
   return {
-    isCompact: enabled && (measurementPending || measurement.presentation === 'compact'),
+    isCompact,
     requestMeasurement
   }
 }

--- a/src/renderer/components/composer/useCompactComposerPresentation.ts
+++ b/src/renderer/components/composer/useCompactComposerPresentation.ts
@@ -99,12 +99,8 @@ export function useCompactComposerPresentation({ enabled, frameRef, isComposing 
       subtree: true
     })
 
-    // Focus-driven affordances (the focus shortcut hint leaving the layout
-    // while the editor is focused) change the editor's inline size without
-    // touching the inputbar's outer width or the content, so neither observer
-    // above would notice: text that fit while focused can wrap on blur and get
-    // clipped by the fixed-height compact frame. Watch the editor width itself
-    // and remeasure on change.
+    // Focus affordances (the focus hint leaving the layout) resize the editor
+    // without touching the inputbar width or content, so watch the editor itself.
     let observedEditorElement: HTMLElement | null = null
     let lastEditorWidth = 0
     let lastSeenRenderedCompact = true
@@ -125,12 +121,8 @@ export function useCompactComposerPresentation({ enabled, frameRef, isComposing 
         if (nextEditorWidth === lastEditorWidth) return
 
         lastEditorWidth = nextEditorWidth
-        // A presentation flip (the optimistic compact render while a
-        // measurement is pending, or the settled re-render afterwards) changes
-        // the editor width on its own. Feeding that echo back into a new
-        // measurement would toggle compact and regular forever while the
-        // compact content keeps overflowing, so consume it here and only
-        // remeasure for width changes that happen in a steady presentation.
+        // Consume the editor resize a presentation flip causes; remeasuring
+        // that echo would cycle compact/regular while compact content overflows.
         const renderedCompactNow = renderedIsCompactRef.current
         const flipDrivenWidthChange = renderedCompactNow !== lastSeenRenderedCompact
         lastSeenRenderedCompact = renderedCompactNow


### PR DESCRIPTION
### What this PR does

Before this PR: while typing in the chat/agent composer, text wraps about 127px short of the right edge of the input frame, leaving a large dead area on the right. The focus shortcut hint (⌘I badge + label, #20079) is a flex sibling of the editor and only turns `invisible` on focus, so it keeps occupying its layout box (~95px span + 32px margin) exactly when the user is typing and needs the width most.

After this PR: the hint uses `hidden` instead of `invisible` when the composer is focused, releasing its space so the editor wraps at the true frame edge. When the composer is unfocused, the hint still occupies its own space and never overlays editor text, preserving the design intent of #20079.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: on blur the hint reappears and the editor reflows to the narrower width. This matches the pre-existing focused/unfocused visual transition of the hint and is only observable while not typing.

The following alternatives were considered: absolutely positioning the hint as an overlay inside the frame, so it never consumes layout width. Rejected because it can overlay editor text when the composer is unfocused with content, which contradicts the deliberately non-overlapping design merged in #20079.

Links to places where the discussion took place: #20079 (the hint's original design), #13246 / #12451 (focus shortcut requests)

### Breaking changes

None.

### Special notes for your reviewer

One-line class change (`invisible` → `hidden`). Existing composer tests pass (`ComposerFocusShortcut.test.tsx`, `ComposerSurface.test.tsx`, 160 tests). This PR touches the same element as my other PR (placeholder/hint simplification); whichever lands second needs a trivial one-line rebase.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Composer] Fixed the chat input wrapping text too early while typing, which left a large blank area on the right side of the input box.
```
