### PR TITLE
docs(contributing): restore the missing DCO sign-off example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,10 @@ Reviewers will be assigned after you mark the draft pull request as ready for re
 We require every contributor to certify that they have the right to legally contribute to our project. Contributors express this by consciously signing their commits, thereby indicating their compliance with the [LICENSE](LICENSE).
 A signed commit is one where the commit message includes the following:
 
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
 You can generate a signed commit using the following command [git commit --signoff](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff):
 
 ```


### PR DESCRIPTION
### What this PR does

Before this PR:

The "Contributor Compliance with Project Terms" section of `CONTRIBUTING.md` promises an example and then never shows it. It reads *"A signed commit is one where the commit message includes the following:"*, and the next non-empty line moves on to a different topic (the `git commit --signoff` command). The `Signed-off-by:` trailer the sentence introduces is missing, so the sentence dangles and contributors are asked to certify their commits without ever being shown the exact trailer format. `Signed-off-by` currently does not appear in any Markdown file in the repository.

After this PR:

The promised fenced example is restored immediately under that sentence, so the paragraph introduces the trailer, shows it, and only then explains how to generate it:

```
Signed-off-by: Your Name <your.email@example.com>
```

### Why we need it and why it was done in this way

This is a regression from the guide's translation, not a gap that was never filled:

- `a5f8ac8587` ("feat: add English contributor guide and update issue templates", #5300) introduced this section in Chinese **with** the fenced block `Signed-off-by: Your Name <your.email@example.com>`.
- `2807e71f1a` ("docs: contributor guide"), committed ten minutes later, replaced the Chinese sentence with the English one that is still in the file today and removed the fenced block along with it.

Both can be verified locally with `git show 2807e71f1a -- CONTRIBUTING.md` and `git log -S'Signed-off-by:' -- CONTRIBUTING.md`, which lists exactly these two commits and nothing since.

The restored line is byte-for-byte the example this project already shipped in `a5f8ac8587`, so no new wording is invented. It also lines up with the upstream guide this documentation is derived from (`kubevirt/kubevirt`, credited in this repository's PR template), where the same sentence is likewise followed by a `Signed-off-by:` block.

The following tradeoffs were made: the change is confined to restoring the lost block. The surrounding sentences, the existing `--signoff` command example, and the heading are left untouched so the diff stays trivially reviewable.

The following alternatives were considered: rewording the sentence to drop its promise instead of restoring the example. That was rejected because signing off is a real requirement for every contributor here, so showing the exact trailer is more useful than deleting the reference to it.

### Breaking changes

None. This is a documentation-only change.

### Special notes for your reviewer

- Scope is one file and a four-line addition, with no deletions and nothing else bundled in.
- No links are added, so `pnpm docs:check-links` behaviour is unchanged. `biome.jsonc` excludes `*.md` from the formatter, so there is no formatting impact either.
- The change is text-only and touches no source, tests, or build configuration.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: No code is changed; the documentation edit is intended to be self-explanatory
- [x] Refactor: No refactoring is bundled with this change
- [x] Upgrade: Not applicable, documentation only
- [x] Documentation: This PR *is* the documentation fix; it changes no user-facing feature or behavior, so no user-guide update is required
- [x] Self-review: Reviewed via `gh pr diff` before opening

### Release note

```release-note
NONE
```
