### PR TITLE
fix(agent-runtime): honor per-server MCP timeout in Pi and dsh runtimes

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -37,6 +37,7 @@ import {
 } from './mcpClientSdk'
 import type { McpPackageService } from './McpPackageService'
 import { redactCacheKey } from './mcpRedact'
+import { resolveMcpRequestOptions } from './mcpRequestOptions'
 import { createTransport, isMcpOAuthEnabled } from './mcpTransport'
 import { CallBackServer } from './oauth/callback'
 import { McpOAuthClientProvider } from './oauth/provider'
@@ -1088,11 +1089,9 @@ export class McpRuntimeService extends BaseService {
               })
             }
           },
-          timeout: server.timeout ? server.timeout * 1000 : 60000, // Default timeout of 1 minute,
-          // 需要服务端支持: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#timeouts
-          // Need server side support: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#timeouts
-          resetTimeoutOnProgress: server.longRunning,
-          maxTotalTimeout: server.longRunning ? 10 * 60 * 1000 : undefined,
+          ...resolveMcpRequestOptions(server),
+          // resetTimeoutOnProgress 需要服务端支持: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#timeouts
+          // resetTimeoutOnProgress needs server side support: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#timeouts
           signal: effectiveSignal
         })
         return result as McpCallToolResponse

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.timeoutPolicy.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.timeoutPolicy.test.ts
@@ -1,0 +1,151 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+  type Progress
+} from '@modelcontextprotocol/sdk/types.js'
+import { MockMainCacheServiceUtils } from '@test-mocks/main/CacheService'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BaseService } from '@main/core/lifecycle'
+import type { McpServer as McpServerEntity } from '@shared/data/types/mcpServer'
+
+const mcpCatalogMock = vi.hoisted(() => ({
+  clearSharedToolsCache: vi.fn(),
+  refreshTools: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({ McpCatalogService: mcpCatalogMock } as Record<string, unknown>)
+})
+
+const getByIdMock = vi.fn<(id: string) => McpServerEntity>()
+vi.mock('@data/services/McpServerService', () => ({
+  mcpServerService: { getById: (id: string) => getByIdMock(id) }
+}))
+
+const { McpRuntimeService } = await import('../McpRuntimeService')
+
+type CallHandler = (
+  request: { params: { _meta?: { progressToken?: string | number } } },
+  extra: {
+    signal: AbortSignal
+    sendNotification: (notification: {
+      method: 'notifications/progress'
+      params: Progress & { progressToken: string | number }
+    }) => Promise<void>
+  }
+) => Promise<CallToolResult>
+
+/**
+ * Real-SDK behavior tests for the timeout policy McpRuntimeService owns: a real Client over
+ * InMemoryTransport so the SDK's request timer and progress-reset machinery actually run,
+ * driven by fake timers. These are the regression guards for #20266 — asserting call outcomes,
+ * never the RequestOptions shape (#20297 review).
+ */
+describe('McpRuntimeService.callTool timeout policy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    BaseService.resetInstances()
+    MockMainCacheServiceUtils.resetMocks()
+    getByIdMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Real SDK client wired to an in-memory server whose tool handler is `handler`. */
+  async function connectRealClient(handler: CallHandler): Promise<Client> {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    const server = new McpServer({ name: 'slow', version: '1.0.0' }, { capabilities: { tools: {} } })
+    server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [{ name: 'slow-tool', description: 'slow', inputSchema: { type: 'object' } }]
+    }))
+    server.server.setRequestHandler(CallToolRequestSchema, async (request, extra) =>
+      handler(request as Parameters<CallHandler>[0], extra)
+    )
+    await server.connect(serverTransport)
+    const client = new Client({ name: 'cherry-test', version: '1.0.0' }, { capabilities: {} })
+    await client.connect(clientTransport)
+    return client
+  }
+
+  function serverWith(policy: { timeout?: number; longRunning?: boolean }): McpServerEntity {
+    return { id: 'srv', name: 'srv', isActive: true, ...policy }
+  }
+
+  it('terminates a call at the per-server timeout', async () => {
+    getByIdMock.mockReturnValue(serverWith({ timeout: 1 }))
+    const client = await connectRealClient(async () => new Promise<CallToolResult>(() => {}))
+    const service = new McpRuntimeService()
+    vi.spyOn(service as any, 'getOrCreateClient').mockResolvedValue(client)
+
+    const call = service.callTool({ serverId: 'srv', name: 'slow-tool', args: {} })
+    const rejection = expect(call).rejects.toThrow(/timed out/i)
+    await vi.advanceTimersByTimeAsync(1_000)
+    await rejection
+    await client.close()
+  })
+
+  it('keeps a long-running call alive through progress notifications', async () => {
+    getByIdMock.mockReturnValue(serverWith({ timeout: 1, longRunning: true }))
+    const client = await connectRealClient(async (request, extra) => {
+      const token = request.params._meta?.progressToken
+      await new Promise<void>((resolve) => {
+        let elapsed = 0
+        const tick = (): void => {
+          elapsed += 500
+          extra
+            .sendNotification({
+              method: 'notifications/progress',
+              params: { progressToken: token!, progress: elapsed }
+            })
+            .catch(() => undefined)
+          if (elapsed >= 2_500) resolve()
+          else setTimeout(tick, 500)
+        }
+        setTimeout(tick, 500)
+      })
+      return { content: [{ type: 'text', text: 'done after renewal' }] }
+    })
+    const service = new McpRuntimeService()
+    vi.spyOn(service as any, 'getOrCreateClient').mockResolvedValue(client)
+
+    // Outlives the 1s per-progress window thanks to renewal; dead at 1s if reset is dropped.
+    const call = service.callTool({ serverId: 'srv', name: 'slow-tool', args: {} })
+    const completion = expect(call).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'done after renewal' }]
+    })
+    await vi.advanceTimersByTimeAsync(3_000)
+    await completion
+    await client.close()
+  })
+
+  it('caps a long-running call at the 10-minute total budget', async () => {
+    getByIdMock.mockReturnValue(serverWith({ timeout: 60, longRunning: true }))
+    const client = await connectRealClient(async (request, extra) => {
+      const token = request.params._meta?.progressToken
+      const tick = (): void => {
+        extra
+          .sendNotification({ method: 'notifications/progress', params: { progressToken: token!, progress: 1 } })
+          .catch(() => undefined)
+        setTimeout(tick, 30_000)
+      }
+      setTimeout(tick, 30_000)
+      return new Promise<CallToolResult>(() => {})
+    })
+    const service = new McpRuntimeService()
+    vi.spyOn(service as any, 'getOrCreateClient').mockResolvedValue(client)
+
+    const call = service.callTool({ serverId: 'srv', name: 'slow-tool', args: {} })
+    const rejection = expect(call).rejects.toThrow(/maximum total timeout exceeded/i)
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 60_000)
+    await rejection
+    await client.close()
+  })
+})

