### PR TITLE
feat(provider-registry): add DeepSeek V4.1 Flash GA model

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -1375,11 +1375,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.04815
+          "perMillionTokens": 0.09
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.19305
+          "perMillionTokens": 0.3
         }
       }
     },
@@ -7250,11 +7250,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.32
+          "perMillionTokens": 0.2574
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.8899999999999999
+          "perMillionTokens": 1.0287
         }
       }
     },
@@ -7270,11 +7270,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.25
+          "perMillionTokens": 0.29
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1
+          "perMillionTokens": 1.1400000000000001
         }
       }
     },
@@ -7290,11 +7290,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.55
+          "perMillionTokens": 0.25
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1.6500000000000001
+          "perMillionTokens": 0.95
         }
       },
       "reasoning": {
@@ -7304,6 +7304,42 @@
           }
         ],
         "supportedEfforts": ["none", "auto"]
+      }
+    },
+    {
+      "capabilities": ["function-call", "image-recognition", "reasoning", "structured-output"],
+      "contextWindow": 1000000,
+      "family": "deepseek-flash",
+      "id": "deepseek-flash",
+      "inputModalities": ["text", "image"],
+      "maxOutputTokens": 393216,
+      "metadata": {},
+      "name": "DeepSeek V4.1 Flash",
+      "openWeights": true,
+      "outputModalities": ["text"],
+      "ownedBy": "deepseek",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.014
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.44
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.32
+        }
+      },
+      "reasoning": {
+        "controls": [
+          {
+            "kind": "effort",
+            "values": ["none", "low", "high", "max"]
+          }
+        ],
+        "supportedEfforts": ["none", "low", "high", "max"]
       }
     },
     {
@@ -7688,29 +7724,22 @@
       }
     },
     {
-      "capabilities": ["function-call", "image-recognition", "reasoning", "structured-output"],
-      "contextWindow": 1000000,
-      "family": "deepseek-flash",
-      "id": "deepseek-v4-1-flash-expires-on",
+      "capabilities": ["function-call", "reasoning", "image-recognition", "structured-output"],
+      "contextWindow": 1048576,
+      "id": "deepseek-v4-1-flash",
       "inputModalities": ["text", "image"],
-      "maxOutputTokens": 393216,
       "metadata": {},
-      "name": "DeepSeek V4.1 Flash Expires-On-0910",
-      "openWeights": true,
+      "name": "DeepSeek: DeepSeek V4.1 Flash",
       "outputModalities": ["text"],
       "ownedBy": "deepseek",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.014
-        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.44
+          "perMillionTokens": 0.3
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1.32
+          "perMillionTokens": 1.2
         }
       },
       "reasoning": {
@@ -7721,6 +7750,44 @@
           }
         ],
         "supportedEfforts": ["none", "low", "high", "max"]
+      }
+    },
+    {
+      "capabilities": ["function-call", "reasoning", "image-recognition", "file-input"],
+      "contextWindow": 1000000,
+      "family": "deepseek",
+      "id": "deepseek-v4-1-flash-beta",
+      "inputModalities": ["text", "image"],
+      "maxOutputTokens": 384000,
+      "metadata": {},
+      "name": "DeepSeek V4.1 Flash Beta",
+      "outputModalities": ["text"],
+      "ownedBy": "deepseek",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.007
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.22
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.66
+        }
+      },
+      "reasoning": {
+        "controls": [
+          {
+            "kind": "effort",
+            "values": ["high", "xhigh"]
+          },
+          {
+            "kind": "toggle"
+          }
+        ],
+        "supportedEfforts": ["high", "xhigh", "none"]
       }
     },
     {
@@ -10731,13 +10798,19 @@
     {
       "capabilities": ["function-call", "reasoning", "structured-output"],
       "contextWindow": 260000,
-      "id": "mercury-2-5-preview",
+      "family": "mercury",
+      "id": "mercury-2-5",
       "inputModalities": ["text"],
+      "maxOutputTokens": 65536,
       "metadata": {},
-      "name": "Inception: Mercury 2.5 Preview",
+      "name": "Mercury 2.5",
       "outputModalities": ["text"],
       "ownedBy": "inception",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.004
+        },
         "input": {
           "currency": "USD",
           "perMillionTokens": 0.04
@@ -10746,6 +10819,15 @@
           "currency": "USD",
           "perMillionTokens": 0.15
         }
+      },
+      "reasoning": {
+        "controls": [
+          {
+            "kind": "effort",
+            "values": ["none", "low", "medium", "high"]
+          }
+        ],
+        "supportedEfforts": ["none", "low", "medium", "high"]
       }
     },
     {
@@ -11802,7 +11884,7 @@
       "inputModalities": ["text"],
       "maxOutputTokens": 4096,
       "metadata": {},
-      "name": "Llama 3.1 70B Instruct",
+      "name": "Llama 3.1 70B Instruct (US)",
       "openWeights": true,
       "outputModalities": ["text"],
       "ownedBy": "meta",
@@ -13688,14 +13770,14 @@
       }
     },
     {
-      "capabilities": ["function-call", "image-recognition"],
+      "capabilities": ["function-call", "image-recognition", "file-input"],
       "contextWindow": 128000,
-      "family": "mistral",
+      "family": "pixtral",
       "id": "pixtral-large",
       "inputModalities": ["text", "image"],
       "maxOutputTokens": 8192,
       "metadata": {},
-      "name": "Pixtral Large (25.02)",
+      "name": "Pixtral Large (25.02) (EU)",
       "outputModalities": ["text"],
       "ownedBy": "mistral",
       "pricing": {
@@ -14191,11 +14273,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 2.5500000000000003
+          "perMillionTokens": 2.4
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 12.75
+          "perMillionTokens": 12
         }
       }
     },
@@ -14236,26 +14318,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 3
-        }
-      }
-    },
-    {
-      "capabilities": ["reasoning", "structured-output"],
-      "contextWindow": 131072,
-      "id": "hermes-4-70b",
-      "inputModalities": ["text"],
-      "metadata": {},
-      "name": "Nous: Hermes 4 70B",
-      "outputModalities": ["text"],
-      "ownedBy": "nousresearch",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.13
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.39999999999999997
         }
       }
     },
