### PR TITLE
docs(ui): drop the deleted styles:legacy-vars command from the token guide

### DIFF
--- a/packages/ui/docs/design-token-system.md
+++ b/packages/ui/docs/design-token-system.md
@@ -268,8 +268,7 @@ new, genuinely host-local App Shell variables with a documented owner.
 
 The renderer legacy alias file was deleted after repository-wide exact usage reached zero. Historical names such
 as `--color-text-1` remain registry sources so old branches and incoming changes can be migrated deterministically,
-but they must not be declared or consumed at runtime. Use `pnpm styles:legacy-vars` to report reintroductions and
-`pnpm styles:legacy-vars --fix` to map approved exact cases back to the canonical graph.
+but they must not be declared or consumed at runtime.
 
 ## 4. Canonical Shadcn contract
 


### PR DESCRIPTION
### What this PR does

Before this PR:

`packages/ui/docs/design-token-system.md` §3.7 "Removed legacy layer" instructed contributors to run
`pnpm styles:legacy-vars` to report reintroduced legacy CSS variables, and `pnpm styles:legacy-vars --fix`
to map approved exact cases back to the canonical graph. Neither command exists any more: commit
`950f9c8b3` ("refactor(styles): remove legacy CSS variable checks and associated tests") deleted both
the `styles:legacy-vars` and `styles:legacy-vars:strict` scripts from `package.json`, along with
`scripts/check-legacy-css-vars.ts` (415 lines) and its 231-line test file. Following the documented
instruction today fails with `ERR_PNPM_NO_SCRIPT`.

After this PR:

§3.7 no longer advertises a deleted command. Its normative statement is untouched — retired names such
as `--color-text-1` are still registry migration sources for old branches and incoming changes, and they
must still not be declared or consumed at runtime. Only the two sentences pointing at the removed
tooling are dropped (net `+1 / -2`).

### Why we need it and why it was done in this way

The reference is an incomplete cleanup rather than deliberate guidance. Commit `82d06345b`, merged
14 minutes after `950f9c8b3`, removed the CI step for the deleted check **and** already stripped the
sibling copy of this same paragraph from §7 of this very file, which shows the intent was to remove
every reference to the script. The §3.7 copy was simply missed.

The following tradeoffs were made:

Deletion rather than substitution. The only surviving `styles:*` script is `styles:canonical`
(`scripts/fix-tailwind-canonical-classes.ts`), which normalises Tailwind class names — a different
concern from legacy CSS variables — so there is no replacement command to point at. Deletion also
matches exactly how `82d06345b` handled the §7 paragraph, keeping the two sections consistent.

The following alternatives were considered:

- Keep the sentence and annotate it as "removed". Rejected: it preserves a command name that no longer
  resolves, which is precisely what makes the section misleading.
- Restore `scripts/check-legacy-css-vars.ts`. Rejected: out of scope for a minimal PR, and it was
  deliberately removed upstream together with the legacy compatibility layer.

Links to places where the discussion took place:

- `950f9c8b33` — refactor(styles): remove legacy CSS variable checks and associated tests
- `82d06345b8` — refactor(ci): remove legacy CSS variables check from CI workflow

### Breaking changes

None. Documentation only: no code, dependency, API, or behavior change.

### Special notes for your reviewer

- Scope: 1 file, `+1 / -2`. No new dependencies, no refactor, no behavior change.
- Residual-reference check: a repo-wide search for `styles:legacy-vars`, `legacy-css-vars` and
  `LEGACY_CSS_VARS` outside `node_modules` now returns nothing. The remaining `legacy-vars.css` hits in
  `packages/ui/scripts/migrations/shadcn-v2.json` and
  `packages/ui/scripts/validate-migration-contract.ts` are the legacy alias *stylesheet path*, not the
  deleted script, and are out of scope here.
- No conflict with my previous PRs in this repo: #19237 touched `docs/contrib/development.md` and
  #20295 touched `CONTRIBUTING.md`; neither file is touched by this PR, and
  `packages/ui/docs/design-token-system.md` overlaps no other change of mine. It is also absent from
  the current open PR set and from recently merged PRs.
- No test added: the change is Markdown-only, and no test in the repo asserts on documentation prose.
- Local verification performed: `git diff` reviewed line by line (1 file, `+1 / -2`, LF line endings
  unchanged, no trailing-whitespace or CRLF churn); repo-wide search re-run afterwards confirming no
  `styles:legacy-vars` reference remains; confirmed no build step, script, or test reads
  `packages/ui/docs/*.md`, so no code path can be affected.
- Local limitation, stated plainly: I could **not** execute `pnpm docs:check` or `pnpm test:pkg:ui`
  here. This sandbox has no reachable npm registry, so pnpm's dependency status check fails and aborts
  before any test or doc check starts — the failure is the network, not this change. I am relying on CI
  for those gates and will re-run them if anything comes back red.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: kept to the minimum deletion that removes the stale reference
- [x] Refactor: left the surrounding section as found; only the stale sentence is gone
- [x] Upgrade: no upgrade impact — documentation only
- [x] Documentation: this PR *is* a documentation fix; no user-guide (docs.cherry-ai.com) update needed
- [x] Self-review: reviewed my own diff (`git diff`) line by line before requesting review

### Release note

```release-note
NONE
```
