### PR TITLE
fix(chat-errors): normalize non-error throws

### DIFF
--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -2875,13 +2875,13 @@ describe('AiStreamManager', () => {
       }
     )
 
-    it('does not treat an undefined stream rejection as successful completion', async () => {
+    it.each([undefined, null])('does not treat a %s stream rejection as successful completion', async (error) => {
       vi.useRealTimers()
 
       mockStreamText.mockResolvedValueOnce(
         new ReadableStream({
           start(controller) {
-            controller.error(undefined)
+            controller.error(error)
           }
         })
       )
@@ -2896,7 +2896,8 @@ describe('AiStreamManager', () => {
 
       await vi.waitFor(() => expect(listener.errorResults).toHaveLength(1))
 
-      expect(listener.errorResults[0].error).toMatchObject({ message: 'undefined' })
+      expect(listener.errorResults[0].error).toMatchObject({ message: 'Unknown error' })
+      expect(listener.errorResults[0].status).toBe('error')
       expect(mgr.inspect('a')!.status).toBe('error')
     })
 

--- a/src/main/ai/utils/__tests__/serializeError.test.ts
+++ b/src/main/ai/utils/__tests__/serializeError.test.ts
@@ -4,6 +4,16 @@ import { describe, expect, it } from 'vitest'
 import { serializeError } from '../serializeError'
 
 describe('serializeError', () => {
+  it('normalizes non-Error throws without leaking object coercions', () => {
+    expect(serializeError(null).message).toBe('Unknown error')
+    expect(serializeError(undefined).message).toBe('Unknown error')
+    expect(serializeError({ error: { message: 'request was rate limited' } }).message).toBe('request was rate limited')
+    expect(serializeError({ error: { message: 'Authorization: Bearer provider-secret' } }).message).toBe(
+      'Authorization: "<redacted>"'
+    )
+    expect(serializeError({ privatePrompt: 'do not expose me' }).message).toBe('Unknown error')
+  })
+
   it('retains quota diagnosis in serialized retry errors without retaining the payload', () => {
     const error = new APICallError({
       message: 'Rate limit exceeded',

--- a/src/main/ai/utils/serializeError.ts
+++ b/src/main/ai/utils/serializeError.ts
@@ -94,9 +94,15 @@ export function serializeError(error: unknown): SerializedError {
 
     return serialized
   }
+
+  const message = getSafeProviderErrorMessage({
+    responseBody: error,
+    data: error,
+    message: typeof error === 'string' ? error : undefined
+  })
   return {
     name: null,
-    message: String(error),
+    message: message || 'Unknown error',
     stack: null
   }
 }


### PR DESCRIPTION
## Description

Fixes the shared IPC serialization fallback that turned non-`Error` provider failures into `null` or `[object Object]`. Structured payloads now retain a safe nested message when present, while empty or opaque values use `Unknown error`; existing provider-error redaction remains in the path.

Fixes #19824

## Changes

- extract safe provider text from plain thrown response objects
- replace null and opaque-object coercions with a readable fallback
- cover nested messages, nullish values, redaction, and private opaque payloads

## Checklist

- [x] Main-process regression tests pass (`135/135`), including nullish stream rejection status
- [x] `pnpm lint` passes, including typechecks and i18n validation
- [x] ESLint passes for the changed files
- [x] Commit is signed and includes DCO sign-off

## Release notes

Fixed chat errors showing `null` or `[object Object]` when a provider throws a non-standard value.