@@ -14898,7 +14960,7 @@
     },
     {
       "capabilities": ["function-call", "reasoning", "structured-output"],
-      "contextWindow": 1000000,
+      "contextWindow": 262144,
       "family": "nemotron",
       "id": "nemotron-3-super-120b-a12b",
       "inputModalities": ["text"],
@@ -16892,6 +16954,7 @@
     {
       "capabilities": ["reasoning", "function-call", "image-recognition", "structured-output", "file-search"],
       "contextWindow": 1050000,
+      "endpointTypes": ["openai-responses"],
       "family": "gpt",
       "id": "gpt-6-astra",
       "inputModalities": ["text", "image"],
@@ -17282,6 +17345,54 @@
       "inputModalities": ["text", "image"],
       "metadata": {},
       "name": "GPT-Image-2",
+      "outputModalities": ["image"],
+      "ownedBy": "openai",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 1.25
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 30
+        }
+      }
+    },
+    {
+      "capabilities": ["image-recognition", "image-generation"],
+      "family": "gpt-image",
+      "id": "gpt-image-2-5-flare",
+      "inputModalities": ["text", "image"],
+      "metadata": {},
+      "name": "GPT Image 2.5 Flare",
+      "outputModalities": ["image"],
+      "ownedBy": "openai",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 1.25
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 30
+        }
+      }
+    },
+    {
+      "capabilities": ["image-recognition", "image-generation"],
+      "family": "gpt-image",
+      "id": "gpt-image-2-5-sunburst",
+      "inputModalities": ["text", "image"],
+      "metadata": {},
+      "name": "GPT Image 2.5 Sunburst",
       "outputModalities": ["image"],
       "ownedBy": "openai",
       "pricing": {
@@ -20062,7 +20173,7 @@
       "inputModalities": ["text"],
       "maxOutputTokens": 8192,
       "metadata": {},
-      "name": "Palmyra X4",
+      "name": "Palmyra X4 (US)",
       "outputModalities": ["text"],
       "ownedBy": "writer",
       "pricing": {
@@ -20084,7 +20195,7 @@
       "inputModalities": ["text"],
       "maxOutputTokens": 8192,
       "metadata": {},
-      "name": "Palmyra X5",
+      "name": "Palmyra X5 (US)",
       "outputModalities": ["text"],
       "ownedBy": "writer",
       "pricing": {
@@ -20631,16 +20742,6 @@
       "inputModalities": ["text", "image", "audio"],
       "metadata": {},
       "name": "Grok Imagine Video 1.5",
-      "outputModalities": ["video"],
-      "ownedBy": "xai"
-    },
-    {
-      "capabilities": ["video-generation"],
-      "family": "grok",
-      "id": "grok-imagine-video-1-5-preview",
-      "inputModalities": ["text"],
-      "metadata": {},
-      "name": "Grok Imagine Video 1.5 Preview",
       "outputModalities": ["video"],
       "ownedBy": "xai"
     },
@@ -21672,7 +21773,7 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.13
+          "perMillionTokens": 0.14
         },
         "cacheWrite": {
           "currency": "USD",
@@ -21680,11 +21781,11 @@
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.7
+          "perMillionTokens": 1.4
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 2.2
+          "perMillionTokens": 4.4
         }
       },
       "reasoning": {
@@ -21768,41 +21869,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 0.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["low", "high", "max"]
-          }
-        ],
-        "supportedEfforts": ["low", "high", "max"]
-      }
-    },
-    {
-      "capabilities": ["function-call", "reasoning"],
-      "contextWindow": 1048576,
-      "family": "glm",
-      "id": "glm-5-3-promo-50",
-      "inputModalities": ["text"],
-      "maxOutputTokens": 1048576,
-      "metadata": {},
-      "name": "GLM 5.3 (50% off)",
-      "outputModalities": ["text"],
-      "ownedBy": "zhipu",
-      "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.13
-        },
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.7
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 2.2
         }
       },
       "reasoning": {
@@ -21945,11 +22011,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.07125000000000001
+          "perMillionTokens": 0.075
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.2375
+          "perMillionTokens": 0.25
         }
       }
     },
@@ -21991,11 +22057,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 1.12
+          "perMillionTokens": 1.085
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 3.52
+          "perMillionTokens": 3.41
         }
       }
     },
@@ -22032,5 +22098,5 @@
       "ownedBy": "zhipu"
     }
   ],
-  "version": "de26437ccfc78a10"
+  "version": "eb94bb51fd08a3eb"
 }

--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -1,49 +1,31 @@
 {
   "overrides": [
     {
-      "apiModelId": "chatgpt-4o-latest",
-      "modelId": "chatgpt-4o-latest",
-      "name": "chatgpt-4o-latest",
+      "apiModelId": "claude-fable-5",
+      "modelId": "claude-fable-5",
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 5
+          "perMillionTokens": 10
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 15
+          "perMillionTokens": 50
         }
       },
       "providerId": "302ai"
     },
     {
-      "apiModelId": "claude-3-5-haiku-20241022",
-      "modelId": "claude-3-5-haiku",
-      "name": "claude-3-5-haiku-20241022",
+      "apiModelId": "claude-fable-5-1",
+      "modelId": "claude-fable-5-1",
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.8
+          "perMillionTokens": 10
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 4
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "claude-3-5-haiku-latest",
-      "modelId": "claude-3-5-haiku-latest",
-      "name": "claude-3-5-haiku-latest",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.8
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 4
+          "perMillionTokens": 50
         }
       },
       "providerId": "302ai"
