### PR TITLE
refactor(edition-policy): enforce edition availability by construction

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -559,6 +559,55 @@ export default defineConfig([
       'filepath-brand/no-as-filepath': process.env.CI ? 'error' : 'warn'
     }
   },
+  // Edition brand integrity — `as EditionDecision` forges the proof that the edition
+  // rule ran. The decision is what row → domain mappers require, so forging one is the
+  // single way to surface an entity this build withholds. `editionPolicy.ts` is the
+  // sanctioned producer and is exempt.
+  {
+    files: ['src/main/**/*.ts'],
+    ignores: [
+      'src/main/data/services/editionPolicy.ts',
+      'src/main/**/__tests__/**',
+      'src/main/**/__mocks__/**',
+      'src/main/**/*.test.*'
+    ],
+    plugins: {
+      'edition-brand': {
+        rules: {
+          'no-as-edition-decision': {
+            meta: {
+              type: 'problem',
+              docs: {
+                description:
+                  'Disallow `as EditionDecision` casts. The decision is the proof that the edition rule was applied to an entity; only EditionScope.resolve may produce one.',
+                recommended: true
+              },
+              messages: {
+                noAsDecision:
+                  '`as EditionDecision` forges the proof that the edition rule ran, which is the only way an entity this build withholds reaches a mapper. Obtain it from the entity\'s `EditionScope.resolve(row)` and handle the `null` (withheld) case.'
+              }
+            },
+            create(context) {
+              function checkAssertion(node) {
+                const ann = node.typeAnnotation
+                if (ann?.type !== 'TSTypeReference' || ann.typeName?.type !== 'Identifier') return
+                if (ann.typeName.name === 'EditionDecision') {
+                  context.report({ node, messageId: 'noAsDecision' })
+                }
+              }
+              return {
+                TSAsExpression: checkAssertion,
+                TSTypeAssertion: checkAssertion
+              }
+            }
+          }
+        }
+      }
+    },
+    rules: {
+      'edition-brand/no-as-edition-decision': process.env.CI ? 'error' : 'warn'
+    }
+  },
   // Application lifecycle - all quit-related APIs and events are managed by Application.ts
   {
     files: ['src/main/**/*.{ts,tsx,js,jsx}'],

--- a/src/main/data/services/MiniAppService.ts
+++ b/src/main/data/services/MiniAppService.ts
@@ -21,6 +21,7 @@ import {
   miniAppTable
 } from '@data/db/schemas/miniApp'
 import { defaultHandlersFor, withSqliteErrors } from '@data/db/sqliteErrors'
+import { defineEditionScope, type EditionDecision, type EditionScopedEntry } from '@data/services/editionPolicy'
 import { loggerService } from '@logger'
 import { getAppLanguage } from '@main/i18n'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
@@ -99,7 +100,39 @@ type InstallationExtras = {
 }
 
 /** Convert a DB row to the public MiniApp DTO. */
-function rowToMiniApp(row: MiniAppRow & InstallationExtras): MiniApp {
+
+/**
+ * Mini apps are edition-scoped by their preset identity, reusing the provider rule
+ * verbatim. The preset's `supportedRegions` is the catalog's statement of which
+ * editions ship the app — read here as a build-time fact, not as the runtime region
+ * the renderer detects. Region detection stays where it is: it curates ordering and
+ * relevance for a user who travels, and a user-flippable setting cannot carry this.
+ *
+ * A user-authored app (`presetMiniAppId === null`) has no catalog identity, and the
+ * `supported_regions` column is left untouched — editions share one database.
+ */
+const EDITION_BY_REGION = { CN: 'cn', Global: 'global' } as const
+
+const miniAppScope = defineEditionScope<Pick<MiniAppRow, 'presetMiniAppId'>, EditionScopedEntry>({
+  lookup: (row) => {
+    const preset = row.presetMiniAppId
+      ? PRESETS_MINI_APPS.find((candidate) => candidate.id === row.presetMiniAppId)
+      : undefined
+    return {
+      entry: { availableInEditions: preset?.supportedRegions?.map((region) => EDITION_BY_REGION[region]) },
+      scoped: row.presetMiniAppId !== null
+    }
+  }
+})
+
+function rowToMiniApp(
+  row: MiniAppRow & InstallationExtras,
+  // Type-level gate, deliberately unread: a mini app renders entirely from its row, so
+  // the decision carries no data — it is here so a mini app this build withholds cannot
+  // be materialized, and a new read path that skips `miniAppScope` fails to compile.
+  // oxlint-disable-next-line no-unused-vars
+  _decision: EditionDecision<EditionScopedEntry>
+): MiniApp {
   const clean = nullsToUndefined(row)
   const presetMiniAppId = clean.presetMiniAppId ?? null
   // An uploaded logo's file id lives in the ref table (single source of truth);
@@ -156,8 +189,9 @@ export class MiniAppService {
   /** Get a miniapp by appId. Throws NOT_FOUND if absent. */
   getByAppId(appId: string): MiniApp {
     const [row] = joinedMiniApp().where(eq(miniAppTable.appId, appId)).limit(1).all()
-    if (!row) throw DataApiErrorFactory.notFound('MiniApp', appId)
-    return rowToMiniApp(row)
+    const decision = row && miniAppScope.resolve(row)
+    if (!row || !decision) throw DataApiErrorFactory.notFound('MiniApp', appId)
+    return rowToMiniApp(row, decision)
   }
 
   /**
@@ -168,7 +202,10 @@ export class MiniAppService {
     const where = query.status !== undefined ? eq(miniAppTable.status, query.status) : undefined
     const rows = joinedMiniApp().where(where).orderBy(asc(miniAppTable.orderKey)).all()
 
-    const items = rows.map(rowToMiniApp)
+    const items = rows.flatMap((row) => {
+      const decision = miniAppScope.resolve(row)
+      return decision ? [rowToMiniApp(row, decision)] : []
+    })
     items.sort((a, b) => {
       const order = (s: MiniAppStatus) => (s === 'pinned' ? 0 : s === 'enabled' ? 1 : 2)
       const diff = order(a.status) - order(b.status)
@@ -221,7 +258,10 @@ export class MiniAppService {
     logger.info('Created custom miniapp', { appId: row.appId, orderKey: row.orderKey })
     // Only site rows are created here (the custom-site form is the sole entry), so
     // there is no installation row to join — say so explicitly.
-    return rowToMiniApp({ ...row, version: null, manifestJson: null, aiModelId: null, aiQuickModelId: null })
+    const created = { ...row, version: null, manifestJson: null, aiModelId: null, aiQuickModelId: null }
+    const decision = miniAppScope.resolve(created)
+    if (!decision) throw DataApiErrorFactory.notFound('MiniApp', row.appId)
+    return rowToMiniApp(created, decision)
   }
 
   /**

--- a/src/main/data/services/ModelService.ts
+++ b/src/main/data/services/ModelService.ts
@@ -134,12 +134,6 @@ function assertManagedCherryAiDefaultModelMutationAllowed(
   throw DataApiErrorFactory.invalidOperation(operation, 'managed CherryAI default model cannot be modified')
 }
 
-function assertProvidersAvailable(providerIds: Iterable<string>): void {
-  for (const providerId of new Set(providerIds)) {
-    providerService.assertAvailable(providerId)
-  }
-}
-
 /**
  * Registry data for model creation.
  * Must stay in sync with the return type of {@link ProviderRegistryService.lookupModel}.
@@ -874,22 +868,19 @@ class ModelService {
    * Get a model by composite key (providerId + modelId)
    */
   getByKey(providerId: string, modelId: string): Model {
-    providerService.assertAvailable(providerId)
-
-    const db = application.get('DbService').getDb()
-
-    const [row] = db
-      .select()
-      .from(userModelTable)
+    const [row] = selectWithProviderIdentity(application.get('DbService').getDb())
       .where(and(eq(userModelTable.providerId, providerId), eq(userModelTable.modelId, modelId)))
       .limit(1)
       .all()
 
-    if (!row) {
+    // A model owned by a provider this build withholds is not surfaced, exactly as
+    // in `list`: the join carries the provider identity, so the same pure predicate
+    // decides here without a second lookup.
+    if (!row || !isProviderIdentityAvailable(row)) {
       throw DataApiErrorFactory.notFound('Model', `${providerId}/${modelId}`)
     }
 
-    return this.enrichRowsFromRegistry([row])[0]
+    return this.enrichRowsFromRegistry([row.model])[0]
   }
 
   /**
@@ -913,7 +904,6 @@ class ModelService {
    */
   create(items: CreateModelInput[]): Model[] {
     if (items.length === 0) return []
-    assertProvidersAvailable(items.map(({ dto }) => dto.providerId))
     for (const { dto } of items) {
       assertManagedCherryAiDefaultModelMutationAllowed(
         dto.providerId,
@@ -972,7 +962,6 @@ class ModelService {
    * Update an existing model
    */
   update(providerId: string, modelId: string, dto: UpdateModelDto): Model {
-    providerService.assertAvailable(providerId)
     assertManagedCherryAiDefaultModelPatchAllowed(providerId, modelId, dto)
 
     const db = application.get('DbService').getDb()
@@ -1020,7 +1009,6 @@ class ModelService {
    */
   bulkUpdate(items: Array<{ providerId: string; modelId: string; patch: UpdateModelDto }>): Model[] {
     if (items.length === 0) return []
-    assertProvidersAvailable(items.map((item) => item.providerId))
 
     const db = application.get('DbService').getDb()
 
@@ -1081,7 +1069,6 @@ class ModelService {
    * one. Pins for removed models are purged in the same transaction.
    */
   reconcileForProvider(providerId: string, payload: { toAdd: CreateModelInput[]; toRemove: string[] }): Model[] {
-    providerService.assertAvailable(providerId)
     if (payload.toAdd.length === 0 && payload.toRemove.length === 0) {
       return this.list({ providerId })
     }
@@ -1180,7 +1167,6 @@ class ModelService {
    * Delete a model
    */
   delete(providerId: string, modelId: string): void {
-    providerService.assertAvailable(providerId)
     assertManagedCherryAiDefaultModelMutationAllowed(providerId, modelId, `delete model ${providerId}/${modelId}`)
 
     const uniqueModelId = createUniqueModelId(providerId, modelId)
@@ -1213,7 +1199,6 @@ class ModelService {
    */
   bulkDelete(items: { providerId: string; modelId: string }[]): void {
     if (items.length === 0) return
-    assertProvidersAvailable(items.map((item) => item.providerId))
 
     const uniqueItems = new Map<string, { providerId: string; modelId: string }>()
 

--- a/src/main/data/services/ProviderRegistryService.ts
+++ b/src/main/data/services/ProviderRegistryService.ts
@@ -1151,7 +1151,6 @@ class ProviderRegistryService {
    * @returns Array of fully resolved Model objects
    */
   resolveModels(providerId: string, modelIds: string[]): Model[] {
-    getDataService('ProviderService').assertAvailable(providerId)
     const loader = this.getLoader()
     const providerContext = this.getEffectiveProviderContext(providerId)
     const presetProvider = this.resolveProviderPreset(providerId, providerContext.presetProviderId, false)
@@ -1331,7 +1330,6 @@ class ProviderRegistryService {
    * (greedy `:modelId` capture for HuggingFace-style ids containing `/`).
    */
   getImageGenerationSupport(providerId: string, modelId: string): ImageGenerationSupport | null {
-    getDataService('ProviderService').assertAvailable(providerId)
     const { presetModel, registryOverride } = this.lookupModel(providerId, modelId)
     // Override wins — lets vendor-exclusive overrides declare their own
     // imageGeneration block without polluting the global models.json.

--- a/src/main/data/services/ProviderService.ts
+++ b/src/main/data/services/ProviderService.ts
@@ -13,8 +13,8 @@ import type { InsertUserProviderRow, UserProviderRow } from '@data/db/schemas/us
 import { type StoredEndpointConfigOverride, userProviderTable } from '@data/db/schemas/userProvider'
 import { type SqliteErrorHandlers, withSqliteErrors } from '@data/db/sqliteErrors'
 import type { DbType } from '@data/db/types'
-import { isMigratedFromV1 } from '@data/migration/v1MigrationOrigin'
 import { getDataService, registerDataService } from '@data/services/dataServiceRegistry'
+import { defineEditionScope, type EditionDecision } from '@data/services/editionPolicy'
 import { pinService } from '@data/services/PinService'
 import type { ProviderDisplayMetadata } from '@data/services/ProviderRegistryService'
 import { applyMoves, insertManyWithOrderKey, insertWithOrderKey } from '@data/services/utils/orderKey'
@@ -25,7 +25,6 @@ import {
   reconcileLogoSlotTx
 } from '@data/services/utils/singleFileRef'
 import { loggerService } from '@logger'
-import { getAppEdition } from '@main/utils/appEdition'
 import { DataApiError, DataApiErrorFactory, ErrorCode } from '@shared/data/api/errors'
 import type { OrderBatchRequest, OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { CreateProviderDto, ListProvidersQuery, UpdateProviderDto } from '@shared/data/api/schemas/providers'
@@ -70,30 +69,39 @@ function applyJsonMergePatch(target: unknown, patch: unknown): unknown {
 type NewUserProviderInput = Omit<InsertUserProviderRow, 'orderKey'>
 export type ProviderIdentity = Pick<UserProviderRow, 'providerId' | 'presetProviderId'>
 
-function isProviderAvailableInCurrentEdition(provider: Pick<Provider, 'availableInEditions'>): boolean {
-  const availableInEditions = provider.availableInEditions
-  return isMigratedFromV1() || !availableInEditions || availableInEditions.includes(getAppEdition())
-}
+/**
+ * Providers are edition-scoped by their preset identity. A fully custom row has no
+ * preset, so no edition rule applies to it; a preset the registry does not describe
+ * yields empty metadata, which declares no restriction and therefore is not withheld.
+ */
+const providerScope = defineEditionScope<ProviderIdentity, ProviderDisplayMetadata>({
+  lookup: (row) => ({
+    entry: getDataService('ProviderRegistryService').getProviderDisplayMetadata(row.providerId, row.presetProviderId),
+    scoped: row.presetProviderId !== null
+  })
+})
 
-function getAvailableProviderMetadata(row: ProviderIdentity): ProviderDisplayMetadata | null {
+/**
+ * The single seam where a persisted row becomes surfaceable. `null` means this build
+ * does not offer the provider — withheld by the edition, or retired outright.
+ *
+ * `rowToRuntimeProvider` takes the returned decision as a required argument and only
+ * this function produces one, so a provider the build withholds cannot be materialized
+ * at all. Read paths stay filtered without repeating a check, and a future mapper that
+ * skips the rule fails to compile rather than leaking.
+ */
+function resolveProviderDecision(row: ProviderIdentity): EditionDecision<ProviderDisplayMetadata> | null {
   if (isRetiredProvider(row.providerId, row.presetProviderId)) return null
-
-  const metadata = getDataService('ProviderRegistryService').getProviderDisplayMetadata(
-    row.providerId,
-    row.presetProviderId
-  )
-  return isProviderAvailableInCurrentEdition(metadata) ? metadata : null
+  return providerScope.resolve(row)
 }
 
 /**
- * Edition availability of a persisted provider, decided from the identity columns
- * alone: static registry metadata, the build-time edition, and the preboot v1-origin
- * flag. Callers that already hold `providerId` / `presetProviderId` — anything reading
- * inside someone else's transaction — must use this instead of a service method that
- * opens its own connection.
+ * Whether this build surfaces the provider owning a persisted row. Callers that
+ * already hold the identity columns — anything reading inside someone else's
+ * transaction — use this instead of a service method that opens its own connection.
  */
 export function isProviderIdentityAvailable(row: ProviderIdentity): boolean {
-  return getAvailableProviderMetadata(row) !== null
+  return resolveProviderDecision(row) !== null
 }
 
 /**
@@ -152,13 +160,33 @@ function assertManagedCherryProviderMutationAllowed(providerId: string, operatio
   throw DataApiErrorFactory.invalidOperation(operation, 'managed Cherry provider cannot be modified')
 }
 
-function assertProviderAvailable<T extends ProviderIdentity>(
+/**
+ * Retired vendors stay frozen: the service is gone, so the row is readable history,
+ * not editable configuration. This is deliberately NOT the edition rule — editions
+ * share one database, so an edition never blocks a write. Keeping them apart is why
+ * the edition rule lives at materialization alone.
+ */
+function assertProviderNotRetired<T extends ProviderIdentity>(
   row: T | null | undefined,
   providerId: string
 ): asserts row is T {
-  if (!row || !isProviderIdentityAvailable(row)) {
+  if (!row || isRetiredProvider(row.providerId, row.presetProviderId)) {
     throw DataApiErrorFactory.notFound('Provider', providerId)
   }
+}
+
+/**
+ * The only way to materialize a runtime `Provider` from a row. `rowToRuntimeProvider`
+ * takes the display metadata as a required argument and this is where that argument
+ * comes from, so a provider the edition does not offer cannot be constructed at all —
+ * read paths stay filtered without each one repeating the check.
+ */
+function toRuntimeProvider(row: UserProviderRow): Provider {
+  const decision = resolveProviderDecision(row)
+  if (!decision) {
+    throw DataApiErrorFactory.notFound('Provider', row.providerId)
+  }
+  return rowToRuntimeProvider(row, decision)
 }
 
 function normalizeApiKeyEntry(entry: ApiKeyEntry): ApiKeyEntry {
@@ -269,10 +297,9 @@ function projectEndpointConfigOverrides(
 /**
  * Convert database row to Provider entity
  */
-function rowToRuntimeProvider(row: UserProviderRow, metadata?: ProviderDisplayMetadata): Provider {
+function rowToRuntimeProvider(row: UserProviderRow, decision: EditionDecision<ProviderDisplayMetadata>): Provider {
   const providerRegistryService = getDataService('ProviderRegistryService')
-  const presetMetadata =
-    metadata ?? providerRegistryService.getProviderDisplayMetadata(row.providerId, row.presetProviderId)
+  const presetMetadata = decision.entry
 
   // Process API keys (strip actual key values for security)
   // oxlint-disable-next-line no-unused-vars
@@ -372,8 +399,8 @@ class ProviderService {
 
     const providers: Provider[] = []
     for (const row of rows) {
-      const metadata = getAvailableProviderMetadata(row)
-      if (metadata) providers.push(rowToRuntimeProvider(row, metadata))
+      const decision = resolveProviderDecision(row)
+      if (decision) providers.push(rowToRuntimeProvider(row, decision))
     }
     return providers
   }
@@ -414,33 +441,15 @@ class ProviderService {
     return row !== undefined && isProviderIdentityAvailable(row)
   }
 
-  /** Assert that a persisted provider is available to runtime callers in this application edition. */
-  assertAvailable(providerId: string): void {
-    const [row] = application
-      .get('DbService')
-      .getDb()
-      .select({
-        providerId: userProviderTable.providerId,
-        presetProviderId: userProviderTable.presetProviderId
-      })
-      .from(userProviderTable)
-      .where(eq(userProviderTable.providerId, providerId))
-      .limit(1)
-      .all()
-
-    assertProviderAvailable(row, providerId)
-  }
-
   /**
    * Get a provider by its provider ID
    */
   getByProviderId(providerId: string): Provider {
     const db = application.get('DbService').getDb()
     const [row] = db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId)).limit(1).all()
+    assertProviderNotRetired(row, providerId)
 
-    assertProviderAvailable(row, providerId)
-
-    return rowToRuntimeProvider(row)
+    return toRuntimeProvider(row)
   }
 
   /**
@@ -457,16 +466,17 @@ class ProviderService {
       dto.providerId,
       dto.presetProviderId ?? null
     )
-    const presetMetadata = getDataService('ProviderRegistryService').getProviderDisplayMetadata(
-      dto.providerId,
-      dto.presetProviderId ?? null
-    )
-    if (!isProviderAvailableInCurrentEdition(presetMetadata)) {
+    const registry = getDataService('ProviderRegistryService')
+    const presetProviderId = dto.presetProviderId ?? null
+    // The one place with no row to scope, so the identity is scoped directly: a copy of
+    // a preset this build withholds must not be creatable either.
+    if (!providerScope.resolve({ providerId: dto.providerId, presetProviderId })) {
       throw DataApiErrorFactory.invalidOperation(
         `create provider ${dto.providerId}`,
         'provider is unavailable in the current application edition'
       )
     }
+    const presetMetadata = registry.getProviderDisplayMetadata(dto.providerId, presetProviderId)
     const defaultChatEndpoint =
       dto.defaultChatEndpoint !== presetMetadata.defaultChatEndpoint ? (dto.defaultChatEndpoint ?? null) : null
 
@@ -499,7 +509,7 @@ class ProviderService {
 
     logger.info('Created provider', { providerId: dto.providerId })
 
-    return rowToRuntimeProvider(row)
+    return toRuntimeProvider(row)
   }
 
   /**
@@ -532,8 +542,7 @@ class ProviderService {
         .where(eq(userProviderTable.providerId, providerId))
         .limit(1)
         .all()
-
-      assertProviderAvailable(current, providerId)
+      assertProviderNotRetired(current, providerId)
 
       const updates: Partial<InsertUserProviderRow> = {}
 
@@ -598,7 +607,7 @@ class ProviderService {
 
     logger.info('Updated provider', { providerId, changes: Object.keys(dto) })
 
-    return rowToRuntimeProvider(row)
+    return toRuntimeProvider(row)
   }
 
   /**
@@ -637,8 +646,7 @@ class ProviderService {
   resolveApiKey(providerId: string, override?: string): ResolvedProviderApiKey {
     const db = application.get('DbService').getDb()
     const [row] = db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId)).limit(1).all()
-
-    assertProviderAvailable(row, providerId)
+    assertProviderNotRetired(row, providerId)
 
     const allKeys = row.apiKeys ?? []
     if (override !== undefined) {
@@ -692,8 +700,7 @@ class ProviderService {
   getApiKeys(providerId: string, options: { enabled?: boolean } = {}): ApiKeyEntry[] {
     const db = application.get('DbService').getDb()
     const [row] = db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId)).limit(1).all()
-
-    assertProviderAvailable(row, providerId)
+    assertProviderNotRetired(row, providerId)
 
     const apiKeys = row.apiKeys ?? []
     return options.enabled ? apiKeys.filter((k) => k.isEnabled) : apiKeys
@@ -705,8 +712,7 @@ class ProviderService {
   getAuthConfig(providerId: string): AuthConfig | null {
     const db = application.get('DbService').getDb()
     const [row] = db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId)).limit(1).all()
-
-    assertProviderAvailable(row, providerId)
+    assertProviderNotRetired(row, providerId)
 
     return row.authConfig ?? null
   }
@@ -726,14 +732,13 @@ class ProviderService {
         .where(eq(userProviderTable.providerId, providerId))
         .limit(1)
         .all()
-
-      assertProviderAvailable(row, providerId)
+      assertProviderNotRetired(row, providerId)
 
       const existingKeys = row.apiKeys ?? []
 
       // Skip if key value already exists
       if (existingKeys.some((k) => k.key === key)) {
-        return { provider: rowToRuntimeProvider(row), added: false }
+        return { provider: toRuntimeProvider(row), added: false }
       }
 
       const newEntry = {
@@ -752,7 +757,7 @@ class ProviderService {
         .returning()
         .all()
 
-      return { provider: rowToRuntimeProvider(updated), added: true }
+      return { provider: toRuntimeProvider(updated), added: true }
     })
 
     if (added) {
@@ -772,18 +777,6 @@ class ProviderService {
 
     const db = application.get('DbService').getDb()
     const provider = db.transaction((tx) => {
-      const [current] = tx
-        .select({
-          providerId: userProviderTable.providerId,
-          presetProviderId: userProviderTable.presetProviderId
-        })
-        .from(userProviderTable)
-        .where(eq(userProviderTable.providerId, providerId))
-        .limit(1)
-        .all()
-
-      assertProviderAvailable(current, providerId)
-
       const normalizedApiKeys = normalizeApiKeyEntries(apiKeys)
       const [row] = tx
         .update(userProviderTable)
@@ -791,12 +784,13 @@ class ProviderService {
         .where(eq(userProviderTable.providerId, providerId))
         .returning()
         .all()
+      assertProviderNotRetired(row, providerId)
 
       if (!row) {
         throw DataApiErrorFactory.notFound('Provider', providerId)
       }
 
-      return rowToRuntimeProvider(row)
+      return toRuntimeProvider(row)
     })
 
     logger.info('Replaced provider API keys', { providerId, count: apiKeys.length })
@@ -826,8 +820,7 @@ class ProviderService {
         .where(eq(userProviderTable.providerId, providerId))
         .limit(1)
         .all()
-
-      assertProviderAvailable(row, providerId)
+      assertProviderNotRetired(row, providerId)
 
       const existingKeys = row.apiKeys ?? []
       const keyIndex = existingKeys.findIndex((entry) => entry.id === keyId)
@@ -874,7 +867,7 @@ class ProviderService {
         .returning()
         .all()
 
-      return rowToRuntimeProvider(updated)
+      return toRuntimeProvider(updated)
     })
 
     logger.info('Updated API key', { providerId, keyId, changes: Object.keys(updates) })
@@ -896,8 +889,7 @@ class ProviderService {
         .where(eq(userProviderTable.providerId, providerId))
         .limit(1)
         .all()
-
-      assertProviderAvailable(row, providerId)
+      assertProviderNotRetired(row, providerId)
 
       const existingKeys = row.apiKeys ?? []
       const updatedKeys = existingKeys.filter((entry) => entry.id !== keyId)
@@ -913,7 +905,7 @@ class ProviderService {
         .returning()
         .all()
 
-      return rowToRuntimeProvider(updated)
+      return toRuntimeProvider(updated)
     })
 
     logger.info('Deleted API key from provider', { providerId, keyId })
@@ -938,8 +930,7 @@ class ProviderService {
         .where(eq(userProviderTable.providerId, providerId))
         .limit(1)
         .all()
-
-      assertProviderAvailable(provider, providerId)
+      assertProviderNotRetired(provider, providerId)
 
       // Block deletion of canonical preset rows. `presetProviderId === providerId`
       // covers presets that group under themselves; the registry check also
@@ -990,7 +981,6 @@ class ProviderService {
 
   move(providerId: string, anchor: OrderRequest): void {
     assertManagedCherryProviderMutationAllowed(providerId, `move provider ${providerId}`)
-    this.assertAvailable(providerId)
 
     const db = application.get('DbService').getDb()
 
@@ -1009,7 +999,6 @@ class ProviderService {
   reorder(moves: OrderBatchRequest['moves']): void {
     for (const move of moves) {
       assertManagedCherryProviderMutationAllowed(move.id, `move provider ${move.id}`)
-      this.assertAvailable(move.id)
     }
 
     const db = application.get('DbService').getDb()

--- a/src/main/data/services/__tests__/MiniAppService.edition.test.ts
+++ b/src/main/data/services/__tests__/MiniAppService.edition.test.ts
@@ -1,0 +1,79 @@
+import { miniAppTable } from '@data/db/schemas/miniApp'
+import { miniAppService } from '@data/services/MiniAppService'
+import { ErrorCode } from '@shared/data/api/errors'
+import type { AppEdition } from '@shared/types/appEdition'
+import { setupTestDatabase } from '@test-helpers/db'
+import { eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { applicationEdition, migrationOrigin } = vi.hoisted(() => ({
+  applicationEdition: { current: 'cn' as AppEdition },
+  migrationOrigin: { current: false }
+}))
+
+vi.mock('@main/utils/appEdition', () => ({ getAppEdition: () => applicationEdition.current }))
+vi.mock('@data/migration/v1MigrationOrigin', () => ({ isMigratedFromV1: () => migrationOrigin.current }))
+
+/** `openai` declares `supportedRegions: ['Global']`; `radeon-cloud` declares both. */
+const GLOBAL_ONLY_PRESET = 'openai'
+const BOTH_EDITIONS_PRESET = 'radeon-cloud'
+
+describe('MiniAppService edition availability', () => {
+  const dbh = setupTestDatabase()
+
+  beforeEach(async () => {
+    applicationEdition.current = 'cn'
+    migrationOrigin.current = false
+    await dbh.db.insert(miniAppTable).values([
+      {
+        appId: GLOBAL_ONLY_PRESET,
+        presetMiniAppId: GLOBAL_ONLY_PRESET,
+        name: 'ChatGPT',
+        url: 'https://chatgpt.com/',
+        status: 'enabled',
+        orderKey: 'a0'
+      },
+      {
+        appId: BOTH_EDITIONS_PRESET,
+        presetMiniAppId: BOTH_EDITIONS_PRESET,
+        name: 'AMD GPU Cloud',
+        url: 'https://developer.amd.com.cn/radeon/',
+        status: 'enabled',
+        orderKey: 'a1'
+      },
+      {
+        appId: 'my-own-app',
+        presetMiniAppId: null,
+        name: 'My own app',
+        url: 'https://example.com/',
+        status: 'enabled',
+        orderKey: 'a2'
+      }
+    ])
+  })
+
+  it('withholds a global-only preset app from every surface in China', () => {
+    expect(miniAppService.list().map((app) => app.appId)).toEqual([BOTH_EDITIONS_PRESET, 'my-own-app'])
+    expect(() => miniAppService.getByAppId(GLOBAL_ONLY_PRESET)).toThrowError(
+      expect.objectContaining({ code: ErrorCode.NOT_FOUND })
+    )
+  })
+
+  it('leaves the row untouched so switching back to the global edition restores it', async () => {
+    applicationEdition.current = 'global'
+
+    expect(miniAppService.list().map((app) => app.appId)).toContain(GLOBAL_ONLY_PRESET)
+    const [persisted] = await dbh.db.select().from(miniAppTable).where(eq(miniAppTable.appId, GLOBAL_ONLY_PRESET))
+    expect(persisted.name).toBe('ChatGPT')
+  })
+
+  it('never withholds a user-authored app, which belongs to no catalog', () => {
+    expect(miniAppService.getByAppId('my-own-app').appId).toBe('my-own-app')
+  })
+
+  it('exempts profiles migrated from v1, matching providers', () => {
+    migrationOrigin.current = true
+
+    expect(miniAppService.list().map((app) => app.appId)).toContain(GLOBAL_ONLY_PRESET)
+  })
+})

--- a/src/main/data/services/__tests__/MiniAppService.test.ts
+++ b/src/main/data/services/__tests__/MiniAppService.test.ts
@@ -15,6 +15,10 @@ import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceServi
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it, type Mock } from 'vitest'
 
+// This file exercises CRUD, not edition scoping: pin the edition so preset apps that
+// declare a region stay visible. Edition behaviour is covered by the edition tests.
+vi.mock('@main/utils/appEdition', () => ({ getAppEdition: () => 'global' }))
+
 /** Every row the service maps today is a site row; narrow so site-only fields can be asserted. */
 function expectSite(app: MiniApp): SiteMiniApp {
   if (app.kind !== 'site') throw new Error(`Expected a site mini app, got kind=${app.kind}`)

--- a/src/main/data/services/__tests__/ModelService.edition.test.ts
+++ b/src/main/data/services/__tests__/ModelService.edition.test.ts
@@ -102,7 +102,12 @@ describe('ModelService edition availability', () => {
     expect(modelService.getNamesByUniqueIdsTx(dbh.db, ['global-only::hidden-model'])).toEqual(new Map())
   })
 
-  it('rejects every direct read and write path for an unavailable persisted provider before mutation', async () => {
+  /**
+   * Editions ship one database, so the rule withholds the model from every surface
+   * without withholding the row: a write still lands, and switching back to the
+   * global edition brings the model back with the edit on it.
+   */
+  it('withholds the model from reads while leaving the row writable', async () => {
     await dbh.db.insert(userProviderTable).values({
       providerId: 'global-only',
       presetProviderId: 'global-only',
@@ -111,27 +116,16 @@ describe('ModelService edition availability', () => {
     })
     await dbh.db.insert(userModelTable).values(modelRow('global-only', 'hidden-model', 'a0'))
 
-    const calls: Array<[string, () => unknown]> = [
-      ['getByKey', () => modelService.getByKey('global-only', 'hidden-model')],
-      ['create', () => modelService.create([{ dto: { providerId: 'global-only', modelId: 'new-model' } }])],
-      ['update', () => modelService.update('global-only', 'hidden-model', { name: 'changed' })],
-      [
-        'bulkUpdate',
-        () =>
-          modelService.bulkUpdate([{ providerId: 'global-only', modelId: 'hidden-model', patch: { name: 'changed' } }])
-      ],
-      ['reconcileForProvider', () => modelService.reconcileForProvider('global-only', { toAdd: [], toRemove: [] })],
-      ['delete', () => modelService.delete('global-only', 'hidden-model')],
-      ['bulkDelete', () => modelService.bulkDelete([{ providerId: 'global-only', modelId: 'hidden-model' }])]
-    ]
+    expect(() => modelService.getByKey('global-only', 'hidden-model')).toThrowError(
+      expect.objectContaining({ code: ErrorCode.NOT_FOUND })
+    )
+    expect(modelService.list({}).map((model) => model.id)).toEqual([])
 
-    for (const [, invoke] of calls) {
-      expect(invoke).toThrowError(expect.objectContaining({ code: ErrorCode.NOT_FOUND }))
-    }
+    modelService.update('global-only', 'hidden-model', { name: 'changed' })
 
     const rows = await dbh.db.select().from(userModelTable).where(eq(userModelTable.providerId, 'global-only'))
     expect(rows).toHaveLength(1)
-    expect(rows[0].name).toBe('hidden-model')
+    expect(rows[0].name).toBe('changed')
   })
 
   it('keeps every persisted model available for users migrated from v1', async () => {

--- a/src/main/data/services/__tests__/ProviderService.edition.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.edition.test.ts
@@ -1,5 +1,8 @@
+// Side-effect import: registers ProviderRegistryService in the data-service registry,
+// which the edition scope looks up.
+import '@data/services/ProviderRegistryService'
+
 import { userProviderTable } from '@data/db/schemas/userProvider'
-import { providerRegistryService } from '@data/services/ProviderRegistryService'
 import { providerService } from '@data/services/ProviderService'
 import { ErrorCode } from '@shared/data/api/errors'
 import type { AppEdition } from '@shared/types/appEdition'
@@ -55,7 +58,13 @@ describe('ProviderService edition availability', () => {
     migrationOrigin.current = false
   })
 
-  it('makes a persisted global-only provider unavailable to every runtime read and mutation in China', async () => {
+  /**
+   * Editions ship one database — seeders and migrators populate both identically —
+   * so the rule decides what this build surfaces, never what the profile stores.
+   * The row, its name and its API keys survive untouched, and switching back to the
+   * global edition restores the provider with everything still on it.
+   */
+  it('withholds a persisted global-only provider from every surface in China', async () => {
     await dbh.db.insert(userProviderTable).values([
       {
         providerId: 'global-only',
@@ -72,35 +81,15 @@ describe('ProviderService edition availability', () => {
       }
     ])
 
-    const displayMetadataSpy = vi.spyOn(providerRegistryService, 'getProviderDisplayMetadata')
     expect(providerService.list({}).map((provider) => provider.id)).toEqual(['custom-provider'])
-    expect(displayMetadataSpy).toHaveBeenCalledTimes(2)
-    displayMetadataSpy.mockRestore()
     expect(providerService.listAvailableProviderIds()).toEqual(new Set(['custom-provider']))
     expect(providerService.listAvailableProviderIds(['global-only', 'custom-provider'])).toEqual(
       new Set(['custom-provider'])
     )
     expect(providerService.isAvailableByProviderId('global-only')).toBe(false)
-
-    const calls: Array<() => unknown> = [
-      () => providerService.assertAvailable('global-only'),
-      () => providerService.getByProviderId('global-only'),
-      () => providerService.resolveApiKey('global-only'),
-      () => providerService.getApiKeys('global-only'),
-      () => providerService.getAuthConfig('global-only'),
-      () => providerService.addApiKey('global-only', 'new-secret'),
-      () => providerService.replaceApiKeys('global-only', []),
-      () => providerService.updateApiKey('global-only', 'key-1', { label: 'Changed' }),
-      () => providerService.deleteApiKey('global-only', 'key-1'),
-      () => providerService.update('global-only', { name: 'Changed' }),
-      () => providerService.move('global-only', { position: 'last' }),
-      () => providerService.reorder([{ id: 'global-only', anchor: { position: 'last' } }]),
-      () => providerService.delete('global-only')
-    ]
-
-    for (const invoke of calls) {
-      expect(invoke).toThrowError(expect.objectContaining({ code: ErrorCode.NOT_FOUND }))
-    }
+    expect(() => providerService.getByProviderId('global-only')).toThrowError(
+      expect.objectContaining({ code: ErrorCode.NOT_FOUND })
+    )
 
     const [persisted] = await dbh.db
       .select()
@@ -108,22 +97,6 @@ describe('ProviderService edition availability', () => {
       .where(eq(userProviderTable.providerId, 'global-only'))
     expect(persisted.name).toBe('Global only')
     expect(persisted.apiKeys).toEqual([{ id: 'key-1', key: 'secret', isEnabled: true }])
-  })
-
-  it('enforces edition availability in provider-backed registry reads', async () => {
-    await dbh.db.insert(userProviderTable).values({
-      providerId: 'global-only',
-      presetProviderId: 'global-only',
-      name: 'Global only',
-      orderKey: 'a0'
-    })
-
-    expect(() => providerRegistryService.resolveModels('global-only', ['model'])).toThrowError(
-      expect.objectContaining({ code: ErrorCode.NOT_FOUND })
-    )
-    expect(() => providerRegistryService.getImageGenerationSupport('global-only', 'model')).toThrowError(
-      expect.objectContaining({ code: ErrorCode.NOT_FOUND })
-    )
   })
 
   it('rejects creating a provider from a preset unavailable in the current edition', async () => {
@@ -152,6 +125,27 @@ describe('ProviderService edition availability', () => {
     })
 
     expect(providerService.getByProviderId('global-only').id).toBe('global-only')
+  })
+
+  /**
+   * Withholding needs a positive statement in the catalog. Treating an unlisted
+   * preset as withheld would make every provider the catalog drops disappear from
+   * the profiles still using it — and would leave a partially readable registry
+   * silently revoking providers instead of reporting a problem.
+   */
+  it('keeps a provider the catalog does not list, while still withholding a listed one', async () => {
+    await dbh.db.insert(userProviderTable).values([
+      {
+        providerId: 'not-in-catalog',
+        presetProviderId: 'not-in-catalog',
+        name: 'Dropped from the catalog',
+        orderKey: 'a0'
+      },
+      { providerId: 'global-only', presetProviderId: 'global-only', name: 'Global only', orderKey: 'a1' }
+    ])
+
+    expect(providerService.list({}).map((provider) => provider.id)).toEqual(['not-in-catalog'])
+    expect(providerService.getByProviderId('not-in-catalog').id).toBe('not-in-catalog')
   })
 
   it('keeps every persisted provider available for users migrated from v1', async () => {

--- a/src/main/data/services/__tests__/ProviderService.readMerge.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.readMerge.test.ts
@@ -111,7 +111,6 @@ describe('ProviderService read-time registry merge (#17096)', () => {
         { providerId: `${retiredId}-copy`, keyId: `${retiredId}-copy-key` }
       ]) {
         const operations = [
-          () => providerService.assertAvailable(providerId),
           () => providerService.update(providerId, { name: 'Still retired' }),
           () => providerService.resolveApiKey(providerId),
           () => providerService.getApiKeys(providerId),

--- a/src/main/data/services/editionPolicy.ts
+++ b/src/main/data/services/editionPolicy.ts
@@ -1,0 +1,83 @@
+import { isMigratedFromV1 } from '@data/migration/v1MigrationOrigin'
+import { getAppEdition } from '@main/utils/appEdition'
+import type { AppEdition } from '@shared/types/appEdition'
+
+/**
+ * Edition availability for catalog-backed entities (providers, mini apps).
+ *
+ * The rule is declared once per entity via {@link defineEditionScope} and reaches
+ * the code through the type system rather than through a call convention: a scope
+ * is the only producer of an {@link EditionDecision}, and each entity's row → domain
+ * mapper takes one as a required argument. An entity this build withholds cannot be
+ * materialized, so nothing that surfaces it needs its own check — and a new mapper
+ * that forgets the rule does not compile.
+ *
+ * What belongs here, and what must not:
+ *
+ * - Only build-time inputs. A runtime signal (detected region, a user setting)
+ *   cannot carry a compliance rule: the same artifact would behave differently per
+ *   machine, and anything the user can flip is not a restriction. Region-based
+ *   curation is a separate, weaker concern and stays where it is.
+ * - Nothing is persisted, and nothing is withheld from a write. Editions share one
+ *   database — seeders and migrators populate both identically — so an edition must
+ *   never cause a row to be written, cleared or skipped. It decides what this build
+ *   surfaces, not what the profile contains.
+ */
+export interface EditionScopedEntry {
+  availableInEditions?: readonly AppEdition[]
+}
+
+declare const editionScoped: unique symbol
+
+/**
+ * Proof that the edition rule was applied to one entity. Produced only by
+ * `EditionScope.resolve`; `withheld` produces no value at all, so a caller cannot
+ * reach the mapper without handling that case.
+ *
+ * `unscoped` covers rows that belong to no catalog — a fully custom provider, a
+ * user-authored mini app. The edition has no opinion on what the user built.
+ */
+export type EditionDecision<Entry> = { readonly [editionScoped]: true; entry: Entry } & (
+  | { status: 'allowed' }
+  | { status: 'unscoped' }
+)
+
+export interface EditionScope<Identity, Entry> {
+  /** `null` when this build withholds the entity. */
+  resolve(identity: Identity): EditionDecision<Entry> | null
+}
+
+/**
+ * Declare an entity as edition-scoped.
+ *
+
+ * `lookup` returns the catalog entry behind a row plus whether the row has a catalog
+ * identity at all. An entry that the catalog does not describe is **not** withheld:
+ * withholding requires a positive statement in the catalog, because rows are the
+ * source of truth and a catalog that dropped an entry — or failed to load — must not
+ * silently revoke what a profile is already using.
+ */
+export function defineEditionScope<Identity, Entry extends EditionScopedEntry>(spec: {
+  lookup: (identity: Identity) => { entry: Entry; scoped: boolean }
+}): EditionScope<Identity, Entry> {
+  return {
+    resolve(identity) {
+      const { entry, scoped } = spec.lookup(identity)
+      if (!scoped) return { status: 'unscoped', entry } as EditionDecision<Entry>
+      if (!isAllowedInCurrentEdition(entry)) return null
+      return { status: 'allowed', entry } as EditionDecision<Entry>
+    }
+  }
+}
+
+/**
+ * Whether the running build offers this catalog entry.
+ *
+ * A profile upgraded from v1 is exempt wholesale: its entities predate the edition
+ * split. Reading the exemption here keeps it at the single seam instead of leaking
+ * into every consumer.
+ */
+export function isAllowedInCurrentEdition(entry: EditionScopedEntry): boolean {
+  if (isMigratedFromV1()) return true
+  return !entry.availableInEditions || entry.availableInEditions.includes(getAppEdition())
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Edition availability was enforced by remembering to call an assertion — eleven
`assertProviderAvailable` sites in `ProviderService`, five more in `ModelService`, two
in `ProviderRegistryService`. Nothing failed when a call site was missing, so the rule
and its enforcement points had drifted apart, and extending the rule to a second entity
meant repeating the discipline by hand. Mini apps had not been brought under the rule at
all: their visibility was filtered in the renderer from an IP-detected region that the
user can override in Settings.

After this PR:

`editionPolicy` declares an entity as edition-scoped once. An `EditionScope` is the only
producer of an `EditionDecision`, each entity's row → domain mapper takes one as a
required argument, and a withheld entity produces no decision at all. An entity this
build does not offer therefore cannot be materialized, and a read path that skips the
rule fails to compile rather than leaking. Providers and mini apps now share one
declaration, one pure predicate and one enforcement seam each.

Fixes # N/A

### Why we need it and why it was done in this way

Edition availability is a property of the build, not of the profile: both editions ship
one database, and seeders and migrators populate them identically. The rule therefore
decides what a build *surfaces*, never what a profile *stores*. Two consequences shape
the design:

- Every write assertion is gone. A row, its name and its API keys survive an edition
  switch untouched, and switching back restores the entity intact. The two Windows
  installers deliberately share one NSIS `guid`, and a backup restores across editions,
  so an edition is reversible — it must never drive an irreversible write.
- Withholding requires a positive statement in the catalog. A preset the registry no
  longer lists, or a registry that cannot be read, is not withheld; failing closed there
  would revoke providers a profile is already using, which `ProviderService.readMerge`
  already pins.

The following tradeoffs were made:

- Retired vendors keep a separate guard, `assertProviderNotRetired`, on nine paths. That
  rule freezes rows because the service is gone — permanent, unlike an edition — and
  folding it into the edition seam would let a mutation land before the response failed
  to materialize. Splitting the two is why the edition rule could shrink to one seam.
- `rowToMiniApp` takes a decision it never reads: a mini app renders entirely from its
  row, so the parameter exists purely as the type-level gate.
- A brand can still be forged with `as`. An `edition-brand/no-as-edition-decision` lint
  makes that visible, mirroring the existing `filepath-brand` rule; a missing assertion
  was invisible.

The following alternatives were considered:

- Keeping the assertions and adding more as entities are added — rejected: the count
  tracked methods rather than the rule, so it grew with every requirement change.
- Routing all reads through a single row-loading function, or a DataApi middleware that
  rejects requests carrying a withheld id — both rejected: they enforce an authorization
  model the requirement does not ask for, since editions share one database and writes
  are legitimate.
- Stripping withheld entries from the shipped catalog at build time — rejected: absence
  is deliberately not withholding, so a stripped catalog would make restricted entries
  available rather than hidden, and the v1 exemption needs those entries present.

Links to places where the discussion took place: N/A

### Breaking changes

Mini app visibility now follows the build edition instead of the runtime region.
Previously a China-edition user whose IP resolved abroad saw global-only mini apps; they
no longer appear, and a global-edition user in China keeps theirs. Region detection stays
in place as ordering and relevance curation. No data is deleted or rewritten, and no user
action is required.

### Special notes for your reviewer

- The provider rule itself is unchanged: same catalog input, same v1-migration exemption,
  same outcomes for reads. What changed is where it is enforced and that writes no longer
  fail on it.
- `ProviderService.edition.test.ts` and `ModelService.edition.test.ts` were rewritten from
  "every read and mutation throws" to "withheld from every surface, row untouched and
  still writable", which is the contract this PR implements.
- A call-count assertion on `getProviderDisplayMetadata` was dropped: it pinned how often
  a collaborator is consulted, which the new short circuit changes without changing the
  contract the surrounding assertions cover.
- Validation: `pnpm exec vitest run --project main src/main/data` — 3598 passed, 1 skipped.
  `pnpm run typecheck:node`, `eslint`, `oxlint --deny-warnings` and `biome check` are clean
  on the changed files. Unrelated pre-existing failures in
  `src/main/services/file/tree/__tests__/builder.test.ts` (chokidar timing) reproduce on a
  clean tree and touch none of the changed modules.
- Commit is SSH-signed and DCO-signed off.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Mini Apps] Mini app availability now follows the installed edition instead of the detected network region, so the set of built-in mini apps no longer changes while travelling.
```
