### PR TITLE
feat(prompt-variables): add {{assistant_name}} system prompt variable

### DIFF
--- a/src/main/ai/runtime/agentPrompt.ts
+++ b/src/main/ai/runtime/agentPrompt.ts
@@ -71,7 +71,7 @@ export async function buildAgentRuntimePrompt({
   if (builtinRole) await provisionBuiltinAgent(agentDataPath, builtinRole)
 
   const resolvedInstructions = instructions?.trim()
-    ? await replacePromptVariables(instructions, agent.modelName ?? undefined)
+    ? await replacePromptVariables(instructions, agent.modelName ?? undefined, agent.name ?? undefined)
     : ''
   const hasAgentInstructions = Boolean(resolvedInstructions.trim())
   const parts = await promptBuilder.buildPromptParts(

--- a/src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts
@@ -4,7 +4,9 @@ import type { ToolSet } from 'ai'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@main/utils/prompt', () => ({
-  replacePromptVariables: vi.fn(async (input: string) => input.replace('{{date}}', '2026-04-20'))
+  replacePromptVariables: vi.fn(async (input: string, _modelName?: string, assistantName?: string) =>
+    input.replace('{{date}}', '2026-04-20').replace('{{assistant_name}}', assistantName ?? '{{assistant_name}}')
+  )
 }))
 
 import { assembleSystemPrompt } from '../assembleSystemPrompt'
@@ -57,6 +59,14 @@ describe('assembleSystemPrompt', () => {
       model
     })
     expect(out).toBe('Today is 2026-04-20')