@@ -64,21 +46,6 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "claude-opus-4-20250514",
-      "modelId": "claude-opus-4",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 15
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 75
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
       "apiModelId": "claude-opus-4-1-20250805",
       "modelId": "claude-opus-4-1",
       "pricing": {
@@ -94,7 +61,7 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "claude-opus-4-5",
+      "apiModelId": "claude-opus-4-5-20251101",
       "modelId": "claude-opus-4-5",
       "pricing": {
         "input": {
@@ -109,32 +76,9 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "claude-opus-4-6",
-      "modelId": "claude-opus-4-6",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 25
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "claude-opus-4-7",
+      "apiModelId": "claude-opus-4-7-thinking",
       "modelId": "claude-opus-4-7",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.5
-        },
-        "cacheWrite": {
-          "currency": "USD",
-          "perMillionTokens": 6.25
-        },
         "input": {
           "currency": "USD",
           "perMillionTokens": 5
@@ -147,16 +91,31 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "claude-sonnet-4-20250514",
-      "modelId": "claude-sonnet-4",
+      "apiModelId": "claude-opus-4-8",
+      "modelId": "claude-opus-4-8",
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 3
+          "perMillionTokens": 5
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 15
+          "perMillionTokens": 25
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "claude-opus-5",
+      "modelId": "claude-opus-5",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 25
         }
       },
       "providerId": "302ai"
@@ -192,32 +151,16 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "deepseek-chat",
-      "modelId": "deepseek-chat",
+      "apiModelId": "claude-sonnet-5",
+      "modelId": "claude-sonnet-5",
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.29
+          "perMillionTokens": 2
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.43
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "deepseek-reasoner",
-      "modelId": "deepseek-reasoner",
-      "name": "Deepseek-Reasoner",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.29
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.43
+          "perMillionTokens": 10
         }
       },
       "providerId": "302ai"
@@ -278,21 +221,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 0.286
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "doubao-seed-code-preview-251028",
-      "modelId": "doubao-seed-code-preview",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.17
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 1.14
         }
       },
       "providerId": "302ai"
@@ -406,6 +334,126 @@
       "providerId": "302ai"
     },
     {
+      "apiModelId": "gemini-3.1-flash-lite",
+      "modelId": "gemini-3-1-flash-lite",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.25
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.5
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gemini-3.1-flash-lite-preview",
+      "modelId": "gemini-3-1-flash-lite-preview",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.25
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.5
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gemini-3.1-pro-preview",
+      "modelId": "gemini-3-1-pro-preview",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 2
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 12
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gemini-3.5-flash-thinking",
+      "modelId": "gemini-3-5-flash",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 1.5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 9
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gemini-3.5-flash-lite",
+      "modelId": "gemini-3-5-flash-lite",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.3
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 2.5
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gemini-3.6-flash",
+      "modelId": "gemini-3-6-flash",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 1.5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 7.5
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gemini-3.7-flash",
+      "modelId": "gemini-3-7-flash",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.75
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 3.75
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gemini-3.8-flash",
+      "modelId": "gemini-3-8-flash",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.75
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 3.75
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
       "apiModelId": "gemini-3-flash-preview",
       "modelId": "gemini-3-flash-preview",
       "pricing": {
@@ -462,53 +510,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 1.142
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "glm-4.5-air",
-      "modelId": "glm-4-5-air",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.1143
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.286
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "glm-4.5-airx",
-      "modelId": "glm-4-5-airx",
-      "name": "glm-4.5-airx",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.572
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 1.714
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "glm-4.5-x",
-      "modelId": "glm-4-5-x",
-      "name": "glm-4.5-x",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 1.143
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 2.29
         }
       },
       "providerId": "302ai"
@@ -574,21 +575,6 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "glm-4.7-flashx",
-      "modelId": "glm-4-7-flashx",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.0715
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.429
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
       "apiModelId": "glm-5",
       "modelId": "glm-5",
       "pricing": {
@@ -609,11 +595,56 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.86
+          "perMillionTokens": 1.4
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 3.5
+          "perMillionTokens": 4.4
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "glm-5.2",
+      "modelId": "glm-5-2",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 1.4
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 4.4
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "glm-5.3",
+      "modelId": "glm-5-3",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 1.4
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 4.4
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "glm-5.3-flash",
+      "modelId": "glm-5-3-flash",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.075
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.25
         }
       },
       "providerId": "302ai"
@@ -644,22 +675,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 3.2
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "glm-for-coding",
-      "modelId": "glm-for-coding",
-      "name": "glm-for-coding",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.086
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.343
         }
       },
       "providerId": "302ai"
