### PR TITLE
fix(tools): keep shell tool output as text and harden terminal rendering

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -793,6 +793,57 @@ describe('ClaudeCodeStreamAdapter', () => {
     })
   })
 
+  it('keeps a Bash result as text even when the output is legal JSON', () => {
+    const { adapter, parts } = createAdapter()
+    const json = JSON.stringify({ results: [{ id: 1, title: 'A', url: 'https://a.com/x' }] })
+
+    adapter.handleMessage({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      session_id: 'sdk-1',
+      uuid: crypto.randomUUID(),
+      message: { content: [{ type: 'tool_use', id: 'bash-1', name: 'Bash', input: { command: 'cat a.json' } }] }
+    } as any)
+    adapter.handleMessage({
+      type: 'user',
+      parent_tool_use_id: null,
+      session_id: 'sdk-1',
+      uuid: crypto.randomUUID(),
+      message: { content: [{ type: 'tool_result', tool_use_id: 'bash-1', content: json, is_error: false }] }
+    } as any)
+
+    expect(parts.at(-1)).toMatchObject({ type: 'tool-output-available', toolCallId: 'bash-1', output: json })
+  })
+
+  it('keeps a shell tool all-text block result as text even when it is legal JSON', () => {
+    const { adapter, parts } = createAdapter()
+    const json = JSON.stringify({
+      content: [{ type: 'text', text: 'command output' }],
+      metadata: { type: 'mcp', serverName: 'looks-like-mcp' }
+    })
+
+    adapter.handleMessage({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      session_id: 'sdk-1',
+      uuid: crypto.randomUUID(),
+      message: { content: [{ type: 'tool_use', id: 'bash-2', name: 'BashOutput', input: { bash_id: 'b1' } }] }
+    } as any)
+    adapter.handleMessage({
+      type: 'user',
+      parent_tool_use_id: null,
+      session_id: 'sdk-1',
+      uuid: crypto.randomUUID(),
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'bash-2', content: [{ type: 'text', text: json }], is_error: false }
+        ]
+      }
+    } as any)
+
+    expect(parts.at(-1)).toMatchObject({ type: 'tool-output-available', toolCallId: 'bash-2', output: json })
+  })
+
   it('maps streamed MCP tool use and result blocks', () => {
     const { adapter, parts } = createAdapter()
 

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -39,6 +39,7 @@ import { extractSystemReminderBodies, SystemReminderTextFilter } from '@main/ai/
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
 import type { AgentSessionBackgroundTask } from '@shared/ai/agentSessionBackgroundTasks'
 import type { AgentSessionCompactionAnchorData } from '@shared/ai/agentSessionCompaction'
+import { CLAUDE_SHELL_TOOL_NAMES } from '@shared/ai/claudecode/toolRegistry'
 import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
 import type { CherryUIMessageChunk, CherryUIMessageMetadata, MessageStats } from '@shared/data/types/message'
 import type { AgentTaskEventPartData } from '@shared/data/types/uiParts'
@@ -1189,7 +1190,7 @@ export class ClaudeCodeStreamAdapter {
     }
     state.name = toolName
 
-    const normalizedResult = this.normalizeToolResult(result.content)
+    const normalizedResult = this.normalizeToolResult(result.content, toolName)
     const errorText =
       typeof result.content === 'string'
         ? result.content
@@ -1686,8 +1687,12 @@ export class ClaudeCodeStreamAdapter {
     return str
   }
 
-  private normalizeToolResult(result: unknown): NonNullable<JSONValue> {
+  private normalizeToolResult(result: unknown, toolName: string): NonNullable<JSONValue> {
+    // Shell tool output stays verbatim text — `cat x.json` output is legal JSON whose parsed
+    // object form breaks the persisted string contract shared across runtimes (#20265).
+    const isShellTool = CLAUDE_SHELL_TOOL_NAMES.has(toolName)
     if (typeof result === 'string') {
+      if (isShellTool) return result
       try {
         return JSON.parse(result)
       } catch {
@@ -1701,6 +1706,7 @@ export class ClaudeCodeStreamAdapter {
 
       if (textBlocks.length !== result.length) return JSON.parse(JSON.stringify(result))
       const combined = textBlocks.join('\n')
+      if (isShellTool) return combined
       try {
         return JSON.parse(combined)
       } catch {

--- a/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
@@ -411,6 +411,63 @@ describe('DshStreamAdapter', () => {
     expect(chunks.at(-1)).toMatchObject({ type: 'tool-output-available', output: content })
   })
 
+  it('keeps a shell tool result as text even when the output is legal JSON', () => {
+    const { adapter, chunks } = makeAdapter()
+    const json = JSON.stringify({ results: [{ id: 'dsh-1', url: 'https://a.com/x', title: 'A' }] })
+    adapter.handleEvent(
+      envelope('tool/call', { turn: 1, step: 1, callId: callId('c1'), name: 'bash', arguments: '{}' })
+    )
+    adapter.handleEvent(
+      envelope('tool/result', {
+        turn: 1,
+        step: 1,
+        message: toolResultMessage('c1', [{ type: 'text', text: json }])
+      })
+    )
+
+    expect(chunks.at(-1)).toMatchObject({ type: 'tool-output-available', output: json })
+  })
+
+  it('keeps the win32 pwsh tool identity in the shell class', () => {
+    const { adapter, chunks } = makeAdapter()
+    const json = JSON.stringify({ ok: true })
+    adapter.handleEvent(
+      envelope('tool/call', { turn: 1, step: 1, callId: callId('c1'), name: 'pwsh', arguments: '{}' })
+    )
+    adapter.handleEvent(
+      envelope('tool/result', {
+        turn: 1,
+        step: 1,
+        message: toolResultMessage('c1', [{ type: 'text', text: json }])
+      })
+    )
+
+    expect(chunks.at(-1)).toMatchObject({ type: 'tool-output-available', output: json })
+  })
+
+  it('does not emit an MCP-envelope-shaped object for shell JSON output', () => {
+    // Regression for the issue #20265 teardown: a parsed `{"content":[…],"metadata":…}` object
+    // would later be mistaken for an MCP envelope by the renderer and torn down.
+    const { adapter, chunks } = makeAdapter()
+    const json = JSON.stringify({
+      content: [{ type: 'text', text: 'command output' }],
+      metadata: { type: 'mcp', serverName: 'looks-like-mcp' }
+    })
+    adapter.handleEvent(
+      envelope('tool/call', { turn: 1, step: 1, callId: callId('c1'), name: 'bash', arguments: '{}' })
+    )
+    adapter.handleEvent(
+      envelope('tool/result', {
+        turn: 1,
+        step: 1,
+        message: toolResultMessage('c1', [{ type: 'text', text: json }])
+      })
+    )
+
+    const output = (chunks.at(-1) as { output?: unknown }).output
+    expect(output).toBe(json)
+  })
+
   it('degrades malformed tool arguments JSON to an empty input', () => {
     const { adapter, chunks } = makeAdapter()
     adapter.handleEvent(

--- a/src/main/ai/runtime/dsh/dshStreamAdapter.ts
+++ b/src/main/ai/runtime/dsh/dshStreamAdapter.ts
@@ -30,6 +30,7 @@ import type { SessionEvent, SessionEventMap, TurnEndReason } from '@deepseek-ai/
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
 import type { AgentSessionApiRetryInfo } from '@shared/ai/agentSessionApiRetry'
 import type { AutonomousTurnOrigin } from '@shared/ai/agentSessionTurnOrigin'
+import { DSH_BUILTIN_TOOLS, getDshRuntimeBuiltinTools } from '@shared/ai/dshBuiltinTools'
 import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
 import type { CherryUIMessageChunk } from '@shared/data/types/message'
 
@@ -439,7 +440,7 @@ export class DshStreamAdapter {
     this.sink.enqueue({
       type: 'tool-output-available',
       toolCallId,
-      output: normalizeToolOutput(output),
+      output: normalizeToolOutput(output, toolName),
       dynamic: true,
       providerExecuted: true,
       providerMetadata: toolProviderMetadata(toolName)
@@ -614,11 +615,24 @@ function parseToolArguments(raw: string): Record<string, unknown> {
 }
 
 /**
+ * Shell-class builtin tool names (the catalog's `bash` plus win32's native `pwsh` identity).
+ * Their output is verbatim command text and must never be JSON.parse'd — `cat x.json` output
+ * is legal JSON, and persisting it as an object breaks the string contract downstream (#20265).
+ */
+const DSH_SHELL_TOOL_NAMES: ReadonlySet<string> = new Set(
+  [...DSH_BUILTIN_TOOLS, ...getDshRuntimeBuiltinTools('win32')]
+    .filter((tool) => tool.category === 'shell')
+    .map((tool) => tool.name)
+)
+
+/**
  * dsh wraps every tool result in MCP content blocks, so an all-text result hides its payload
  * inside a JSON string. Unwrap it the way the Claude Code adapter does, so downstream consumers
  * (tool cards, citation resolution, persisted projection) see one shape across runtimes.
  */
-function normalizeToolOutput(output: ContentBlock[]): unknown {
+function normalizeToolOutput(output: ContentBlock[], toolName: string): unknown {
+  if (DSH_SHELL_TOOL_NAMES.has(toolName)) return stringifyToolOutput(output)
+
   const texts = output.filter((entry): entry is Extract<ContentBlock, { type: 'text' }> => entry.type === 'text')
   if (texts.length === 0 || texts.length !== output.length) return output
 

--- a/src/renderer/components/chat/messages/tools/__tests__/bashToolCorruption.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/bashToolCorruption.test.tsx
@@ -1,0 +1,80 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+vi.mock('@renderer/hooks/useToolResult', () => ({
+  useToolResult: vi.fn(() => ({ output: undefined, error: undefined, isLoading: true }))
+}))
+vi.mock('../../MessageListProvider', () => ({
+  useOptionalMessageListTopicId: () => 'topic-1',
+  useOptionalMessageListActions: () => undefined
+}))
+
+import type { CherryMessagePart } from '@shared/data/types/message'
+
+import { MessagePartsScopeProvider } from '../../blocks/MessagePartsContext'
+import MessageTools from '../MessageTools'
+import { buildToolResponseFromPart } from '../toolResponse'
+
+// Issue #20265 regression: the dsh bash tool's JSON-looking output used to be JSON.parse'd
+// before persistence, so stored parts carry corrupted shapes (an object `output`, or an
+// `output-error` part with no `output` key) and a corrupt non-string `input.command`. The
+// full dispatch chain (part → toolResponse → MessageTools → BashTool → TerminalOutput) must
+// render every stored shape without throwing, or the whole chat page white-screens.
+const DSH_TRANSPORT = 'dsh-agent'
+
+function bashPart(overrides: Record<string, unknown>): CherryMessagePart {
+  return {
+    type: 'dynamic-tool',
+    toolName: 'bash',
+    toolCallId: 'bash-1',
+    input: { command: 'echo hi' },
+    callProviderMetadata: { cherry: { transport: DSH_TRANSPORT, tool: { type: 'builtin', name: 'bash' } } },
+    ...overrides
+  } as unknown as CherryMessagePart
+}
+
+async function renderPartExpectingText(part: CherryMessagePart, expectedText: string): Promise<void> {
+  const toolResponse = buildToolResponseFromPart(part)
+  expect(toolResponse).not.toBeNull()
+  const { container } = render(
+    <MessagePartsScopeProvider messageId="m1" parts={[part]}>
+      <MessageTools toolResponse={toolResponse!} />
+    </MessagePartsScopeProvider>
+  )
+  // The lazy agent-timeline chunk loads async; textContent also survives the collapsed
+  // disclosure and ANSI-colorized spans, so assert against the raw container text.
+  await waitFor(() => expect(container.textContent).toContain(expectedText))
+}
+
+describe('bash tool corrupted-output dispatch regression (#20265)', () => {
+  it('renders a JSON.parse-d output object part without throwing', async () => {
+    await renderPartExpectingText(
+      bashPart({
+        state: 'output-available',
+        output: { content: [{ type: 'text', text: 'persisted bash stdout' }] }
+      }),
+      'persisted bash stdout'
+    )
+  })
+
+  it('renders an output-error part carrying only errorText without throwing', async () => {
+    await renderPartExpectingText(
+      bashPart({ state: 'output-error', errorText: 'command failed with exit 1' }),
+      'command failed with exit 1'
+    )
+  })
+
+  it('renders a non-string input.command without throwing', async () => {
+    await renderPartExpectingText(
+      bashPart({
+        state: 'output-available',
+        input: { command: { script: 'echo hi' } },
+        output: 'plain stdout'
+      }),
+      'plain stdout'
+    )
+  })
+})

--- a/src/renderer/components/chat/messages/tools/agent/TerminalOutput.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/TerminalOutput.tsx
@@ -11,6 +11,7 @@ import {
   TERMINAL_LINK_CLASS,
   TERMINAL_SURFACE_CLASS
 } from '../shared/terminalOutputHelpers'
+import { toOutputText } from '../shared/truncateOutput'
 
 interface TerminalOutputProps {
   content: string
@@ -26,7 +27,10 @@ export const TerminalOutput = memo(function TerminalOutput({
   const { theme } = useTheme()
   const isDark = theme !== ThemeMode.light
   const palette = isDark ? shellColorPalettes.dark : shellColorPalettes.light
-  const colorized = useMemo(() => colorizeShellOutput(content, commandMode, palette), [content, commandMode, palette])
+  // Persisted parts can carry non-string content (JSON.parse'd bash output, corrupt command
+  // input); normalize at the single rendering exit so no stored shape crashes the page (#20265).
+  const text = toOutputText(content)
+  const colorized = useMemo(() => colorizeShellOutput(text, commandMode, palette), [text, commandMode, palette])
 
   return (
     <TerminalContainer style={{ maxHeight }}>

--- a/src/renderer/components/chat/messages/tools/agent/__tests__/TerminalOutput.test.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/__tests__/TerminalOutput.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { TerminalOutput } from '../TerminalOutput'
+
+// Issue #20265 hardening: persisted tool parts can carry non-string terminal content (a
+// JSON.parse'd bash output object, a corrupt input.command). TerminalOutput is the single
+// rendering exit for those payloads, so it must normalize instead of throwing.
+describe('TerminalOutput non-string content hardening', () => {
+  it('renders an MCP-envelope-shaped content object as its text', () => {
+    const { container } = render(
+      <TerminalOutput content={{ content: [{ type: 'text', text: 'hello world' }] } as unknown as string} />
+    )
+
+    expect(container.textContent).toContain('hello world')
+  })
+
+  it('renders a text-block array content as its joined text', () => {
+    const { container } = render(
+      <TerminalOutput
+        content={
+          [
+            { type: 'text', text: 'line 1' },
+            { type: 'text', text: 'line 2' }
+          ] as unknown as string
+        }
+      />
+    )
+
+    expect(container.textContent).toContain('line 1')
+    expect(container.textContent).toContain('line 2')
+  })
+
+  it('renders a plain object content as serialized JSON text', () => {
+    const { container } = render(<TerminalOutput content={{ exitCode: 1 } as unknown as string} />)
+
+    expect(container.textContent).toContain('exitCode')
+  })
+
+  it.each([42, undefined, null])('renders non-string content %# without throwing', (content) => {
+    const { container } = render(<TerminalOutput content={content as unknown as string} />)
+
+    expect(container.firstChild).not.toBeNull()
+  })
+
+  it('keeps colorizing plain string command content', () => {
+    const { container } = render(<TerminalOutput content="pnpm test" commandMode />)
+
+    expect(container.textContent).toContain('pnpm test')
+  })
+})

--- a/src/renderer/components/chat/messages/tools/shared/terminalOutputHelpers.ts
+++ b/src/renderer/components/chat/messages/tools/shared/terminalOutputHelpers.ts
@@ -278,6 +278,8 @@ function colorizeLine(line: string, commandMode: boolean, p: ColorPalette): stri
 }
 
 export function colorizeShellOutput(text: string, commandMode: boolean, palette: ColorPalette): string {
+  // Guard direct callers that bypass TerminalOutput's entry normalization (#20265 crash site).
+  if (typeof text !== 'string') return String(text)
   if (text.includes('\x1b[')) return text
 
   return text

--- a/src/renderer/components/chat/messages/tools/shared/truncateOutput.ts
+++ b/src/renderer/components/chat/messages/tools/shared/truncateOutput.ts
@@ -13,7 +13,8 @@ const getTextItems = (value: unknown): TextOutputItem[] => {
   return value.filter(isTextOutputItem)
 }
 
-const toOutputText = (output: unknown): string => {
+/** Normalize any persisted tool output value (string / MCP envelope / block array / object) to text. */
+export const toOutputText = (output: unknown): string => {
   if (output === undefined || output === null || output === '') return ''
   if (typeof output === 'string') return output
 

--- a/src/shared/ai/claudecode/toolRegistry.ts
+++ b/src/shared/ai/claudecode/toolRegistry.ts
@@ -416,6 +416,15 @@ export const CLAUDE_KNOWLEDGE_TOOL_NAMES: ReadonlySet<string> = new Set(
 )
 
 /**
+ * Runtime-native names of the shell-category tools (Bash / BashOutput / REPL). Stream adapters
+ * use this set to keep shell tool results as verbatim text: their JSON-looking output must not
+ * be JSON.parse'd into the object shape the persisted string contract forbids (#20265).
+ */
+export const CLAUDE_SHELL_TOOL_NAMES: ReadonlySet<string> = new Set(
+  CLAUDE_TOOL_DEFS.filter((def) => def.category === 'shell').map((def) => def.name)
+)
+
+/**
  * Descriptors for the canUseTool / catalog policy layer: every non-disabled SDK tool.
  * Disabled tools are omitted (they are hard-blocked via disallowedTools and never invoked).
  */


### PR DESCRIPTION
### What this PR does

Before this PR:

- The dsh and Claude Code stream adapters `JSON.parse`-ed every all-text tool result before persisting it. When a shell command's stdout happened to be valid JSON (`cat data.json`, `ls --json`), the persisted `dynamic-tool` part's `output` became a JS **object**, breaking the string contract that downstream consumers (renderer, projections, export) rely on.
- The renderer's `colorizeShellOutput` had no type guard. A non-string `input.command` (or any future non-string content) crashed `TerminalOutput` with `TypeError: text.includes is not a function` (#20265), and the corrupted part made the topic **permanently unopenable** because the bad shape is persisted.
- The Claude Code adapter had the same `JSON.parse` unwrap, so the two runtimes disagreed on the persisted shape for the same bash tool.

After this PR:

- Shell-category tools (dsh: `bash`/`pwsh` from `DSH_BUILTIN_TOOLS`; Claude Code: `Bash`/`BashOutput`/`REPL` from the new `CLAUDE_SHELL_TOOL_NAMES`) keep their output as **verbatim text** — no `JSON.parse`. Non-shell (MCP/structured) tools keep the existing unwrap behavior, unchanged.
- `TerminalOutput` normalizes any persisted `content` through the existing `toOutputText` at its single rendering exit, and `colorizeShellOutput` gained a `typeof` guard for direct callers. Every stored shape — including already-corrupted objects from existing databases — renders without crashing, so previously poisoned topics open again (no data migration needed).
- Bonus: shell output shaped like `{content, metadata}` is no longer mis-unwrapped as an MCP envelope by `extractOutputMetadata`.

Fixes #20265

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Renderer-side hardening (defense in depth) **and** writer-side contract fix ship together: the renderer guard alone would keep accumulating corrupted objects in the database (the reporter had 308 of them); the writer fix alone leaves already-corrupted topics unopenable.
- No data migration: the renderer normalization makes legacy corrupted data renderable, per the v2 rule of not adding fallbacks/layers for already-persisted shapes.
- `output-error` parts without an `output` key stay as-is (that shape is the AI-SDK `DynamicToolUIPart` contract); the renderer already handles it.

The following alternatives were considered:

- Normalizing in the persisted-projection layer instead of the stream adapters (rejected: shared pipeline affecting all runtimes, larger blast radius).
- Hard-coding `['bash', 'pwsh']` shell lists (rejected: derived from each runtime's own catalog so registry changes are followed automatically; the two runtimes' name spaces differ and must not share one list).
- Guarding each call site of `colorizeShellOutput` (rejected: the crash proved call-site guards get bypassed; the component entry is the single rendering exit).

Links to places where the discussion took place: #20265

### Breaking changes

None. All changes are behavior-narrowing (crash → render, object → string); no public interface changes.

### Special notes for your reviewer

- The three commits are independent and individually revertable: `fix(chat)` renderer hardening, `fix(dsh)` writer fix, `fix(claude-code)` same-family writer fix.
- `DSH_SHELL_TOOL_NAMES` / `CLAUDE_SHELL_TOOL_NAMES` are module-level sets derived from each runtime's own tool catalog (`category === 'shell'`); they intentionally do **not** cross runtime boundaries (dsh lowercase native names vs Claude Code display names).
- Verified beyond unit tests: a live CDP A/B smoke on dev builds — injecting the issue's exact corrupted part shapes (JSON.parse'd output object, `output-error` without `output`, non-string `input.command`) reproduced `text.includes is not a function` on the pre-fix baseline and renders all three shapes cleanly on this branch.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#codeforhumans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed agent chat topics becoming unopenable (white screen) when a bash command's output happened to be valid JSON: shell tool output is now always stored and rendered as plain text, and previously corrupted topics open again.
```
