### PR TITLE
fix(code-cli): launch macOS CLIs via a temp script

### DIFF
--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -699,7 +699,12 @@ export class CodeCliService extends BaseService {
         // Combine directory change with the main command to ensure they execute in the same shell session.
         // Single-quote the directory so a path containing spaces / `$()` / backticks / `;` can't inject
         // (double-quoting it only blocks `"`, leaving command substitution live).
-        const fullCommand = `cd ${posixQuote(directory)} && clear && ${command}`
+        const scriptBody = `#!/bin/sh\ncd ${posixQuote(directory)} && clear && ${command}`
+
+        // Inline env exports made the typed command exceed 2KB and hit the AppleEvent
+        // text-injection truncation on macOS terminals (#20338); a script file keeps it short.
+        const scriptPath = writeLaunchScript(cliTool, scriptBody, '.sh')
+        const fullCommand = `sh ${posixQuote(scriptPath)}`
 
         const terminalConfig = await this.getTerminalConfig(input.terminal)
         logger.info(`Using terminal: ${terminalConfig.name} (${terminalConfig.id})`)

--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -42,6 +42,7 @@ import { REDACTED } from '@shared/utils/redaction'
 
 import { prepareAntigravityLaunch } from './antigravity'
 import { type CliConfigReadFile, readCliConfigFiles, writeCliConfigFiles } from './configWriter'
+import { writeLaunchScript } from './launchScript'
 import { isShellSafeModelId, posixQuote } from './shellQuote'
 import {
   MACOS_TERMINALS,
@@ -81,10 +82,6 @@ const MACOS_APPLICATION_LOOKUP_SCRIPT = [
 @ServicePhase(Phase.Background)
 @DependsOn(['BinaryManager'])
 export class CodeCliService extends BaseService {
-  // Static properties for cleanup management (avoid listener accumulation)
-  private static pendingBatCleanups = new Set<string>()
-  private static exitCleanupRegistered = false
-
   private terminalsCache: {
     terminals: TerminalConfig[]
     timestamp: number
@@ -717,20 +714,6 @@ export class CodeCliService extends BaseService {
         const envPrefix = buildEnvPrefix(true)
         const command = envPrefix ? `${envPrefix} && ${baseCommand}` : baseCommand
 
-        // Create temp bat file for debugging and avoid complex command line escaping issues
-        const tempDir = application.getPath('feature.cli.temp')
-        const timestamp = Date.now()
-        const batFileName = `launch_${cliTool}_${timestamp}.bat`
-        const batFilePath = path.join(tempDir, batFileName)
-
-        // Ensure temp directory exists
-        if (!fs.existsSync(tempDir)) {
-          fs.mkdirSync(tempDir, { recursive: true })
-        }
-
-        // Escape special characters in paths for Windows batch scripting
-        // Using double quotes for compatibility with CMD
-
         // Build bat file content, including debug information
         // Use labels and goto to handle errors properly (fixes CMD control-flow issue)
         const batContent = [
@@ -775,16 +758,8 @@ export class CodeCliService extends BaseService {
           'pause'
         ].join('\r\n')
 
-        // Write to bat file
-        try {
-          fs.writeFileSync(batFilePath, batContent, 'utf8')
-          // Set restrictive permissions for bat file
-          fs.chmodSync(batFilePath, 0o600)
-          logger.info(`Created temp bat file: ${batFilePath}`)
-        } catch (error) {
-          logger.error(`Failed to create bat file: ${error}`)
-          throw new Error(`Failed to create launch script: ${error}`)
-        }
+        // Write to bat file (naming, 0600, and cleanup live in writeLaunchScript)
+        const batFilePath = writeLaunchScript(cliTool, batContent, '.bat')
 
         // Use selected terminal configuration
         const terminalConfig = await this.getTerminalConfig(input.terminal)
@@ -797,44 +772,6 @@ export class CodeCliService extends BaseService {
 
         terminalCommand = cmd
         terminalArgs = args
-
-        // Add to cleanup set
-        CodeCliService.pendingBatCleanups.add(batFilePath)
-
-        // Register exit handler only once (using process.once to avoid accumulation)
-        if (!CodeCliService.exitCleanupRegistered) {
-          process.once('exit', () => {
-            // Clean up all remaining bat files on process exit
-            for (const filePath of CodeCliService.pendingBatCleanups) {
-              try {
-                if (fs.existsSync(filePath)) {
-                  fs.unlinkSync(filePath)
-                  logger.debug(`Cleaned up temp bat file on exit: ${filePath}`)
-                }
-              } catch (error) {
-                logger.warn(`Failed to cleanup temp bat file: ${error}`)
-              }
-            }
-            CodeCliService.pendingBatCleanups.clear()
-          })
-          CodeCliService.exitCleanupRegistered = true
-        }
-
-        // Set timeout for cleanup (normal case - file deleted after 60 seconds)
-        const cleanup = () => {
-          try {
-            if (fs.existsSync(batFilePath)) {
-              fs.unlinkSync(batFilePath)
-              logger.debug(`Cleaned up temp bat file: ${batFilePath}`)
-            }
-            // Remove from pending set
-            CodeCliService.pendingBatCleanups.delete(batFilePath)
-          } catch (error) {
-            logger.warn(`Failed to cleanup temp bat file: ${error}`)
-          }
-        }
-
-        setTimeout(cleanup, 60 * 1000)
 
         break
       }

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -150,9 +150,14 @@ async function loadModules() {
 }
 
 describe('CodeCliService', () => {
+  // Each resetModules reload re-registers launchScript's exit handler; track
+  // the count so afterEach can drop only what this case added.
+  let exitListenerBaseline = 0
+
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    exitListenerBaseline = process.listeners('exit').length
     platformMock.isMac = true
     platformMock.isWin = false
     shellEnvMock.getShellEnv.mockResolvedValue({})
@@ -185,6 +190,13 @@ describe('CodeCliService', () => {
       geminiDir: '/mock/antigravity data',
       model: 'gemini-2.5-pro'
     })
+  })
+
+  afterEach(() => {
+    // Drop the exit handlers this case's fresh launchScript import registered.
+    for (const handler of process.listeners('exit').slice(exitListenerBaseline)) {
+      process.off('exit', handler)
+    }
   })
 
   it('should extend BaseService', async () => {
@@ -721,14 +733,14 @@ describe('CodeCliService', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(scriptPath).toMatch(/launch_claude-code_\d+\.sh$/)
+      expect(scriptPath).toMatch(/launch_claude-code_\d+_[0-9a-f]{8}\.sh$/)
       expect(body).toMatch(/^#!\/bin\/sh\n/)
       expect(vi.mocked(fs.chmodSync)).toHaveBeenCalledWith(scriptPath, 0o600)
       // The command typed into the terminal must stay far below the AppleEvent
       // text-injection truncation zone that swallowed the old 2KB inline command.
       const typed = launchArgs.match(/do script "(.+?)" in front window/)?.[1] ?? ''
       expect(typed.startsWith("sh '\\''/mock/binary-data/launch_claude-code_")).toBe(true)
-      expect(typed).toMatch(/\d+\.sh'\\''$/) // timestamped name, then the closing quote sequence
+      expect(typed).toMatch(/\d+_[0-9a-f]{8}\.sh'\\''$/) // timestamped+random name, then the closing quote sequence
       expect(typed.length).toBeLessThan(200)
     })
 
@@ -916,7 +928,7 @@ describe('CodeCliService', () => {
         const writeCall = vi.mocked(fs.writeFileSync).mock.calls.at(-1)
         expect(writeCall).toBeDefined()
         const [batPath, batContent] = writeCall! as unknown as [string, string]
-        expect(batPath).toMatch(/launch_claude-code_\d+\.bat$/)
+        expect(batPath).toMatch(/launch_claude-code_\d+_[0-9a-f]{8}\.bat$/)
         // CMD expands %…% even inside double quotes, so the bat writer must double them.
         expect(batContent).toContain('if not exist "C:\\Users\\me\\100%% proj" goto :dir_missing')
         expect(batContent).toContain('pushd "C:\\Users\\me\\100%% proj"')

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -427,7 +427,7 @@ describe('CodeCliService', () => {
     it('launches without --model and disables OpenCode auto-update via env', async () => {
       vi.useFakeTimers()
       try {
-        const { spawn } = await import('child_process')
+        const fs = (await import('node:fs')).default
         const { codeCliService } = await loadModules()
 
         const result = await codeCliService.run({
@@ -439,11 +439,9 @@ describe('CodeCliService', () => {
         })
 
         expect(result.success).toBe(true)
-        const call = vi.mocked(spawn).mock.calls.at(-1)
-        expect(call).toBeDefined()
-        const script = (call![1] as string[]).join(' ')
-        expect(script).not.toContain('--model')
-        expect(script).toContain('OPENCODE_DISABLE_AUTOUPDATE=')
+        const body = String((vi.mocked(fs.writeFileSync).mock.calls.at(-1) as [string, string])[1])
+        expect(body).not.toContain('--model')
+        expect(body).toContain('OPENCODE_DISABLE_AUTOUPDATE=')
       } finally {
         vi.useRealTimers()
       }
@@ -458,7 +456,7 @@ describe('CodeCliService', () => {
       })
       vi.useFakeTimers()
       try {
-        const { spawn } = await import('child_process')
+        const fs = (await import('node:fs')).default
         const { codeCliService } = await loadModules()
 
         const result = await codeCliService.run({
@@ -470,11 +468,9 @@ describe('CodeCliService', () => {
         })
 
         expect(result.success).toBe(true)
-        const call = vi.mocked(spawn).mock.calls.at(-1)
-        expect(call).toBeDefined()
-        const script = (call![1] as string[]).join(' ')
-        expect(script).toContain('OPENCODE_DISABLE_AUTOUPDATE=')
-        expect(script).not.toContain('_cherry_mise_key')
+        const body = String((vi.mocked(fs.writeFileSync).mock.calls.at(-1) as [string, string])[1])
+        expect(body).toContain('OPENCODE_DISABLE_AUTOUPDATE=')
+        expect(body).not.toContain('_cherry_mise_key')
       } finally {
         vi.useRealTimers()
       }
@@ -501,13 +497,13 @@ describe('CodeCliService', () => {
     const launchScript = async (input: CodeCliRunInput) => {
       vi.useFakeTimers()
       try {
-        const { spawn } = await import('child_process')
+        const fs = (await import('node:fs')).default
         const { codeCliService } = await loadModules()
         const result = await codeCliService.run(input)
         expect(result.success).toBe(true)
-        const call = vi.mocked(spawn).mock.calls.at(-1)
-        expect(call).toBeDefined()
-        return (call![1] as string[]).join(' ')
+        // The darwin branch launches via a temp .sh script; assert on its written body.
+        const writeCall = vi.mocked(fs.writeFileSync).mock.calls.at(-1) as [string, string]
+        return String(writeCall[1])
       } finally {
         vi.useRealTimers()
       }
@@ -581,17 +577,19 @@ describe('CodeCliService', () => {
       vi.useFakeTimers()
       try {
         const { spawn } = await import('child_process')
+        const fs = (await import('node:fs')).default
         const { codeCliService } = await loadModules()
         const result = await codeCliService.run(input)
         const call = vi.mocked(spawn).mock.calls.at(-1)
-        return { result, script: call ? (call[1] as string[]).join(' ') : '' }
+        const writeCall = vi.mocked(fs.writeFileSync).mock.calls.at(-1) as [string, string] | undefined
+        return { result, script: call ? (call[1] as string[]).join(' ') : '', body: String(writeCall?.[1] ?? '') }
       } finally {
         vi.useRealTimers()
       }
     }
 
     it('quotes the isolated directory and model while injecting Cherry credentials for a normal launch', async () => {
-      const { result, script } = await launchScript({
+      const { result, body } = await launchScript({
         mode: 'normal',
         cliTool: CodeCli.ANTIGRAVITY_CLI,
         providerId: 'gemini',
@@ -603,13 +601,14 @@ describe('CodeCliService', () => {
       expect(antigravityLaunchMock).toHaveBeenCalledWith(
         expect.objectContaining({ providerId: 'gemini', model: 'gemini-2.5-pro' })
       )
-      expect(script).toContain("'--gemini_dir=/mock/antigravity data'")
-      expect(script).toContain("--model '\\''gemini-2.5-pro'\\''")
-      expect(script).toContain("GEMINI_API_KEY='\\''antigravity-secret'\\''")
+      // posixQuote wraps each token in single quotes inside the temp .sh body.
+      expect(body).toContain("'--gemini_dir=/mock/antigravity data'")
+      expect(body).toContain("--model 'gemini-2.5-pro'")
+      expect(body).toContain("GEMINI_API_KEY='antigravity-secret'")
     })
 
     it('leaves the user Google login and global Antigravity settings untouched in own-login mode', async () => {
-      const { result, script } = await launchScript({
+      const { result, body } = await launchScript({
         mode: 'own-login',
         cliTool: CodeCli.ANTIGRAVITY_CLI,
         directory: '/tmp/project'
@@ -617,9 +616,9 @@ describe('CodeCliService', () => {
 
       expect(result.success).toBe(true)
       expect(antigravityLaunchMock).not.toHaveBeenCalled()
-      expect(script).not.toContain('--gemini_dir')
-      expect(script).not.toContain('GEMINI_API_KEY')
-      expect(script).not.toContain('--model')
+      expect(body).not.toContain('--gemini_dir')
+      expect(body).not.toContain('GEMINI_API_KEY')
+      expect(body).not.toContain('--model')
     })
 
     it('rejects an unsafe resolved model before opening a terminal', async () => {
@@ -675,8 +674,8 @@ describe('CodeCliService', () => {
     })
   })
 
-  // Reviewer A4: the launch directory is interpolated into a shell string (macOS: wrapped again by
-  // AppleScript). It must be single-quoted so a path with spaces / $() / backticks can't inject.
+  // Reviewer A4: the launch directory is interpolated into a shell string (macOS: now the body of a
+  // temp .sh script). It must be single-quoted so a path with spaces / $() / backticks can't inject.
   // Skipped on win32: `process.platform` is pinned to darwin below, but `node:path` still follows
   // the host, so the assembled command mixes `\` separators and `;` PATH delimiters into sh syntax.
   describe.skipIf(process.platform === 'win32')('run (launch command shell-quotes the directory)', () => {
@@ -695,14 +694,49 @@ describe('CodeCliService', () => {
       Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
     })
 
+    const darwinLaunch = async (input: CodeCliRunInput) => {
+      const { spawn } = await import('child_process')
+      const fs = (await import('node:fs')).default
+      const { codeCliService } = await loadModules()
+      const result = await codeCliService.run(input)
+      const launchCall = vi.mocked(spawn).mock.calls.at(-1)
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls.at(-1) as [string, string] | undefined
+      return {
+        result,
+        launchArgs: (launchCall?.[1] ?? []).join(' '),
+        scriptPath: String(writeCall?.[0] ?? ''),
+        body: String(writeCall?.[1] ?? '')
+      }
+    }
+
+    it('launches via a short sh command pointing at a 0600 temp script (#20338)', async () => {
+      binaryManagerMock.getToolSnapshots.mockResolvedValue({
+        claude: { name: 'claude', availability: { source: 'system', path: '/usr/local/bin/claude' } }
+      })
+      const fs = (await import('node:fs')).default
+      const { result, launchArgs, scriptPath, body } = await darwinLaunch({
+        mode: 'login-flow',
+        cliTool: CodeCli.CLAUDE_CODE,
+        directory: '/tmp/project'
+      })
+
+      expect(result.success).toBe(true)
+      expect(scriptPath).toMatch(/launch_claude-code_\d+\.sh$/)
+      expect(body).toMatch(/^#!\/bin\/sh\n/)
+      expect(vi.mocked(fs.chmodSync)).toHaveBeenCalledWith(scriptPath, 0o600)
+      // The command typed into the terminal must stay far below the AppleEvent
+      // text-injection truncation zone that swallowed the old 2KB inline command.
+      const typed = launchArgs.match(/do script "(.+?)" in front window/)?.[1] ?? ''
+      expect(typed.startsWith("sh '\\''/mock/binary-data/launch_claude-code_")).toBe(true)
+      expect(typed).toMatch(/\d+\.sh'\\''$/) // timestamped name, then the closing quote sequence
+      expect(typed.length).toBeLessThan(200)
+    })
+
     it('launches a system PATH binary without installing a managed copy', async () => {
       binaryManagerMock.getToolSnapshots.mockResolvedValue({
         claude: { name: 'claude', availability: { source: 'system', path: '/usr/local/bin/claude' } }
       })
-      const { spawn } = await import('child_process')
-      const { codeCliService } = await loadModules()
-
-      const result = await codeCliService.run({
+      const { result, body } = await darwinLaunch({
         mode: 'login-flow',
         cliTool: CodeCli.CLAUDE_CODE,
         directory: '/tmp/project'
@@ -711,11 +745,8 @@ describe('CodeCliService', () => {
       expect(result.success).toBe(true)
       expect(binaryManagerMock.installByName).not.toHaveBeenCalled()
       expect(binaryManagerMock.getToolSnapshots).toHaveBeenCalledWith(['claude'])
-      const launchCall = vi.mocked(spawn).mock.calls.at(-1)
-      expect(launchCall).toBeDefined()
-      const launchArgs = (launchCall?.[1] ?? []).join(' ')
-      expect(launchArgs).toContain('/usr/local/bin/claude')
-      expect(launchArgs).not.toContain('MISE_DATA_DIR')
+      expect(body).toContain("'/usr/local/bin/claude'")
+      expect(body).not.toContain('MISE_DATA_DIR')
     })
 
     it('single-quotes a system executable path containing shell metacharacters', async () => {
@@ -725,19 +756,18 @@ describe('CodeCliService', () => {
           availability: { source: 'system', path: '/tmp/$(touch pwned)/`whoami`/claude' }
         }
       })
-      const { spawn } = await import('child_process')
-      const { codeCliService } = await loadModules()
-
-      const result = await codeCliService.run({
+      const { result, launchArgs, body } = await darwinLaunch({
         mode: 'login-flow',
         cliTool: CodeCli.CLAUDE_CODE,
         directory: '/tmp/project'
       })
 
       expect(result.success).toBe(true)
-      const launchArgs = (vi.mocked(spawn).mock.calls.at(-1)?.[1] ?? []).join(' ')
-      expect(launchArgs).toContain("'\\''/tmp/$(touch pwned)/`whoami`/claude'\\''")
-      expect(launchArgs).not.toContain('"/tmp/$(touch pwned)')
+      // posixQuote in the script body keeps the metacharacters inert data.
+      expect(body).toContain("'/tmp/$(touch pwned)/`whoami`/claude'")
+      expect(body).not.toContain('"/tmp/$(touch pwned)')
+      // The Terminal.app adapter additionally rewrites those quotes for its osascript -e layer.
+      expect(launchArgs).toContain('do script "sh')
     })
 
     it('lazily recovers a missing CLI by name only, writing no Preference', async () => {
@@ -751,9 +781,7 @@ describe('CodeCliService', () => {
             availability: { source: 'mise', path: '/mock/binary-data/shims/claude', version: '1.0.0' }
           }
         })
-      const { codeCliService } = await loadModules()
-
-      const result = await codeCliService.run({
+      const { result } = await darwinLaunch({
         mode: 'login-flow',
         cliTool: CodeCli.CLAUDE_CODE,
         directory: '/tmp/project'
@@ -777,30 +805,30 @@ describe('CodeCliService', () => {
           availability: { source: 'mise', path: '/mock/binary-data/shims/claude', version: '1.0.0' }
         }
       })
-      const { spawn } = await import('child_process')
-      const { codeCliService } = await loadModules()
-
-      const result = await codeCliService.run({
+      const { result, launchArgs, body } = await darwinLaunch({
         mode: 'login-flow',
         cliTool: CodeCli.CLAUDE_CODE,
         directory: '/tmp/project'
       })
 
       expect(result.success).toBe(true)
-      const launchCall = vi.mocked(spawn).mock.calls.at(-1)!
-      const launchArgs = (launchCall[1] ?? []).join(' ')
-      const launchEnv = launchCall[2]?.env as Record<string, string>
-      expect(launchArgs).toContain(
-        "PATH='\\''/mock/binary-data/shims:/mock/binary-data:/usr/local/$(touch /tmp/pwn):`whoami`:$HOME:/usr/bin'\\''"
+      expect(body).toContain(
+        "PATH='/mock/binary-data/shims:/mock/binary-data:/usr/local/$(touch /tmp/pwn):`whoami`:$HOME:/usr/bin'"
       )
-      expect(launchArgs).toContain("MISE_DATA_DIR='\\''/mock/binary-data'\\''")
-      expect(launchArgs).toContain('for _cherry_mise_key in $(env | sed -n')
-      expect(launchArgs).toContain('do unset')
-      expect(launchArgs).toContain('$_cherry_mise_key')
-      expect(launchArgs.indexOf('unset')).toBeLessThan(launchArgs.indexOf('export MISE_DATA_DIR'))
-      expect(launchArgs).not.toContain('MISE_CONFIG_FILE')
-      expect(launchArgs).not.toContain('PRIVATE_TOKEN')
-      expect(launchArgs).not.toContain('must-not-be-exported')
+      expect(body).toContain("MISE_DATA_DIR='/mock/binary-data'")
+      expect(body).toContain('for _cherry_mise_key in $(env | sed -n')
+      expect(body).toContain('do unset')
+      expect(body).toContain('$_cherry_mise_key')
+      expect(body.indexOf('unset')).toBeLessThan(body.indexOf('export MISE_DATA_DIR'))
+      expect(body).not.toContain('MISE_CONFIG_FILE')
+      expect(body).not.toContain('PRIVATE_TOKEN')
+      expect(body).not.toContain('must-not-be-exported')
+      // The typed terminal command must not carry the env exports inline anymore.
+      expect(launchArgs).not.toContain('MISE_DATA_DIR=')
+      const launchEnv = vi.mocked((await import('child_process')).spawn).mock.calls.at(-1)![2]?.env as Record<
+        string,
+        string
+      >
       expect(launchEnv.MISE_CONFIG_FILE).toBeUndefined()
       expect(launchEnv.MISE_DATA_DIR).toBe('/mock/binary-data')
       expect(launchEnv.PRIVATE_TOKEN).toBe('must-not-be-exported')
@@ -811,25 +839,15 @@ describe('CodeCliService', () => {
       // awaits depends on them — the mocked probe resolves via microtasks).
       vi.useFakeTimers()
       try {
-        const { spawn } = await import('child_process')
-        const { codeCliService } = await loadModules()
-
-        // The login-flow mode exempts Claude Code from the provider/model requirement, so control
-        // reaches the command assembly + spawn without needing a provider.
-        const result = await codeCliService.run({
+        const { body } = await darwinLaunch({
           mode: 'login-flow',
           cliTool: CodeCli.CLAUDE_CODE,
           directory: '/tmp/$(reboot) proj'
         })
 
-        expect(result.success).toBe(true)
-        const call = vi.mocked(spawn).mock.calls.at(-1)
-        expect(call).toBeDefined()
-        const script = (call![1] as string[]).join(' ')
-        // posixQuote wraps the directory in single quotes; the Terminal.app adapter then rewrites those
-        // quotes to the sh-safe '\'' form for its `osascript -e '…'` layer. Either way $(reboot) sits
+        // posixQuote wraps the directory in single quotes inside the temp script; $(reboot) sits
         // inside the quotes as inert data — never a substitution.
-        expect(script).toContain("cd '\\''/tmp/$(reboot) proj'\\''")
+        expect(body).toContain("cd '/tmp/$(reboot) proj'")
       } finally {
         vi.useRealTimers()
       }

--- a/src/main/services/codeCli/__tests__/launchScript.test.ts
+++ b/src/main/services/codeCli/__tests__/launchScript.test.ts
@@ -1,8 +1,34 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import type fsDefault from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// One-shot fault injection for the two cleanup-failure paths; a fault destroys
+// itself on first call, everything else passes through to the real filesystem.
+const fsFaults = vi.hoisted(() => ({
+  chmodSync: null as null | (() => void),
+  unlinkSync: null as null | (() => void)
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fsDefault>()
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      chmodSync: (...args: [string, number]): void => {
+        if (fsFaults.chmodSync) return fsFaults.chmodSync()
+        actual.chmodSync(...args)
+      },
+      unlinkSync: (scriptPath: string): void => {
+        if (fsFaults.unlinkSync) return fsFaults.unlinkSync()
+        actual.unlinkSync(scriptPath)
+      }
+    }
+  }
+})
 
 const loggerMock = vi.hoisted(() => ({
   info: vi.fn(),
@@ -36,24 +62,34 @@ const importFresh = async () => {
 describe('writeLaunchScript', () => {
   // Cases may repoint `tempDir` at a nested path; always remove the mkdtemp root.
   let tempDirRoot: string
+  // Listener count before the case, so afterEach removes only what it added.
+  let exitListenerBaseline = 0
 
   beforeEach(() => {
     tempDirRoot = mkdtempSync(path.join(tmpdir(), 'launch-script-test-'))
     tempDir = tempDirRoot
+    fsFaults.chmodSync = null
+    fsFaults.unlinkSync = null
+    exitListenerBaseline = process.listeners('exit').length
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    // Each importFresh registers a fresh exit handler; drop the ones this
+    // case added so the suite does not pile up process listeners.
+    for (const handler of process.listeners('exit').slice(exitListenerBaseline)) {
+      process.off('exit', handler)
+    }
     rmSync(tempDirRoot, { recursive: true, force: true })
   })
 
-  it('creates the script with exact body, 0600 mode, and launch_<tool>_<ts> naming', async () => {
+  it('creates the script with exact body, 0600 mode, and launch_<tool>_<ts>_<rand> naming', async () => {
     const { writeLaunchScript } = await importFresh()
     const body = '#!/bin/sh\ncd /tmp && clear\n'
 
     const scriptPath = writeLaunchScript('qwen-code', body, '.sh')
 
-    expect(path.basename(scriptPath)).toMatch(/^launch_qwen-code_\d+\.sh$/)
+    expect(path.basename(scriptPath)).toMatch(/^launch_qwen-code_\d+_[0-9a-f]{8}\.sh$/)
     expect(existsSync(scriptPath)).toBe(true)
     expect(readFileSync(scriptPath, 'utf8')).toBe(body)
     expect(statSync(scriptPath).mode & 0o777).toBe(0o600)
@@ -94,6 +130,48 @@ describe('writeLaunchScript', () => {
 
     vi.advanceTimersByTime(60_000)
     expect(existsSync(scriptPath)).toBe(false)
+  })
+
+  it('never reuses a path when two launches of one tool land on the same millisecond', async () => {
+    vi.useFakeTimers() // freezes Date.now
+    const { writeLaunchScript } = await importFresh()
+
+    const p1 = writeLaunchScript('qwen-code', 'body1', '.sh')
+    const p2 = writeLaunchScript('qwen-code', 'body2', '.sh')
+
+    expect(p1).not.toBe(p2)
+    expect(readFileSync(p1, 'utf8')).toBe('body1')
+    expect(readFileSync(p2, 'utf8')).toBe('body2')
+  })
+
+  it('keeps a script exit-tracked when the timed deletion fails, so exit retries it', async () => {
+    vi.useFakeTimers()
+    fsFaults.unlinkSync = () => {
+      fsFaults.unlinkSync = null // one-shot: the exit-handler retry must succeed
+      throw new Error('EPERM: file is locked')
+    }
+    const { writeLaunchScript } = await importFresh()
+
+    const scriptPath = writeLaunchScript('qwen-code', 'body', '.sh')
+
+    vi.advanceTimersByTime(60_000)
+    // The timed deletion failed; the file must survive, pending an exit retry.
+    expect(existsSync(scriptPath)).toBe(true)
+
+    const handler = process.listeners('exit').at(-1) as () => void
+    handler()
+    expect(existsSync(scriptPath)).toBe(false)
+  })
+
+  it('leaves no partial file behind when the post-write chmod fails', async () => {
+    fsFaults.chmodSync = () => {
+      throw new Error('EIO')
+    }
+    const { writeLaunchScript } = await importFresh()
+
+    expect(() => writeLaunchScript('qwen-code', 'body', '.sh')).toThrow(/Failed to create launch script/)
+    // A partially written script must not survive with default permissions.
+    expect(readdirSync(tempDir)).toHaveLength(0)
   })
 
   it('throws and registers no exit handler when the temp dir is unwritable', async () => {

--- a/src/main/services/codeCli/__tests__/launchScript.test.ts
+++ b/src/main/services/codeCli/__tests__/launchScript.test.ts
@@ -1,0 +1,109 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn()
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => loggerMock
+  }
+}))
+
+// The module reads the temp dir through the path registry; point it at a real
+// throwaway directory so assertions run against the real filesystem.
+let tempDir: string
+vi.mock('@application', () => ({
+  application: {
+    getPath: vi.fn(() => tempDir)
+  }
+}))
+
+// Module-level singletons (pending-cleanups set, exit-handler flag) must not
+// leak across test cases — re-import a fresh module instance per test.
+const importFresh = async () => {
+  vi.resetModules()
+  vi.doUnmock('@application')
+  vi.doMock('@application', () => ({ application: { getPath: () => tempDir } }))
+  return import('../launchScript')
+}
+
+describe('writeLaunchScript', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'launch-script-test-'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('creates the script with exact body, 0600 mode, and launch_<tool>_<ts> naming', async () => {
+    const { writeLaunchScript } = await importFresh()
+    const body = '#!/bin/sh\ncd /tmp && clear\n'
+
+    const scriptPath = writeLaunchScript('qwen-code', body, '.sh')
+
+    expect(path.basename(scriptPath)).toMatch(/^launch_qwen-code_\d+\.sh$/)
+    expect(existsSync(scriptPath)).toBe(true)
+    expect(readFileSync(scriptPath, 'utf8')).toBe(body)
+    expect(statSync(scriptPath).mode & 0o777).toBe(0o600)
+  })
+
+  it('creates the temp dir when missing and supports .bat extension', async () => {
+    const nested = path.join(tempDir, 'missing', 'cli')
+    tempDir = nested
+    const { writeLaunchScript } = await importFresh()
+
+    const scriptPath = writeLaunchScript('claude-code', '@echo off', '.bat')
+
+    expect(existsSync(scriptPath)).toBe(true)
+    expect(path.extname(scriptPath)).toBe('.bat')
+  })
+
+  it('registers exactly one exit handler across multiple launches and cleans all pending files on exit', async () => {
+    const { writeLaunchScript } = await importFresh()
+    const before = process.listenerCount('exit')
+
+    const p1 = writeLaunchScript('qwen-code', 'body1', '.sh')
+    const p2 = writeLaunchScript('claude-code', 'body2', '.sh')
+
+    expect(process.listenerCount('exit')).toBe(before + 1)
+    // Drive the registered handler the way a real 'exit' event would.
+    const handler = process.listeners('exit').at(-1) as () => void
+    handler()
+    expect(existsSync(p1)).toBe(false)
+    expect(existsSync(p2)).toBe(false)
+  })
+
+  it('deletes the script 60s after creation', async () => {
+    vi.useFakeTimers()
+    const { writeLaunchScript } = await importFresh()
+
+    const scriptPath = writeLaunchScript('qwen-code', 'body', '.sh')
+    expect(existsSync(scriptPath)).toBe(true)
+
+    vi.advanceTimersByTime(60_000)
+    expect(existsSync(scriptPath)).toBe(false)
+  })
+
+  it('throws and registers no exit handler when the temp dir is unwritable', async () => {
+    const readOnly = path.join(tempDir, 'readonly')
+    mkdirSync(readOnly)
+    chmodSync(readOnly, 0o500)
+    tempDir = readOnly
+    const before = process.listenerCount('exit')
+
+    const { writeLaunchScript } = await importFresh()
+
+    expect(() => writeLaunchScript('qwen-code', 'body', '.sh')).toThrow(/Failed to create launch script/)
+    expect(process.listenerCount('exit')).toBe(before)
+  })
+})

--- a/src/main/services/codeCli/__tests__/launchScript.test.ts
+++ b/src/main/services/codeCli/__tests__/launchScript.test.ts
@@ -26,23 +26,25 @@ vi.mock('@application', () => ({
   }
 }))
 
-// Module-level singletons (pending-cleanups set, exit-handler flag) must not
-// leak across test cases — re-import a fresh module instance per test.
+// Module-level singletons must not leak across cases — import fresh each
+// time; the file-level @application mock factory reads tempDir live.
 const importFresh = async () => {
   vi.resetModules()
-  vi.doUnmock('@application')
-  vi.doMock('@application', () => ({ application: { getPath: () => tempDir } }))
   return import('../launchScript')
 }
 
 describe('writeLaunchScript', () => {
+  // Cases may repoint `tempDir` at a nested path; always remove the mkdtemp root.
+  let tempDirRoot: string
+
   beforeEach(() => {
-    tempDir = mkdtempSync(path.join(tmpdir(), 'launch-script-test-'))
+    tempDirRoot = mkdtempSync(path.join(tmpdir(), 'launch-script-test-'))
+    tempDir = tempDirRoot
   })
 
   afterEach(() => {
     vi.useRealTimers()
-    rmSync(tempDir, { recursive: true, force: true })
+    rmSync(tempDirRoot, { recursive: true, force: true })
   })
 
   it('creates the script with exact body, 0600 mode, and launch_<tool>_<ts> naming', async () => {

--- a/src/main/services/codeCli/launchScript.ts
+++ b/src/main/services/codeCli/launchScript.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { application } from '@application'
+import { loggerService } from '@logger'
+
+const logger = loggerService.withContext('LaunchScript')
+
+// Scripts awaiting the 60s cleanup; the exit handler drains whatever is left.
+const pendingCleanups = new Set<string>()
+let exitCleanupRegistered = false
+
+/**
+ * Write a terminal-launch script (macOS `.sh` / Windows `.bat`) into the CLI
+ * temp dir with a short-lived lifecycle: 0600, deleted after 60s, and drained
+ * on process exit as a fallback. Keeping the terminal command at `sh '<path>'`
+ * avoids the AppleEvent/argv length limits that truncated inline commands.
+ *
+ * @param cliTool - CLI tool id, used in the file name only
+ * @param body - Full script content; the caller owns shell/bat semantics
+ * @param ext - Script flavor, also the file extension
+ * @returns Absolute path of the written script
+ */
+export function writeLaunchScript(cliTool: string, body: string, ext: '.sh' | '.bat'): string {
+  const tempDir = application.getPath('feature.cli.temp')
+  const scriptPath = path.join(tempDir, `launch_${cliTool}_${Date.now()}${ext}`)
+
+  if (!fs.existsSync(tempDir)) {
+    fs.mkdirSync(tempDir, { recursive: true })
+  }
+
+  try {
+    fs.writeFileSync(scriptPath, body, 'utf8')
+    // The body may carry env layout details; restrict reads to the owner.
+    fs.chmodSync(scriptPath, 0o600)
+    logger.info(`Created launch script: ${scriptPath}`)
+  } catch (error) {
+    throw new Error(`Failed to create launch script: ${error}`)
+  }
+
+  registerCleanup(scriptPath)
+  return scriptPath
+}
+
+function registerCleanup(scriptPath: string): void {
+  pendingCleanups.add(scriptPath)
+
+  if (!exitCleanupRegistered) {
+    process.once('exit', () => {
+      for (const pending of pendingCleanups) {
+        removeScript(pending, 'on exit')
+      }
+      pendingCleanups.clear()
+    })
+    exitCleanupRegistered = true
+  }
+
+  setTimeout(() => {
+    removeScript(scriptPath, '')
+    pendingCleanups.delete(scriptPath)
+  }, 60 * 1000)
+}
+
+function removeScript(scriptPath: string, phase: string): void {
+  try {
+    if (fs.existsSync(scriptPath)) {
+      fs.unlinkSync(scriptPath)
+      logger.debug(`Cleaned up launch script${phase}: ${scriptPath}`)
+    }
+  } catch (error) {
+    // Cleanup is best-effort; a stale 0600 file in temp must never fail a launch.
+    logger.warn(`Failed to cleanup launch script${phase}: ${error}`)
+  }
+}

--- a/src/main/services/codeCli/launchScript.ts
+++ b/src/main/services/codeCli/launchScript.ts
@@ -35,6 +35,7 @@ export function writeLaunchScript(cliTool: string, body: string, ext: '.sh' | '.
     fs.chmodSync(scriptPath, 0o600)
     logger.info(`Created launch script: ${scriptPath}`)
   } catch (error) {
+    logger.error(`Failed to create launch script: ${error}`)
     throw new Error(`Failed to create launch script: ${error}`)
   }
 

--- a/src/main/services/codeCli/launchScript.ts
+++ b/src/main/services/codeCli/launchScript.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -23,19 +24,24 @@ let exitCleanupRegistered = false
  */
 export function writeLaunchScript(cliTool: string, body: string, ext: '.sh' | '.bat'): string {
   const tempDir = application.getPath('feature.cli.temp')
-  const scriptPath = path.join(tempDir, `launch_${cliTool}_${Date.now()}${ext}`)
-
-  if (!fs.existsSync(tempDir)) {
-    fs.mkdirSync(tempDir, { recursive: true })
-  }
+  // Same-ms launches of one tool must not collide: the later write would
+  // silently replace the earlier script another terminal is about to run.
+  const scriptPath = path.join(tempDir, `launch_${cliTool}_${Date.now()}_${randomUUID().slice(0, 8)}${ext}`)
 
   try {
-    fs.writeFileSync(scriptPath, body, 'utf8')
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true })
+    }
+    // mode only applies at creation; create-with-0600 avoids a window where a
+    // partially written script sits world-readable before chmod runs.
+    fs.writeFileSync(scriptPath, body, { encoding: 'utf8', mode: 0o600 })
     // The body may carry env layout details; restrict reads to the owner.
     fs.chmodSync(scriptPath, 0o600)
     logger.info(`Created launch script: ${scriptPath}`)
   } catch (error) {
     logger.error(`Failed to create launch script: ${error}`)
+    // A partial write can leave a credential-bearing file behind; drop it.
+    removeScript(scriptPath, ' after a failed create')
     throw new Error(`Failed to create launch script: ${error}`)
   }
 
@@ -57,19 +63,23 @@ function registerCleanup(scriptPath: string): void {
   }
 
   setTimeout(() => {
-    removeScript(scriptPath, '')
-    pendingCleanups.delete(scriptPath)
+    // Stay in the set on failure so the exit handler retries the removal.
+    if (removeScript(scriptPath, '')) {
+      pendingCleanups.delete(scriptPath)
+    }
   }, 60 * 1000)
 }
 
-function removeScript(scriptPath: string, phase: string): void {
+function removeScript(scriptPath: string, phase: string): boolean {
   try {
     if (fs.existsSync(scriptPath)) {
       fs.unlinkSync(scriptPath)
       logger.debug(`Cleaned up launch script${phase}: ${scriptPath}`)
     }
+    return true
   } catch (error) {
     // Cleanup is best-effort; a stale 0600 file in temp must never fail a launch.
     logger.warn(`Failed to cleanup launch script${phase}: ${error}`)
+    return false
   }
 }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

On macOS, launching a coding-partner CLI (Claude Code, Gemini CLI, …) typed the entire initialization command into the terminal via `osascript … do script`: 11 `export MISE_*` statements plus the full login `PATH` and the unset loop — measured at 2.4KB+ for a Cherry-installed CLI. The AppleEvent → terminal text-injection layer drops or truncates commands in that length band (reproduced stably at ~1.1K–3.2K on macOS), so affected users saw a cut-off command in the shell that never executed (#20338).

After this PR:

Both macOS and Windows launch through a short-lived temp script. macOS writes a `0600` `.sh` (semantically identical to the previous inline command: `#!/bin/sh` + `cd` + `clear` + env exports + CLI) and types only `sh '<script path>'` (~100–125 chars) into the terminal. Windows keeps its `.bat` flow unchanged but now shares the same lifecycle module.

Fixes #20338

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Extracted a shared `writeLaunchScript(cliTool, body, ext)` module instead of duplicating the win32 lifecycle inline: two real callers (`.sh` / `.bat`) behind one small interface — naming, `0600`, the 60s cleanup timer, and a one-shot process-exit fallback live in one place.
- Script content is a verbatim port of the previous inline command (D4): the osascript → Terminal session does not inherit the spawn env, so env exports must ride in the script — zero semantic drift, and the API-key exposure surface actually shrinks (keys move from terminal keystroke text/scrollback into a `0600` file deleted after 60s).
- Declared micro-deviation: cleanup registration now happens at write time instead of after terminal-config resolution, so a config-failure path that previously leaked a `.bat` now self-cleans (improvement, called out for reviewers).
- Behavioral edge on typed-command adapters (Terminal.app / iTerm2): the script runs as a child `sh` process, so after the CLI exits the interactive shell sits in its original directory instead of the project directory, and the exported env (including keys) does not persist into the session. The second half is a security improvement; the directory difference is accepted as part of the fix.

The following alternatives were considered:

- Keep the command inline but shrink it (drop MISE exports): treats the symptom — login `PATH` length is unbounded and the dangerous band starts at ~1.1K, plus it would break mise isolation semantics.
- Clipboard + synthetic keystrokes (the Tabby path): needs accessibility permissions and a worse UX.
- `open -a Terminal <script>` direct execution: needs `+x`, loses `cd`/`clear` semantics control, larger behavior change.

Links to places where the discussion took place: issue #20338 (investigation comments include the AppleEvent truncation-band measurements across all macOS terminal adapters).

### Breaking changes

None. The terminal-side text changes from the long inline command to `sh '<path>'`; script execution semantics are byte-for-byte equivalent, and the Windows path is unchanged apart from the shared module.

### Special notes for your reviewer

- Verified by unit tests: `launchScript.test.ts` (real filesystem — exact body, `0600`, 60s fake-timer cleanup, one-shot exit handler, unwritable-dir error path) and migrated darwin assertions (typed command shape `<200` chars, script-body contract: posixQuote escaping, unset-before-export ordering, no ambient-secret leakage). 62 tests green in `src/main/services/codeCli/`; the fault-injection mock was re-run 8+ consecutive rounds without a flake.
- Verified on a real machine (dev build + CDP driving `code_cli.run`): Terminal.app and Ghostty branches, mise-installed Gemini CLI (2269-byte script) — the terminal received only `sh '<launch_….sh>'`, the TUI started, and the script auto-deleted after 60s. Re-verified after the cherry-review fix round (random-suffix name, `0600` mode, auto-delete observed on disk).
- Three rounds of sub-agent code review converged (spec drift, security/injection surface, win32 line-by-line semantic parity, test quality); the cherry-review round-1 findings (same-ms name collision, cleanup-set drop on failed deletion, partial-write permissions window) are fixed in the last commit.
- Out of scope on purpose: the `open -na Terminal` new-instance-per-launch behavior (separate follow-up).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every-programmer-should-know/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered: internal launch mechanism change, no user-facing usage change, not required
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix macOS terminal launch of coding-partner CLIs failing with a truncated command: the initialization is now written to a short-lived temp script and the terminal runs `sh <script>` instead of typing a 2KB+ command that Apple events can truncate.
```