@@ -801,6 +816,21 @@
       "providerId": "302ai"
     },
     {
+      "apiModelId": "gpt-5.3-chat-latest",
+      "modelId": "gpt-5-3-chat-latest",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 1.75
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 14
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
       "apiModelId": "gpt-5.4",
       "modelId": "gpt-5-4",
       "pricing": {
@@ -824,7 +854,7 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "gpt-5.4-mini-2026-03-17",
+      "apiModelId": "gpt-5.4-mini",
       "modelId": "gpt-5-4-mini",
       "pricing": {
         "input": {
@@ -839,7 +869,7 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "gpt-5.4-nano-2026-03-17",
+      "apiModelId": "gpt-5.4-nano",
       "modelId": "gpt-5-4-nano",
       "pricing": {
         "input": {
@@ -854,24 +884,106 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "gpt-5.4-pro",
-      "modelId": "gpt-5-4-pro",
+      "apiModelId": "gpt-5.5",
+      "modelId": "gpt-5-5",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0
-        },
-        "cacheWrite": {
-          "currency": "USD",
-          "perMillionTokens": 0
-        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 30
+          "perMillionTokens": 5
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 180
+          "perMillionTokens": 30
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gpt-5.6-luna",
+      "modelId": "gpt-5-6-luna",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.2
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.2
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gpt-5.6-luna-pro",
+      "modelId": "gpt-5-6-luna-pro",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.2
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.2
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gpt-5.6-sol",
+      "modelId": "gpt-5-6-sol",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 30
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gpt-5.6-sol-pro",
+      "modelId": "gpt-5-6-sol-pro",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 30
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gpt-5.6-terra",
+      "modelId": "gpt-5-6-terra",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 2
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 12
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "gpt-5.6-terra-pro",
+      "modelId": "gpt-5-6-terra-pro",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 2
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 12
         }
       },
       "providerId": "302ai"
@@ -907,6 +1019,21 @@
       "providerId": "302ai"
     },
     {
+      "apiModelId": "gpt-6-astra",
+      "modelId": "gpt-6-astra",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 10
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 50
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
       "apiModelId": "grok-4.1",
       "modelId": "grok-4-1",
       "pricing": {
@@ -937,21 +1064,6 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "grok-4-1-fast-non-reasoning",
-      "modelId": "grok-4-1-fast-non-reasoning",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.2
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.5
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
       "apiModelId": "grok-4.20-beta-0309-reasoning",
       "modelId": "grok-4-20-beta",
       "name": "grok-4.20-beta-0309-reasoning",
@@ -968,9 +1080,23 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "grok-4.20-beta-0309-non-reasoning",
-      "modelId": "grok-4-20-beta-0309-non-reasoning",
-      "name": "grok-4.20-beta-0309-non-reasoning",
+      "apiModelId": "grok-4.3",
+      "modelId": "grok-4-3",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 1.25
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 2.5
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "grok-4.5",
+      "modelId": "grok-4-5",
       "pricing": {
         "input": {
           "currency": "USD",
@@ -984,8 +1110,8 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "grok-4.20-multi-agent-beta-0309",
-      "modelId": "grok-4-20-multi-agent-beta",
+      "apiModelId": "grok-4.6",
+      "modelId": "grok-4-6",
       "pricing": {
         "input": {
           "currency": "USD",
@@ -1061,17 +1187,61 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "kimi-k2-thinking-turbo",
-      "modelId": "kimi-k2-thinking-turbo",
-      "name": "kimi-k2-thinking-turbo",
+      "apiModelId": "kimi-k2.5",
+      "modelId": "kimi-k2-5",
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 1.265
+          "perMillionTokens": 0.66
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 9.119
+          "perMillionTokens": 3.3
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "kimi-k2.6",
+      "modelId": "kimi-k2-6",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.95
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 4
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "kimi-k2.7-code",
+      "modelId": "kimi-k2-7-code",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.95
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 4
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "kimi-k3",
+      "modelId": "kimi-k3",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 3
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 15
         }
       },
       "providerId": "302ai"
@@ -1122,6 +1292,21 @@
       "providerId": "302ai"
     },
     {
+      "apiModelId": "MiniMax-M2.5",
+      "modelId": "minimax-m2-5",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.3
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.2
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
       "apiModelId": "MiniMax-M2.7",
       "modelId": "minimax-m2-7",
       "pricing": {
@@ -1137,16 +1322,16 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "MiniMax-M2.7-highspeed",
-      "modelId": "minimax-m2-7-highspeed",
+      "apiModelId": "MiniMax-M3",
+      "modelId": "minimax-m3",
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.6
+          "perMillionTokens": 0.72
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 4.8
+          "perMillionTokens": 2.88
         }
       },
       "providerId": "302ai"
@@ -1182,47 +1367,16 @@
       "providerId": "302ai"
     },
     {
-      "apiModelId": "qwen-flash",
-      "modelId": "qwen-flash",
+      "apiModelId": "o3",
+      "modelId": "o3",
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.022
+          "perMillionTokens": 2
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.22
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "qwen-max-latest",
-      "modelId": "qwen-max-latest",
-      "name": "Qwen-Max-Latest",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.343
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 1.372
-        }
-      },
-      "providerId": "302ai"
-    },
-    {
-      "apiModelId": "qwen-plus",
-      "modelId": "qwen-plus",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.12
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 1.2
+          "perMillionTokens": 8
         }
       },
       "providerId": "302ai"
@@ -1269,6 +1423,141 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 1.08
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.5-35b-a3b",
+      "modelId": "qwen3-5-35b-a3b",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.06
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.46
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.5-plus",
+      "modelId": "qwen3-5-plus",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.12
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.69
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.6-35b-a3b",
+      "modelId": "qwen3-6-35b-a3b",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.283
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.705
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.6-flash",
+      "modelId": "qwen3-6-flash",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.188
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.133
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.6-plus",
+      "modelId": "qwen3-6-plus",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.3
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.8
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.7-max",
+      "modelId": "qwen3-7-max",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 1.8
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 5.3
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.7-plus",
+      "modelId": "qwen3-7-plus",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.285
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.15
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.8-flash",
+      "modelId": "qwen3-8-flash",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.18
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.564
+        }
+      },
+      "providerId": "302ai"
+    },
+    {
+      "apiModelId": "qwen3.8-max",
+      "modelId": "qwen3-8-max",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 2.16
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 6.36
         }
       },
       "providerId": "302ai"