--- a/src/main/ai/mcp/__tests__/mcpRequestOptions.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpRequestOptions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveMcpRequestOptions } from '../mcpRequestOptions'
+
+describe('resolveMcpRequestOptions', () => {
+  it('falls back to the SDK-aligned 60s default with no long-running support when unconfigured', () => {
+    expect(resolveMcpRequestOptions(undefined)).toEqual({
+      timeout: 60_000,
+      resetTimeoutOnProgress: false,
+      maxTotalTimeout: undefined
+    })
+    expect(resolveMcpRequestOptions({})).toEqual({
+      timeout: 60_000,
+      resetTimeoutOnProgress: false,
+      maxTotalTimeout: undefined
+    })
+  })
+
+  it('converts the per-server timeout from seconds to milliseconds', () => {
+    expect(resolveMcpRequestOptions({ timeout: 180 })).toEqual({
+      timeout: 180_000,
+      resetTimeoutOnProgress: false,
+      maxTotalTimeout: undefined
+    })
+  })
+
+  it('enables progress-based timeout extension with a 10min ceiling for long-running servers', () => {
+    expect(resolveMcpRequestOptions({ timeout: 180, longRunning: true })).toEqual({
+      timeout: 180_000,
+      resetTimeoutOnProgress: true,
+      maxTotalTimeout: 10 * 60 * 1000
+    })
+  })
+
+  it('keeps the 60s default as the per-progress window when longRunning is on without a timeout', () => {
+    const options = resolveMcpRequestOptions({ longRunning: true })
+    expect(options.timeout).toBe(60_000)
+    expect(options.resetTimeoutOnProgress).toBe(true)
+    expect(options.maxTotalTimeout).toBe(10 * 60 * 1000)
+  })
+})

