### PR TITLE
fix(directory-tree): retain mirrors across brief activity suspension

### DIFF
--- a/docs/references/file/directory-tree.md
+++ b/docs/references/file/directory-tree.md
@@ -6,6 +6,7 @@ sources:
   - src/shared/utils/file/tree.ts
   - src/shared/ipc/schemas/file.ts
   - src/renderer/hooks/useDirectoryTree.ts
+  - src/renderer/services/DirectoryTreeSession.ts
 ---
 
 # Directory Tree Architecture
@@ -20,8 +21,9 @@ artifact file tree.
 ## 1. Positioning
 
 `DirectoryTreeBuilder` owns one in-memory tree, its absolute-path index, initial scan, and watcher.
-`DirectoryTreeManager` owns builder sharing and renderer consumers. `useDirectoryTree` owns a
-renderer mirror and the snapshot-to-stream handshake.
+`DirectoryTreeManager` owns builder sharing and renderer consumers. `DirectoryTreeSession` owns
+the renderer mirror and snapshot-to-stream handshake. `useDirectoryTree` subscribes React to its
+external snapshot.
 
 The primitive is separate from FileManager because its identity and lifecycle differ:
 
@@ -53,7 +55,8 @@ src/main/services/file/
 
 src/shared/utils/file/tree.ts      # options, DTOs, mutation types, TreeNode classes
 src/shared/ipc/schemas/file.ts     # file.tree.* request/event contracts