@@ -8405,6 +8694,137 @@
       "providerId": "deepseek"
     },
     {
+      "endpointTypes": ["openai-responses", "openai-chat-completions", "anthropic-messages"],
+      "modelId": "deepseek-flash",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.014
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.44
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.32
+        }
+      },
+      "providerId": "deepseek",
+      "reasoningContracts": {
+        "openai-chat-completions": {
+          "wire": {
+            "auto": {
+              "effortMap": {
+                "auto": "high",
+                "low": "low",
+                "medium": "high",
+                "minimal": "low",
+                "xhigh": "max"
+              },
+              "operations": [
+                {
+                  "target": "thinking.type",
+                  "value": {
+                    "source": "literal",
+                    "value": "enabled"
+                  }
+                },
+                {
+                  "target": "reasoningEffort",
+                  "value": {
+                    "source": "effort"
+                  }
+                }
+              ]
+            },
+            "effort": {
+              "effortMap": {
+                "low": "low",
+                "medium": "high",
+                "minimal": "low",
+                "xhigh": "max"
+              },
+              "operations": [
+                {
+                  "target": "thinking.type",
+                  "value": {
+                    "source": "literal",
+                    "value": "enabled"
+                  }
+                },
+                {
+                  "target": "reasoningEffort",
+                  "value": {
+                    "source": "effort"
+                  }
+                }
+              ]
+            },
+            "off": {
+              "operations": [
+                {
+                  "target": "thinking.type",
+                  "value": {
+                    "source": "literal",
+                    "value": "disabled"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "openai-responses": {
+          "wire": {
+            "auto": {
+              "effortMap": {
+                "auto": "high",
+                "low": "low",
+                "medium": "high",
+                "minimal": "low",
+                "xhigh": "max"
+              },
+              "operations": [
+                {
+                  "target": "reasoningEffort",
+                  "value": {
+                    "source": "effort"
+                  }
+                }
+              ]
+            },
+            "effort": {
+              "effortMap": {
+                "low": "low",
+                "medium": "high",
+                "minimal": "low",
+                "xhigh": "max"
+              },
+              "operations": [
+                {
+                  "target": "reasoningEffort",
+                  "value": {
+                    "source": "effort"
+                  }
+                }
+              ]
+            },
+            "off": {
+              "operations": [
+                {
+                  "target": "reasoningEffort",
+                  "value": {
+                    "source": "literal",
+                    "value": "none"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "endpointTypes": ["openai-chat-completions"],
       "modelId": "deepseek-reasoner",
       "name": "DeepSeek Reasoner",
@@ -10865,6 +11285,25 @@
       "providerId": "fireworks"
     },
     {
+      "apiModelId": "accounts/fireworks/routers/glm-5p3-fast",
+      "modelId": "glm-5-3-fast",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.39
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 2.1
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 6.6
+        }
+      },
+      "providerId": "fireworks"
+    },
+    {
       "apiModelId": "accounts/fireworks/models/glm-5p3-flash",
       "modelId": "glm-5-3-flash",
       "pricing": {
@@ -12021,6 +12460,25 @@
       "providerId": "gateway"
     },
     {
+      "apiModelId": "deepseek/deepseek-v4.1-flash-beta",
+      "modelId": "deepseek-v4-1-flash-beta",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.007
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.22
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.66
+        }
+      },
+      "providerId": "gateway"
+    },
+    {
       "apiModelId": "deepseek/deepseek-v4-flash-0731",
       "modelId": "deepseek-v4-flash",
       "pricing": {
@@ -12701,15 +13159,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.13
+          "perMillionTokens": 0.14
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.7
+          "perMillionTokens": 1.4
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 2.2
+          "perMillionTokens": 4.4
         }
       },
       "providerId": "gateway"
@@ -12748,25 +13206,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 0.5
-        }
-      },
-      "providerId": "gateway"
-    },
-    {
-      "apiModelId": "zai/glm-5.3-promo-50",
-      "modelId": "glm-5-3-promo-50",
-      "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.13
-        },
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.7
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 2.2
         }
       },
       "providerId": "gateway"
@@ -13461,6 +13900,44 @@
     {
       "apiModelId": "openai/gpt-image-2",
       "modelId": "gpt-image-2",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 1.25
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 30
+        }
+      },
+      "providerId": "gateway"
+    },
+    {
+      "apiModelId": "openai/gpt-image-2.5-flare",
+      "modelId": "gpt-image-2-5-flare",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 1.25
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 30
+        }
+      },
+      "providerId": "gateway"
+    },
+    {
+      "apiModelId": "openai/gpt-image-2.5-sunburst",
+      "modelId": "gpt-image-2-5-sunburst",
       "pricing": {
         "cacheRead": {
           "currency": "USD",
@@ -14345,6 +14822,25 @@
       "providerId": "gateway"
     },
     {
+      "apiModelId": "inception/mercury-2.5",
+      "modelId": "mercury-2-5",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.004
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.04
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.15
+        }
+      },
+      "providerId": "gateway"
+    },
+    {
       "apiModelId": "inception/mercury-coder-small",
       "modelId": "mercury-coder-small",
       "pricing": {
@@ -14393,25 +14889,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 0.87
-        }
-      },
-      "providerId": "gateway"
-    },
-    {
-      "apiModelId": "xiaomi/mimo-v2.5-pro-ultraspeed",
-      "modelId": "mimo-v2-5-pro-ultraspeed",
-      "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.0108
-        },
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 1.305
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 2.61
         }
       },
       "providerId": "gateway"
@@ -20483,21 +20960,53 @@
       "supportsFastMode": true
     },
     {
+      "apiModelId": "deepseek-flash",
+      "endpointTypes": ["openai-chat-completions"],
+      "modelId": "deepseek-flash",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.003
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.15
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.6
+        }
+      },
+      "providerId": "opencode",
+      "reasoningContracts": {
+        "openai-chat-completions": {
+          "support": {
+            "controls": [
+              {
+                "kind": "effort",
+                "values": ["high", "max"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
       "apiModelId": "deepseek-v4-flash",
       "endpointTypes": ["openai-chat-completions"],
       "modelId": "deepseek-v4-flash",
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.007
+          "perMillionTokens": 0.003
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.22
+          "perMillionTokens": 0.15
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.66
+          "perMillionTokens": 0.6
         }
       },
       "providerId": "opencode",
@@ -20521,15 +21030,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.007
+          "perMillionTokens": 0.003
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.22
+          "perMillionTokens": 0.15
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.66
+          "perMillionTokens": 0.6
         }
       },
       "providerId": "opencode",
@@ -22763,11 +23272,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.32
+          "perMillionTokens": 0.2574
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.89
+          "perMillionTokens": 1.0287
         }
       },
       "providerId": "openrouter"
@@ -22776,13 +23285,17 @@
       "apiModelId": "deepseek/deepseek-chat-v3-0324",
       "modelId": "deepseek-chat-v3",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.11
+        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.25
+          "perMillionTokens": 0.29
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1
+          "perMillionTokens": 1.14
         }
       },
       "providerId": "openrouter"
@@ -22793,15 +23306,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.55
+          "perMillionTokens": 0.13
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.55
+          "perMillionTokens": 0.25
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1.65
+          "perMillionTokens": 0.95
         }
       },
       "providerId": "openrouter",
@@ -22958,20 +23471,58 @@
       }
     },
     {
+      "apiModelId": "deepseek/deepseek-v4.1-flash",
+      "modelId": "deepseek-v4-1-flash",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.006
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.3
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.2
+        }
+      },
+      "providerId": "openrouter",
+      "reasoningContracts": {
+        "openai-chat-completions": {
+          "support": {
+            "controls": [
+              {
+                "default": "high",
+                "kind": "effort",
+                "values": ["max", "high", "low"]
+              },
+              {
+                "default": true,
+                "kind": "toggle"
+              }
+            ],
+            "defaultEffort": "high",
+            "supportedEfforts": ["max", "high", "low", "none"]
+          }
+        }
+      }
+    },
+    {
       "apiModelId": "deepseek/deepseek-v4-flash-0731",
       "modelId": "deepseek-v4-flash",
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.028
+          "perMillionTokens": 0.016
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.14
+          "perMillionTokens": 0.065
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.28
+          "perMillionTokens": 0.18
         }
       },
       "providerId": "openrouter",
@@ -23026,15 +23577,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.014
+          "perMillionTokens": 0.007
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.44
+          "perMillionTokens": 0.22
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1.32
+          "perMillionTokens": 0.66
         }
       },
       "providerId": "openrouter",
@@ -23064,15 +23615,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.03718
+          "perMillionTokens": 0.03498
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 1.1154
+          "perMillionTokens": 1.0494
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 3.3462
+          "perMillionTokens": 3.1482
         }
       },
       "providerId": "openrouter",
