### PR TITLE
fix(quick-assistant): preserve dark surface on Windows

### DIFF
--- a/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
+++ b/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
@@ -403,6 +403,9 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
   }
 
   const backgroundColor = useMemo(() => {
+    if (!isMac) {
+      return 'var(--popover)'
+    }
     if (isMac && windowStyle === 'transparent' && theme === ThemeMode.light) {
       return 'transparent'
     }

--- a/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
+++ b/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
@@ -38,7 +38,10 @@ const state = vi.hoisted(() => ({
   setMessages: vi.fn(),
   resetExecutionMessages: vi.fn(),
   clearExecutionMessages: vi.fn(),
-  resetTemporaryTopic: vi.fn()
+  resetTemporaryTopic: vi.fn(),
+  isMac: false,
+  theme: 'light',
+  windowStyle: 'default'
 }))
 
 import HomeWindow, { finalizeLiveMessages } from '../HomeWindow'
@@ -63,14 +66,20 @@ vi.mock('@data/hooks/usePreference', () => ({
       'feature.quick_assistant.read_clipboard_at_startup': false,
       'feature.quick_assistant.assistant_id': state.quickAssistantId,
       'app.language': 'en-US',
-      'ui.window_style': 'default'
+      'ui.window_style': state.windowStyle
     }
     return [values[key], vi.fn()]
   }
 }))
 
 vi.mock('@renderer/hooks/useTheme', () => ({
-  useTheme: () => ({ theme: 'light' })
+  useTheme: () => ({ theme: state.theme })
+}))
+
+vi.mock('@renderer/utils/platform', () => ({
+  get isMac() {
+    return state.isMac
+  }
 }))
 
 vi.mock('@renderer/hooks/useAssistant', () => ({
@@ -228,6 +237,20 @@ describe('HomeWindow', () => {
     state.resetExecutionMessages.mockClear()
     state.clearExecutionMessages.mockClear()
     state.resetTemporaryTopic.mockClear()
+    state.isMac = false
+    state.theme = 'light'
+    state.windowStyle = 'default'
+  })
+
+  it('uses an opaque floating surface for the Windows dark-mode first render', () => {
+    state.theme = 'dark'
+
+    const { container } = render(<HomeWindow draggable={false} />)
+
+    // Windows needs the opaque floating-surface token because its native window is not transparent.
+    expect(container.querySelector('[data-ui~="quick-assistant.view"]')).toHaveStyle({
+      backgroundColor: 'var(--popover)'
+    })
   })
 
   it('uses the configured quick model in model-only mode', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

On Windows, the Quick Assistant root used the application page background token. In dark mode, that translucent surface could lose contrast against the floating input and feature controls.

After this PR:

Non-macOS Quick Assistant windows use the opaque semantic popover surface token. The existing macOS transparent-window behavior remains unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20307

### Why we need it and why it was done in this way

The Quick Assistant is a standalone floating surface on Windows, so its root should use the same semantic surface as other popovers instead of the main page background. Keeping the platform branch at the existing background selection point scopes the change to this window and preserves macOS transparency handling.

The following tradeoffs were made:

- The fix changes only the Quick Assistant root surface; shared theme tokens and global theme behavior are unchanged.

The following alternatives were considered:

- Changing the global background token was rejected because it would affect unrelated application surfaces.
- Adding Windows transparency behavior was rejected because the native Windows Quick Assistant window is opaque.

Links to places where the discussion took place: #20307 <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Before:

![Quick Assistant before the fix in Windows dark mode](https://github.com/user-attachments/assets/a8b444b3-413a-49d1-b9e2-400ed617f9c9)

After screenshot unavailable: the execution host is macOS and cannot credibly capture the changed non-macOS branch.

Alternative verification:

- Static token evidence: dark `--background` resolves to translucent `oklch(0.209 0 0 / 0.55)`, while dark `--popover` resolves to opaque `--cs-neutral-800` (`oklch(0.27 0 0)`).
- Focused renderer Vitest passed 5/5 tests, including the Windows dark-mode first-render regression.
- `pnpm lint` passed with 47 existing non-blocking warnings unrelated to this change.
- `git diff --check` passed, and self-review found no blocking issues in the focused two-file diff.
- Fresh CI passed on signed rebased head `1a5923ec1c`: 9 checks succeeded, 0 failed, and 0 remain pending.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Quick Assistant text and controls losing contrast in Windows dark mode.
```