+  })
+
+  it('resolves {{assistant_name}} to the assistant own name', async () => {
+    const out = await assembleSystemPrompt({
+      assistant: makeAssistant({ prompt: 'You are {{assistant_name}}.', name: 'Translator' }),
+      model
+    })
+    expect(out).toBe('You are Translator.')
   })
 
   it('returns just the assistant prompt when no tool_search is present, regardless of mcpMode', async () => {

--- a/src/main/ai/runtime/aiSdk/params/assembleSystemPrompt.ts
+++ b/src/main/ai/runtime/aiSdk/params/assembleSystemPrompt.ts
@@ -34,7 +34,7 @@ export async function assembleSystemPrompt(input: AssembleSystemPromptInput): Pr
 
   // `anthropic-cache` checks the original assistant prompt for volatile time variables before caching.
   if (assistant?.prompt) {
-    const resolved = await replacePromptVariables(assistant.prompt, model.name)
+    const resolved = await replacePromptVariables(assistant.prompt, model.name, assistant.name)
     if (resolved) sections.push(resolved)
   }
 

--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -1505,6 +1505,29 @@ describe('deriveConnectionConfig', () => {
     ).toEqual(['promptModelName'])
   })
 
+  it('changes only the prompt assistant name rebuild fact when the Agent is renamed', async () => {
+    const agent = {
+      id: 'agent-1',
+      name: 'Release Manager',
+      model: 'provider-1::model-1',
+      disabledTools: [],
+      mcps: [],
+      configuration: {}
+    }
+    mocks.getAgent.mockReturnValue(agent)
+    const original = await deriveSignature()
+
+    mocks.getAgent.mockReturnValue({ ...agent, name: 'Ship Captain' })
+    const renamed = await deriveSignature()
+
+    expect(renamed.rebuildSignature).not.toBe(original.rebuildSignature)
+    expect(
+      Object.keys(original.rebuildFactFingerprints).filter(
+        (name) => original.rebuildFactFingerprints[name] !== renamed.rebuildFactFingerprints[name]
+      )
+    ).toEqual(['promptAssistantName'])
+  })
+
   it('changes only the proxy-environment rebuild fact when the effective Cherry proxy changes', async () => {
     mocks.getProxyEnvironment.mockReturnValue({ HTTP_PROXY: 'http://proxy-a.example.com:8080' })
     const first = await deriveSignature()

--- a/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
@@ -107,7 +107,13 @@ beforeEach(() => {
   mockProvisionBuiltinAgent.mockReset()
   mockBuildMemoriesSection.mockReset().mockResolvedValue(undefined)
   mockBuildPrompt.mockReset().mockResolvedValue({ base: { kind: 'native' }, context: 'SOUL_PROMPT' })
-  mockReplacePromptVariables.mockReset().mockImplementation(async (prompt: string) => prompt)
+  mockReplacePromptVariables
+    .mockReset()
+    .mockImplementation(async (prompt: string, modelName?: string, agentName?: string) =>
+      prompt
+        .replace('{{model_name}}', modelName ?? '{{model_name}}')
+        .replace('{{assistant_name}}', agentName ?? '{{assistant_name}}')
+    )
   mockGetAppLanguage.mockReturnValue('en-US')
 })
 
@@ -222,6 +228,16 @@ describe('buildSystemPrompt — current workspace', () => {
   })
 })
 
+describe('buildSystemPrompt — assistant name variable', () => {
+  it('resolves {{assistant_name}} in the instructions to the agent own name', async () => {
+    const agent = makeAgent({ name: 'Release Manager', instructions: 'You are {{assistant_name}}.' })
+
+    const result = promptText(await buildSystemPrompt(agent, '/tmp/cwd'))
+
+    expect(result).toContain('You are Release Manager.')
+  })
+})
+
 describe('buildSystemPrompt — Agent System Prompt authority', () => {
   it.each([{ instructions: undefined }, { instructions: '' }, { instructions: '   ' }])(
     'keeps legacy persona role guidance when Agent System Prompt is blank: $instructions',
@@ -262,20 +278,14 @@ describe('buildSystemPrompt — Agent System Prompt authority', () => {
   })
 
   it('resolves Agent System Prompt variables with the embedded Agent model name', async () => {
-    mockReplacePromptVariables.mockResolvedValueOnce('Address Alice while using Claude Sonnet 4.5.')
     const agent = makeAgent({
-      instructions: 'Address {{username}} while using {{model_name}}.',
+      instructions: 'You run on {{model_name}}.',
       modelName: 'Claude Sonnet 4.5'
     })
 
     const text = promptText(await buildSystemPrompt(agent, '/tmp/cwd'))
 
-    expect(mockReplacePromptVariables).toHaveBeenCalledWith(
-      'Address {{username}} while using {{model_name}}.',
-      'Claude Sonnet 4.5'
-    )
-    expect(text).toContain('Address Alice while using Claude Sonnet 4.5.')
-    expect(text).not.toContain('{{username}}')
+    expect(text).toContain('You run on Claude Sonnet 4.5.')
     expect(text).not.toContain('{{model_name}}')
   })
 })

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -398,6 +398,7 @@ async function deriveConnectionConfigFromSnapshot(
     // connection snapshots instead of invalidating this signature every turn.
     promptUserName: application.get('PreferenceService').get('app.user.name') || 'Unknown Username',
     promptModelName: agent.modelName || null,
+    promptAssistantName: agent.name || null,
     builtinRole: agent.configuration?.builtin_role ?? null,
     bootstrapCompleted: agent.configuration?.bootstrap_completed ?? null,
     skills: [...skills].sort(),

--- a/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
@@ -1769,17 +1769,19 @@ describe('PiRuntimeConnection', () => {
       mocks.getAgent.mockReturnValue({
         id: 'agent-1',
         model: 'p::m',
+        name: 'Pi Agent',
         modelName: 'Pi Model',
-        instructions: 'Use {{model_name}}.',
+        instructions: '{{assistant_name}} uses {{model_name}}.',
         configuration: {}
       })
       mocks.getById.mockReturnValue(agentSession)
-      mocks.replacePromptVariables.mockResolvedValue('Use Pi Model.')
+      mocks.replacePromptVariables.mockImplementation(async (prompt: string, modelName?: string, agentName?: string) =>
+        prompt.replace('{{model_name}}', modelName ?? '').replace('{{assistant_name}}', agentName ?? '')
+      )
 
       await new PiRuntimeConnection(input).start()
 
-      expect(mocks.replacePromptVariables).toHaveBeenCalledWith('Use {{model_name}}.', 'Pi Model')
-      expect(appendedSystemPrompt()).toContain('<agent_instructions>\nUse Pi Model.\n</agent_instructions>')
+      expect(appendedSystemPrompt()).toContain('<agent_instructions>\nPi Agent uses Pi Model.\n</agent_instructions>')
     })
 
     it('resolves and provisions the bundled definition for a built-in Agent', async () => {

--- a/src/main/utils/__tests__/prompt.test.ts
+++ b/src/main/utils/__tests__/prompt.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { replacePromptVariables } from '../prompt'
+
+describe('replacePromptVariables — {{assistant_name}}', () => {
+  it('substitutes an assistant name containing replacement tokens literally', async () => {
+    const result = await replacePromptVariables('You are {{assistant_name}}.', undefined, 'Cost $& $1 $$')
+    expect(result).toBe('You are Cost $& $1 $$.')
+  })
+
+  it('leaves the placeholder untouched when the call site has no assistant', async () => {
+    const result = await replacePromptVariables('You are {{assistant_name}}.')
+    expect(result).toBe('You are {{assistant_name}}.')
+  })
+})

--- a/src/main/utils/prompt.ts
+++ b/src/main/utils/prompt.ts
@@ -119,7 +119,8 @@ export const replacePromptVariables = async (
   }
 
   if (assistantName && userSystemPrompt.includes('{{assistant_name}}')) {
-    userSystemPrompt = userSystemPrompt.replace(/{{assistant_name}}/g, assistantName)
+    // Function replacer keeps `$&`-style tokens in user-chosen names literal.
+    userSystemPrompt = userSystemPrompt.replace(/{{assistant_name}}/g, () => assistantName)
   }
 
   return userSystemPrompt

--- a/src/main/utils/prompt.ts
+++ b/src/main/utils/prompt.ts
@@ -9,7 +9,8 @@
  *      `app.language`)
  *   - `{{system}}`   → Node `os.platform()`
  *   - `{{arch}}`     → Node `os.arch()`
- *   - `{{model_name}}` → supplied by caller (no Redux default-model fallback)
+ *   - `{{model_name}}` / `{{assistant_name}}` → supplied by caller (no Redux
+ *      default-model fallback)
  */
 
 import os from 'node:os'
@@ -28,13 +29,19 @@ const supportedVariables = [
   '{{system}}',
   '{{language}}',
   '{{arch}}',
-  '{{model_name}}'
+  '{{model_name}}',
+  '{{assistant_name}}'
 ] as const
 
 export const containsSupportedVariables = (userSystemPrompt: string): boolean =>
   supportedVariables.some((variable) => userSystemPrompt.includes(variable))
 
-export const replacePromptVariables = async (userSystemPrompt: string, modelName?: string): Promise<string> => {
+export const replacePromptVariables = async (
+  userSystemPrompt: string,
+  modelName?: string,
+  /** Name of the assistant/agent owning this prompt; left unreplaced when the call site has none. */
+  assistantName?: string
+): Promise<string> => {
   if (typeof userSystemPrompt !== 'string') {
     logger.warn('User system prompt is not a string', { userSystemPrompt })
     return userSystemPrompt
@@ -109,6 +116,10 @@ export const replacePromptVariables = async (userSystemPrompt: string, modelName
 
   if (userSystemPrompt.includes('{{model_name}}')) {
     userSystemPrompt = userSystemPrompt.replace(/{{model_name}}/g, modelName ?? 'Unknown Model')
+  }
+
+  if (assistantName && userSystemPrompt.includes('{{assistant_name}}')) {
+    userSystemPrompt = userSystemPrompt.replace(/{{assistant_name}}/g, assistantName)
   }
 
   return userSystemPrompt

--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -102,7 +102,8 @@ const PROMPT_VARIABLES: { name: string; i18n: string }[] = [
   { name: '{{arch}}', i18n: 'library.config.prompt.vars.arch' },
   { name: '{{language}}', i18n: 'library.config.prompt.vars.language' },
   { name: '{{model_name}}', i18n: 'library.config.prompt.vars.model_name' },
-  { name: '{{username}}', i18n: 'library.config.prompt.vars.username' }
+  { name: '{{username}}', i18n: 'library.config.prompt.vars.username' },
+  { name: '{{assistant_name}}', i18n: 'library.config.prompt.vars.assistant_name' }
 ]
 
 export const EDIT_DIALOG_PROMPT_MIN_HEIGHT = '200px'

--- a/src/renderer/components/resourceCatalog/dialogs/create/steps/SystemPromptStep.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/create/steps/SystemPromptStep.tsx
@@ -33,7 +33,7 @@ export function SystemPromptStep({ form, portalContainer }: SystemPromptStepProp
   const modelId = useWatch({ control: form.control, name: 'modelId' })
   const prompt = useWatch({ control: form.control, name: 'prompt' })
   const { model } = useModelById(modelId)
-  const processedPrompt = usePromptProcessor({ prompt, modelName: model?.name })
+  const processedPrompt = usePromptProcessor({ prompt, modelName: model?.name, assistantName: name })
 
   return (
     <FormField

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -869,7 +869,8 @@ function AgentPromptField({
   const name = form.watch('name')
   const processedInstructions = usePromptProcessor({
     prompt: instructions,
-    modelName: modelName ?? undefined
+    modelName: modelName ?? undefined,
+    assistantName: name
   })
 
   const handlePromptChange = (nextInstructions: string) => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -561,7 +561,8 @@ function AssistantPromptField({
   const name = form.watch('name')
   const processedPrompt = usePromptProcessor({
     prompt,
-    modelName: modelName ?? resource.modelName ?? undefined
+    modelName: modelName ?? resource.modelName ?? undefined,
+    assistantName: name
   })
 
   const handlePromptChange = (nextPrompt: string) => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1048,13 +1048,14 @@ describe('edit dialogs', () => {
   })
 
   it('submits agent instructions and model changes as a PATCH', async () => {
-    promptProcessorMock.mockImplementation(({ prompt, modelName }: { prompt: string; modelName?: string }) =>
-      prompt.replaceAll('{{model_name}}', modelName ?? '')
+    promptProcessorMock.mockImplementation(
+      ({ prompt, modelName, assistantName }: { prompt: string; modelName?: string; assistantName?: string }) =>
+        prompt.replaceAll('{{model_name}}', modelName ?? '').replaceAll('{{assistant_name}}', assistantName ?? '')
     )
     render(
       <AgentEditDialog
         open
-        resource={{ ...AGENT, instructions: 'Original instructions {{model_name}}' }}
+        resource={{ ...AGENT, instructions: 'Original instructions {{model_name}} for {{assistant_name}}' }}
         onOpenChange={vi.fn()}
       />
     )
@@ -1066,11 +1067,7 @@ describe('edit dialogs', () => {
     ).toBeInTheDocument()
     const instructionsInput = screen.getByLabelText('Prompt editor')
     expect(instructionsInput).toHaveAttribute('placeholder', 'Tell this assistant how to respond')
-    expect(screen.getByLabelText('Prompt preview')).toHaveTextContent('Original instructions Old Model')
-    expect(promptProcessorMock).toHaveBeenLastCalledWith({
-      prompt: 'Original instructions {{model_name}}',
-      modelName: 'Old Model'
-    })
+    expect(screen.getByLabelText('Prompt preview')).toHaveTextContent('Original instructions Old Model for Alpha Agent')
     fireEvent.change(instructionsInput, { target: { value: 'Updated instructions {{model_name}}' } })
     selectTab('Basic')
     const modelTrigger = screen.getByRole('button', { name: 'Model' })
@@ -1082,10 +1079,6 @@ describe('edit dialogs', () => {
     await waitFor(() =>
       expect(screen.getByLabelText('Prompt preview')).toHaveTextContent('Updated instructions Updated Model')
     )
-    expect(promptProcessorMock).toHaveBeenLastCalledWith({
-      prompt: 'Updated instructions {{model_name}}',
-      modelName: 'Updated Model'
-    })
     await waitFor(() =>
       expect(updateAgentMock).toHaveBeenCalledWith({
         body: expect.objectContaining({

--- a/src/renderer/hooks/usePromptProcessor.ts
+++ b/src/renderer/hooks/usePromptProcessor.ts
@@ -7,24 +7,25 @@ const logger = loggerService.withContext('usePromptProcessor')
 interface PromptProcessor {
   prompt: string
   modelName?: string
+  assistantName?: string
 }
 
-export function usePromptProcessor({ prompt, modelName }: PromptProcessor): string {
-  const [processedPrompt, setProcessedPrompt] = useState({ modelName, prompt, value: prompt })
+export function usePromptProcessor({ prompt, modelName, assistantName }: PromptProcessor): string {
+  const [processedPrompt, setProcessedPrompt] = useState({ assistantName, modelName, prompt, value: prompt })
 
   useEffect(() => {
     let cancelled = false
 
     const setCurrentProcessedPrompt = (value: string) => {
       if (!cancelled) {
-        setProcessedPrompt({ modelName, prompt, value })
+        setProcessedPrompt({ assistantName, modelName, prompt, value })
       }
     }
 
     const processPrompt = async () => {
       try {
         if (containsSupportedVariables(prompt)) {
-          const result = await replacePromptVariables(prompt, modelName)
+          const result = await replacePromptVariables(prompt, modelName, assistantName)
           setCurrentProcessedPrompt(result)
         } else {
           setCurrentProcessedPrompt(prompt)
@@ -40,7 +41,11 @@ export function usePromptProcessor({ prompt, modelName }: PromptProcessor): stri
     return () => {
       cancelled = true
     }
-  }, [prompt, modelName])
+  }, [prompt, modelName, assistantName])
 
-  return processedPrompt.prompt === prompt && processedPrompt.modelName === modelName ? processedPrompt.value : prompt
+  return processedPrompt.prompt === prompt &&
+    processedPrompt.modelName === modelName &&
+    processedPrompt.assistantName === assistantName
+    ? processedPrompt.value
+    : prompt
 }

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Beispiel: Heute ist {{variable}}, und das aktuelle Datum wird verwendet.",
   "library.config.prompt.variables_title": "Verfügbare Variablen",
   "library.config.prompt.vars.arch": "CPU-Architektur",
+  "library.config.prompt.vars.assistant_name": "Name des Assistenten / Agenten",
   "library.config.prompt.vars.date": "Datum",
   "library.config.prompt.vars.datetime": "Datum und Uhrzeit",
   "library.config.prompt.vars.language": "Sprache",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Παράδειγμα: Σήμερα είναι {{variable}}, και χρησιμοποιείται η τρέχουσα ημερομηνία.",
   "library.config.prompt.variables_title": "Διαθέσιμες μεταβλητές",
   "library.config.prompt.vars.arch": "αρχιτεκτονική CPU",
+  "library.config.prompt.vars.assistant_name": "Όνομα βοηθού / πράκτορα",
   "library.config.prompt.vars.date": "Ημερομηνία",
   "library.config.prompt.vars.datetime": "Ημερομηνία και ώρα",
   "library.config.prompt.vars.language": "Γλώσσα",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Example: Today is {{variable}}, and the current date is used.",
   "library.config.prompt.variables_title": "System variables",
   "library.config.prompt.vars.arch": "CPU architecture",
+  "library.config.prompt.vars.assistant_name": "Assistant / agent name",
   "library.config.prompt.vars.date": "Date",
   "library.config.prompt.vars.datetime": "Date and time",
   "library.config.prompt.vars.language": "Language",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Ejemplo: Hoy es {{variable}}, y se utiliza la fecha actual.",
   "library.config.prompt.variables_title": "Variables disponibles",
   "library.config.prompt.vars.arch": "arquitectura de CPU",
+  "library.config.prompt.vars.assistant_name": "Nombre del asistente / agente",
   "library.config.prompt.vars.date": "Fecha",
   "library.config.prompt.vars.datetime": "Fecha y hora",
   "library.config.prompt.vars.language": "Idioma",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Exemple : Aujourd'hui est {{variable}}, et la date actuelle est utilisée.",
   "library.config.prompt.variables_title": "Variables disponibles",
   "library.config.prompt.vars.arch": "architecture du processeur",
+  "library.config.prompt.vars.assistant_name": "Nom de l'assistant / de l'agent",
   "library.config.prompt.vars.date": "Date",
   "library.config.prompt.vars.datetime": "Date et heure",
   "library.config.prompt.vars.language": "Langue",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "例：今日は{{variable}}で、現在の日付が使用されます。",
   "library.config.prompt.variables_title": "利用可能な変数",
   "library.config.prompt.vars.arch": "CPUアーキテクチャ",
+  "library.config.prompt.vars.assistant_name": "アシスタント / エージェント名",
   "library.config.prompt.vars.date": "日付",
   "library.config.prompt.vars.datetime": "日付と時刻",
   "library.config.prompt.vars.language": "言語",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Exemplo: Hoje é {{variable}}, e a data atual é utilizada.",
   "library.config.prompt.variables_title": "Variáveis disponíveis",
   "library.config.prompt.vars.arch": "arquitetura da CPU",
+  "library.config.prompt.vars.assistant_name": "Nome do assistente / agente",
   "library.config.prompt.vars.date": "Data",
   "library.config.prompt.vars.datetime": "Data e hora",
   "library.config.prompt.vars.language": "Idioma",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Exemplu: Astăzi este {{variable}}, iar data curentă este folosită.",
   "library.config.prompt.variables_title": "Variabile disponibile",
   "library.config.prompt.vars.arch": "arhitectura CPU",
+  "library.config.prompt.vars.assistant_name": "Numele asistentului / agentului",
   "library.config.prompt.vars.date": "Dată",
   "library.config.prompt.vars.datetime": "Dată și oră",
   "library.config.prompt.vars.language": "Limbă",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Пример: Сегодня {{variable}}, и используется текущая дата.",
   "library.config.prompt.variables_title": "Доступные переменные",
   "library.config.prompt.vars.arch": "архитектура процессора",
+  "library.config.prompt.vars.assistant_name": "Имя ассистента / агента",
   "library.config.prompt.vars.date": "Дата",
   "library.config.prompt.vars.datetime": "Дата и время",
   "library.config.prompt.vars.language": "Язык",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Örnek: Bugün {{variable}} ve güncel tarih kullanılıyor.",
   "library.config.prompt.variables_title": "Sistem değişkenleri",
   "library.config.prompt.vars.arch": "CPU mimarisi",
+  "library.config.prompt.vars.assistant_name": "Asistan / ajan adı",
   "library.config.prompt.vars.date": "Tarih",
   "library.config.prompt.vars.datetime": "Tarih ve saat",
   "library.config.prompt.vars.language": "Dil",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "Ví dụ: Hôm nay là {{variable}}, và ngày hiện tại được sử dụng.",
   "library.config.prompt.variables_title": "Biến có sẵn",
   "library.config.prompt.vars.arch": "Kiến trúc CPU",
+  "library.config.prompt.vars.assistant_name": "Tên trợ lý / tác nhân",
   "library.config.prompt.vars.date": "Ngày",
   "library.config.prompt.vars.datetime": "Ngày và giờ",
   "library.config.prompt.vars.language": "Ngôn ngữ",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "例如：今天是 {{variable}}，会使用当前日期。",
   "library.config.prompt.variables_title": "系统变量",
   "library.config.prompt.vars.arch": "CPU 架构",
+  "library.config.prompt.vars.assistant_name": "助手 / 智能体名称",
   "library.config.prompt.vars.date": "日期",
   "library.config.prompt.vars.datetime": "日期和时间",
   "library.config.prompt.vars.language": "语言",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -1945,6 +1945,7 @@
   "library.config.prompt.variables_example": "例如：今天是 {{variable}}，會使用目前日期。",
   "library.config.prompt.variables_title": "系統變數",
   "library.config.prompt.vars.arch": "CPU 架構",
+  "library.config.prompt.vars.assistant_name": "助理 / 智能體名稱",
   "library.config.prompt.vars.date": "日期",
   "library.config.prompt.vars.datetime": "日期與時間",
   "library.config.prompt.vars.language": "語言",

--- a/src/renderer/utils/__tests__/prompt.test.ts
+++ b/src/renderer/utils/__tests__/prompt.test.ts
@@ -97,5 +97,15 @@ describe('prompt', () => {
       const result = await replacePromptVariables(null as any)
       expect(result).toBe(null)
     })
+
+    it('should substitute the owning assistant name', async () => {
+      const result = await replacePromptVariables('You are {{assistant_name}}.', undefined, 'Translator')
+      expect(result).toBe('You are Translator.')
+    })
+
+    it('should leave {{assistant_name}} untouched when the call site has no assistant', async () => {
+      const result = await replacePromptVariables('You are {{assistant_name}}.')
+      expect(result).toBe('You are {{assistant_name}}.')
+    })
   })
 })

--- a/src/renderer/utils/__tests__/prompt.test.ts
+++ b/src/renderer/utils/__tests__/prompt.test.ts
@@ -103,6 +103,11 @@ describe('prompt', () => {
       expect(result).toBe('You are Translator.')
     })
 
+    it('should substitute an assistant name containing replacement tokens literally', async () => {
+      const result = await replacePromptVariables('You are {{assistant_name}}.', undefined, 'Cost $& $1 $$')
+      expect(result).toBe('You are Cost $& $1 $$.')
+    })
+
     it('should leave {{assistant_name}} untouched when the call site has no assistant', async () => {
       const result = await replacePromptVariables('You are {{assistant_name}}.')
       expect(result).toBe('You are {{assistant_name}}.')

--- a/src/renderer/utils/prompt.ts
+++ b/src/renderer/utils/prompt.ts
@@ -106,7 +106,8 @@ export const replacePromptVariables = async (
   }
 
   if (assistantName && userSystemPrompt.includes('{{assistant_name}}')) {
-    userSystemPrompt = userSystemPrompt.replace(/{{assistant_name}}/g, assistantName)
+    // Function replacer keeps `$&`-style tokens in user-chosen names literal.
+    userSystemPrompt = userSystemPrompt.replace(/{{assistant_name}}/g, () => assistantName)
   }
 
   return userSystemPrompt

--- a/src/renderer/utils/prompt.ts
+++ b/src/renderer/utils/prompt.ts
@@ -13,14 +13,20 @@ const supportedVariables = [
   '{{system}}',
   '{{language}}',
   '{{arch}}',
-  '{{model_name}}'
+  '{{model_name}}',
+  '{{assistant_name}}'
 ]
 
 export const containsSupportedVariables = (userSystemPrompt: string): boolean => {
   return supportedVariables.some((variable) => userSystemPrompt.includes(variable))
 }
 
-export const replacePromptVariables = async (userSystemPrompt: string, modelName?: string): Promise<string> => {
+export const replacePromptVariables = async (
+  userSystemPrompt: string,
+  modelName?: string,
+  /** Name of the assistant/agent owning this prompt; left unreplaced when the call site has none. */
+  assistantName?: string
+): Promise<string> => {
   if (typeof userSystemPrompt !== 'string') {
     logger.warn('User system prompt is not a string:', userSystemPrompt)
     return userSystemPrompt
@@ -97,6 +103,10 @@ export const replacePromptVariables = async (userSystemPrompt: string, modelName
 
   if (modelName && userSystemPrompt.includes('{{model_name}}')) {
     userSystemPrompt = userSystemPrompt.replace(/{{model_name}}/g, modelName)
+  }
+
+  if (assistantName && userSystemPrompt.includes('{{assistant_name}}')) {
+    userSystemPrompt = userSystemPrompt.replace(/{{assistant_name}}/g, assistantName)
   }
 
   return userSystemPrompt


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The assistant's or agent's own name never reached the model. The classic chat path sends only `assistant.prompt` (`assembleSystemPrompt`) and the agent path only `agent.instructions` (`buildAgentRuntimePrompt`). The `name` field existed purely as persisted display and usage-attribution data (`messageSnapshot.name`, `SourceSnapshot`), so a system prompt could not refer to the assistant by name without hardcoding it — and hardcoding goes stale the moment the user renames.

After this PR:

`{{assistant_name}}` joins the existing system-prompt variables. It resolves to `assistant.name` in assistant chats and to `agent.name` in agent sessions, so one prompt works for both and survives a rename.

- Both prompt assemblers pass the owning name into `replacePromptVariables`.
- Call sites with no assistant context (topic naming, note summaries) pass nothing, and the placeholder is left untouched — the same way `{{model_name}}` already behaves in the renderer.
- The edit-dialog live preview takes the name from the form, so it reflects a pending rename before it is saved.
- The variable popover lists the new entry, translated in all 13 locales.

Fixes: N/A — no tracking issue; this came out of a code question about whether the assistant name reaches the model context.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **One variable, not two.** Assistants and agents share the same prompt-variable popover, so a `{{assistant_name}}` / `{{agent_name}}` split would need two sets of strings and would silently fail whenever a user wrote the "wrong" one for the surface they were on. A single name that resolves per surface avoids that trap; the popover label reads "Assistant / agent name".
- **Unresolved rather than substituted when there is no owner.** Reusing the existing renderer behavior for `{{model_name}}` keeps the helper predictable; the affected call sites (topic naming, note summaries) have no assistant and would otherwise inject a fabricated name into an unrelated prompt.
- **A positional parameter, not an options object.** The helper has four call sites and already took `modelName` positionally; an options object would have churned every caller for no gain.

The following alternatives were considered:

- `{{char}}` (the SillyTavern convention) — rejected as inconsistent with this repo's `{{model_name}}` / `{{username}}` naming.
- Injecting the name unconditionally into every system prompt — rejected: it spends tokens on every request and takes the choice away from the prompt author.

Links to places where the discussion took place: N/A

### Breaking changes

None. The variable is additive; a prompt that does not contain `{{assistant_name}}` assembles byte-for-byte as before, so prompt caching is unaffected.

### Special notes for your reviewer

Four existing tests asserted the exact mock argument list of `replacePromptVariables` (`toHaveBeenCalledWith(prompt, modelName)`) rather than any real behavior. They broke on the added third argument and certified nothing, so they now assert the actual product: the rendered preview text and the assembled system prompt. This is the `AGENTS.md` "no behavior-pinning tests" rule applied to files this PR already touches.

The Documentation checkbox is left unchecked deliberately: this adds a user-facing variable, so the prompt-variable list on docs.cherry-ai.com should gain a matching entry, but that lives outside this repo. Happy to file it wherever maintainers prefer.

Verified in a running dev build against a live provider, both paths:

- Assistant renamed to "小樱桃" with prompt `你叫 {{assistant_name}}，运行在 {{model_name}} 上` — preview rendered "你叫 小樱桃，运行在 Qwen 上"; asked the model its name, it answered "小樱桃".
- Agent renamed to "反馈小助理" with the same variable — preview resolved, and a live agent turn answered "反馈小助理。"

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Assistants] New system prompt variable {{assistant_name}}, which fills in the current assistant's or agent's own name.
```
