### PR TITLE
fix(composer): accept any file type on the agent surface

### DIFF
--- a/src/renderer/components/composer/composerPaste.ts
+++ b/src/renderer/components/composer/composerPaste.ts
@@ -1,6 +1,6 @@
 import type { JSONContent } from '@tiptap/core'
 
-import { getFileExtension } from '@renderer/utils/file'
+import { getFileExtension, isSupportedExtension } from '@renderer/utils/file'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import type { ComposerClipboardFragment, ComposerClipboardToken } from '@renderer/utils/message/composerClipboard'
 import { createComposerAttachmentFromComposerClipboardToken } from '@renderer/utils/message/composerClipboard'
@@ -23,7 +23,9 @@ export function hasSupportedClipboardImage(
   files: readonly Pick<File, 'name' | 'type'>[],
   supportedExts: readonly string[]
 ) {
-  return files.some((file) => file.type.startsWith('image/') && supportedExts.includes(getFileExtension(file.name)))
+  return files.some(
+    (file) => file.type.startsWith('image/') && isSupportedExtension(getFileExtension(file.name), supportedExts)
+  )
 }
 
 interface ComposerPlainTextPasteOptions {

--- a/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
+++ b/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { toast } from '@renderer/services/toast'
 import { COMPOSER_FILE_KIND, FILE_TYPE, type FileMetadata } from '@renderer/types/file'
+import { anyFileExt } from '@renderer/utils/file'
 import { type ComposerAttachment, toComposerAttachment } from '@renderer/utils/message/composerAttachment'
 
 import { LONG_TEXT_PASTE_THRESHOLD } from '../../composerPaste'
@@ -241,6 +242,114 @@ describe('pasteHandling', () => {
     expect(window.api.file.write).toHaveBeenCalledWith(tempImageFile.path, new Uint8Array([1, 2, 3]))
     expect(files).toHaveLength(1)
     expect(files[0]).toMatchObject({ path: tempImageFile.path, ext: '.png', type: FILE_TYPE.IMAGE })
+  })
+
+  it('attaches a clipboard image whose extension no catalog lists when the surface declares the wildcard', async () => {
+    // The agent surface only forwards the path, so the allowlist it hands the paste
+    // handler carries the wildcard. A clipboard image the modality catalogs miss
+    // (`.avif`, or a screenshot the OS named without a known extension) must attach
+    // instead of being refused with `file_not_supported`.
+    const tempImageFile: FileMetadata = {
+      ...selectedFile,
+      name: 'temp_file_123_image.avif',
+      origin_name: 'temp_file_123_image.avif',
+      path: '/tmp/temp_file_123_image.avif',
+      ext: '.avif',
+      type: FILE_TYPE.IMAGE
+    }
+    const clipboardImage = {
+      name: 'image.avif',
+      type: 'image/avif',
+      arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+    } as unknown as File
+    vi.mocked(window.api.file.createTempFile).mockResolvedValue(tempImageFile.path)
+    vi.mocked(window.api.file.get).mockResolvedValue(tempImageFile)
+
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
+      files = updater(files)
+    })
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: { getData: () => '', files: [clipboardImage] }
+    } as unknown as ClipboardEvent
+
+    const handled = await pasteHandling.handlePaste(event, ['.png', anyFileExt], setFiles)
+
+    expect(handled).toBe(true)
+    expect(window.api.file.createTempFile).toHaveBeenCalledWith('image.avif')
+    expect(toast.info).not.toHaveBeenCalled()
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatchObject({ path: tempImageFile.path, ext: '.avif', type: FILE_TYPE.IMAGE })
+  })
+
+  it('prefers that wildcard-accepted clipboard image over the text flavor next to it', async () => {
+    const tempImageFile: FileMetadata = {
+      ...selectedFile,
+      name: 'temp_file_123_image.avif',
+      origin_name: 'temp_file_123_image.avif',
+      path: '/tmp/temp_file_123_image.avif',
+      ext: '.avif',
+      type: FILE_TYPE.IMAGE
+    }
+    const clipboardImage = {
+      name: 'image.avif',
+      type: 'image/avif',
+      arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+    } as unknown as File
+    vi.mocked(window.api.file.createTempFile).mockResolvedValue(tempImageFile.path)
+    vi.mocked(window.api.file.get).mockResolvedValue(tempImageFile)
+
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
+      files = updater(files)
+    })
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: (type: string) => (type === 'text' ? 'clipboard image' : ''),
+        files: [clipboardImage]
+      }
+    } as unknown as ClipboardEvent
+
+    const handled = await pasteHandling.handlePaste(event, ['.png', anyFileExt], setFiles)
+
+    expect(handled).toBe(true)
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatchObject({ path: tempImageFile.path, ext: '.avif', type: FILE_TYPE.IMAGE })
+  })
+
+  it('still refuses an unlisted clipboard image when the surface has no wildcard', async () => {
+    const clipboardImage = {
+      name: 'image.avif',
+      type: 'image/avif',
+      arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+    } as unknown as File
+
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
+      files = updater(files)
+    })
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: { getData: () => '', files: [clipboardImage] }
+    } as unknown as ClipboardEvent
+
+    const handled = await pasteHandling.handlePaste(
+      event,
+      ['.png'],
+      setFiles,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      (key) => key
+    )
+    expect(handled).toBe(true)
+    expect(window.api.file.createTempFile).not.toHaveBeenCalled()
+    expect(files).toHaveLength(0)
+    expect(toast.info).toHaveBeenCalledWith('chat.input.file_not_supported')
   })
 
   it('processes path-backed clipboard files concurrently and commits them once in order', async () => {

--- a/src/renderer/components/composer/paste/__tests__/useFileDragDrop.test.ts
+++ b/src/renderer/components/composer/paste/__tests__/useFileDragDrop.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { toast } from '@renderer/services/toast'
 import { FILE_TYPE, type FileMetadata } from '@renderer/types/file'
+import { anyFileExt } from '@renderer/utils/file'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 
 import { getSingleDroppedPathFromText, useFileDragDrop } from '../useFileDragDrop'
@@ -336,5 +337,39 @@ describe('useFileDragDrop', () => {
     expect(onTextDropped).not.toHaveBeenCalled()
     expect(onFolderPathDropped).not.toHaveBeenCalled()
     expect(setFiles).not.toHaveBeenCalled()
+  })
+
+  it('attaches an unlisted binary format when the surface declares the wildcard', async () => {
+    // The agent composer's shape: it only ever hands the path to the agent, so a
+    // format no modality catalog lists must still attach instead of being refused.
+    const path = '/Users/jd/Models/weights.onnx'
+    const file = { ...createFileMetadata(path), ext: '.onnx' }
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
+      files = updater(files)
+    })
+    const onTextDropped = vi.fn()
+    const onFolderPathDropped = vi.fn()
+    mocks.request.mockResolvedValue({ kind: 'file', type: FILE_TYPE.OTHER })
+    fileApi.get.mockResolvedValue(file)
+
+    const { result } = renderHook(() =>
+      useFileDragDrop({
+        supportedExts: ['.md', anyFileExt],
+        setFiles,
+        onTextDropped,
+        onFolderPathDropped,
+        enabled: true,
+        t
+      })
+    )
+
+    await act(async () => {
+      await result.current.handleDrop?.(createDropEvent(path))
+    })
+
+    expect(files).toEqual([expect.objectContaining({ path, origin_name: 'weights.onnx' })])
+    expect(toast.info).not.toHaveBeenCalled()
+    expect(onTextDropped).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/composer/paste/pasteHandling.ts
+++ b/src/renderer/components/composer/paste/pasteHandling.ts
@@ -1,7 +1,7 @@
 import { loggerService } from '@logger'
 import { toast } from '@renderer/services/toast'
 import { COMPOSER_FILE_KIND, type PastedTextFileMetadata } from '@renderer/types/file'
-import { getFileExtension, isSupportedFile, removeFileExtension } from '@renderer/utils/file'
+import { getFileExtension, isSupportedExtension, isSupportedFile, removeFileExtension } from '@renderer/utils/file'
 import { type ComposerAttachment, toComposerAttachment } from '@renderer/utils/message/composerAttachment'
 
 import { hasSupportedClipboardImage, LONG_TEXT_PASTE_THRESHOLD, PASTED_TEXT_FILE_EXTENSION } from '../composerPaste'
@@ -137,7 +137,7 @@ export const handlePaste = async (
           // 如果没有路径，可能是剪贴板中的图像数据
           if (!filePath) {
             // 图像生成也支持图像编辑
-            if (file.type.startsWith('image/') && supportExts.includes(getFileExtension(file.name))) {
+            if (file.type.startsWith('image/') && isSupportedExtension(getFileExtension(file.name), supportExts)) {
               const tempFilePath = await window.api.file.createTempFile(file.name)
               const arrayBuffer = await file.arrayBuffer()
               const uint8Array = new Uint8Array(arrayBuffer)

--- a/src/renderer/components/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
+++ b/src/renderer/components/composer/variants/shared/__tests__/useComposerFileCapabilities.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { anyFileExt } from '@renderer/utils/file'
 import type { Model } from '@shared/data/types/model'
 import { archiveExts, audioExts, documentExts, imageExts, textExts, videoExts } from '@shared/utils/file'
 
@@ -45,6 +46,9 @@ describe('useComposerFileCapabilities', () => {
       expect(result.current.canAddImageFile).toBe(true)
       expect(result.current.canAddTextFile).toBe(true)
       expect(containsAll(result.current.supportedExts, ALL_EXTS)).toBe(true)
+      // "Every file type" is the wildcard, not the modality catalogs: a format none
+      // of them lists (`.onnx`, `.dwg`, `.h5`) must attach on the agent surface too.
+      expect(result.current.supportedExts).toContain(anyFileExt)
     })
 
     it('allows common archive formats', () => {

--- a/src/renderer/components/composer/variants/shared/useComposerFileCapabilities.ts
+++ b/src/renderer/components/composer/variants/shared/useComposerFileCapabilities.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { anyFileExt } from '@renderer/utils/file'
 import { isAudioModel, isAudioModels, isVideoModel, isVideoModels } from '@renderer/utils/model'
 import type { Model } from '@shared/data/types/model'
 import { archiveExts, audioExts, documentExts, imageExts, textExts, videoExts } from '@shared/utils/file'
@@ -60,10 +61,12 @@ export function useComposerFileCapabilities(
     // Agent reads attachments from disk by path → all file types, any active model.
     if (!isChatSurface) {
       const enabled = fallbackModel != null
+      // The modality lists stay for callers that read them as a catalog (dialog
+      // filters, image-paste detection); `anyFileExt` is what lifts the filter.
       return {
         canAddImageFile: enabled,
         canAddTextFile: enabled,
-        supportedExts: enabled ? [...ALL_FILE_EXTS] : []
+        supportedExts: enabled ? [...ALL_FILE_EXTS, anyFileExt] : []
       }
     }
 

--- a/src/renderer/utils/__tests__/file.test.ts
+++ b/src/renderer/utils/__tests__/file.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { formatFileSize, getFileDirectory, getFileExtension, removeSpecialCharactersForFileName } from '../file'
+import {
+  anyFileExt,
+  formatFileSize,
+  getFileDirectory,
+  getFileExtension,
+  isSupportedExtension,
+  isSupportedFile,
+  removeSpecialCharactersForFileName
+} from '../file'
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }))
+
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: mocks.request } }))
+
+beforeEach(() => {
+  mocks.request.mockReset()
+  mocks.request.mockResolvedValue({ kind: 'file', type: 'other' })
+})
 
 describe('file', () => {
   describe('getFileDirectory', () => {
@@ -114,6 +131,49 @@ describe('file', () => {
     it('should return empty string for empty input', () => {
       // 验证空字符串
       expect(removeSpecialCharactersForFileName('')).toBe('')
+    })
+  })
+
+  describe('isSupportedFile', () => {
+    it('accepts a listed extension without consulting the file', async () => {
+      expect(await isSupportedFile('/tmp/report.pdf', new Set(['.pdf']))).toBe(true)
+      expect(mocks.request).not.toHaveBeenCalled()
+    })
+
+    it('accepts an unlisted extension when the file content is text', async () => {
+      mocks.request.mockResolvedValue({ kind: 'file', type: 'text' })
+
+      expect(await isSupportedFile('/tmp/netlist.sp', new Set(['.pdf']))).toBe(true)
+    })
+
+    it('rejects an unlisted binary extension', async () => {
+      expect(await isSupportedFile('/tmp/weights.onnx', new Set(['.pdf']))).toBe(false)
+    })
+
+    it('accepts any extension when the allowlist carries the wildcard', async () => {
+      // The wildcard means "this caller only needs the path" — an unknown binary
+      // format must not be rejected on a caller that never reads the bytes.
+      expect(await isSupportedFile('/tmp/weights.onnx', new Set([anyFileExt]))).toBe(true)
+    })
+  })
+
+  describe('isSupportedExtension', () => {
+    // The pathless-paste checks (clipboard images) can only consult the allowlist, so
+    // the array form of the same question has to answer identically to isSupportedFile.
+    it('accepts a listed extension', () => {
+      expect(isSupportedExtension('.png', ['.png'])).toBe(true)
+    })
+
+    it('rejects an unlisted extension without the wildcard', () => {
+      expect(isSupportedExtension('.avif', ['.png'])).toBe(false)
+    })
+
+    it('accepts an unlisted extension when the allowlist carries the wildcard', () => {
+      expect(isSupportedExtension('.avif', ['.png', anyFileExt])).toBe(true)
+    })
+
+    it('rejects an extensionless name without the wildcard', () => {
+      expect(isSupportedExtension('.', ['.png'])).toBe(false)
     })
   })
 })

--- a/src/renderer/utils/file.ts
+++ b/src/renderer/utils/file.ts
@@ -7,6 +7,15 @@ import { GB, KB, MB } from '@shared/utils/constants'
 import { audioExts, createFilePathHandle, documentExts, imageExts, textExts, videoExts } from '@shared/utils/file'
 
 /**
+ * Wildcard entry for an extension allowlist: a list containing it accepts every file,
+ * whatever its extension. Only the composer's capability lists carry it, and only on the
+ * agent surface — there the attachment is forwarded to the agent as a path and never read
+ * by Cherry, so no catalog of presentable formats describes what is attachable. Same token
+ * the file dialogs already use for their "all files" filter.
+ */
+export const anyFileExt = '*'
+
+/**
  * 从文件路径中提取目录路径。
  * @param {string} filePath 文件路径
  * @returns {string} 目录路径
@@ -79,17 +88,31 @@ export function removeSpecialCharactersForFileName(str: string): string {
 }
 
 /**
+ * 判断扩展名是否被允许列表接受，遵守 anyFileExt 通配符。
+ *
+ * 所有对能力列表的接受判断都必须走这里：直接用 `supportExts.includes(ext)` 会悄悄
+ * 恢复通配符已经解除的格式过滤（剪贴板图片粘贴就是这样被拒的）。
+ * @param {string} ext 待判断的扩展名（含点号）
+ * @param {readonly string[]} supportExts 支持的文件扩展名列表
+ * @returns {boolean} 被接受返回true，否则返回false
+ */
+export function isSupportedExtension(ext: string, supportExts: readonly string[]): boolean {
+  return supportExts.includes(anyFileExt) || supportExts.includes(ext)
+}
+
+/**
  * 检查文件是否为支持的类型。
  * 支持的文件类型包括:
- * 1. 文件扩展名在supportExts集合中的文件
- * 2. 文本文件
+ * 1. supportExts 含有通配符 anyFileExt（不做任何过滤）
+ * 2. 文件扩展名在supportExts集合中的文件
+ * 3. 文本文件
  * @param {string} filePath 文件路径
  * @param {Set<string>} supportExts 支持的文件扩展名集合
  * @returns {Promise<boolean>} 如果文件类型受支持返回true，否则返回false
  */
 export async function isSupportedFile(filePath: string, supportExts: Set<string>): Promise<boolean> {
   try {
-    if (supportExts.has(getFileExtension(filePath))) {
+    if (supportExts.has(anyFileExt) || supportExts.has(getFileExtension(filePath))) {
       return true
     }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Dragging a file into the **agent** composer was filtered by an extension allowlist. `useComposerFileCapabilities` handed the agent surface `ALL_FILE_EXTS` (image + audio + video + document + text + archive), so a binary format outside those catalogs — `.onnx`, `.dwg`, `.h5`, `.safetensors`, `.sqlite`, `.psd`, `.pages`, … — was refused with `chat.input.file_not_supported`, even though the message only ever carries the file's **path**.

After this PR:

The agent surface declares a wildcard (`anyFileExt = '*'`) alongside the catalogs, and every acceptance check honours it. Any file the user can point at is attachable there, and the composer's file dialog — which already opens with `'*'` once the extension list exceeds 20 entries — finally agrees with the post-filter that reads it.

That "every acceptance check" is load-bearing: the two paste-path checks (`composerPaste.hasSupportedClipboardImage`, and `handlePaste`'s pathless-clipboard-image branch) compared the extension against the list directly rather than through the wildcard-aware predicate. A pasted clipboard image with an unlisted extension was therefore still refused — and, when the clipboard also carried a text flavor, the paste was silently left to the editor instead of attaching the image. Both now go through one predicate, `isSupportedExtension`, which is the only spelling of the question in the renderer that reads capability lists.

The chat surface is unchanged: it keeps its allowlist, because there the model consumes the file rather than only receiving a path.

Fixes: None — no existing issue tracks this.

### Why we need it and why it was done in this way

The agent runtime already receives non-image attachments as **local paths** and reads them with its own tools. `materializeUserContent`'s docblock states it ("Non-image attachments are sent as current local paths so the Agent decides how to inspect them with its tools"), and the path reaches the message through `appendAgentAttachmentPaths`. Nothing on that path decodes the bytes, so the extension list was never a capability check — it only decided which formats the user was allowed to *name*.

The surface's own contract already said this, and the code disagreed with it:

- the `useComposerFileCapabilities` docblock says "every file type is attachable on any active model";
- its test is named `allows every file type on any model — agent reads attachments by path, not by modality`, but only asserts the catalogs are a subset;
- a maintainer closed #14694 with "the requested behavior is already implemented on main via useComposerFileCapabilities (agent surface allows all file types regardless of model modality)".

This PR makes the implementation match the contract all three already state.

The following tradeoffs were made:

- The wildcard is built into the allowlist's meaning (`'*'` present ⇒ accept) rather than added as a boolean beside `supportedExts`. The token is already this codebase's vocabulary for "all files" (`window.api.file.select` filters, `AttachmentButton`), so the picker and its post-filter share one meaning instead of two — and because the token lives in the list, every reader has to consult it, which is what forced the paste checks to be routed through `isSupportedExtension` instead of indexing the catalogs directly.
- `anyFileExt` lives in `@renderer/utils/file`, not `@shared/utils/file`. Only the renderer produces it (the agent capability list) and only renderer modules read it; the shared layer keeps the modality catalogs, which both processes genuinely use.
- The modality catalogs stay in the agent list. Callers still read `supportedExts` as a catalog, not only as a filter: `shouldDelegateLongTextPasteToFileHandler` looks for the pasted-text extension, and `composerPaste` looks for image extensions.
- No user-facing setting. The wildcard is a fixed declaration of the agent surface, not something to configure.

The following alternatives were considered:

- **Adding more extensions to `ALL_FILE_EXTS`.** This is the path #17398 took for archives. It cannot converge: every list still refuses the next format a user has, and the refusal is indistinguishable from a capability limit the agent does not have.
- **A user-configurable allowlist** (as LibreChat and Open WebUI offer). Rejected: those products read the file's bytes and pay a model-side MIME cost, so a configurable gate earns its keep. The agent path has no such cost, and #8630 records the maintainer concern that user-filled format lists invite misuse.
- **Relaxing the chat surface too.** Rejected as out of scope: there the model consumes the file, and the audio/video gates mirror real model capability — that is a different decision.

Links to places where the discussion took place:

- [#17349](https://github.com/CherryHQ/cherry-studio/pull/17349) (closed, superseded) — "Agent runtimes consume attachments as local paths and can inspect them with file tools, so their accepted file types should not be limited to formats that chat models process directly."
- [#17398](https://github.com/CherryHQ/cherry-studio/pull/17398) (merged) — landed the archive extensions into `ALL_FILE_EXTS`.
- [#16516](https://github.com/CherryHQ/cherry-studio/pull/16516) (merged) — established that agent attachments do not depend on model modality.
- [#14694](https://github.com/CherryHQ/cherry-studio/pull/14694) (closed) — the maintainer statement quoted above.

### Breaking changes

None. The chat surface behaves exactly as before; the agent surface accepts a superset of what it accepted.

### Special notes for your reviewer

Five tests fail on the pre-fix code and pass after it, each verified by restoring the behaviour line it covers and re-running:

| Test | Pre-fix source restored |
| --- | --- |
| `file > isSupportedFile > accepts any extension when the allowlist carries the wildcard` | the wildcard branch in `isSupportedFile` |
| `useComposerFileCapabilities > agent surface > allows every file type on any model …` | `anyFileExt` in the agent capability list |
| `useFileDragDrop > attaches an unlisted binary format when the surface declares the wildcard` | the wildcard branch in `isSupportedFile` (the dropped path goes through it) |
| `pasteHandling > attaches a clipboard image whose extension no catalog lists when the surface declares the wildcard` | `isSupportedExtension` in `handlePaste` |
| `pasteHandling > prefers that wildcard-accepted clipboard image over the text flavor next to it` | `isSupportedExtension` in `hasSupportedClipboardImage` |

`file > isSupportedExtension` covers the new predicate directly (listed extension, unlisted extension with and without the wildcard, and the extensionless-name case).

The chat surface's behaviour is pinned unchanged by `file > isSupportedExtension > rejects an unlisted extension without the wildcard` and `pasteHandling > still refuses an unlisted clipboard image when the surface has no wildcard`.

Verification run locally:

- `pnpm typecheck` (tsgo node + web) — clean.
- `pnpm test:lint` — 0 errors; `eslint --max-warnings=0` clean on every changed file.
- `vitest run --project renderer src/renderer/components/composer src/renderer/utils src/renderer/hooks` — 233 files / 3040 tests pass.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) — not applicable, this is a scoped behaviour fix
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required — not applicable, no persisted data or defaults change
- [x] Documentation: not required — no user-guide page documents the composer's accepted extension list
- [x] Self-review: I have reviewed my own code (`gh pr diff`) before requesting review

### Release note

```release-note
[Agent] Files attached in agent sessions are no longer rejected for having an extension outside a fixed list — the agent reads attachments by path with its own tools, so any file can now be attached.
```