@@ -24954,13 +25505,9 @@
       "apiModelId": "z-ai/glm-4.7-flash",
       "modelId": "glm-4-7-flash",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.01
-        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.06
+          "perMillionTokens": 0.0605
         },
         "output": {
           "currency": "USD",
@@ -25222,15 +25769,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.01425
+          "perMillionTokens": 0.015
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.07125
+          "perMillionTokens": 0.075
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.2375
+          "perMillionTokens": 0.25
         }
       },
       "providerId": "openrouter",
@@ -25256,15 +25803,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.234
+          "perMillionTokens": 0.2028
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 1.17
+          "perMillionTokens": 1.092
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 3.96
+          "perMillionTokens": 3.432
         }
       },
       "providerId": "openrouter",
@@ -26924,6 +27471,126 @@
       "providerId": "openrouter"
     },
     {
+      "apiModelId": "openai/gpt-image-2.5-flare",
+      "capabilities": {
+        "add": ["image-generation"]
+      },
+      "endpointTypes": ["openai-image-generation"],
+      "imageGeneration": {
+        "modes": {
+          "edit": {
+            "maxInputImages": 16,
+            "supports": {
+              "aspectRatio": {
+                "options": ["1:1", "3:2", "2:3", "4:3", "3:4", "16:9", "9:16", "21:9", "auto"],
+                "type": "enum"
+              },
+              "background": {
+                "options": ["auto", "opaque"],
+                "type": "enum"
+              },
+              "numImages": {
+                "max": 10,
+                "min": 1,
+                "step": 1,
+                "type": "range"
+              },
+              "quality": {
+                "options": ["auto", "low", "medium", "high", "xhigh", "max"],
+                "type": "enum"
+              }
+            }
+          },
+          "generate": {
+            "supports": {
+              "aspectRatio": {
+                "options": ["1:1", "3:2", "2:3", "4:3", "3:4", "16:9", "9:16", "21:9", "auto"],
+                "type": "enum"
+              },
+              "background": {
+                "options": ["auto", "opaque"],
+                "type": "enum"
+              },
+              "numImages": {
+                "max": 10,
+                "min": 1,
+                "step": 1,
+                "type": "range"
+              },
+              "quality": {
+                "options": ["auto", "low", "medium", "high", "xhigh", "max"],
+                "type": "enum"
+              }
+            }
+          }
+        }
+      },
+      "inputModalities": ["text", "image"],
+      "modelId": "gpt-image-2-5-flare",
+      "outputModalities": ["image"],
+      "providerId": "openrouter"
+    },
+    {
+      "apiModelId": "openai/gpt-image-2.5-sunburst",
+      "capabilities": {
+        "add": ["image-generation"]
+      },
+      "endpointTypes": ["openai-image-generation"],
+      "imageGeneration": {
+        "modes": {
+          "edit": {
+            "maxInputImages": 16,
+            "supports": {
+              "aspectRatio": {
+                "options": ["1:1", "3:2", "2:3", "4:3", "3:4", "16:9", "9:16", "21:9", "auto"],
+                "type": "enum"
+              },
+              "background": {
+                "options": ["auto", "opaque"],
+                "type": "enum"
+              },
+              "numImages": {
+                "max": 10,
+                "min": 1,
+                "step": 1,
+                "type": "range"
+              },
+              "quality": {
+                "options": ["auto", "low", "medium", "high", "xhigh", "max"],
+                "type": "enum"
+              }
+            }
+          },
+          "generate": {
+            "supports": {
+              "aspectRatio": {
+                "options": ["1:1", "3:2", "2:3", "4:3", "3:4", "16:9", "9:16", "21:9", "auto"],
+                "type": "enum"
+              },
+              "background": {
+                "options": ["auto", "opaque"],
+                "type": "enum"
+              },
+              "numImages": {
+                "max": 10,
+                "min": 1,
+                "step": 1,
+                "type": "range"
+              },
+              "quality": {
+                "options": ["auto", "low", "medium", "high", "xhigh", "max"],
+                "type": "enum"
+              }
+            }
+          }
+        }
+      },
+      "inputModalities": ["text", "image"],
+      "modelId": "gpt-image-2-5-sunburst",
+      "outputModalities": ["image"],
+      "providerId": "openrouter"
+    },
+    {
       "apiModelId": "~openai/gpt-latest",
       "modelId": "gpt-latest",
       "pricing": {
@@ -27116,15 +27783,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.05
+          "perMillionTokens": 0.015
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.1
+          "perMillionTokens": 0.06
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.15
+          "perMillionTokens": 0.25
         }
       },
       "providerId": "openrouter",
@@ -27611,33 +28278,6 @@
       }
     },
     {
-      "apiModelId": "nousresearch/hermes-4-70b",
-      "modelId": "hermes-4-70b",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.13
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.4
-        }
-      },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "kind": "toggle"
-              }
-            ],
-            "supportedEfforts": ["none", "auto"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "tencent/hunyuan-a13b-instruct",
       "modelId": "hunyuan-a13b-instruct",
       "pricing": {
@@ -28025,15 +28665,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.18
+          "perMillionTokens": 0.15
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.66
+          "perMillionTokens": 0.71
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 3.4
+          "perMillionTokens": 3.5
         }
       },
       "providerId": "openrouter",
@@ -28089,15 +28729,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.256
+          "perMillionTokens": 0.24
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 2.55
+          "perMillionTokens": 2.4
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 12.75
+          "perMillionTokens": 12
         }
       },
       "providerId": "openrouter",
@@ -28904,8 +29544,8 @@
       }
     },
     {
-      "apiModelId": "inception/mercury-2.5-preview",
-      "modelId": "mercury-2-5-preview",
+      "apiModelId": "inception/mercury-2.5",
+      "modelId": "mercury-2-5",
       "pricing": {
         "cacheRead": {
           "currency": "USD",
@@ -29099,15 +29739,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.027
+          "perMillionTokens": 0.03
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.27
+          "perMillionTokens": 0.3
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1.08
+          "perMillionTokens": 1.2
         }
       },
       "providerId": "openrouter",
@@ -29931,21 +30571,17 @@
       }
     },
     {
-      "apiModelId": "nex-agi/nex-n2-mini",
-      "modelId": "nex-n2-mini",
-      "name": "Nex-N2-Mini",
+      "apiModelId": "nex-agi/nex-n2.5-mini:free",
+      "modelId": "nex-n2-5-mini",
+      "name": "Nex-N2.5-Mini (free)",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.0025
-        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.025
+          "perMillionTokens": 0
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.1
+          "perMillionTokens": 0
         }
       },
       "providerId": "openrouter",