--- a/src/main/ai/mcp/mcpRequestOptions.ts
+++ b/src/main/ai/mcp/mcpRequestOptions.ts
@@ -1,0 +1,29 @@
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
+
+/** The slice of per-server config that governs tool-call timeouts. */
+export interface McpCallPolicy {
+  /** User-configured timeout in seconds; falls back to the SDK's 60s default. */
+  timeout?: number
+  /** Long Running Mode: progress notifications reset the timer, up to a 10min ceiling. */
+  longRunning?: boolean
+}
+
+/**
+ * Derive MCP SDK RequestOptions from per-server user config.
+ * Single source of truth for timeout policy — consumed by McpRuntimeService on the live
+ * config it reads per call (#20266).
+ */
+export function resolveMcpRequestOptions(policy?: McpCallPolicy): RequestOptions {
+  return {
+    timeout: policy?.timeout ? policy.timeout * 1000 : 60_000,
+    resetTimeoutOnProgress: policy?.longRunning ?? false,
+    maxTotalTimeout: policy?.longRunning ? 10 * 60 * 1000 : undefined
+  }
+}
+
+/**
+ * setTimeout-safe maximum (~24.8 days) standing in for "no timeout" — the SDK offers no way
+ * to disable the request timer. The Pi/dsh forwarding clients impose no budget of their own:
+ * McpRuntimeService owns every timeout decision on the live per-server config (#20266).
+ */
+export const MCP_FORWARDING_TIMEOUT_MS = 2 ** 31 - 1

--- a/src/main/ai/runtime/dsh/DshCherryToolBridge.ts
+++ b/src/main/ai/runtime/dsh/DshCherryToolBridge.ts
@@ -8,6 +8,7 @@ import { application } from '@application'
 import type { BridgeToolCallResult, BridgeToolDescriptor } from '@cherrystudio/dsh-bridge'
 import { mcpServerService } from '@data/services/McpServerService'
 import { loggerService } from '@logger'
+import { MCP_FORWARDING_TIMEOUT_MS } from '@main/ai/mcp/mcpRequestOptions'
 import type { AgentMcpServer } from '@main/ai/runtime/agentMcpServers'
 import { listBuiltinToolPolicies } from '@main/ai/toolApproval/builtinToolPolicy'
 import { toCamelCase } from '@shared/ai/tools/mcpToolName'
@@ -128,7 +129,8 @@ export async function buildDshCherryToolBridge(
       const result = (await binding.client.callTool(
         { name: binding.rawName, arguments: toToolArguments(args) },
         undefined,
-        signal ? { signal } : undefined
+        // Forwarding only: no timeout policy at this layer — McpRuntimeService owns it (#20266).
+        { signal, timeout: MCP_FORWARDING_TIMEOUT_MS }
       )) as CallToolResult
       if (result.isError) throw new Error(dshToolResultErrorText(result.content, binding.rawName))
       const text = await projectDshToolResult(result.content, binding.rawName, {

--- a/src/main/ai/runtime/dsh/__tests__/DshCherryToolBridge.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshCherryToolBridge.test.ts
@@ -241,4 +241,32 @@ describe('DshCherryToolBridge', () => {
     await expect(access(toolResultRoot)).rejects.toMatchObject({ code: 'ENOENT' })
     await bridge.close()
   })
+
+  // Real-chain behavior tests driven by fake timers: the SDK client's request timer actually
+  // runs, so a regression to the 60s default fires it and turns these red (#20266). Outcomes
+  // are asserted, never the RequestOptions shape (#20297 review).
+  describe('forwarding behavior', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('completes a signal-less call that outlasts the SDK 60s default timeout (#20266)', async () => {
+      const server = createServer([tool('run')], async () => {
+        await new Promise((resolve) => setTimeout(resolve, 65_000))
+        return { content: [{ type: 'text', text: 'slow but done' }] }
+      })
+      const bridge = await buildDshCherryToolBridge({ server: { name: 'server', instance: server } }, bridgeOptions())
+
+      const completion = expect(bridge.callTool('mcp__server__run', { value: 'x' })).resolves.toMatchObject({
+        text: 'slow but done'
+      })
+      await vi.advanceTimersByTimeAsync(65_000)
+      await completion
+      await bridge.close()
+    })
+  })
 })

