### PR TITLE
fix(new-api): restore Gemini web search through relays

### DIFF
--- a/patches/@ai-sdk__openai-compatible@2.0.72.patch
+++ b/patches/@ai-sdk__openai-compatible@2.0.72.patch
@@ -1,7 +1,8 @@
 diff --git a/dist/index.js b/dist/index.js
+index ea415b862b2c36c3771b52ed8cd4fe88a784a46a..dbe7772ae88509d86ca27584369a45f1ffacc43b 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -257,7 +257,11 @@
+@@ -257,7 +257,11 @@ function convertToOpenAICompatibleChatMessages(prompt) {
          messages.push({
            role: "assistant",
            content: toolCalls.length > 0 ? text || null : text,
@@ -14,10 +15,20 @@ diff --git a/dist/index.js b/dist/index.js
            tool_calls: toolCalls.length > 0 ? toolCalls : void 0,
            ...metadata
          });
-@@ -599,6 +603,17 @@
+@@ -599,6 +603,27 @@ var OpenAICompatibleChatLanguageModel = class {
          text: reasoning
        });
      }
++    for (const annotation of choice.message.annotations || []) {
++      if (annotation?.type !== "url_citation" || typeof annotation.url_citation?.url !== "string") continue;
++      content.push({
++        type: "source",
++        sourceType: "url",
++        id: (0, import_provider_utils2.generateId)(),
++        url: annotation.url_citation.url,
++        title: typeof annotation.url_citation.title === "string" ? annotation.url_citation.title : void 0
++      });
++    }
 +    if (choice.message.images) {
 +      for (const image of choice.message.images) {
 +        const match1 = image.image_url.url.match(/^data:([^;]+)/);
@@ -32,7 +43,7 @@ diff --git a/dist/index.js b/dist/index.js
      if (choice.message.tool_calls != null) {
        for (const toolCall of choice.message.tool_calls) {
          const thoughtSignature = (_c = (_b = toolCall.extra_content) == null ? void 0 : _b.google) == null ? void 0 : _c.thought_signature;
-@@ -758,6 +773,17 @@
+@@ -758,6 +782,17 @@ var OpenAICompatibleChatLanguageModel = class {
                  delta: delta.content
                });
              }
@@ -50,7 +61,32 @@ diff --git a/dist/index.js b/dist/index.js
              if (delta.tool_calls != null) {
                if (isActiveReasoning) {
                  controller.enqueue({
-@@ -983,6 +1009,14 @@
+@@ -871,6 +906,16 @@ var OpenAICompatibleChatLanguageModel = class {
+                 });
+               }
+             }
++            for (const annotation of delta.annotations || []) {
++              if (annotation?.type !== "url_citation" || typeof annotation.url_citation?.url !== "string") continue;
++              controller.enqueue({
++                type: "source",
++                sourceType: "url",
++                id: (0, import_provider_utils2.generateId)(),
++                url: annotation.url_citation.url,
++                title: typeof annotation.url_citation.title === "string" ? annotation.url_citation.title : void 0
++              });
++            }
+           },
+           flush(controller) {
+             var _a2, _b, _c, _d, _e;
+@@ -969,6 +1013,7 @@ var OpenAICompatibleChatResponseSchema = import_v43.z.looseObject({
+         content: import_v43.z.string().nullish(),
+         reasoning_content: import_v43.z.string().nullish(),
+         reasoning: import_v43.z.string().nullish(),
++        annotations: import_v43.z.array(import_v43.z.unknown()).nullish(),
+         tool_calls: import_v43.z.array(
+           import_v43.z.object({
+             id: import_v43.z.string().nullish(),
+@@ -983,6 +1036,14 @@ var OpenAICompatibleChatResponseSchema = import_v43.z.looseObject({
                }).nullish()
              }).nullish()
            })
@@ -65,7 +101,15 @@ diff --git a/dist/index.js b/dist/index.js
          ).nullish()
        }),
        finish_reason: import_v43.z.string().nullish()
-@@ -1019,6 +1053,14 @@
+@@ -1003,6 +1064,7 @@ var chunkBaseSchema = import_v43.z.looseObject({
+         // providers serving `gpt-oss` set `reasoning`. See #7866
+         reasoning_content: import_v43.z.string().nullish(),
+         reasoning: import_v43.z.string().nullish(),
++        annotations: import_v43.z.array(import_v43.z.unknown()).nullish(),
+         tool_calls: import_v43.z.array(
+           import_v43.z.object({
+             index: import_v43.z.number().nullish(),
+@@ -1019,6 +1089,14 @@ var chunkBaseSchema = import_v43.z.looseObject({
                }).nullish()
              }).nullish()
            })
@@ -80,7 +124,7 @@ diff --git a/dist/index.js b/dist/index.js
          ).nullish()
        }).nullish(),
        finish_reason: import_v43.z.string().nullish()