@@ -29954,30 +30590,32 @@
           "support": {
             "controls": [
               {
+                "default": "high",
+                "kind": "effort",
+                "values": ["high", "medium", "none"]
+              },
+              {
                 "kind": "toggle"
               }
             ],
-            "supportedEfforts": ["none", "auto"]
+            "defaultEffort": "high",
+            "supportedEfforts": ["high", "medium", "none"]
           }
         }
       }
     },
     {
-      "apiModelId": "nex-agi/nex-n2-pro",
-      "modelId": "nex-n2-pro",
-      "name": "Nex-N2-Pro",
+      "apiModelId": "nex-agi/nex-n2.5-pro:free",
+      "modelId": "nex-n2-5-pro",
+      "name": "Nex-N2.5-Pro (free)",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.025
-        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.25
+          "perMillionTokens": 0
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1
+          "perMillionTokens": 0
         }
       },
       "providerId": "openrouter",
@@ -29986,10 +30624,16 @@
           "support": {
             "controls": [
               {
+                "default": "high",
+                "kind": "effort",
+                "values": ["high", "medium", "none"]
+              },
+              {
                 "kind": "toggle"
               }
             ],
-            "supportedEfforts": ["none", "auto"]
+            "defaultEffort": "high",
+            "supportedEfforts": ["high", "medium", "none"]
           }
         }
       }
@@ -30623,11 +31267,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.12
+          "perMillionTokens": 0.2275
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.24
+          "perMillionTokens": 0.91
         }
       },
       "providerId": "openrouter",
@@ -30694,11 +31338,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.04815
+          "perMillionTokens": 0.09
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.19305
+          "perMillionTokens": 0.3
         }
       },
       "providerId": "openrouter"
@@ -30736,11 +31380,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.29
+          "perMillionTokens": 0.26
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 2.4
+          "perMillionTokens": 2.08
         }
       },
       "providerId": "openrouter",
@@ -30819,13 +31463,17 @@
       "apiModelId": "qwen/qwen3.5-397b-a17b",
       "modelId": "qwen3-5-397b-a17b",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.225
+        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.39
+          "perMillionTokens": 0.55
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 2.34
+          "perMillionTokens": 3.5
         }
       },
       "providerId": "openrouter",
@@ -31558,13 +32206,9 @@
       "apiModelId": "qwen/qwen3-next-80b-a3b-instruct",
       "modelId": "qwen3-next-80b-a3b-instruct",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.07
-        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.1
+          "perMillionTokens": 0.09
         },
         "output": {
           "currency": "USD",
@@ -39388,5 +40032,5 @@
       "providerId": "zhipu"
     }
   ],
-  "version": "ce24dfb71cd68d13"
+  "version": "6dc84a57c36a718a"
 }

--- a/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
@@ -78,7 +78,7 @@ describe('deepseek endpoint matrix', () => {
       {
         id: 'web-search',
         modelScope: 'model-dependent',
-        modelIdPrefixes: ['deepseek-v4-flash', 'deepseek-v4-pro'],
+        modelIdPrefixes: ['deepseek-flash', 'deepseek-v4-flash', 'deepseek-v4-pro'],
         endpointTypes: ['openai-responses']
       }
     ])