--- a/src/main/ai/runtime/pi/__tests__/piMcpToolAdapter.test.ts
+++ b/src/main/ai/runtime/pi/__tests__/piMcpToolAdapter.test.ts
@@ -1,0 +1,92 @@
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+  type Tool
+} from '@modelcontextprotocol/sdk/types.js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  refreshTools: vi.fn()
+}))
+
+vi.mock('@application', () => ({
+  application: { get: () => ({ refreshTools: mocks.refreshTools }) }
+}))
+vi.mock('@data/services/McpServerService', () => ({
+  mcpServerService: { findByIdOrName: vi.fn() }
+}))
+
+const { buildMcpToolDefinitions } = await import('../piMcpToolAdapter')
+
+// The adapter's execute never reads the pi-only execution context; a stub satisfies the signature.
+const stubCtx = {} as ExtensionContext
+
+const slowTool: Tool = {
+  name: 'slow-tool',
+  description: 'a slow tool',
+  inputSchema: { type: 'object', properties: { value: { type: 'string' } } }
+}
+
+/**
+ * Real-chain behavior tests over a real in-memory transport, driven by fake timers: the SDK
+ * client's request timer actually runs, so a regression to the 60s default fires it and turns
+ * these red (#20266). Outcomes are asserted, never the RequestOptions shape (#20297 review).
+ */
+describe('buildMcpToolDefinitions forwarding behavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function createServer(call: (extra: { signal: AbortSignal }) => Promise<CallToolResult>): McpServer {
+    const server = new McpServer({ name: 'test', version: '1.0.0' }, { capabilities: { tools: {} } })
+    server.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [slowTool] }))
+    server.server.setRequestHandler(CallToolRequestSchema, async (_request, extra) => call(extra))
+    return server
+  }
+
+  async function buildBridge(call: (extra: { signal: AbortSignal }) => Promise<CallToolResult>) {
+    return buildMcpToolDefinitions({ 'srv-1': { name: 'srv-1', instance: createServer(call) } })
+  }
+
+  it('completes a tool call that outlasts the SDK 60s default timeout (#20266)', async () => {
+    const bridge = await buildBridge(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 65_000))
+      return { content: [{ type: 'text', text: 'slow but done' }] }
+    })
+
+    const completion = expect(
+      bridge.tools[0].execute('call-1', { value: 'x' }, undefined, undefined, stubCtx)
+    ).resolves.toMatchObject({ content: [{ type: 'text', text: 'slow but done' }] })
+    await vi.advanceTimersByTimeAsync(65_000)
+    await completion
+    await bridge.close()
+  })
+
+  it('forwards abort into a slow tool call', async () => {
+    const bridge = await buildBridge(
+      (extra) =>
+        new Promise<CallToolResult>((_, reject) => {
+          extra.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), {
+            once: true
+          })
+        })
+    )
+    const controller = new AbortController()
+
+    const rejection = expect(
+      bridge.tools[0].execute('call-1', { value: 'x' }, controller.signal, undefined, stubCtx)
+    ).rejects.toThrow(/abort/i)
+    // Let the request reach the server handler before aborting it.
+    await vi.advanceTimersByTimeAsync(5)
+    controller.abort()
+    await rejection
+    await bridge.close()
+  })
+})

--- a/src/main/ai/runtime/pi/piMcpToolAdapter.ts
+++ b/src/main/ai/runtime/pi/piMcpToolAdapter.ts
@@ -8,6 +8,7 @@ import type { CallToolResult, ContentBlock, Tool } from '@modelcontextprotocol/s
 import { application } from '@application'
 import { mcpServerService } from '@data/services/McpServerService'
 import { loggerService } from '@logger'