-src/renderer/hooks/useDirectoryTree.ts
+src/renderer/services/DirectoryTreeSession.ts # retained mirror and IPC lifetime
+src/renderer/hooks/useDirectoryTree.ts        # React subscription
 ```
 
 ### 2.1 Shared Contract
@@ -144,7 +147,7 @@ until the renderer:
 4. calls `file.tree.activate` with the snapshot revision.
 
 Activation sends buffered mutations before it returns. The pending queue is capped at 1,000
-events; overflow disposes that consumer. `useDirectoryTree` retries a refused activation with a
+events; overflow disposes that consumer. `DirectoryTreeSession` retries a refused activation with a
 fresh snapshot up to three times.
 
 Each push carries a monotonic revision. The renderer ignores duplicates, but a gap is terminal for
@@ -212,6 +215,19 @@ awaits watcher closure. The last-consumer grace window is described in §3.2.
 The root object mutates in place, so derived React values must depend on `version`. A side consumer
 that must observe every mutation uses the hook's `onMutation` callback; subscribing later with the
 published `treeId` can miss mutations flushed during activation.
+
+The hook retains one directory session per root. Activity suspension unsubscribes React immediately,
+so mutations update the mirror without scheduling view projections. The IPC stream remains active
+for a ten-second idle grace period, matching the artifact tree's lazy watcher retention. Returning
+within that period reuses the mirror and tree ID; after release, returning takes a fresh snapshot.
+A root change immediately retires the previous session, including an in-flight create. Unmounts
+release after the same bounded grace period; closing the renderer releases native consumers through
+`DirectoryTreeManager`. There is no persistent cache or always-on directory watcher.
+
+The `onMutation` callback remains a business-side subscription during the grace period, including
+activation replay and brief Activity suspension. Rendering and expensive projections belong to
+React subscribers; callbacks that need filesystem events must not be conditional on view visibility.
+Revision gaps remain terminal, so retaining the mirror never hides missed mutations.
 
 Options are sampled when a root mounts. Changing the options object while `rootPath` is unchanged
 does not rebuild the tree.

--- a/src/renderer/hooks/__tests__/useDirectoryTree.test.tsx
+++ b/src/renderer/hooks/__tests__/useDirectoryTree.test.tsx
@@ -5,8 +5,8 @@ import type {
   TreeMutationEvent,
   TreeMutationPushPayload
 } from '@shared/utils/file'
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { StrictMode } from 'react'
+import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react'
+import { Activity, StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useDirectoryTree } from '../useDirectoryTree'
@@ -36,13 +36,16 @@ vi.mock('@renderer/ipc', () => ({
 }))
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
   mocks.create.mockReset()
   mocks.activate.mockReset().mockResolvedValue(true)
   mocks.dispose.mockReset().mockResolvedValue(undefined)
   mocks.onMutation.mockReset()
 })
 
-afterEach(() => {
+afterEach(async () => {
+  cleanup()
+  await vi.runOnlyPendingTimersAsync()
   vi.restoreAllMocks()
   vi.useRealTimers()
 })
@@ -155,7 +158,7 @@ describe('useDirectoryTree', () => {
     expect(result.current.root?.hasChild('renamed.md')).toBe(true)
   })
 
-  it('disposes the tree on unmount', async () => {
+  it('releases an unused tree after the idle grace period', async () => {
     mocks.create.mockResolvedValue({ treeId: 't-3', revision: 0, snapshot: makeSnapshot('/notes', []) })
     const unsub = vi.fn()
     mocks.onMutation.mockReturnValue(unsub)
@@ -167,6 +170,8 @@ describe('useDirectoryTree', () => {
     })
 
     unmount()
+    expect(mocks.dispose).not.toHaveBeenCalled()
+    await act(() => vi.advanceTimersByTimeAsync(10_000))
     expect(unsub).toHaveBeenCalled()
     expect(mocks.dispose).toHaveBeenCalledWith('t-3')
   })
@@ -304,6 +309,7 @@ describe('useDirectoryTree', () => {
     expect(result.current.isLoading).toBe(true)
 
     unmount()
+    await act(() => vi.advanceTimersByTimeAsync(10_000))
 
     // Rejecting after the cleanup ran must not trigger any state update
     // on the unmounted hook. React would log an act() warning if it did.
@@ -316,22 +322,93 @@ describe('useDirectoryTree', () => {
     expect(mocks.dispose).not.toHaveBeenCalled()
   })
 
-  it('disposes the first tree under React StrictMode mount-unmount-mount', async () => {
-    mocks.create
-      .mockResolvedValueOnce({ treeId: 't-strict-1', revision: 0, snapshot: makeSnapshot('/notes', []) })
-      .mockResolvedValueOnce({ treeId: 't-strict-2', revision: 0, snapshot: makeSnapshot('/notes', []) })
-    const unsub1 = vi.fn()
-    const unsub2 = vi.fn()
-    mocks.onMutation.mockReturnValueOnce(unsub1).mockReturnValueOnce(unsub2)
+  it('reuses its resource through StrictMode cleanup and releases it after the real unmount', async () => {
+    mocks.create.mockResolvedValue({ treeId: 'strict-tree', revision: 0, snapshot: makeSnapshot('/notes', ['a.md']) })
+    const { result, unmount } = renderHook(() => useDirectoryTree('/notes'), { wrapper: StrictMode })
+    await waitFor(() => expect(result.current.root?.hasChild('a.md')).toBe(true))
+    expect(mocks.create).toHaveBeenCalledTimes(1)
+    expect(mocks.dispose).not.toHaveBeenCalled()
+    unmount()
+    await act(() => vi.advanceTimersByTimeAsync(10_000))
+    expect(mocks.dispose).toHaveBeenCalledWith('strict-tree')
+  })
 
-    const { result } = renderHook(() => useDirectoryTree('/notes'), { wrapper: StrictMode })
-
-    await waitFor(() => {
-      expect(result.current.treeId).toBe('t-strict-2')
+  it('updates the mirror while Activity suspends rendering and resumes without another scan', async () => {
+    mocks.create.mockResolvedValue({ treeId: 'activity-tree', revision: 0, snapshot: makeSnapshot('/notes', ['a.md']) })
+    let publish: ((payload: TreeMutationPushPayload) => void) | undefined
+    mocks.onMutation.mockImplementation((listener) => {
+      publish = listener
+      return () => {
+        publish = undefined
+      }
     })
+    function Tree() {
+      const tree = useDirectoryTree('/notes')
+      return (
+        <output>
+          {tree.root
+            ? Object.values(tree.root.children)
+                .map((node) => node.basename)
+                .join(',')
+            : ''}
+        </output>
+      )
+    }
+    const view = render(
+      <Activity mode="visible">
+        <Tree />
+      </Activity>
+    )
+    await waitFor(() => expect(view.getByRole('status').textContent).toBe('a.md'))
+    view.rerender(
+      <Activity mode="hidden">
+        <Tree />
+      </Activity>
+    )
+    act(() =>
+      publish?.({
+        treeId: 'activity-tree',
+        revision: 1,
+        event: { type: 'renamed', oldPath: '/notes/a.md', newPath: '/notes/b.md', basename: 'b.md' }
+      })
+    )
+    expect(mocks.dispose).not.toHaveBeenCalled()
+    view.rerender(
+      <Activity mode="visible">
+        <Tree />
+      </Activity>
+    )
+    await waitFor(() => expect(view.getByRole('status').textContent).toBe('b.md'))
+    expect(mocks.create).toHaveBeenCalledTimes(1)
+  })
 
-    // StrictMode's discarded mount must hand back its treeId, not leak it.
-    expect(mocks.dispose).toHaveBeenCalledWith('t-strict-1')
+  it('takes a fresh snapshot after an inactive tree has released its watcher', async () => {
+    mocks.create
+      .mockResolvedValueOnce({ treeId: 'old', revision: 0, snapshot: makeSnapshot('/notes', ['old.md']) })
+      .mockResolvedValueOnce({ treeId: 'fresh', revision: 0, snapshot: makeSnapshot('/notes', ['fresh.md']) })
+    function Tree() {
+      const tree = useDirectoryTree('/notes')
+      return <output>{tree.treeId}</output>
+    }
+    const view = render(
+      <Activity mode="visible">
+        <Tree />
+      </Activity>
+    )
+    await waitFor(() => expect(view.getByRole('status').textContent).toBe('old'))
+    view.rerender(
+      <Activity mode="hidden">
+        <Tree />
+      </Activity>
+    )
+    await act(() => vi.advanceTimersByTimeAsync(10_000))
+    expect(mocks.dispose).toHaveBeenCalledWith('old')
+    view.rerender(
+      <Activity mode="visible">
+        <Tree />
+      </Activity>
+    )
+    await waitFor(() => expect(view.getByRole('status').textContent).toBe('fresh'))
   })
 
   it('ignores file.tree.mutation payloads whose treeId does not match', async () => {

--- a/src/renderer/hooks/useDirectoryTree.ts
+++ b/src/renderer/hooks/useDirectoryTree.ts
@@ -1,305 +1,41 @@
-import { loggerService } from '@logger'
-import { ipcApi } from '@renderer/ipc'
-import { fileErrorCodes } from '@shared/ipc/errors/file'
-import { IpcError } from '@shared/ipc/errors/IpcError'
-import { AbsoluteFilePathSchema } from '@shared/types/file'
-import {
-  type CreateTreeIpcResult,
-  type DirectoryTreeOptions,
-  rootFromSerialized,
-  TreeDir,
-  type TreeDirRoot,
-  TreeFile,
-  type TreeMutationEvent,
-  type TreeNode
-} from '@shared/utils/file'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { DirectoryTreeSession, type DirectoryTreeState } from '@renderer/services/DirectoryTreeSession'
+import type { DirectoryTreeOptions, TreeMutationEvent, TreeNode } from '@shared/utils/file'
+import { useLayoutEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 
-const logger = loggerService.withContext('useDirectoryTree')
-
-/**
- * How many `create → subscribe → activate` rounds to try before giving up.
- *
- * Main refuses activation when it has already dropped the consumer — today only
- * when the pending buffer overflowed, which needs this renderer to stall between
- * the two calls while the workspace churns. Retrying takes a fresh snapshot, so
- * it is correct rather than hopeful; the bound is what keeps a persistently
- * stalled renderer from looping.
- */
-const MAX_ACTIVATION_ATTEMPTS = 3
-
-export interface UseDirectoryTreeResult {
-  readonly root: TreeDirRoot | null
-  readonly isLoading: boolean
-  readonly error: Error | null
-  /** Monotonic counter that ticks whenever the mirror mutates. */
-  readonly version: number
-  /**
-   * Identifier of the live tree on the main side, for routes that address it
-   * (`file.tree.rename`). `null` until the create/activate handoff completes —
-   * which is why side consumers must observe mutations through `onMutation`
-   * rather than subscribing on this id, see the parameter's docs.
-   */
-  readonly treeId: string | null
-  /** O(1) lookup keyed by absolute path. Stable across mutations. */
+export interface UseDirectoryTreeResult extends DirectoryTreeState {
   getNode(absPath: string): TreeNode | null
 }
 
-interface MirrorState {
-  readonly root: TreeDirRoot
-  readonly nodes: Map<string, TreeNode>
-  revision: number
-}
-
-function indexTree(root: TreeDirRoot): Map<string, TreeNode> {
-  const map = new Map<string, TreeNode>()
-  root.walk((n) => {
-    map.set(n.path, n)
-  })
-  return map
-}
-
-function applyMutation(state: MirrorState, event: TreeMutationEvent): boolean {
-  if (event.type === 'added') {
-    if (state.nodes.has(event.path)) return false
-    const parent = state.nodes.get(event.parentPath)
-    if (!parent || !(parent instanceof TreeDir)) return false
-    const node =
-      event.kind === 'directory'
-        ? new TreeDir({ path: event.path, stats: event.stats })
-        : new TreeFile({ path: event.path, stats: event.stats })
-    parent.attachChild(node)
-    state.nodes.set(event.path, node)
-    return true
-  }
-  if (event.type === 'removed') {
-    const node = state.nodes.get(event.path)
-    if (!node) return false
-    if (node instanceof TreeDir) {
-      const drop: string[] = []
-      node.walk((n) => {
-        if (n !== node) drop.push(n.path)
-      })
-      for (const p of drop) state.nodes.delete(p)
-    }
-    state.nodes.delete(event.path)
-    node.remove()
-    return true
-  }
-  if (event.type === 'renamed') {
-    // Identity-preserving: the same `TreeNode` instance gets its path
-    // mutated via the setter, which cascades through `adjustChildrenPaths`
-    // and repoints the parent's `_children` map. The reverse-lookup index
-    // (state.nodes) is rekeyed for the node and every descendant whose
-    // path also changed.
-    const node = state.nodes.get(event.oldPath)
-    if (!node) return false
-    const oldPaths: string[] = [node.path]
-    if (node instanceof TreeDir) {
-      node.walk((n) => {
-        if (n !== node) oldPaths.push(n.path)
-      })
-    }
-    node.path = event.newPath
-    for (const p of oldPaths) state.nodes.delete(p)
-    state.nodes.set(node.path, node)
-    if (node instanceof TreeDir) {
-      node.walk((n) => {
-        if (n !== node) state.nodes.set(n.path, n)
-      })
-    }
-    return true
-  }
-  // updated
-  const node = state.nodes.get(event.path)
-  if (!node) return false
-  node.stats = event.stats
-  return true
-}
+const EMPTY: DirectoryTreeState = { root: null, treeId: null, isLoading: false, error: null, version: 0 }
+const emptySnapshot = () => EMPTY
+const emptySubscribe = () => () => undefined
+const emptyNode = () => null
 
 /**
- * @param onMutation Side consumers that need *every* mutation must go through this
- *   callback rather than their own `ipcApi.on`: `activate` flushes the buffered
- *   mutations before it resolves, so a subscriber keyed on the published `treeId`
- *   misses that replay. Invoked after the mirror is updated, already filtered to
- *   this tree. Read from a ref, so its identity may change freely between renders.
+ * @param onMutation Receives every revision after the mirror applies it, including activation replay
+ *   and brief Activity suspension. Changing roots immediately retires the old stream.
  */
 export function useDirectoryTree(
   rootPath: string | undefined,
   options?: DirectoryTreeOptions,
   onMutation?: (event: TreeMutationEvent) => void
 ): UseDirectoryTreeResult {
-  const normalizedRootPath = rootPath?.replace(/\\/g, '/')
-  const [root, setRoot] = useState<TreeDirRoot | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<Error | null>(null)
-  const [version, setVersion] = useState(0)
-  const [treeId, setTreeId] = useState<string | null>(null)
-  const mirrorRef = useRef<MirrorState | null>(null)
-  // Hold options in a ref. The ref is refreshed every render so that the
-  // *next* mount (i.e. after a rootPath change) uses the caller's latest
-  // option object — but it is read **only once** per mount, inside the
-  // effect's IIFE below. Stale options between rootPath-equal renders are
-  // therefore intentional, not a bug.
-  const optionsRef = useRef<DirectoryTreeOptions | undefined>(options)
-  optionsRef.current = options
-  const onMutationRef = useRef(onMutation)
-  onMutationRef.current = onMutation
-
-  useEffect(() => {
-    if (!rootPath) {
-      setRoot(null)
-      setError(null)
-      setIsLoading(false)
-      setTreeId(null)
-      mirrorRef.current = null
-      return
-    }
-
-    let cancelled = false
-    let released = false
-    let unsubscribeMutations: (() => void) | null = null
-    let createdTreeId: string | null = null
-
-    setRoot(null)
-    setIsLoading(true)
-    setError(null)
-
-    const disposeTree = (treeId: string): void => {
-      // Wrap so mocked / synchronous dispose impls that return `undefined`
-      // don't throw before our `.catch`. The IPC contract is async; we
-      // treat the result defensively.
-      Promise.resolve(ipcApi.request('file.tree.dispose', { treeId })).catch((err) => {
-        logger.error(`Failed to dispose tree ${treeId}`, err as Error)
-      })
-    }
-
-    /** Release the stream and the main-side tree. Idempotent — every path may call it. */
-    const releaseTree = (): void => {
-      unsubscribeMutations?.()
-      unsubscribeMutations = null
-      if (createdTreeId) {
-        disposeTree(createdTreeId)
-        createdTreeId = null
-      }
-      mirrorRef.current = null
-    }
-
-    void (async () => {
-      try {
-        for (let attempt = 1; attempt <= MAX_ACTIVATION_ATTEMPTS; attempt += 1) {
-          const result: CreateTreeIpcResult = await ipcApi.request('file.tree.create', {
-            rootPath: AbsoluteFilePathSchema.parse(rootPath),
-            options: optionsRef.current
+  const inputs = useRef({ rootPath, options, onMutation })
+  inputs.current = { rootPath, options, onMutation }
+  const session = useMemo(
+    () =>
+      rootPath
+        ? new DirectoryTreeSession(rootPath, inputs.current.options, (event) => {
+            if (inputs.current.rootPath === rootPath) inputs.current.onMutation?.(event)
           })
-          if (cancelled) {
-            disposeTree(result.treeId)
-            return
-          }
-
-          createdTreeId = result.treeId
-
-          const snapshotRoot = rootFromSerialized(result.snapshot)
-          const nodes = indexTree(snapshotRoot)
-          mirrorRef.current = { root: snapshotRoot, nodes, revision: result.revision }
-
-          unsubscribeMutations = ipcApi.on('file.tree.mutation', (payload) => {
-            if (payload.treeId !== result.treeId) return
-            const mirror = mirrorRef.current
-            if (!mirror) return
-            if (payload.revision <= mirror.revision) return
-            const expectedRevision = mirror.revision + 1
-            if (payload.revision !== expectedRevision) {
-              const revisionError = new Error(
-                `Directory tree ${result.treeId} mutation gap: expected ${expectedRevision}, received ${payload.revision}`
-              )
-              logger.error(`Directory tree mutation stream became stale for ${rootPath}`, revisionError)
-              // A gap is unrecoverable without a replay or a fresh snapshot, so this is
-              // terminal: tear the stream down and report once. Staying subscribed would
-              // re-gap on every later push — a new Error each time, which consumers that
-              // toast on `error` (Notes) turn into an endless stream of toasts, while the
-              // dead mirror keeps a watcher and its IPC traffic alive. Terminal here also
-              // means no retry: unlike a refused activation, a fresh snapshot would not
-              // tell us what the mirror missed.
-              released = true
-              releaseTree()
-              setRoot(null)
-              setTreeId(null)
-              setError(revisionError)
-              setIsLoading(false)
-              return
-            }
-            const changed = applyMutation(mirror, payload.event)
-            mirror.revision = payload.revision
-            onMutationRef.current?.(payload.event)
-            if (changed) setVersion((v) => v + 1)
-          })
-
-          const activated = await ipcApi.request('file.tree.activate', {
-            treeId: result.treeId,
-            revision: result.revision
-          })
-          // `activate` flushes the buffered mutations before it resolves, so the listener
-          // may have hit a revision gap and torn everything down while this await was
-          // pending. Publishing now would resurrect a snapshot with no mirror behind it —
-          // a tree whose `getNode()` returns null for every path it displays.
-          if (cancelled || released) return
-
-          if (activated) {
-            setRoot(snapshotRoot)
-            setTreeId(result.treeId)
-            setIsLoading(false)
-            return
-          }
-
-          // Main refused the handshake — it dropped this consumer, today because the
-          // pending buffer overflowed while we were between `create` and `activate`.
-          // The snapshot we hold can never be completed, but the condition is transient,
-          // so take a fresh one instead of leaving the caller with a dead tree.
-          logger.warn(`Directory tree ${result.treeId} refused activation, retaking the snapshot`, {
-            rootPath,
-            attempt
-          })
-          releaseTree()
-        }
-        throw new Error(`Directory tree for ${rootPath} was refused activation ${MAX_ACTIVATION_ATTEMPTS} times`)
-      } catch (err) {
-        if (cancelled) return
-        releaseTree()
-        const normalized = err instanceof Error ? err : new Error(String(err))
-        // Distinguish "the main-side manager stopped while our create was
-        // in flight" from a real failure — it fires during app shutdown or
-        // service restart, where no consumer toast is useful.
-        if (normalized instanceof IpcError && normalized.code === fileErrorCodes.DIRECTORY_TREE_STOPPED) {
-          setIsLoading(false)
-          return
-        }
-        logger.error(`Failed to create directory tree for ${rootPath}`, normalized)
-        setError(normalized)
-        setIsLoading(false)
-      }
-    })()
-
-    return () => {
-      cancelled = true
-      releaseTree()
-      setTreeId(null)
-    }
-    // Re-create only on rootPath change. The `options` argument is sampled
-    // exactly once per mount (via `optionsRef.current` inside the IIFE
-    // above); subsequent renders update `optionsRef` but do NOT trigger a
-    // rebuild. Pass a new `rootPath` if you need a different scan.
-  }, [rootPath])
-
-  const currentRoot = root?.path === normalizedRootPath ? root : null
-  const getNode = useCallback(
-    (absPath: string): TreeNode | null => {
-      const mirror = mirrorRef.current
-      if (!mirror || mirror.root.path !== normalizedRootPath) return null
-      return mirror.nodes.get(absPath) ?? null
-    },
-    [normalizedRootPath]
+        : undefined,
+    [rootPath]
   )
-
-  return { root: currentRoot, isLoading, error, version, treeId: currentRoot ? treeId : null, getNode }
+  const previous = useRef(session)
+  useLayoutEffect(() => {
+    if (previous.current !== session) previous.current?.dispose()
+    previous.current = session
+  }, [session])
+  const state = useSyncExternalStore(session?.subscribe ?? emptySubscribe, session?.getSnapshot ?? emptySnapshot)
+  return { ...state, getNode: session?.getNode ?? emptyNode }
 }

--- a/src/renderer/services/DirectoryTreeSession.ts
+++ b/src/renderer/services/DirectoryTreeSession.ts
@@ -1,0 +1,251 @@
+import { loggerService } from '@logger'
+import { ipcApi } from '@renderer/ipc'
+import { fileErrorCodes } from '@shared/ipc/errors/file'
+import { IpcError } from '@shared/ipc/errors/IpcError'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
+import {
+  type CreateTreeIpcResult,
+  type DirectoryTreeOptions,
+  rootFromSerialized,
+  TreeDir,
+  type TreeDirRoot,
+  TreeFile,
+  type TreeMutationEvent,
+  type TreeNode
+} from '@shared/utils/file'
+
+const logger = loggerService.withContext('DirectoryTreeSession')
+
+const MAX_ACTIVATION_ATTEMPTS = 3
+
+export interface DirectoryTreeState {
+  readonly root: TreeDirRoot | null
+  readonly isLoading: boolean
+  readonly error: Error | null
+  /** Monotonic counter that ticks whenever the mirror mutates. */
+  readonly version: number
+  /**
+   * Identifier of the live tree on the main side, for routes that address it
+   * (`file.tree.rename`). `null` until the create/activate handoff completes —
+   * which is why side consumers must observe mutations through `onMutation`
+   * rather than subscribing on this id, see the parameter's docs.
+   */
+  readonly treeId: string | null
+  /** O(1) lookup keyed by absolute path. Stable across mutations. */
+}
+
+interface MirrorState {
+  readonly root: TreeDirRoot
+  readonly nodes: Map<string, TreeNode>
+  revision: number
+}
+
+function indexTree(root: TreeDirRoot): Map<string, TreeNode> {
+  const map = new Map<string, TreeNode>()
+  root.walk((n) => {
+    map.set(n.path, n)
+  })
+  return map
+}
+
+function applyMutation(state: MirrorState, event: TreeMutationEvent): boolean {
+  if (event.type === 'added') {
+    if (state.nodes.has(event.path)) return false
+    const parent = state.nodes.get(event.parentPath)
+    if (!parent || !(parent instanceof TreeDir)) return false
+    const node =
+      event.kind === 'directory'
+        ? new TreeDir({ path: event.path, stats: event.stats })
+        : new TreeFile({ path: event.path, stats: event.stats })
+    parent.attachChild(node)
+    state.nodes.set(event.path, node)
+    return true
+  }
+  if (event.type === 'removed') {
+    const node = state.nodes.get(event.path)
+    if (!node) return false
+    if (node instanceof TreeDir) {
+      const drop: string[] = []
+      node.walk((n) => {
+        if (n !== node) drop.push(n.path)
+      })
+      for (const p of drop) state.nodes.delete(p)
+    }
+    state.nodes.delete(event.path)
+    node.remove()
+    return true
+  }
+  if (event.type === 'renamed') {
+    // Renames preserve node identity; reindex descendants after their paths cascade.
+    const node = state.nodes.get(event.oldPath)
+    if (!node) return false
+    const oldPaths: string[] = [node.path]
+    if (node instanceof TreeDir) {
+      node.walk((n) => {
+        if (n !== node) oldPaths.push(n.path)
+      })
+    }
+    node.path = event.newPath
+    for (const p of oldPaths) state.nodes.delete(p)
+    state.nodes.set(node.path, node)
+    if (node instanceof TreeDir) {
+      node.walk((n) => {
+        if (n !== node) state.nodes.set(n.path, n)
+      })
+    }
+    return true
+  }
+  // updated
+  const node = state.nodes.get(event.path)
+  if (!node) return false
+  node.stats = event.stats
+  return true
+}
+
+const IDLE_RELEASE_MS = 10_000
+
+/** A directory mirror whose native subscription can outlive its React subscribers briefly. */
+export class DirectoryTreeSession {
+  private mirror: MirrorState | null = null
+  private state: DirectoryTreeState = { root: null, isLoading: false, error: null, version: 0, treeId: null }
+  private readonly listeners = new Set<() => void>()
+  private release?: () => void
+  private idleTimer?: ReturnType<typeof setTimeout>
+
+  constructor(
+    private readonly rootPath: string,
+    private readonly options: DirectoryTreeOptions | undefined,
+    private readonly onMutation: (event: TreeMutationEvent) => void
+  ) {}
+
+  getSnapshot = (): DirectoryTreeState => this.state
+  getNode = (path: string): TreeNode | null => this.mirror?.nodes.get(path) ?? null
+
+  subscribe = (listener: () => void): (() => void) => {
+    clearTimeout(this.idleTimer)
+    this.idleTimer = undefined
+    this.listeners.add(listener)
+    this.release ??= this.start()
+    return () => {
+      this.listeners.delete(listener)
+      if (this.listeners.size === 0) this.idleTimer = setTimeout(() => this.dispose(), IDLE_RELEASE_MS)
+    }
+  }
+
+  dispose(): void {
+    clearTimeout(this.idleTimer)
+    this.idleTimer = undefined
+    this.release?.()
+    this.release = undefined
+    this.update({ root: null, treeId: null, isLoading: false })
+  }
+
+  private update(patch: Partial<DirectoryTreeState>): void {
+    this.state = { ...this.state, ...patch }
+    for (const listener of this.listeners) listener()
+  }
+
+  private start(): () => void {
+    const rootPath = this.rootPath
+    let cancelled = false
+    let released = false
+    let unsubscribeMutations: (() => void) | null = null
+    let createdTreeId: string | null = null
+
+    this.update({ root: null, treeId: null, isLoading: true, error: null })
+
+    const disposeTree = (treeId: string): void => {
+      ipcApi.request('file.tree.dispose', { treeId }).catch((err) => {
+        logger.error(`Failed to dispose tree ${treeId}`, err as Error)
+      })
+    }
+
+    /** Release the stream and the main-side tree. Idempotent — every path may call it. */
+    const releaseTree = (): void => {
+      unsubscribeMutations?.()
+      unsubscribeMutations = null
+      if (createdTreeId) {
+        disposeTree(createdTreeId)
+        createdTreeId = null
+      }
+      this.mirror = null
+    }
+
+    void (async () => {
+      try {
+        for (let attempt = 1; attempt <= MAX_ACTIVATION_ATTEMPTS; attempt += 1) {
+          const result: CreateTreeIpcResult = await ipcApi.request('file.tree.create', {
+            rootPath: AbsoluteFilePathSchema.parse(rootPath),
+            options: this.options
+          })
+          if (cancelled) {
+            disposeTree(result.treeId)
+            return
+          }
+
+          createdTreeId = result.treeId
+
+          const snapshotRoot = rootFromSerialized(result.snapshot)
+          const nodes = indexTree(snapshotRoot)
+          this.mirror = { root: snapshotRoot, nodes, revision: result.revision }
+
+          unsubscribeMutations = ipcApi.on('file.tree.mutation', (payload) => {
+            if (payload.treeId !== result.treeId) return
+            const mirror = this.mirror
+            if (!mirror) return
+            if (payload.revision <= mirror.revision) return
+            const expectedRevision = mirror.revision + 1
+            if (payload.revision !== expectedRevision) {
+              const revisionError = new Error(
+                `Directory tree ${result.treeId} mutation gap: expected ${expectedRevision}, received ${payload.revision}`
+              )
+              logger.error(`Directory tree mutation stream became stale for ${rootPath}`, revisionError)
+              released = true
+              releaseTree()
+              this.update({ root: null, treeId: null, error: revisionError, isLoading: false })
+              return
+            }
+            const changed = applyMutation(mirror, payload.event)
+            mirror.revision = payload.revision
+            this.onMutation(payload.event)
+            if (changed) this.update({ version: this.state.version + 1 })
+          })
+
+          const activated = await ipcApi.request('file.tree.activate', {
+            treeId: result.treeId,
+            revision: result.revision
+          })
+          if (cancelled || released) return
+
+          if (activated) {
+            this.update({ root: snapshotRoot, treeId: result.treeId, isLoading: false })
+            return
+          }
+
+          logger.warn(`Directory tree ${result.treeId} refused activation, retaking the snapshot`, {
+            rootPath,
+            attempt
+          })
+          releaseTree()
+        }
+        throw new Error(`Directory tree for ${rootPath} was refused activation ${MAX_ACTIVATION_ATTEMPTS} times`)
+      } catch (err) {
+        if (cancelled) return
+        releaseTree()
+        const normalized = err instanceof Error ? err : new Error(String(err))
+        if (normalized instanceof IpcError && normalized.code === fileErrorCodes.DIRECTORY_TREE_STOPPED) {
+          this.update({ isLoading: false })
+          return
+        }
+        logger.error(`Failed to create directory tree for ${rootPath}`, normalized)
+        this.update({ error: normalized, isLoading: false })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      releaseTree()
+      this.update({ treeId: null })
+    }
+  }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Activity cleanup tears down the renderer directory mirror and its IPC subscription, causing a fresh handshake and transient empty state when the page returns.

After this PR: DirectoryTreeSession owns the mirror and IPC handshake. React subscribes through useSyncExternalStore; brief suspension preserves the stream, revision and node identities while stopping view notifications.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

None. Related work: #20335.

### Why we need it and why it was done in this way

The file tree needs its own mirror lifetime rather than a browser or window host abstraction. Existing DirectoryTreeManager builder sharing remains the native resource owner.

The following tradeoffs were made: After ten seconds without React subscribers the session releases its stream, matching the artifact tree lazy-watcher grace period. Returning afterward takes a fresh snapshot. Changing roots releases immediately. Business mutation callbacks continue during the short grace period; revision gaps remain terminal.

The following alternatives were considered: Keeping the whole page active retains unrelated UI work. Recreating every mirror on Activity cleanup repeats the snapshot handshake even when the main builder is still warm.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20335

### Breaking changes

<!-- optional -->

None. No migration, Electron upgrade or settings change.

### Special notes for your reviewer

Independent PR based on main; no browser-stack dependency.

Validation: 87 focused hook, ArtifactPane and RightPanel tests passed; lint, CI-equivalent lint and docs checks passed. Tests cover Activity reuse, idle release and fresh resume, in-flight root replacement, activation replay, refused activation and revision gaps. Full tests intentionally skipped under the workspace local override.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[File tree] Preserve directory state across brief page switches without keeping the page active.
```