--- a/packages/provider-registry/src/creators/deepseek.ts
+++ b/packages/provider-registry/src/creators/deepseek.ts
@@ -49,8 +49,8 @@ export default defineCreator({
       openWeights: true
     },
     {
-      id: 'deepseek-v4.1-flash-expires-on-0910',
-      name: 'DeepSeek V4.1 Flash Expires-On-0910',
+      id: 'deepseek-flash',
+      name: 'DeepSeek V4.1 Flash',
       family: 'deepseek-flash',
       capabilities: ['function-call', 'image-recognition', 'reasoning', 'structured-output'],
       contextWindow: 1000000,
@@ -77,6 +77,7 @@ export default defineCreator({
   ],
   reasoningFamilies: [
     { pattern: '^deepseek-v(?:[4-9]\\d*|[1-9]\\d{1,})(?:\\.\\d+)?', effort: ['none', 'low', 'high', 'max'] },
+    { pattern: '^deepseek-flash', effort: ['none', 'low', 'high', 'max'] },
     // v3.x hybrid inference (thinking / non-thinking at one endpoint).
     { pattern: 'deepseek-(?:chat|v3(?:\\.\\d|-\\d))', toggle: true, template: true },
     // Membership profiles (no knobs): reasoning SKUs beyond the knob rules above.

--- a/packages/provider-registry/src/patterns/reasoning-families.gen.ts
+++ b/packages/provider-registry/src/patterns/reasoning-families.gen.ts
@@ -136,6 +136,7 @@ export const REASONING_FAMILY_RULES: readonly ReasoningFamilyRule[] = [
   { pattern: '^north-mini-code' },
   // deepseek
   { pattern: '^deepseek-v(?:[4-9]\\d*|[1-9]\\d{1,})(?:\\.\\d+)?', effort: ['none', 'low', 'high', 'max'] },
+  { pattern: '^deepseek-flash', effort: ['none', 'low', 'high', 'max'] },
   { pattern: 'deepseek-(?:chat|v3(?:\\.\\d|-\\d))', toggle: true, template: true },
   { pattern: '(\\w+-)?deepseek-v3(?:\\.\\d|-\\d)(?:(\\.|-)(?!speciale$)\\w+)?$' },
   { pattern: 'deepseek-chat' },

--- a/packages/provider-registry/src/patterns/server-tool-models.gen.ts
+++ b/packages/provider-registry/src/patterns/server-tool-models.gen.ts
@@ -277,13 +277,12 @@ export const PROVIDER_SERVER_TOOL_MODEL_IDS: Readonly<Record<string, Partial<Rec
         'glm-5-3',
         'glm-5-3-fast',
         'glm-5-3-flash',
-        'glm-5-3-promo-50',
         'glm-5-maas',
         'glm-5-turbo'
       ]
     },
     deepseek: {
-      'web-search': ['deepseek-v4-flash', 'deepseek-v4-flash-vision-exp', 'deepseek-v4-pro']
+      'web-search': ['deepseek-flash', 'deepseek-v4-flash', 'deepseek-v4-flash-vision-exp', 'deepseek-v4-pro']
     },
     'new-api': {
       'web-search': [
@@ -751,7 +750,6 @@ export const PROVIDER_SERVER_TOOL_MODEL_IDS: Readonly<Record<string, Partial<Rec
         'glm-5-3',
         'glm-5-3-fast',
         'glm-5-3-flash',
-        'glm-5-3-promo-50',
         'glm-5-maas',
         'glm-5-turbo',
         'kimi-k2',
@@ -964,7 +962,6 @@ export const PROVIDER_SERVER_TOOL_MODEL_IDS: Readonly<Record<string, Partial<Rec
         'glm-5-3',
         'glm-5-3-fast',
         'glm-5-3-flash',
-        'glm-5-3-promo-50',
         'glm-5-maas',
         'glm-5-turbo',
         'gpt-4-1',

--- a/packages/provider-registry/src/providers/deepseek.ts
+++ b/packages/provider-registry/src/providers/deepseek.ts
@@ -88,7 +88,7 @@ export default defineProvider({
     {
       id: 'web-search',
       modelScope: 'model-dependent',
-      modelIdPrefixes: ['deepseek-v4-flash', 'deepseek-v4-pro'],
+      modelIdPrefixes: ['deepseek-flash', 'deepseek-v4-flash', 'deepseek-v4-pro'],
       endpointTypes: ['openai-responses']
     }
   ],
@@ -100,12 +100,21 @@ export default defineProvider({
       official: 'https://deepseek.com/'
     }
   },
-  // The Anthropic-compatible endpoint serves V4 Pro / V4 Flash / V4 Flash Vision Exp only, and silently maps any other
-  // model name onto v4-flash — so it is pinned on those three and withheld from chat/reasoner. It
+  // The Anthropic-compatible endpoint serves the V4 flash/pro SKUs only, and silently maps any other
+  // model name onto v4-flash — so it is pinned on those and withheld from chat/reasoner. It
   // trails Chat Completions because `endpointTypes[0]` routes in-app chat.
   overrides: [
     { modelId: 'deepseek-chat', endpointTypes: ['openai-chat-completions'] },
     { modelId: 'deepseek-reasoner', name: 'DeepSeek Reasoner', endpointTypes: ['openai-chat-completions'] },
+    {
+      modelId: 'deepseek-flash',
+      endpointTypes: ['openai-responses', 'openai-chat-completions', 'anthropic-messages'],
+      pricing: v4FlashPeakPricing,
+      reasoningContracts: {
+        'openai-chat-completions': { wire: v4ChatEffortWire },
+        'openai-responses': { wire: v4ResponsesEffortWire }
+      }
+    },
     {
       modelId: 'deepseek-v4-flash',
       endpointTypes: ['openai-responses', 'openai-chat-completions', 'anthropic-messages'],

--- a/packages/provider-registry/src/providers/opencode.ts
+++ b/packages/provider-registry/src/providers/opencode.ts
@@ -44,6 +44,7 @@ const chatEffortModels: Array<{
   defaultEffort?: ReasoningEffort
   pricing?: ProviderModelOverride['pricing']
 }> = [
+  { modelId: 'deepseek-flash', values: ['high', 'max'] },
   { modelId: 'deepseek-v4-flash', values: ['high', 'max'] },
   { modelId: 'deepseek-v4-flash-vision-exp', values: ['high', 'max'] },
   { modelId: 'deepseek-v4-pro', values: ['high', 'max'] },


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The DeepSeek creator only carried the time-limited preview SKU `deepseek-v4.1-flash-expires-on-0910`, whose id was mangled to `deepseek-v4-1-flash-expires-on` by catalog canonicalization. The released `deepseek-flash` id existed nowhere in the registry, so it was dropped as an unclaimed model, had no provider endpoints, no reasoning wire contract, and no `web-search` eligibility.

After this PR:

`deepseek-flash` ("DeepSeek V4.1 Flash") replaces the expiring preview entry in `src/creators/deepseek.ts`, and `src/providers/deepseek.ts` serves it over Responses / Chat Completions / Anthropic Messages with V4 Flash pricing, the shared V4 effort wire contracts, and `web-search` eligibility. A `^deepseek-flash` reasoning-family rule is added because the GA id drops the `v` prefix that every existing DeepSeek V4 pattern relies on, and `src/providers/opencode.ts` pins the model to chat/completions since models.dev already lists it under OpenCode Go.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The preview entry is replaced rather than kept alongside the GA id — it expires on 2026-09-10 and its canonicalized id was already wrong. The `deepseek-flash` overrides duplicate the `deepseek-v4-flash` shape (endpoints, pricing, reasoning contracts) instead of introducing a shared helper, matching how the sibling SKUs are already declared in this file.

The following alternatives were considered:

Relying on the existing `^deepseek-v(?:[4-9]...)` reasoning-family pattern was considered and rejected: it cannot match `deepseek-flash`, so custom-provider rows for this model would lose reasoning membership and its effort ladder. Leaving OpenCode Go unpinned was also rejected — the `pins an endpoint on every OpenCode Go model` catalog invariant rejects it, and an unpinned row silently falls back to chat/completions.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

`data/*.json` is regenerated, not hand-edited. `pnpm generate` re-pulls models.dev / OpenRouter live, so most of the `data/provider-models.json` and `data/models.json` diff is unrelated upstream metadata and pricing drift accumulated since the last regeneration — the DeepSeek-specific rows are the `deepseek-flash` model entry plus its `deepseek` and `opencode` provider rows. Verified with `pnpm --filter @cherrystudio/provider-registry generate` and `pnpm exec vitest run --project provider-registry` (439/439 passing). Two pre-existing `tsgo` errors in `registry-loader.ts` and `buildParamsSchema.ts` are untouched by this change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Provider] Add the released DeepSeek V4.1 Flash (`deepseek-flash`) model, replacing the expiring preview entry, with reasoning effort control and built-in web search support.
```
