### PR TITLE
fix(agent-runtime): align Claude Code timeout budgets on v1

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/tools.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/tools.test.ts
@@ -209,4 +209,62 @@ describe('ClaudeCodeService runtime authorization wiring', () => {
     expect(session.allowed_tools).toEqual(['PowerShell', 'Bash'])
     expect(serviceMocks.updateSession).not.toHaveBeenCalled()
   })
+
+  it('uses extended idle timeout defaults for Claude Code sessions', async () => {
+    const { default: ClaudeCodeService } = await import('../index')
+    const service = new ClaudeCodeService()
+    const session = {
+      id: 'session-default-timeouts',
+      agent_id: 'agent-test',
+      agent_type: 'claude-code',
+      accessible_paths: ['/tmp/claude-tools-test'],
+      allowed_tools: [],
+      configuration: {},
+      instructions: '',
+      mcps: [],
+      model: 'anthropic:claude-test'
+    }
+
+    await service.invoke('hello', session as never, new AbortController())
+    await vi.waitFor(() => expect(serviceMocks.query).toHaveBeenCalledTimes(1))
+
+    expect(serviceMocks.query.mock.calls[0][0].options.env).toMatchObject({
+      API_TIMEOUT_MS: '1800000',
+      API_FORCE_IDLE_TIMEOUT: '0',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: '1800000'
+    })
+  })
+
+  it('preserves explicit Claude Code timeout controls', async () => {
+    const { default: ClaudeCodeService } = await import('../index')
+    const service = new ClaudeCodeService()
+    const session = {
+      id: 'session-explicit-timeouts',
+      agent_id: 'agent-test',
+      agent_type: 'claude-code',
+      accessible_paths: ['/tmp/claude-tools-test'],
+      allowed_tools: [],
+      configuration: {
+        env_vars: {
+          API_TIMEOUT_MS: '3600000',
+          API_FORCE_IDLE_TIMEOUT: '1',
+          CLAUDE_STREAM_IDLE_TIMEOUT_MS: '900000',
+          CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '600000'
+        }
+      },
+      instructions: '',
+      mcps: [],
+      model: 'anthropic:claude-test'
+    }
+
+    await service.invoke('hello', session as never, new AbortController())
+    await vi.waitFor(() => expect(serviceMocks.query).toHaveBeenCalledTimes(1))
+
+    expect(serviceMocks.query.mock.calls[0][0].options.env).toMatchObject({
+      API_TIMEOUT_MS: '3600000',
+      API_FORCE_IDLE_TIMEOUT: '1',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: '900000',
+      CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '600000'
+    })
+  })
 })

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -34,6 +34,7 @@ import {
   GLOBALLY_DISALLOWED_TOOLS,
   SOUL_MODE_DISALLOWED_TOOLS
 } from '@shared/agents/claudecode/constants'
+import { DEFAULT_TIMEOUT } from '@shared/config/constant'
 import { languageEnglishNameMap } from '@shared/config/languages'
 import { defaultAppHeaders, withoutTrailingApiVersion } from '@shared/utils'
 import { app } from 'electron'
@@ -225,6 +226,9 @@ class ClaudeCodeService implements AgentServiceInterface {
       ANTHROPIC_DEFAULT_SONNET_MODEL: sdkModelId,
       // TODO: support set small model in UI
       ANTHROPIC_DEFAULT_HAIKU_MODEL: sdkModelId,
+      API_TIMEOUT_MS: String(DEFAULT_TIMEOUT),
+      API_FORCE_IDLE_TIMEOUT: '0',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: String(DEFAULT_TIMEOUT),
       ELECTRON_RUN_AS_NODE: '1',
       ELECTRON_NO_ATTACH_CONSOLE: '1',
       // Set CLAUDE_CONFIG_DIR to app's userData directory to avoid path encoding issues


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR: v1 Claude Code agent sessions inherited independent SDK idle watchdogs that could terminate slow local or gateway-backed model responses after about five minutes.

After this PR: v1 defaults the API and stream idle budgets to thirty minutes and disables the redundant body-idle timeout while preserving explicit Agent environment overrides.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Related to #19923. Backport of #20176.

### Why we need it and why it was done in this way

The following tradeoffs were made: A silent Claude Code request may remain active for up to thirty minutes instead of failing after about five minutes.

The following alternatives were considered: Extending only `API_TIMEOUT_MS` was insufficient because the stream and body-idle watchdogs are independent. Cherry-picking #20176 was not possible because v1 constructs the Claude Code environment in the legacy `ClaudeCodeService` path.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19923 and https://github.com/CherryHQ/cherry-studio/pull/20176

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

This is the v1 architecture equivalent of #20176. Verified with Node 24.11.1 using the focused main-process test, `pnpm format`, `pnpm lint`, and the full `pnpm test` suite (4,866 passed, 72 skipped).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix v1 Claude Code agent sessions using slow local or gateway-backed models disconnecting after about five minutes of silent generation.
```
