### PR TITLE
fix(data-api): avoid overlapping timed-out reads

### DIFF
--- a/src/renderer/data/DataApiService.ts
+++ b/src/renderer/data/DataApiService.ts
@@ -14,7 +14,7 @@
  * Key Features:
  * - Type-safe requests with full TypeScript inference
  * - Automatic retry with exponential backoff (network, timeout, 500/503 errors)
- * - Request timeout management (3s default)
+ * - Bounded request timeouts (reads share the retry budget without overlapping IPC)
  * - Data change notification fan-out (cross-window convergence)
  *
  * Architecture:
@@ -39,6 +39,7 @@ import type { DataRequest, DataResponse, HttpMethod } from '@shared/data/api/typ
 import { DataApiDevtools } from './utils/dataApiDevtools'
 
 const logger = loggerService.withContext('DataApiService')
+const REQUEST_TIMEOUT_MS = 3000
 
 /**
  * Retry options interface.
@@ -114,11 +115,12 @@ export class DataApiService implements ApiClient {
    * Send request via IPC with direct return and retry logic.
    * Uses DataApiError.isRetryable to determine if retry is appropriate.
    */
-  private async sendRequest<T>(request: DataRequest, retryCount = 0): Promise<T> {
+  private async sendRequest<T>(request: DataRequest, retryCount = 0, readDeadline?: number): Promise<T> {
     if (!window.api.dataApi.request) {
       throw DataApiErrorFactory.create(ErrorCode.SERVICE_UNAVAILABLE, 'Data API not available')
     }
     let errorMetadata: DataResponse['metadata'] | undefined
+    let didTimeout = false
     DataApiDevtools.recordStart({
       requestId: request.id,
       method: request.method,
@@ -139,13 +141,24 @@ export class DataApiService implements ApiClient {
     try {
       logger.debug(`Making ${request.method} request to ${request.path}`, { request })
 
-      // Direct IPC call with timeout
+      const timeoutMs = readDeadline === undefined ? REQUEST_TIMEOUT_MS : Math.max(0, readDeadline - Date.now())
+      if (timeoutMs === 0) {
+        didTimeout = true
+        throw DataApiErrorFactory.timeout(request.path, timeoutMs, requestContext)
+      }
+
+      // IPC invoke cannot be cancelled. Reads spend their recovery budget on the
+      // original response instead of sending overlapping retries after three seconds.
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
       const response = await Promise.race([
         window.api.dataApi.request(request),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(DataApiErrorFactory.timeout(request.path, 3000, requestContext)), 3000)
-        )
-      ])
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            didTimeout = true
+            reject(DataApiErrorFactory.timeout(request.path, timeoutMs, requestContext))
+          }, timeoutMs)
+        })
+      ]).finally(() => clearTimeout(timeoutId))
 
       if (response.error) {
         // Reconstruct DataApiError from serialized response
@@ -183,7 +196,11 @@ export class DataApiService implements ApiClient {
       logger.debug(`Request failed: ${request.method} ${request.path}`, apiError)
 
       // Check if should retry using the error's built-in isRetryable getter
-      if (retryCount < this.defaultRetryOptions.maxRetries && apiError.isRetryable) {
+      if (
+        retryCount < this.defaultRetryOptions.maxRetries &&
+        apiError.isRetryable &&
+        !(readDeadline !== undefined && didTimeout)
+      ) {
         DataApiDevtools.recordRetry({
           requestId: request.id,
           method: request.method,
@@ -201,11 +218,13 @@ export class DataApiService implements ApiClient {
         const delay =
           this.defaultRetryOptions.retryDelay * Math.pow(this.defaultRetryOptions.backoffMultiplier, retryCount)
 
-        await new Promise((resolve) => setTimeout(resolve, delay))
+        const remainingDelay =
+          readDeadline === undefined ? delay : Math.min(delay, Math.max(0, readDeadline - Date.now()))
+        await new Promise((resolve) => setTimeout(resolve, remainingDelay))
 
         // Create new request with new ID for retry
         const retryRequest = { ...request, id: this.generateRequestId() }
-        return this.sendRequest<T>(retryRequest, retryCount + 1)
+        return this.sendRequest<T>(retryRequest, retryCount + 1, readDeadline)
       }
 
       throw apiError
@@ -243,7 +262,17 @@ export class DataApiService implements ApiClient {
 
     logger.debug(`Making ${method} request to ${path}`, { request })
 
-    return this.sendRequest<T>(request).catch((error) => {
+    let readDeadline: number | undefined
+    if (method === 'GET') {
+      const { maxRetries, retryDelay, backoffMultiplier } = this.defaultRetryOptions
+      let budget = REQUEST_TIMEOUT_MS * (maxRetries + 1)
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        budget += retryDelay * Math.pow(backoffMultiplier, attempt)
+      }
+      readDeadline = Date.now() + budget
+    }
+
+    return this.sendRequest<T>(request, 0, readDeadline).catch((error) => {
       logger.error(`Request failed: ${method} ${path}`, error)
       throw toDataApiError(error, `${method} ${path}`)
     })

--- a/src/renderer/data/__tests__/DataApiService.timeout.test.ts
+++ b/src/renderer/data/__tests__/DataApiService.timeout.test.ts
@@ -1,0 +1,139 @@
+import { DataApiErrorFactory } from '@shared/data/api/errors'
+import type { DataRequest, DataResponse } from '@shared/data/api/types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.unmock('@data/DataApiService')
+
+const request = vi.fn<(request: DataRequest) => Promise<DataResponse>>()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  request.mockReset()
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { dataApi: { request } }
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+async function createService() {
+  const { DataApiService } = await import('../DataApiService')
+  return new DataApiService()
+}
+
+function delayedResponse(delay: number, data: unknown) {
+  request.mockImplementation(
+    (req) => new Promise((resolve) => setTimeout(() => resolve({ id: req.id, status: 200, data }), delay))
+  )
+}
+
+describe('DataApiService local read timeouts', () => {
+  it.each(['/topics', '/topics/topic-1', '/topics/topic-1/messages'] as const)(
+    'recovers a delayed %s response without discarding it at three seconds',
+    async (path) => {
+      const service = await createService()
+      const data = { items: [{ id: 'first' }, { id: 'second' }] }
+      delayedResponse(3500, data)
+
+      const result = expect(service.get(path)).resolves.toEqual(data)
+      await vi.advanceTimersByTimeAsync(12000)
+      await result
+      expect(request).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('does not start another IPC read while a slow response is still pending', async () => {
+    const service = await createService()
+    delayedResponse(5000, { id: 'topic-1' })
+
+    const result = expect(service.get('/topics/topic-1')).resolves.toEqual({ id: 'topic-1' })
+    await vi.advanceTimersByTimeAsync(4500)
+    expect(request).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(7500)
+    await result
+  })
+
+  it('rejects a persistently stalled read within the existing total retry budget', async () => {
+    const service = await createService()
+    request.mockImplementation(() => new Promise(() => {}))
+    const result = expect(service.get('/topics')).rejects.toMatchObject({ code: 'TIMEOUT' })
+
+    await vi.advanceTimersByTimeAsync(12000)
+    await result
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('still retries a completed retryable error response', async () => {
+    const service = await createService()
+    const error = DataApiErrorFactory.timeout('/topics', 3000)
+    request
+      .mockImplementationOnce(async (req) => ({ id: req.id, status: error.status, error: error.toJSON() }))
+      .mockImplementationOnce(async (req) => ({ id: req.id, status: 200, data: { items: [] } }))
+
+    const result = expect(service.get('/topics')).resolves.toEqual({ items: [] })
+    await vi.advanceTimersByTimeAsync(1000)
+    await result
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares the read deadline with retries of completed error responses', async () => {
+    const service = await createService()
+    const error = DataApiErrorFactory.timeout('/topics', 3000)
+    request
+      .mockImplementationOnce(
+        (req) =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: req.id, status: error.status, error: error.toJSON() }), 10500)
+          )
+      )
+      .mockImplementation(() => new Promise(() => {}))
+
+    const result = expect(service.get('/topics')).rejects.toMatchObject({ code: 'TIMEOUT' })
+    await vi.advanceTimersByTimeAsync(12000)
+    await result
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('honors disabled retries with the original three-second read budget', async () => {
+    const service = await createService()
+    service.configureRetry({ maxRetries: 0 })
+    request.mockImplementation(() => new Promise(() => {}))
+
+    const result = expect(service.get('/topics')).rejects.toMatchObject({ code: 'TIMEOUT' })
+    await vi.advanceTimersByTimeAsync(3000)
+    await result
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a deleted topic error without retrying', async () => {
+    const service = await createService()
+    const error = DataApiErrorFactory.notFound('Topic', 'deleted')
+    request.mockImplementation(async (req) => ({ id: req.id, status: error.status, error: error.toJSON() }))
+
+    await expect(service.get('/topics/deleted')).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each(['GET', 'POST'] as const)(
+    'preserves fast %s requests and clears completed timeout timers',
+    async (method) => {
+      const service = await createService()
+      delayedResponse(100, { id: 'created-topic' })
+
+      const response =
+        method === 'GET' ? service.get('/topics') : service.post('/topics', { body: { name: 'New topic' } })
+      const result = expect(response).resolves.toEqual({
+        id: 'created-topic'
+      })
+      await vi.advanceTimersByTimeAsync(100)
+      await result
+      expect(request).toHaveBeenCalledTimes(1)
+      expect(vi.getTimerCount()).toBe(0)
+    }
+  )
+})

--- a/src/renderer/data/hooks/__tests__/useDataApi.timeout.test.ts
+++ b/src/renderer/data/hooks/__tests__/useDataApi.timeout.test.ts
@@ -1,0 +1,62 @@
+import type { DataRequest, DataResponse } from '@shared/data/api/types'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createSWRTestWrapper } from './testUtils'
+
+vi.unmock('@data/DataApiService')
+vi.unmock('@data/hooks/useDataApi')
+
+import { useQuery } from '../useDataApi'
+
+const request = vi.fn<(request: DataRequest) => Promise<DataResponse>>()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  request.mockReset()
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { dataApi: { request } }
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useQuery delayed local IPC recovery', () => {
+  it('leaves loading with ordered data when a local topic read exceeds three seconds', async () => {
+    const data = { items: [{ id: 'first' }, { id: 'second' }], nextCursor: null }
+    request.mockImplementation(
+      (req) => new Promise((resolve) => setTimeout(() => resolve({ id: req.id, status: 200, data }), 3500))
+    )
+    const { Wrapper } = createSWRTestWrapper()
+    const { result } = renderHook(() => useQuery('/topics'), { wrapper: Wrapper })
+
+    expect(result.current.isLoading).toBe(true)
+    await act(() => vi.advanceTimersByTimeAsync(3500))
+    expect(result.current).toMatchObject({ data, isLoading: false, isRefreshing: false, error: undefined })
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves loading on a stalled read and clears the error after an explicit successful refresh', async () => {
+    request.mockImplementationOnce(() => new Promise(() => {}))
+    const { Wrapper } = createSWRTestWrapper()
+    const { result } = renderHook(() => useQuery('/topics'), { wrapper: Wrapper })
+
+    await act(() => vi.advanceTimersByTimeAsync(12000))
+    expect(result.current).toMatchObject({ isLoading: false, isRefreshing: false, error: { code: 'TIMEOUT' } })
+    expect(request).toHaveBeenCalledTimes(1)
+
+    request.mockImplementationOnce(async (req) => ({ id: req.id, status: 200, data: { items: [], nextCursor: null } }))
+    await act(async () => {
+      await result.current.refetch()
+    })
+    expect(result.current).toMatchObject({
+      data: { items: [], nextCursor: null },
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined
+    })
+  })
+})


### PR DESCRIPTION
## 中文

### 改动

本地 Data API 的 GET 请求此前每 3 秒超时并重试，但 Electron IPC invoke 无法取消，旧请求仍在执行；慢读因此会被丢弃，并与新重试重叠。

本 PR 让 GET 在既有的总恢复预算内等待同一个 IPC 请求。已完成的可重试服务端错误仍按原退避策略重试并共享该截止时间；写请求保持原策略，已结束请求会清理 timeout timer。

Refs #20333

### 验证

- 新增 DataApiService / useQuery timeout 回归：13/13 通过
- renderer data 相关测试：10 files，152/152 通过
- SQLite TopicService / MessageService：204/204 通过
- `pnpm lint`：通过（typecheck、i18n、Biome；ESLint 0 errors）
- `git diff --cached --check`：通过

### 破坏性变更

无。

## English

### Changes

Local Data API GET requests previously timed out and retried every three seconds even though Electron IPC invokes cannot be cancelled. A slow read could therefore be discarded while a replacement request overlapped it.

This PR waits for the same GET IPC request within the existing total recovery budget. Completed retryable server errors still use the existing backoff policy while sharing that deadline. Writes retain their current policy, and settled requests clear their timeout timers.

Refs #20333

### Validation

- New DataApiService / useQuery timeout regressions: 13/13 passed
- Related renderer data tests: 10 files, 152/152 passed
- SQLite TopicService / MessageService tests: 204/204 passed
- `pnpm lint`: passed (typecheck, i18n, Biome; ESLint 0 errors)
- `git diff --cached --check`: passed

### Breaking changes

None.

### AI assistance

The investigation, implementation, and tests were prepared with Codex on behalf of @Dante-dan. The validation results above are from commands that were actually run; no human technical review is being claimed.

### Release note

```release-note
<!--LANG:en-->
[Data API] Prevent overlapping local read retries while preserving a bounded recovery deadline.
<!--LANG:zh-CN-->
[Data API] 避免本地读取超时后产生重叠重试，同时保留有界恢复截止时间。
<!--LANG:END-->
```