+import { MCP_FORWARDING_TIMEOUT_MS } from '@main/ai/mcp/mcpRequestOptions'
 import type { AgentMcpServer } from '@main/ai/runtime/agentMcpServers'
 import { toCamelCase } from '@shared/ai/tools/mcpToolName'
 
@@ -102,7 +103,8 @@ function toPiToolDefinition(serverName: string, tool: Tool, client: Client): PiM
       const result = (await client.callTool(
         { name: tool.name, arguments: params as Record<string, unknown> },
         undefined,
-        { signal }
+        // Forwarding only: no timeout policy at this layer — McpRuntimeService owns it (#20266).
+        { signal, timeout: MCP_FORWARDING_TIMEOUT_MS }
       )) as CallToolResult
       if (result.isError) throw new Error(joinErrorText(result.content))
       return {


### PR DESCRIPTION
## Problem

In Agent mode with the Pi or dsh runtime, every MCP tool call to a user-configured server is aborted after exactly 60 seconds — the per-server **timeout** setting and **Long Running Mode** are silently ignored (#20266).

## Root cause

The two session runtimes build in-memory MCP clients per session over the runtime-neutral bridge. Their `client.callTool(...)` passed only the abort signal, so the SDK fell back to `DEFAULT_REQUEST_TIMEOUT_MSEC` (60s) and aborted before `McpRuntimeService` — which already applies the configured policy and relays progress — could finish.

## Design (ownership model — reworked per @EurFelux's review)

One set of user settings must correspond to one timeout owner. The first iteration of this PR mirrored the per-server policy onto the forwarding clients; the review correctly identified that as two independent, mutually interfering timers: the mirror would come from the **session snapshot** while `McpRuntimeService` reads **live config on every call**, so e.g. raising the timeout mid-session would still abort at the stale snapshot value.

The forwarding layer now interprets no server timeout policy at all:

- Both forwarding clients pass `{ signal, timeout: MCP_FORWARDING_TIMEOUT_MS }` — the constant is the setTimeout-safe maximum standing in for "no budget" (the SDK offers no way to disable its request timer). They forward cancellation and results; that's their whole job.
- `McpRuntimeService` is the single owner of timeout and progress-renewal semantics (per-server `timeout`, `resetTimeoutOnProgress` + 10-min `maxTotalTimeout` under Long Running Mode), reading live config per call.
- `resolveMcpRequestOptions` is extracted as the one derivation of SDK `RequestOptions` from per-server config, consumed by `McpRuntimeService` (also a dedupe of the previously inline policy).
- No `AgentMcpServer` shape changes, no claudeCode changes — the earlier config channel and whitelist hardening became unnecessary and were dropped.

If a runtime ever needs an overall execution budget, it should be designed as its own semantically explicit policy, not by re-interpreting server settings at the forwarding layer.

## Test plan

Behavior tests run the **real SDK client over InMemoryTransport under fake timers**, asserting call outcomes (never the RequestOptions shape — per the review, an options check with the implementation's own constant cannot catch a regression to the 60s default):

- [x] `McpRuntimeService.timeoutPolicy.test.ts` (new): terminates at the per-server timeout; a long-running call survives past the per-progress window via progress notifications; progress cannot extend past the 10-minute `maxTotalTimeout`
- [x] Pi bridge: a 65s tool call completes (fires red if the forwarding client ever falls back to the SDK's 60s default); abort forwarding on a slow call
- [x] dsh bridge: a signal-less 65s call completes; existing real-chain cancellation test retained
- [x] Unit tests for `resolveMcpRequestOptions` derivation (4)
- [x] Mutation-checked: reverting the forwarding options to a bare signal, or dropping the policy spread in `McpRuntimeService`, turns the corresponding tests red
- [x] Full affected suites: 1551 passed (ai/mcp + pi + dsh + claudeCode); `typecheck:node`, eslint `--no-cache`, oxlint, biome clean

Fixes: #20266