-@@ -1577,7 +1619,7 @@
+@@ -1577,7 +1655,7 @@ var OpenAICompatibleEmbeddingModel = class {
      return {
        warnings,
        embeddings: response.data.map((item) => item.embedding),
@@ -89,7 +133,7 @@ diff --git a/dist/index.js b/dist/index.js
        providerMetadata: response.providerMetadata,
        response: { headers: responseHeaders, body: rawValue }
      };
-@@ -1585,13 +1627,23 @@
+@@ -1585,13 +1663,23 @@ var OpenAICompatibleEmbeddingModel = class {
  };
  var openaiTextEmbeddingResponseSchema = import_v47.z.object({
    data: import_v47.z.array(import_v47.z.object({ embedding: import_v47.z.array(import_v47.z.number()) })),
@@ -114,7 +158,7 @@ diff --git a/dist/index.js b/dist/index.js
  var OpenAICompatibleImageModel = class {
    constructor(modelId, config) {
      this.modelId = modelId;
-@@ -1667,7 +1719,11 @@
+@@ -1667,7 +1755,11 @@ var OpenAICompatibleImageModel = class {
          fetch: this.config.fetch
        });
        return {
@@ -127,7 +171,7 @@ diff --git a/dist/index.js b/dist/index.js
          warnings,
          response: {
            timestamp: currentDate,
-@@ -1676,7 +1732,7 @@
+@@ -1676,7 +1768,7 @@ var OpenAICompatibleImageModel = class {
          }
        };
      }
@@ -136,7 +180,7 @@ diff --git a/dist/index.js b/dist/index.js
        url: this.config.url({
          path: "/images/generations",
          modelId: this.modelId
-@@ -1687,8 +1743,8 @@
+@@ -1687,8 +1779,8 @@ var OpenAICompatibleImageModel = class {
          prompt,
          n,
          size,
@@ -147,7 +191,7 @@ diff --git a/dist/index.js b/dist/index.js
        },
        failedResponseHandler: (0, import_provider_utils5.createJsonErrorResponseHandler)(
          (_e = this.config.errorStructure) != null ? _e : defaultOpenAICompatibleErrorStructure
-@@ -1699,8 +1755,28 @@
+@@ -1699,8 +1791,28 @@ var OpenAICompatibleImageModel = class {
        abortSignal,
        fetch: this.config.fetch
      });
@@ -177,7 +221,7 @@ diff --git a/dist/index.js b/dist/index.js
        warnings,
        response: {
          timestamp: currentDate,
-@@ -1711,7 +1787,7 @@
+@@ -1711,7 +1823,7 @@ var OpenAICompatibleImageModel = class {
    }
  };
  var openaiCompatibleImageResponseSchema = import_v48.z.object({
@@ -187,9 +231,10 @@ diff --git a/dist/index.js b/dist/index.js
  async function fileToBlob(file) {
    if (file.type === "url") {
 diff --git a/dist/index.mjs b/dist/index.mjs
+index 66ab6a1aeeb1c4c72a81136a042052e50b55ba4b..679e3e4f5cb025a692473c150fe9dd07d6084a67 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -241,7 +241,11 @@
+@@ -241,7 +241,11 @@ function convertToOpenAICompatibleChatMessages(prompt) {
          messages.push({
            role: "assistant",
            content: toolCalls.length > 0 ? text || null : text,
@@ -202,10 +247,20 @@ diff --git a/dist/index.mjs b/dist/index.mjs
            tool_calls: toolCalls.length > 0 ? toolCalls : void 0,
            ...metadata
          });
-@@ -585,6 +589,17 @@
+@@ -585,6 +589,27 @@ var OpenAICompatibleChatLanguageModel = class {
          text: reasoning
        });
      }
++    for (const annotation of choice.message.annotations || []) {
++      if (annotation?.type !== "url_citation" || typeof annotation.url_citation?.url !== "string") continue;
++      content.push({
++        type: "source",
++        sourceType: "url",
++        id: generateId(),
++        url: annotation.url_citation.url,
++        title: typeof annotation.url_citation.title === "string" ? annotation.url_citation.title : void 0
++      });
++    }
 +    if (choice.message.images) {
 +      for (const image of choice.message.images) {
 +        const match1 = image.image_url.url.match(/^data:([^;]+)/);
@@ -220,7 +275,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
      if (choice.message.tool_calls != null) {
        for (const toolCall of choice.message.tool_calls) {
          const thoughtSignature = (_c = (_b = toolCall.extra_content) == null ? void 0 : _b.google) == null ? void 0 : _c.thought_signature;
-@@ -744,6 +759,17 @@
+@@ -744,6 +768,17 @@ var OpenAICompatibleChatLanguageModel = class {
                  delta: delta.content
                });
              }
@@ -238,7 +293,32 @@ diff --git a/dist/index.mjs b/dist/index.mjs
              if (delta.tool_calls != null) {
                if (isActiveReasoning) {
                  controller.enqueue({
-@@ -969,6 +995,14 @@
+@@ -857,6 +892,16 @@ var OpenAICompatibleChatLanguageModel = class {
+                 });
+               }
+             }
++            for (const annotation of delta.annotations || []) {
++              if (annotation?.type !== "url_citation" || typeof annotation.url_citation?.url !== "string") continue;
++              controller.enqueue({
++                type: "source",
++                sourceType: "url",
++                id: generateId(),
++                url: annotation.url_citation.url,
++                title: typeof annotation.url_citation.title === "string" ? annotation.url_citation.title : void 0
++              });
++            }
+           },
+           flush(controller) {
+             var _a2, _b, _c, _d, _e;
+@@ -955,6 +999,7 @@ var OpenAICompatibleChatResponseSchema = z3.looseObject({
+         content: z3.string().nullish(),
+         reasoning_content: z3.string().nullish(),
+         reasoning: z3.string().nullish(),
++        annotations: z3.array(z3.unknown()).nullish(),
+         tool_calls: z3.array(
+           z3.object({
+             id: z3.string().nullish(),
+@@ -969,6 +1022,14 @@ var OpenAICompatibleChatResponseSchema = z3.looseObject({
                }).nullish()
              }).nullish()
            })
@@ -253,7 +333,15 @@ diff --git a/dist/index.mjs b/dist/index.mjs
          ).nullish()
        }),
        finish_reason: z3.string().nullish()
-@@ -1005,6 +1039,14 @@
+@@ -989,6 +1050,7 @@ var chunkBaseSchema = z3.looseObject({
+         // providers serving `gpt-oss` set `reasoning`. See #7866
+         reasoning_content: z3.string().nullish(),
+         reasoning: z3.string().nullish(),
++        annotations: z3.array(z3.unknown()).nullish(),
+         tool_calls: z3.array(
+           z3.object({
+             index: z3.number().nullish(),
+@@ -1005,6 +1075,14 @@ var chunkBaseSchema = z3.looseObject({
                }).nullish()
              }).nullish()
            })
@@ -268,7 +356,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
          ).nullish()
        }).nullish(),
        finish_reason: z3.string().nullish()
-@@ -1581,7 +1623,7 @@
+@@ -1581,7 +1659,7 @@ var OpenAICompatibleEmbeddingModel = class {
      return {
        warnings,
        embeddings: response.data.map((item) => item.embedding),
@@ -277,7 +365,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
        providerMetadata: response.providerMetadata,
        response: { headers: responseHeaders, body: rawValue }
      };
-@@ -1589,7 +1631,7 @@
+@@ -1589,7 +1667,7 @@ var OpenAICompatibleEmbeddingModel = class {
  };
  var openaiTextEmbeddingResponseSchema = z7.object({
    data: z7.array(z7.object({ embedding: z7.array(z7.number()) })),
@@ -286,7 +374,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
    providerMetadata: z7.record(z7.string(), z7.record(z7.string(), z7.any())).optional()
  });
  
-@@ -1605,6 +1647,16 @@
+@@ -1605,6 +1683,16 @@ import {
    postJsonToApi as postJsonToApi4
  } from "@ai-sdk/provider-utils";
  import { z as z8 } from "zod/v4";
@@ -303,7 +391,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
  var OpenAICompatibleImageModel = class {
    constructor(modelId, config) {
      this.modelId = modelId;
-@@ -1680,7 +1732,11 @@
+@@ -1680,7 +1768,11 @@ var OpenAICompatibleImageModel = class {
          fetch: this.config.fetch
        });
        return {
@@ -316,7 +404,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
          warnings,
          response: {
            timestamp: currentDate,
-@@ -1689,7 +1745,7 @@
+@@ -1689,7 +1781,7 @@ var OpenAICompatibleImageModel = class {
          }
        };
      }
@@ -325,7 +413,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
        url: this.config.url({
          path: "/images/generations",
          modelId: this.modelId
-@@ -1700,8 +1756,8 @@
+@@ -1700,8 +1792,8 @@ var OpenAICompatibleImageModel = class {
          prompt,
          n,
          size,
@@ -336,7 +424,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
        },
        failedResponseHandler: createJsonErrorResponseHandler4(
          (_e = this.config.errorStructure) != null ? _e : defaultOpenAICompatibleErrorStructure
-@@ -1712,8 +1768,28 @@
+@@ -1712,8 +1804,28 @@ var OpenAICompatibleImageModel = class {
        abortSignal,
        fetch: this.config.fetch
      });
@@ -366,7 +454,7 @@ diff --git a/dist/index.mjs b/dist/index.mjs
        warnings,
        response: {
          timestamp: currentDate,
-@@ -1724,7 +1800,7 @@
+@@ -1724,7 +1836,7 @@ var OpenAICompatibleImageModel = class {
    }
  };
  var openaiCompatibleImageResponseSchema = z8.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ patchedDependencies:
   '@ai-sdk/anthropic': a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34
   '@ai-sdk/google@3.0.113': 8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874
   '@ai-sdk/open-responses@1.0.34': 7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648
-  '@ai-sdk/openai-compatible@2.0.72': e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480
+  '@ai-sdk/openai-compatible@2.0.72': 151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b
   '@ai-sdk/openai@3.0.109': 06ca4fc04539f60d23f2a9f6e04e48ce0fc8460402f6535703bf315bf25132c4
   '@ai-sdk/react@3.0.187': 8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230
   '@deepseek-ai/dsh-llm-pi-ai@0.1.0-rc.7': f86a171ce4900f53dd830525528b5f669b8f4a582c852365cc0415ccfdfaee2f
@@ -269,7 +269,7 @@ importers:
         version: 3.0.109(patch_hash=06ca4fc04539f60d23f2a9f6e04e48ce0fc8460402f6535703bf315bf25132c4)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.72
-        version: 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
+        version: 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)
       '@ai-sdk/perplexity':
         specifier: ^3.0.29
         version: 3.0.29(zod@4.3.4)
@@ -1455,7 +1455,7 @@ importers:
         version: 3.0.109(patch_hash=06ca4fc04539f60d23f2a9f6e04e48ce0fc8460402f6535703bf315bf25132c4)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.72
-        version: 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.4.3)
+        version: 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.4.3)
       '@ai-sdk/provider':
         specifier: 3.0.15
         version: 3.0.15
@@ -1492,7 +1492,7 @@ importers:
         version: 3.0.109(patch_hash=06ca4fc04539f60d23f2a9f6e04e48ce0fc8460402f6535703bf315bf25132c4)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.72
-        version: 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
+        version: 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)
       '@ai-sdk/provider':
         specifier: 3.0.15
         version: 3.0.15
@@ -16382,7 +16382,7 @@ snapshots:
 
   '@ai-sdk/cerebras@2.0.78(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
@@ -16429,7 +16429,7 @@ snapshots:
     dependencies:
       '@ai-sdk/anthropic': 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)
       '@ai-sdk/google': 3.0.113(patch_hash=8cbaff63516ef35b2a638a683af4799855611da4a40b71ff896798ba90e30874)(zod@4.3.4)
-      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       google-auth-library: 10.6.2
@@ -16457,7 +16457,7 @@ snapshots:
 
   '@ai-sdk/huggingface@1.0.74(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
@@ -16474,13 +16474,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)':
+  '@ai-sdk/openai-compatible@2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.50(zod@4.4.3)
@@ -16551,14 +16551,14 @@ snapshots:
 
   '@ai-sdk/togetherai@2.0.78(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/xai@3.0.126(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
       zod: 4.3.4
@@ -20623,7 +20623,7 @@ snapshots:
 
   '@opeoginni/github-copilot-openai-compatible@1.0.0(patch_hash=4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25)(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=e1c53c511799253d3cc69a6a2bdcba7cb2ea5792b27b243fd82cb8f086d50480)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.72(patch_hash=151bd29833c36fe5c5374d1b193420781ad48333a8376ce7e72382f1853f377b)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.15
       '@ai-sdk/provider-utils': 4.0.50(zod@4.3.4)
     transitivePeerDependencies:

--- a/src/main/ai/provider/custom/__tests__/boundary/newapi.webSearch.test.ts
+++ b/src/main/ai/provider/custom/__tests__/boundary/newapi.webSearch.test.ts
@@ -1,0 +1,278 @@
+import type { LanguageModelV3CallOptions } from '@ai-sdk/provider'
+import { describe, expect, it } from 'vitest'
+
+import { createNewApi } from '../../newapiProvider'
+import { captureWithFetch, runWithResponse } from './captureRequest'
+
+const prompt: LanguageModelV3CallOptions['prompt'] = [
+  { role: 'user', content: [{ type: 'text', text: 'What happened today?' }] }
+]
+
+function createModel(fetch: typeof globalThis.fetch) {
+  return createNewApi({
+    apiKey: 'sk',
+    baseURL: 'https://example.com/v1',
+    endpointType: 'openai',
+    fetch
+  }).languageModel('gemini-2.5-pro')
+}
+
+describe('New API Gemini web search boundary', () => {
+  it('passes web_search_options through the compatible chat request', async () => {
+    const request = await captureWithFetch((fetch) =>
+      createModel(fetch).doGenerate({
+        prompt,
+        providerOptions: { newapi: { web_search_options: {} } }
+      })
+    )
+
+    expect(request.body).toMatchObject({ web_search_options: {} })
+  })
+
+  it('converts OpenAI-compatible URL citations to sources', async () => {
+    const response = {
+      id: 'chatcmpl-1',
+      created: 1,
+      model: 'gemini-2.5-pro',
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'Current information.',
+            annotations: [
+              {
+                type: 'url_citation',
+                url_citation: {
+                  start_index: 0,
+                  end_index: 20,
+                  url: 'https://example.com/source',
+                  title: 'Example source'
+                }
+              }
+            ]
+          },
+          finish_reason: 'stop'
+        }
+      ],
+      usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 }
+    }
+
+    const result = await runWithResponse(response, (fetch) => createModel(fetch).doGenerate({ prompt }))
+
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'source',
+          sourceType: 'url',
+          url: 'https://example.com/source',
+          title: 'Example source'
+        })
+      ])
+    )
+  })
+
+  it('ignores unknown annotations without rejecting a non-streaming answer', async () => {
+    const response = {
+      id: 'chatcmpl-mixed',
+      created: 1,
+      model: 'gemini-2.5-pro',
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'Answer with a file annotation.',
+            annotations: [
+              { type: 'file_citation', file_citation: { file_id: 'file-1', quote: 'supporting text' } },
+              { type: 'custom_annotation', payload: { vendor: 'openrouter' } }
+            ]
+          },
+          finish_reason: 'stop'
+        }
+      ],
+      usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 }
+    }
+
+    const result = await runWithResponse(response, (fetch) => createModel(fetch).doGenerate({ prompt }))
+
+    expect(result.content).toEqual([{ type: 'text', text: 'Answer with a file annotation.' }])
+  })
+
+  it('omits a non-string URL citation title', async () => {
+    const response = {
+      id: 'chatcmpl-invalid-title',
+      created: 1,
+      model: 'gemini-2.5-pro',
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'Answer with an untrusted title.',
+            annotations: [
+              {
+                type: 'url_citation',
+                url_citation: {
+                  url: 'https://example.com/untrusted-title',
+                  title: { label: 'not a string' }
+                }
+              }
+            ]
+          },
+          finish_reason: 'stop'
+        }
+      ],
+      usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 }
+    }
+
+    const result = await runWithResponse(response, (fetch) => createModel(fetch).doGenerate({ prompt }))
+
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'source',
+          sourceType: 'url',
+          url: 'https://example.com/untrusted-title',
+          title: undefined
+        })
+      ])
+    )
+  })
+
+  it('converts streamed URL citation annotations to source parts', async () => {
+    const annotation = {
+      type: 'url_citation',
+      url_citation: {
+        start_index: 0,
+        end_index: 20,
+        url: 'https://example.com/live-source',
+        title: 'Live source'
+      }
+    }
+    const body = [
+      `data: ${JSON.stringify({
+        id: 'chatcmpl-2',
+        created: 1,
+        model: 'gemini-2.5-pro',
+        choices: [
+          {
+            delta: { role: 'assistant', content: 'Current information.', annotations: [annotation] },
+            finish_reason: 'stop'
+          }
+        ],
+        usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 }
+      })}`,
+      'data: [DONE]',
+      ''
+    ].join('\n\n')
+    const fetch = (() =>
+      Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' }
+        })
+      )) as typeof globalThis.fetch
+
+    const result = await createModel(fetch).doStream({ prompt })
+    const parts = await Array.fromAsync(result.stream)
+
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'source',
+          sourceType: 'url',
+          url: 'https://example.com/live-source',
+          title: 'Live source'
+        })
+      ])
+    )
+  })
+
+  it('ignores unknown streamed annotations without emitting an error', async () => {
+    const body = [
+      `data: ${JSON.stringify({
+        id: 'chatcmpl-mixed-stream',
+        created: 1,
+        model: 'gemini-2.5-pro',
+        choices: [
+          {
+            delta: {
+              role: 'assistant',
+              content: 'Streaming answer.',
+              annotations: [{ type: 'file_citation', file_citation: { file_id: 'file-1' } }]
+            },
+            finish_reason: 'stop'
+          }
+        ],
+        usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 }
+      })}`,
+      'data: [DONE]',
+      ''
+    ].join('\n\n')
+    const fetch = (() =>
+      Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' }
+        })
+      )) as typeof globalThis.fetch
+
+    const result = await createModel(fetch).doStream({ prompt })
+    const parts = await Array.fromAsync(result.stream)
+
+    expect(parts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'text-delta', delta: 'Streaming answer.' })])
+    )
+    expect(parts).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: 'error' })]))
+  })
+
+  it('omits a non-string streamed URL citation title', async () => {
+    const body = [
+      `data: ${JSON.stringify({
+        id: 'chatcmpl-invalid-stream-title',
+        created: 1,
+        model: 'gemini-2.5-pro',
+        choices: [
+          {
+            delta: {
+              role: 'assistant',
+              content: 'Streaming answer.',
+              annotations: [
+                {
+                  type: 'url_citation',
+                  url_citation: {
+                    url: 'https://example.com/untrusted-stream-title',
+                    title: { label: 'not a string' }
+                  }
+                }
+              ]
+            },
+            finish_reason: 'stop'
+          }
+        ],
+        usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 }
+      })}`,
+      'data: [DONE]',
+      ''
+    ].join('\n\n')
+    const fetch = (() =>
+      Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' }
+        })
+      )) as typeof globalThis.fetch
+
+    const result = await createModel(fetch).doStream({ prompt })
+    const parts = await Array.fromAsync(result.stream)
+
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'source',
+          sourceType: 'url',
+          url: 'https://example.com/untrusted-stream-title',
+          title: undefined
+        })
+      ])
+    )
+  })
+})

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -504,6 +504,66 @@ describe('buildCapabilityProviderOptions', () => {
     expect(result[key].reasoning_effort).toBeUndefined()
   })
 
