### PR TITLE
feat(qq-channel): outbound images and files, inbound images as file parts, queued follow-up admission

### DIFF
--- a/src/main/ai/channels/ChannelMessageHandler.ts
+++ b/src/main/ai/channels/ChannelMessageHandler.ts
@@ -920,6 +920,9 @@ export class ChannelMessageHandler {
     let accumulatedText = ''
     const sentinel: StreamListener = {
       id: `channel-completion:${chatId}`,
+      // Cleanup phase: settle after the runtime terminal listener flips the session idle, or the
+      // per-chat queue re-enters `requireIdle` while delivery is still awaiting the platform send.
+      terminalPhase: 'cleanup',
       onChunk(chunk) {
         // `text-delta`'s field is `delta`, not `text` (AI SDK `UIMessageChunk`).
         if (chunk.type === 'text-delta') accumulatedText += chunk.delta

--- a/src/main/ai/channels/ChannelMessageHandler.ts
+++ b/src/main/ai/channels/ChannelMessageHandler.ts
@@ -21,6 +21,9 @@ import type { FileAttachment, ImageAttachment } from '@main/utils/downloadAsBase
 import { AGENT_SESSION_SLASH_COMMANDS_CACHE_KEY } from '@shared/ai/agentSessionSlashCommands'
 import type { AgentChannelEntity } from '@shared/data/api/schemas/agentChannels'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
+import { toFileUrl } from '@shared/utils/file'
 
 import type { ChannelAdapter, ChannelCommandEvent, ChannelMessageEvent, SendMessageOptions } from './ChannelAdapter'
 import { SLASH_COMMANDS } from './constants'
@@ -449,14 +452,13 @@ export class ChannelMessageHandler {
         }
       }
 
-      // Build text with attachment file paths appended so the agent knows where they are saved
-      let textWithAttachments = message.text
-      if (imagePaths.length > 0) {
-        textWithAttachments += `\n\n[Attached images saved to workspace]\n${imagePaths.map((p) => `- ${p}`).join('\n')}`
-      }
-      if (filePaths.length > 0) {
-        textWithAttachments += `\n\n[Attached files saved to workspace]\n${filePaths.map((p) => `- ${p}`).join('\n')}`
-      }
+      // Attachments travel as `file` parts (the shape the in-app composer emits): the UI renders
+      // them, image-capable runtimes see the pixels, and every runtime appends on-disk paths itself.
+      const images = message.images ?? []
+      const files = message.files ?? []
+      const userParts: CherryMessagePart[] = message.text ? [{ type: 'text', text: message.text }] : []
+      imagePaths.forEach((filePath, i) => userParts.push(toFilePart(filePath, images[i].media_type)))
+      filePaths.forEach((filePath, i) => userParts.push(toFilePart(filePath, files[i].media_type, files[i].filename)))
 
       const abortController = new AbortController()
       this.activeAbortControllers.set(session.id, abortController)
@@ -476,7 +478,7 @@ export class ChannelMessageHandler {
         // read never accumulated — and reviving it would double-send.)
         await this.collectStreamResponse(
           session,
-          textWithAttachments,
+          userParts,
           abortController,
           adapter,
           message.chatId,
@@ -604,7 +606,7 @@ export class ChannelMessageHandler {
           try {
             const response = await this.collectStreamResponse(
               session,
-              '/compact',
+              [{ type: 'text', text: '/compact' }],
               abortController,
               adapter,
               command.chatId,
@@ -898,7 +900,7 @@ export class ChannelMessageHandler {
 
   private async collectStreamResponse(
     session: AgentSessionEntity,
-    content: string,
+    userParts: CherryMessagePart[],
     abortController: AbortController,
     adapter: ChannelAdapter,
     chatId: string,
@@ -937,7 +939,7 @@ export class ChannelMessageHandler {
     try {
       const started = await startAgentSessionRun({
         sessionId: session.id,
-        userParts: [{ type: 'text', text: content }],
+        userParts,
         listeners: [sentinel, new ChannelAdapterListener(adapter, chatId, false, responseOptions)],
         headless: true,
         requireIdle: { expectedAgentId: session.agentId }
@@ -995,6 +997,10 @@ export class ChannelMessageHandler {
 
     return paths
   }
+}
+
+function toFilePart(filePath: string, mediaType: string, filename = path.basename(filePath)): CherryMessagePart {
+  return { type: 'file', url: toFileUrl(AbsoluteFilePathSchema.parse(filePath)), mediaType, filename }
 }
 
 export const channelMessageHandler = new ChannelMessageHandler()

--- a/src/main/ai/channels/__tests__/ChannelMessageHandler.test.ts
+++ b/src/main/ai/channels/__tests__/ChannelMessageHandler.test.ts
@@ -896,6 +896,63 @@ describe('ChannelMessageHandler', () => {
     expect(mockStartAgentSessionRun.mock.calls[0][0].userParts[0].text).toBe('first\nsecond')
   })
 
+  it('admits a follow-up queued behind a running turn once the runtime marks it idle', async () => {
+    const adapter = createMockAdapter()
+    // Delivery awaits the platform send; the runtime's idle marker lands inside that window.
+    adapter.sendMessage.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 200)))
+    let runtimeBusy = false
+    const admissions: string[] = []
+    mockStartAgentSessionRun.mockImplementation(async ({ listeners, requireIdle }: any) => {
+      if (requireIdle && runtimeBusy) {
+        admissions.push('busy')
+        return { mode: 'not-started', reason: 'busy' }
+      }
+      runtimeBusy = true
+      admissions.push('started')
+      const runtimeTerminal = {
+        onChunk() {},
+        onDone() {
+          runtimeBusy = false
+        }
+      }
+      // Mirror AiStreamManager: persistence, then unphased (delivery + runtime terminal), then cleanup.
+      const byPhase = (phase?: 'persistence' | 'cleanup') => listeners.filter((l: any) => l.terminalPhase === phase)
+      const ordered = [...byPhase('persistence'), ...byPhase(undefined), runtimeTerminal, ...byPhase('cleanup')]
+      // Like the real call, return once the stream is started; the turn runs on its own.
+      void (async () => {
+        // The model thinks long enough for the follow-up to queue behind this turn.
+        await new Promise((resolve) => setTimeout(resolve, 5000))
+        for (const listener of ordered) {
+          listener.onChunk({ type: 'text-delta', delta: 'reply' })
+          await listener.onDone({ status: 'success' })
+        }
+      })()
+      return { mode: 'started' }
+    })
+
+    try {
+      const first = channelMessageHandler.handleIncoming(adapter, {
+        chatId: 'chat-1',
+        userId: 'user-1',
+        userName: 'User',
+        text: 'first'
+      })
+      await vi.advanceTimersByTimeAsync(1000)
+      const second = channelMessageHandler.handleIncoming(adapter, {
+        chatId: 'chat-1',
+        userId: 'user-1',
+        userName: 'User',
+        text: 'second'
+      })
+      await vi.advanceTimersByTimeAsync(15_000)
+      await Promise.all([first, second])
+
+      expect(admissions).toEqual(['started', 'started'])
+    } finally {
+      mockStartAgentSessionRun.mockReset()
+    }
+  })
+
   it('flushes a sustained message burst at the original sixteen-second deadline', async () => {
     const adapter = createMockAdapter()
     simulateStream([{ type: 'text-delta', delta: 'reply' }])

--- a/src/main/ai/channels/__tests__/ChannelMessageHandler.test.ts
+++ b/src/main/ai/channels/__tests__/ChannelMessageHandler.test.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from 'events'
-import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { MockMainCacheServiceUtils } from '@test-mocks/main/CacheService'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -397,6 +398,84 @@ describe('ChannelMessageHandler', () => {
       expect(written[0]).toMatch(/\.png$/)
       expect(await readdir(workDir)).toEqual(['.cherry-studio'])
       expect(await readdir(path.join(workDir, '.cherry-studio'))).toEqual(['channel-images'])
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+    }
+  })
+
+  it('attaches inbound images and files as file parts so the UI renders them and the model sees them', async () => {
+    const adapter = createMockAdapter()
+    const workDir = await mkdtemp(path.join(os.tmpdir(), 'channel-attachments-'))
+    const session = {
+      id: 'session-1',
+      agentId: 'agent-1',
+      agentType: 'claude-code',
+      model: 'openai::gpt-4',
+      workspace: { path: workDir },
+      configuration: {}
+    }
+    vi.mocked(agentSessionService.create).mockReturnValueOnce(session as any)
+    simulateStream([{ type: 'text-delta', delta: 'ok' }])
+
+    try {
+      await handleIncomingAndFlush(adapter, {
+        chatId: 'chat-1',
+        userId: 'user-1',
+        userName: 'User',
+        text: 'what is this',
+        images: [{ media_type: 'image/jpeg', data: Buffer.from('jpeg-bytes').toString('base64') }],
+        files: [
+          {
+            filename: 'report.pdf',
+            media_type: 'application/pdf',
+            data: Buffer.from('pdf').toString('base64'),
+            size: 3
+          }
+        ]
+      })
+
+      const { userParts } = mockStartAgentSessionRun.mock.calls[0][0]
+      expect(userParts).toHaveLength(3)
+      const [textPart, imagePart, filePart] = userParts
+      // The caption is the whole text: runtimes derive attachment paths from the parts themselves.
+      expect(textPart).toEqual({ type: 'text', text: 'what is this' })
+      expect(imagePart).toMatchObject({ type: 'file', mediaType: 'image/jpeg' })
+      expect(imagePart.url).toMatch(/^file:\/\/.*\/\.cherry-studio\/channel-images\/[^/]+\.jpg$/)
+      expect(filePart).toMatchObject({ type: 'file', mediaType: 'application/pdf', filename: 'report.pdf' })
+      expect(filePart.url).toMatch(/^file:\/\/.*\/\.cherry-studio\/channel-files\/[^/]+report\.pdf$/)
+      // The parts point at the bytes actually written, so a runtime can materialize them.
+      expect(await readFile(fileURLToPath(imagePart.url))).toEqual(Buffer.from('jpeg-bytes'))
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+    }
+  })
+
+  it('sends an image-only message as a lone file part, with no empty text bubble', async () => {
+    const adapter = createMockAdapter()
+    const workDir = await mkdtemp(path.join(os.tmpdir(), 'channel-attachments-'))
+    const session = {
+      id: 'session-1',
+      agentId: 'agent-1',
+      agentType: 'claude-code',
+      model: 'openai::gpt-4',
+      workspace: { path: workDir },
+      configuration: {}
+    }
+    vi.mocked(agentSessionService.create).mockReturnValueOnce(session as any)
+    simulateStream([{ type: 'text-delta', delta: 'ok' }])
+
+    try {
+      await handleIncomingAndFlush(adapter, {
+        chatId: 'chat-1',
+        userId: 'user-1',
+        userName: 'User',
+        text: '',
+        images: [{ media_type: 'image/png', data: Buffer.from('png-bytes').toString('base64') }]
+      })
+
+      const { userParts } = mockStartAgentSessionRun.mock.calls[0][0]
+      expect(userParts).toHaveLength(1)
+      expect(userParts[0]).toMatchObject({ type: 'file', mediaType: 'image/png' })
     } finally {
       await rm(workDir, { recursive: true, force: true })
     }

--- a/src/main/ai/channels/adapters/__tests__/QqAdapter.test.ts
+++ b/src/main/ai/channels/adapters/__tests__/QqAdapter.test.ts
@@ -72,7 +72,9 @@ function createAdapter() {
 }
 
 describe('QqAdapter.downloadAttachments', () => {
-  beforeEach(() => mockNetFetch.mockReset())
+  beforeEach(() => {
+    mockNetFetch.mockReset()
+  })
   afterEach(() => vi.restoreAllMocks())
 
   it('rejects an SSRF target before any (token-bearing) fetch (C8)', async () => {
@@ -129,7 +131,9 @@ describe('QqAdapter.downloadAttachments', () => {
 })
 
 describe('QqAdapter passive reply', () => {
-  beforeEach(() => mockNetFetch.mockReset())
+  beforeEach(() => {
+    mockNetFetch.mockReset()
+  })
   afterEach(() => vi.restoreAllMocks())
 
   function capturePostBodies(): any[] {
@@ -249,14 +253,117 @@ describe('QqAdapter passive reply', () => {
   })
 })
 
-describe('ChannelAdapter.sendFile default', () => {
+describe('QqAdapter.sendFile', () => {
+  beforeEach(() => {
+    mockNetFetch.mockReset()
+  })
   afterEach(() => vi.restoreAllMocks())
 
-  it('rejects with the channel type for adapters that inherit the base default (QQ)', async () => {
-    const adapter = createAdapter()
-    const file = { filename: 'a.txt', data: 'eA==', media_type: 'text/plain', size: 1 }
+  const png = { filename: 'chart.png', data: 'aW1n', media_type: 'image/png', size: 3 }
+  const pdf = { filename: 'report.pdf', data: 'cGRm', media_type: 'application/pdf', size: 3 }
 
-    await expect(adapter.sendFile('100', file)).rejects.toThrow('Channel type "qq" does not support sending files')
+  /** Answer the `/files` upload POST with `uploadJson` and any other POST with an empty ok body. */
+  function capturePosts(uploadJson: Record<string, unknown>): Array<{ url: string; body: any }> {
+    const posts: Array<{ url: string; body: any }> = []
+    mockNetFetch.mockImplementation((url: string, init?: any) => {
+      posts.push({ url, body: JSON.parse(init.body) })
+      const json = url.endsWith('/files') ? uploadJson : {}
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(json),
+        text: () => Promise.resolve('{}')
+      })
+    })
+    return posts
+  }
+
+  it('uploads an image inline to a private chat, then sends it as a msg_type 7 media message', async () => {
+    const adapter = createAdapter()
+    vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
+    const posts = capturePosts({ file_uuid: 'u', file_info: 'INFO-1', ttl: 0 })
+
+    await adapter.sendFile('c2c:u1', png)
+
+    expect(posts.map((p) => p.url)).toEqual([
+      'https://api.sgroup.qq.com/v2/users/u1/files',
+      'https://api.sgroup.qq.com/v2/users/u1/messages'
+    ])
+    expect(posts[0].body).toEqual({ file_type: 1, file_data: 'aW1n', srv_send_msg: false })
+    expect(posts[1].body).toEqual({ msg_type: 7, media: { file_info: 'INFO-1' } })
+  })
+
+  it('sends a non-media file to a group as file_type 4 carrying its filename', async () => {
+    const adapter = createAdapter()
+    vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
+    const posts = capturePosts({ file_uuid: 'u', file_info: 'INFO-2', ttl: 0 })
+
+    await adapter.sendFile('group:g1', pdf)
+
+    expect(posts.map((p) => p.url)).toEqual([
+      'https://api.sgroup.qq.com/v2/groups/g1/files',
+      'https://api.sgroup.qq.com/v2/groups/g1/messages'
+    ])
+    expect(posts[0].body).toEqual({ file_type: 4, file_data: 'cGRm', srv_send_msg: false, file_name: 'report.pdf' })
+    expect(posts[1].body.media).toEqual({ file_info: 'INFO-2' })
+  })
+
+  it('strips path, control and bidi-format characters from the upload file name', async () => {
+    const adapter = createAdapter()
+    vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
+    const posts = capturePosts({ file_uuid: 'u', file_info: 'INFO-4', ttl: 0 })
+
+    await adapter.sendFile('group:g1', { ...pdf, filename: 'a/b:c\u202Ereport.pdf\u0000' })
+
+    expect(posts[0].body.file_name).toBe('a_b_c_report.pdf_')
+  })
+
+  it('maps video to file_type 2 without a filename', async () => {
+    const adapter = createAdapter()
+    vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
+    const posts = capturePosts({ file_uuid: 'u', file_info: 'INFO-3', ttl: 0 })
+
+    await adapter.sendFile('c2c:u1', { filename: 'clip.mp4', data: 'bXA0', media_type: 'video/mp4', size: 3 })
+
+    expect(posts[0].body.file_type).toBe(2)
+    expect(posts[0].body.file_name).toBeUndefined()
+  })
+
+  it('rejects guild channels and guild DMs before any request', async () => {
+    const adapter = createAdapter()
+
+    await expect(adapter.sendFile('channel:c1', png)).rejects.toThrow('accept text only')
+    await expect(adapter.sendFile('dm:guild1', png)).rejects.toThrow('accept text only')
+    expect(mockNetFetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects files over the 10 MB inline cap before any request', async () => {
+    const adapter = createAdapter()
+
+    await expect(adapter.sendFile('c2c:u1', { ...pdf, size: 10 * 1024 * 1024 + 1 })).rejects.toThrow('10 MB')
+    expect(mockNetFetch).not.toHaveBeenCalled()
+  })
+
+  it('does not send a message when the upload returns no file_info', async () => {
+    const adapter = createAdapter()
+    vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
+    const posts = capturePosts({ file_uuid: 'u', ttl: 0 })
+
+    await expect(adapter.sendFile('c2c:u1', png)).rejects.toThrow('no file_info')
+    expect(posts).toHaveLength(1)
+  })
+
+  it('surfaces the QQ error body when the platform rejects the upload', async () => {
+    const adapter = createAdapter()
+    vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
+    mockNetFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('{"message":"file type not allowed","code":40034}')
+    })
+
+    await expect(adapter.sendFile('group:g1', pdf)).rejects.toThrow('file type not allowed')
+    expect(mockNetFetch).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/main/ai/channels/adapters/qq/QqAdapter.ts
+++ b/src/main/ai/channels/adapters/qq/QqAdapter.ts
@@ -4,6 +4,7 @@ import WebSocket from 'ws'
 
 import { type FileAttachment, type ImageAttachment, MAX_FILE_SIZE_BYTES } from '@main/utils/downloadAsBase64'
 import { sanitizeRemoteUrl } from '@main/utils/remoteUrlSafety'
+import { MB } from '@shared/utils/constants'
 
 import { ChannelAdapter, type ChannelAdapterConfig, type SendMessageOptions } from '../../ChannelAdapter'
 import { registerAdapterFactory } from '../../ChannelManager'
@@ -32,6 +33,12 @@ const QQ_PASSIVE_REPLY_TTL_DEFAULT = 5 * 60 * 1000
 const QQ_MAX_PASSIVE_REPLIES = 5
 /** Cap on tracked inbound ids; evict oldest beyond this so the map can't grow unbounded. */
 const QQ_MAX_PASSIVE_ENTRIES = 1000
+/** QQ rich-media `file_type` values. 3 (voice) is deliberately unmapped: it accepts silk audio only. */
+const QQ_FILE_TYPE_IMAGE = 1
+const QQ_FILE_TYPE_VIDEO = 2
+const QQ_FILE_TYPE_FILE = 4
+/** Inline base64 upload cap; larger files need QQ's undocumented chunked protocol. */
+const QQ_MAX_INLINE_UPLOAD_BYTES = 10 * MB
 
 // QQ Bot WebSocket opcodes
 const OP_DISPATCH = 0
@@ -87,6 +94,16 @@ type QqMessage = {
   group_id?: string
   group_openid?: string
   attachments?: QqAttachment[]
+}
+
+function qqMediaFileType(mediaType: string): number {
+  if (mediaType.startsWith('image/')) return QQ_FILE_TYPE_IMAGE
+  if (mediaType.startsWith('video/')) return QQ_FILE_TYPE_VIDEO
+  return QQ_FILE_TYPE_FILE
+}
+
+function sanitizeUploadFileName(filename: string): string {
+  return filename.trim().replace(/[<>:"/\\|?*\p{Cc}\p{Cf}]/gu, '_') || 'file'
 }
 
 class QqAdapter extends ChannelAdapter {
@@ -720,6 +737,37 @@ class QqAdapter extends ChannelAdapter {
     }
     entry.seq += 1
     return entry.seq
+  }
+
+  override async sendFile(chatId: string, file: FileAttachment): Promise<void> {
+    const [type, id] = chatId.split(':')
+    if (type === 'channel' || type === 'dm') {
+      throw new Error('QQ guild channels and guild DMs accept text only; send files to a private (c2c) or group chat')
+    }
+    if (type !== 'c2c' && type !== 'group') {
+      throw new Error(`Unknown chat type: ${type}`)
+    }
+    if (file.size > QQ_MAX_INLINE_UPLOAD_BYTES) {
+      throw new Error(
+        `QQ inline upload limit is ${QQ_MAX_INLINE_UPLOAD_BYTES / MB} MB; "${file.filename}" is ${(file.size / MB).toFixed(1)} MB`
+      )
+    }
+
+    const base = type === 'c2c' ? `${QQ_API_BASE}/v2/users/${id}` : `${QQ_API_BASE}/v2/groups/${id}`
+    const fileType = qqMediaFileType(file.media_type)
+    // The docs still list `file_data` as unsupported, but production accepts inline base64 —
+    // and a desktop app has no public URL to hand QQ instead.
+    const upload: Record<string, unknown> = { file_type: fileType, file_data: file.data, srv_send_msg: false }
+    if (fileType === QQ_FILE_TYPE_FILE) upload.file_name = sanitizeUploadFileName(file.filename)
+
+    const uploadResponse = await this.apiRequest(`${base}/files`, { method: 'POST', body: upload })
+    const { file_info } = (await uploadResponse.json()) as { file_info?: string }
+    if (!file_info) {
+      throw new Error(`QQ media upload returned no file_info for "${file.filename}"`)
+    }
+
+    await this.apiRequest(`${base}/messages`, { method: 'POST', body: { msg_type: 7, media: { file_info } } })
+    this.log.info('Sent file', { chatId, filename: file.filename, size: file.size, mediaType: file.media_type })
   }
 
   // oxlint-disable-next-line no-unused-vars -- no-op abstract method

--- a/src/main/ai/mcp/servers/cherryAutonomyTools.ts
+++ b/src/main/ai/mcp/servers/cherryAutonomyTools.ts
@@ -138,7 +138,7 @@ const CRON_TOOL: Tool = {
 const NOTIFY_TOOL: Tool = {
   name: NOTIFY_TOOL_NAME,
   description:
-    'Deliver a message, a workspace file, or both to this turn’s configured notification recipients. Files are first-class deliverables: use file_path for final workspace artifacts. Telegram/Feishu/WeChat forward any file, and WeChat sends video as native video media; Discord/Slack/QQ do not support files yet. Omit channel_id to deliver to all configured recipients; provide channel_id only to select one configured recipient. In a source-channel session, channel_id may also select another live channel owned by this Agent.',
+    'Deliver a message, a workspace file, or both to this turn’s configured notification recipients. Files are first-class deliverables: use file_path for final workspace artifacts. Telegram/Feishu/WeChat forward any file, and WeChat sends video as native video media; QQ forwards files up to 10 MB to private and group chats only; Discord/Slack do not support files yet. Omit channel_id to deliver to all configured recipients; provide channel_id only to select one configured recipient. In a source-channel session, channel_id may also select another live channel owned by this Agent.',
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- The QQ adapter did not implement `sendFile`, so `notify` with a `file_path` against a QQ channel always failed with `Channel type "qq" does not support sending files`.
- Inbound channel attachments reached the agent session as a single text part with the saved paths appended as prose. The session UI showed a path block instead of the image, and image-capable runtimes never saw the pixels, so the model guessed at image content.
- A message sent while the agent was still replying was rejected with "Agent session is busy" every time: the channel completion sentinel released the per-chat queue before the runtime marked the turn idle.

After this PR:

- `QqAdapter.sendFile` uploads the attachment inline (`file_data`) to `/v2/users|groups/{id}/files`, then sends a `msg_type: 7` message with the returned `file_info`. Images map to `file_type` 1, video to 2, everything else to 4 with a sanitized `file_name`. Guild channels and guild DMs get a clear text-only error, and files over the 10 MB inline cap are rejected before any request. The `notify` tool description states what QQ accepts.
- Inbound images are emitted as `file` parts, the same shape the in-app composer produces: the UI renders them, Claude Code receives native image blocks, and every runtime derives the on-disk path from the part itself. Ordinary files keep the existing path-as-text delivery (see the tradeoffs below).
- The completion sentinel is phased as `cleanup`, so it settles after the runtime's terminal listener and a queued follow-up is admitted instead of bounced.

Fixes #20263

### Why we need it and why it was done in this way

QQ was the only IM channel without outbound media. A desktop app has no public URL to hand QQ, so inline `file_data` is the only viable upload path. The official docs still list it as unsupported, but DeepChat, openclaw-china, AstrBot and LangBot all ship it, and it was verified live here (see below).

The following tradeoffs were made:

- Inline uploads are capped at 10 MB locally. QQ documents no limit; AstrBot switches to an undocumented chunked protocol above 10 MB, which is out of scope.
- Audio is sent as a file (`file_type` 4) rather than voice (`file_type` 3), because voice accepts silk-encoded audio only.
- `content` is omitted on the `msg_type: 7` message, following current shipping implementations rather than the 2024 doc note asking for a placeholder space. Verified live: no blank bubble.
- Outbound files are active pushes (no `msg_id`), mirroring how `notify` text is delivered today; the caller never supplies a message id.
- Ordinary files still arrive as a `[Attached files saved to workspace]` note in the prompt rather than as `file` parts. A `file` part keeps the sender's filename, the Claude Code runtime admits images by extension, and `fileProcessor` re-derives the MIME from the path on read, so unrecognized bytes named `a.png` would be promoted to a native image block. The shared byte-recognition fix is tracked in #20503; until it lands, ordinary files show as a path note in the session instead of a file card. The image path note was dropped: Claude Code, dsh/pi (`buildAgentUserContent`) and the AI SDK runtime all derive image paths from the `file` part.

The following alternatives were considered:

- Sending guild-channel images through multipart `file_image`. Deferred: the issue accepts text-only guild chats, and it needs a second request path.
- Waiting for runtime idle inside the channel handler with a timeout instead of phasing the sentinel. Rejected: `terminalPhase: 'cleanup'` is the existing contract for "run after notifications" and is a one-line fix.

Links to places where the discussion took place: #20263

### Breaking changes

None.

### Special notes for your reviewer

Live verification against a QQ bot (c2c chat). Every `notify` send logged `Sent file` with HTTP 2xx on both the upload and the message request.

| Scenario | Phone (QQ) | Desktop (Cherry Studio) |
| --- | --- | --- |
| Inbound photo: rendered in the session and described correctly by the model | <img width="1179" height="2556" alt="01-phone-inbound-photo-recognized" src="https://github.com/user-attachments/assets/b68128f3-05e4-445a-bd68-aad04b1c80aa" /> | <img width="1640" height="1400" alt="02-desktop-inbound-photo-rendered" src="https://github.com/user-attachments/assets/636448eb-6580-40e3-aa3c-2cdbe74b8625" /> |
| Outbound `test.txt` (`file_type` 4) and outbound image via `notify` | <img width="1179" height="2556" alt="03-phone-outbound-txt-and-image" src="https://github.com/user-attachments/assets/72f9d970-3fb3-4213-a1ea-18a7e3deb7ae" /> | <img width="1614" height="846" alt="04-desktop-outbound-notify-turns" src="https://github.com/user-attachments/assets/6e4b3c27-b44e-40d3-9b84-3bd933e93eac" />  |
| Inbound `test.txt`: agent reads it and replies (screenshot predates the path-as-text containment; the session now shows the path note instead of a card) | <img width="1179" height="2556" alt="05-phone-inbound-txt-roundtrip" src="https://github.com/user-attachments/assets/d132e9ef-18a4-41b7-afb9-cb048c10e1bb" /> |  <img width="1550" height="456" alt="06-desktop-inbound-txt-attachment-card" src="https://github.com/user-attachments/assets/d9debb56-ba02-4060-ba67-382c36ae9b4e" />|
| Before: "session busy" on a follow-up sent mid-turn, and a guessed image description|<img width="880" height="1908" alt="07-before-phone-busy-and-cat-hallucination" src="https://github.com/user-attachments/assets/fd2a9a4a-79a0-4fc3-877b-b54ed4282d00" />| <img width="1564" height="1154" alt="08-before-desktop-path-text-only" src="https://github.com/user-attachments/assets/b52be336-006a-4a17-8188-13cd535c2881" />|

Also exercised live: follow-ups sent while the agent was still replying were queued and answered, with no "session busy" reply.

Platform facts that differ from the QQ docs (last touched 2024-03): inline `file_data` upload and `file_type` 4 both work in production. Not tested live: group chats and guild channels (covered by unit tests).

Checks run: the four touched test files (`QqAdapter`, `ChannelMessageHandler`, `ChannelMessageHandler.pause`, `cherryAutonomyTools`), a narrow `tsc` over the touched files, `oxlint --deny-warnings`, `eslint`, and `oxfmt --check`. The full gate is left to CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
QQ channels can now receive images and files the agent sends through `notify` in private and group chats. Images sent to any channel now show up in the agent session, and the model sees them directly. A follow-up message sent while the agent is still replying is queued instead of being rejected as "session busy".
```

