### PR TITLE
fix(work): keep pinned tasks in agent grouping

### DIFF
--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -691,7 +691,7 @@ const Sessions = ({
         },
         mode: displayMode,
         now: groupNow,
-        pinnedAsSection: displayMode === 'workdir',
+        pinnedAsSection: displayMode !== 'time',
         workdirDisplay
       }),
     [agentById, displayMode, groupNow, t, workdirDisplay]
@@ -724,7 +724,7 @@ const Sessions = ({
     if (displayMode === 'time') return undefined
 
     return (session: SessionListItem): ResourceListSection => {
-      if (displayMode === 'workdir' && session.pinned) {
+      if (session.pinned) {
         return { id: SESSION_PINNED_SECTION_ID, label: t('selector.common.pinned_title') }
       }
 

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -1433,23 +1433,37 @@ describe('Sessions', () => {
     expect(getSessionGroupExpansionCache().agent).not.toContain('session:agent:agent-b')
   })
 
-  it('keeps a pinned session in its expanded agent group', () => {
+  it.each([false, true])('keeps a pinned session above its agent group (collapsed: %s)', (collapsed) => {
     preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    setSessionGroupExpansionCache({
+      ...createExpandedSessionGroupExpansionFixture(),
+      agent: collapsed ? ['session:agent:agent-a'] : []
+    })
     agentDataMocks.useAgents.mockReturnValue({
       agents: [{ id: 'agent-a', model: 'model-a', name: 'Alpha agent', configuration: { avatar: 'A' } }],
       isLoading: false,
       error: undefined
     })
     setupSessions({
-      sessions: [createSession({ id: 'session-pinned', name: 'Pinned session', agentId: 'agent-a' })],
+      sessions: [
+        createSession({ id: 'session-pinned', name: 'Pinned session', agentId: 'agent-a' }),
+        createSession({ id: 'session-regular', name: 'Regular session', agentId: 'agent-a' })
+      ],
       pinIdBySessionId: new Map([['session-pinned', 'pin-session-pinned']])
     })
 
     render(<SessionsForTest />)
 
-    expect(screen.queryByRole('button', { name: 'Pinned' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Alpha agent' })).toBeInTheDocument()
-    expect(screen.getByText('Pinned session')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Pinned' })).toBeInTheDocument()
+    const agentGroup = screen.getByRole('button', { name: 'Alpha agent' })
+    const pinnedSession = screen.getByText('Pinned session')
+    expect(screen.getAllByText('Pinned session')).toHaveLength(1)
+    expect(pinnedSession.compareDocumentPosition(agentGroup) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    if (collapsed) {
+      expect(screen.queryByText('Regular session')).not.toBeInTheDocument()
+    } else {
+      expect(screen.getByText('Regular session')).toBeInTheDocument()
+    }
     expect(screen.queryByText('No tasks')).not.toBeInTheDocument()
   })
 

--- a/src/renderer/utils/chat/__tests__/sessionListHelpers.test.ts
+++ b/src/renderer/utils/chat/__tests__/sessionListHelpers.test.ts
@@ -196,7 +196,7 @@ describe('SessionList helpers', () => {
     expect(allPinned(pinned)).toEqual({ id: SESSION_PINNED_GROUP_ID, label: 'Pinned' })
   })
 
-  it('keeps pinned sessions inside their agent group', () => {
+  it('keeps pinned sessions in their dedicated section in agent mode', () => {
     const groupSession = createSessionDisplayGroupResolver({
       agentById: new Map([['agent-1', { id: 'agent-1', name: 'Alpha agent' }]]),
       labels: SESSION_GROUP_LABELS,
@@ -204,8 +204,8 @@ describe('SessionList helpers', () => {
     })
 
     expect(groupSession(createSession({ agentId: 'agent-1', pinned: true }))).toEqual({
-      id: 'session:agent:agent-1',
-      label: 'Alpha agent'
+      id: SESSION_PINNED_GROUP_ID,
+      label: 'Pinned'
     })
   })
 
@@ -424,7 +424,7 @@ describe('SessionList helpers', () => {
     ).toEqual(['pinned', 'newer', 'older'])
   })
 
-  it('sorts pinned sessions first within each agent group', () => {
+  it('sorts the pinned section before every agent group', () => {
     const sessions = [
       createSession({ id: 'regular-b', agentId: 'agent-b', orderKey: 'b' }),
       createSession({ id: 'regular-a', agentId: 'agent-a', orderKey: 'a' }),
@@ -440,7 +440,7 @@ describe('SessionList helpers', () => {
         ]),
         mode: 'agent'
       }).map((session) => session.id)
-    ).toEqual(['pinned-a', 'regular-a', 'pinned-b', 'regular-b'])
+    ).toEqual(['pinned-b', 'pinned-a', 'regular-a', 'regular-b'])
   })
 
   it('keeps system workspace sessions at the bottom only in workdir mode', () => {

--- a/src/renderer/utils/chat/sessionListHelpers.ts
+++ b/src/renderer/utils/chat/sessionListHelpers.ts
@@ -275,13 +275,15 @@ export function createSessionDisplayGroupResolver<T extends SessionListItem>({
   workdirDisplay
 }: SessionDisplayGroupOptions): ResourceListGroupResolver<T> {
   const pinnedGroupLabel = mode === 'time' || !pinnedAsSection ? labels.pinned : ''
+  const pinnedResolver = createPinnedGroupResolver<T>({
+    isPinned: (session) => session.pinned === true,
+    group: {
+      id: mode === 'workdir' ? SESSION_PINNED_GROUP_ID : 'pinned',
+      label: pinnedGroupLabel
+    } satisfies ResourceListGroup
+  })
 
   if (mode === 'time') {
-    const pinnedResolver = createPinnedGroupResolver<T>({
-      isPinned: (session) => session.pinned === true,
-      group: { id: 'pinned', label: pinnedGroupLabel } satisfies ResourceListGroup
-    })
-
     return withSessionGroupIdPrefix(
       composeResourceListGroupResolvers(
         pinnedResolver,
@@ -295,23 +297,20 @@ export function createSessionDisplayGroupResolver<T extends SessionListItem>({
   }
 
   if (mode === 'agent') {
-    return (session) => {
-      const agentId = session.agentId
-      if (!agentId) {
-        return { id: SESSION_UNKNOWN_AGENT_GROUP_ID, label: labels.agent.unknown }
-      }
+    return withSessionGroupIdPrefix(
+      composeResourceListGroupResolvers(pinnedResolver, (session) => {
+        const agentId = session.agentId
+        if (!agentId) {
+          return { id: 'agent:unknown', label: labels.agent.unknown }
+        }
 
-      const agent = agentById?.get(agentId)
-      return agent
-        ? { id: getSessionAgentGroupId(agent.id), label: agent.name }
-        : { id: SESSION_UNKNOWN_AGENT_GROUP_ID, label: labels.agent.unknown }
-    }
+        const agent = agentById?.get(agentId)
+        return agent
+          ? { id: `agent:${agent.id}`, label: agent.name }
+          : { id: 'agent:unknown', label: labels.agent.unknown }
+      })
+    )
   }
-
-  const pinnedResolver = createPinnedGroupResolver<T>({
-    isPinned: (session) => session.pinned === true,
-    group: { id: SESSION_PINNED_GROUP_ID, label: pinnedGroupLabel } satisfies ResourceListGroup
-  })
 
   return composeResourceListGroupResolvers(pinnedResolver, (session) => {
     if (isSystemWorkspaceSession(session)) {
@@ -366,7 +365,11 @@ export function sortSessionsForDisplayGroups<T extends SessionListItem>(
 
   if (options.mode === 'agent') {
     return sessions
-      .map((session, index) => ({ session, index, rank: getAgentGroupRank(session, options.agentRankById) }))
+      .map((session, index) => ({
+        session,
+        index,
+        rank: isPinned(session) ? -1 : getAgentGroupRank(session, options.agentRankById)
+      }))
       .sort((a, b) => {
         if (a.rank !== b.rank) return a.rank - b.rank
         const aPinned = isPinned(a.session)


### PR DESCRIPTION
## Description

When the session list is grouped by agent, pinned tasks were placed inside their agent groups. Pinned tasks now use the dedicated pinned section above agent groups, preserving their order and visibility when their owner group is collapsed.

Fixes #20292

## Validation

- Renderer Vitest: 119/119 passed across session grouping helpers and Sessions component integration, including expanded and collapsed agent groups
- `pnpm lint` passed, including typechecks and i18n validation
- Biome check passed for the changed files
- ESLint passed for the changed files
- `git diff --check` passed