+  it('enables Gemini native search through the New API chat endpoint', () => {
+    const result = buildCapabilityProviderOptions(
+      {
+        id: 'new-api::gemini-2.5-pro',
+        apiModelId: 'gemini-2.5-pro',
+        providerId: 'new-api',
+        name: 'Gemini 2.5 Pro',
+        capabilities: []
+      } as unknown as Model,
+      {
+        id: 'new-api',
+        presetProviderId: 'new-api',
+        name: 'New API',
+        settings: {}
+      } as Provider,
+      { enableReasoning: false, enableWebSearch: true, enableGenerateImage: false },
+      {
+        aiSdkProviderId: 'newapi',
+        runtimeProviderId: 'newapi',
+        providerOptionsKey: 'newapi',
+        endpointType: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        reasoning: {
+          kind: 'omit',
+          selection: 'default',
+          emissions: []
+        }
+      }
+    )
+
+    expect(result).toEqual({ newapi: { web_search_options: {} } })
+  })
+
+  it('does not enable New API search parameters for non-Gemini models', () => {
+    const result = buildCapabilityProviderOptions(
+      {
+        id: 'new-api::qwen-plus',
+        apiModelId: 'qwen-plus',
+        providerId: 'new-api',
+        name: 'Qwen Plus',
+        capabilities: []
+      } as unknown as Model,
+      {
+        id: 'new-api',
+        presetProviderId: 'new-api',
+        name: 'New API',
+        settings: {}
+      } as Provider,
+      { enableReasoning: false, enableWebSearch: true, enableGenerateImage: false },
+      {
+        aiSdkProviderId: 'newapi',
+        runtimeProviderId: 'newapi',
+        providerOptionsKey: 'newapi',
+        endpointType: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        reasoning: { kind: 'omit', selection: 'default', emissions: [] }
+      }
+    )
+
+    expect(result).toEqual({ newapi: {} })
+  })
+
   it('preserves an audited compatible-provider budget field in the concrete namespace', () => {
     const result = buildCapabilityProviderOptions(
       {

--- a/src/main/ai/utils/websearch.ts
+++ b/src/main/ai/utils/websearch.ts
@@ -2,7 +2,12 @@ import type { WebSearchToolConfigMap } from '@cherrystudio/ai-core/provider'
 import { ENDPOINT_TYPE, type Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { mapRegexToPatterns } from '@shared/utils/blacklistMatchPattern'
-import { getRawModelId, isOpenAIDeepResearchModel, isOpenAIWebSearchChatCompletionOnlyModel } from '@shared/utils/model'
+import {
+  getRawModelId,
+  isGeminiModel,
+  isOpenAIDeepResearchModel,
+  isOpenAIWebSearchChatCompletionOnlyModel
+} from '@shared/utils/model'
 import { isBuiltinWebFetchAvailable, matchesPreset } from '@shared/utils/provider'
 
 import type { KimiFormulaCredentials } from '../provider/custom/moonshotProvider'
@@ -28,6 +33,12 @@ export interface CherryWebSearchConfig {
  * `model.providerId` there routed those copies to the server side and then injected nothing.
  */
 export function getWebSearchParams(model: Model, provider: Provider | undefined): Record<string, any> {
+  // New API translates OpenAI Chat's standard web_search_options into the native search tool for
+  // Gemini routes. Keep this preset-specific: other compatible gateways may reject the field.
+  if (provider && matchesPreset(provider, 'new-api') && isGeminiModel(model)) {
+    return { web_search_options: {} }
+  }
+
   if (provider && matchesPreset(provider, 'zhipu')) {
     // BigModel's web search rides the tools array, which providerOptions cannot
     // reach — transformZhipuRequestBody moves this marker into `tools`


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Enabling web search for a Gemini model routed through the New API OpenAI-compatible chat endpoint did not add a server-side search option. Even when a relay returned standard URL citation annotations, the compatible adapter discarded them, so the response contained no sources.

After this PR:

New API's Gemini chat route sends `web_search_options: {}`, which New API translates to Gemini's native Google Search tool. The compatible adapter converts valid URL citation annotations from both regular and streaming responses into AI SDK URL sources. Unknown, malformed, and non-URL annotation types remain non-fatal and are ignored.

Fixes #20379

### Why we need it and why it was done in this way

New API already exposes Gemini native search through the standard OpenAI Chat `web_search_options` field, so the request-side change is limited to the New API preset and Gemini models. This avoids sending an unsupported option to arbitrary OpenAI-compatible providers.

The response-side change lives in the existing pinned `@ai-sdk/openai-compatible` patch because this adapter parses both non-streaming messages and SSE deltas before Cherry Studio can forward source parts. It follows the OpenAI Chat URL-citation shape while keeping the compatible boundary tolerant of other providers' annotation extensions.

The following tradeoffs were made:

Only URL citations with a string URL become sources. Unknown annotations are preserved as a successful answer but are not exposed until the AI SDK has a source type for them. Non-string titles are omitted so untrusted compatible responses cannot break citation rendering.

The following alternatives were considered:

- Adding a generic web-search option to every compatible provider was rejected because many gateways reject unknown request fields.
- Parsing raw response annotations after the AI SDK adapter was rejected because the adapter had already discarded them by that boundary.
- Routing New API Gemini models through the native Gemini endpoint was rejected because it changes the configured relay protocol and authentication contract.

Links to places where the discussion took place: #20379

### Breaking changes

None.

### Special notes for your reviewer

Validation completed on the final rebased commit:

- Targeted Vitest coverage for option generation and the New API wire boundary: 47/47 passed.
- Non-streaming and SSE cases cover valid URL citations, file/custom/mixed annotations, malformed values, and non-string titles.
- Node TypeScript check, targeted ESLint, changed-file Oxfmt, and diff checks passed.
- Frozen offline installation applied the updated dependency patch successfully.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Web Search] Gemini models routed through New API can use native web search and display URL sources again.
```
