### PR TITLE
fix(agent-channels): stop trusting platform-declared attachment types

### DIFF
--- a/src/main/ai/channels/ChannelMessageHandler.ts
+++ b/src/main/ai/channels/ChannelMessageHandler.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
+import mime from 'mime'
+
 import { application } from '@application'
 import { agentChannelService as channelService } from '@data/services/AgentChannelService'
 import { agentService } from '@data/services/AgentService'
@@ -962,7 +964,8 @@ export class ChannelMessageHandler {
 
     const paths: string[] = []
     for (const img of images) {
-      const ext = img.media_type.split('/')[1]?.replace('jpeg', 'jpg') || 'png'
+      // media_type is attacker-supplied; only a registered extension may reach the filename.
+      const ext = mime.getExtension(img.media_type) || 'png'
       const filename = `${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`
       const filePath = path.join(dir, filename)
       await fs.writeFile(filePath, Buffer.from(img.data, 'base64'))

--- a/src/main/ai/channels/__tests__/ChannelMessageHandler.test.ts
+++ b/src/main/ai/channels/__tests__/ChannelMessageHandler.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'events'
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 
 import { MockMainCacheServiceUtils } from '@test-mocks/main/CacheService'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -364,6 +367,39 @@ describe('ChannelMessageHandler', () => {
     )
     expect(mockStartAgentSessionRun).not.toHaveBeenCalled()
     expect(adapter.sendMessage).toHaveBeenCalledWith('chat-1', 'workspace is missing', { replyToMessageId: undefined })
+  })
+
+  it('confines an image with a hostile media type to channel-images as .png', async () => {
+    const workDir = await mkdtemp(path.join(os.tmpdir(), 'channel-images-'))
+    try {
+      const adapter = createMockAdapter()
+      const session = {
+        id: 'session-1',
+        agentId: 'agent-1',
+        agentType: 'claude-code',
+        model: 'openai::gpt-4',
+        workspace: { path: workDir },
+        configuration: {}
+      }
+      vi.mocked(agentSessionService.create).mockReturnValueOnce(session as any)
+      simulateStream([{ type: 'text-delta', delta: 'ok' }])
+
+      await handleIncomingAndFlush(adapter, {
+        chatId: 'chat-1',
+        userId: 'user-1',
+        userName: 'User',
+        text: 'Hi',
+        images: [{ media_type: 'image/a\\..\\..\\..\\evil', data: Buffer.from('img').toString('base64') }]
+      })
+
+      const written = await readdir(path.join(workDir, '.cherry-studio', 'channel-images'))
+      expect(written).toHaveLength(1)
+      expect(written[0]).toMatch(/\.png$/)
+      expect(await readdir(workDir)).toEqual(['.cherry-studio'])
+      expect(await readdir(path.join(workDir, '.cherry-studio'))).toEqual(['channel-images'])
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+    }
   })
 
   it('skips final send when adapter handles stream completion', async () => {

--- a/src/main/ai/channels/adapters/__tests__/QqAdapter.test.ts
+++ b/src/main/ai/channels/adapters/__tests__/QqAdapter.test.ts
@@ -49,6 +49,11 @@ function mockOkJson(): Response {
   } as unknown as Response
 }
 
+// PNG signature followed by an empty IDAT chunk: the smallest layout file-type sniffs as image/png.
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0, 0x49, 0x44, 0x41, 0x54, 0, 0, 0, 0
+])
+
 function groupMessage(id: string, groupOpenid = 'g1', content = 'hi'): any {
   return {
     id,
@@ -85,7 +90,7 @@ describe('QqAdapter.downloadAttachments', () => {
   it('downloads a public attachment URL', async () => {
     const adapter = createAdapter()
     vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
-    mockNetFetch.mockResolvedValue(mockBinaryResponse(Buffer.from('img'), 'image/png'))
+    mockNetFetch.mockResolvedValue(mockBinaryResponse(PNG_BYTES, 'image/png'))
 
     const result = await adapter.downloadAttachments([
       { url: 'https://gchat.qpic.cn/a.png', content_type: 'image/png', filename: 'a.png' }
@@ -93,6 +98,33 @@ describe('QqAdapter.downloadAttachments', () => {
 
     expect(result.images).toHaveLength(1)
     expect(mockNetFetch).toHaveBeenCalled()
+  })
+
+  it('routes a ZIP declared as image/png to files under its sniffed type', async () => {
+    const adapter = createAdapter()
+    vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
+    const zipBytes = Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.alloc(64)])
+    mockNetFetch.mockResolvedValue(mockBinaryResponse(zipBytes, 'image/png'))
+
+    const result = await adapter.downloadAttachments([
+      { url: 'https://gchat.qpic.cn/a.png', content_type: 'image/png', filename: 'a.png' }
+    ])
+
+    expect(result.images).toBeUndefined()
+    expect(result.files).toEqual([expect.objectContaining({ filename: 'a.png', media_type: 'application/zip' })])
+  })
+
+  it('routes PNG bytes declared as application/octet-stream to images', async () => {
+    const adapter = createAdapter()
+    vi.spyOn(adapter, 'getAccessToken').mockResolvedValue('tok')
+    mockNetFetch.mockResolvedValue(mockBinaryResponse(PNG_BYTES, 'application/octet-stream'))
+
+    const result = await adapter.downloadAttachments([
+      { url: 'https://gchat.qpic.cn/a.bin', content_type: 'application/octet-stream', filename: 'a.bin' }
+    ])
+
+    expect(result.files).toBeUndefined()
+    expect(result.images).toEqual([expect.objectContaining({ media_type: 'image/png' })])
   })
 })
 

--- a/src/main/ai/channels/adapters/qq/QqAdapter.ts
+++ b/src/main/ai/channels/adapters/qq/QqAdapter.ts
@@ -1,4 +1,5 @@
 import { net } from 'electron'
+import { fileTypeFromBuffer } from 'file-type'
 import WebSocket from 'ws'
 
 import { type FileAttachment, type ImageAttachment, MAX_FILE_SIZE_BYTES } from '@main/utils/downloadAsBase64'
@@ -560,11 +561,11 @@ class QqAdapter extends ChannelAdapter {
               const buffer = Buffer.from(await retry.arrayBuffer())
               // `att.size` is attacker-supplied metadata; cap on the real downloaded bytes.
               if (buffer.length > MAX_FILE_SIZE_BYTES) return
-              this.pushAttachment(att, buffer, images, files)
+              await this.pushAttachment(att, buffer, images, files)
             } else {
               const buffer = Buffer.from(await response.arrayBuffer())
               if (buffer.length > MAX_FILE_SIZE_BYTES) return
-              this.pushAttachment(att, buffer, images, files)
+              await this.pushAttachment(att, buffer, images, files)
             }
           } catch {
             this.log.warn('Failed to download QQ attachment', { filename: att.filename, url: att.url })
@@ -578,15 +579,21 @@ class QqAdapter extends ChannelAdapter {
     }
   }
 
-  private pushAttachment(att: QqAttachment, buffer: Buffer, images: ImageAttachment[], files: FileAttachment[]): void {
-    const mediaType = att.content_type || 'application/octet-stream'
-    if (mediaType.startsWith('image/')) {
-      images.push({ data: buffer.toString('base64'), media_type: mediaType })
+  private async pushAttachment(
+    att: QqAttachment,
+    buffer: Buffer,
+    images: ImageAttachment[],
+    files: FileAttachment[]
+  ): Promise<void> {
+    // `att.content_type` is attacker-supplied metadata; route on the sniffed bytes instead.
+    const sniffedType = (await fileTypeFromBuffer(buffer))?.mime
+    if (sniffedType?.startsWith('image/')) {
+      images.push({ data: buffer.toString('base64'), media_type: sniffedType })
     } else {
       files.push({
         filename: att.filename || 'file',
         data: buffer.toString('base64'),
-        media_type: mediaType,
+        media_type: sniffedType || att.content_type || 'application/octet-stream',
         size: buffer.length
       })
     }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- `ChannelMessageHandler.persistImages` derived the on-disk extension straight from the platform-declared `media_type` (`split('/')[1]`). A hostile type such as `image/a\..\..\..\evil` reaches the filename; on Windows `path.win32.join` normalizes the `..` segments and the bytes are written outside the session workspace, with a filename chosen by the sender.
- `QqAdapter.pushAttachment` trusted the QQ payload's `content_type` verbatim to decide whether an attachment is an image and what media type to report downstream, so a declared `image/png` with non-image bytes was handed on as an image.

After this PR:

- The extension comes from `mime.getExtension(media_type)`, falling back to `png`. Unknown or hostile types can no longer influence the path.
- QQ attachments are typed by sniffing the downloaded bytes with `file-type`. Only a sniffed `image/*` is routed as an image; everything else is a file whose media type is the sniffed type, then the declared type, then `application/octet-stream`.

Fixes: none (found during the #20383 security review).

### Why we need it and why it was done in this way

Both values cross a trust boundary (an IM platform relaying sender-controlled metadata) and previously flowed into a filesystem path and into downstream type-based routing. Deriving the extension from a registered MIME table and the type from the bytes removes the sender's influence with a few lines and no new dependency: `mime` and `file-type` are already used in the main process.

The following tradeoffs were made:

- `mime.getExtension('image/jpeg')` yields `.jpeg` where the old code produced `.jpg`; both are valid and nothing depends on the old spelling.
- `||` rather than `??` on the extension fallback, because `mime.getExtension('')` returns an empty string, which would otherwise produce a filename ending in a bare dot.
- A declared image whose bytes `file-type` cannot identify (for example an SVG, which has no magic bytes) now arrives as a file with the declared type instead of as an image. The existing "downloads a public attachment URL" test was updated to use real PNG bytes for that reason.

The following alternatives were considered:

- Whitelisting extensions with a regex instead of the `mime` table. Rejected: the table already exists and also normalizes odd but valid types.

Links to places where the discussion took place: #20383 review.

### Breaking changes

None.

### Special notes for your reviewer

Three new contract tests, each verified to fail without the fix: a hostile `media_type` is confined to `.cherry-studio/channel-images/` as `.png`; a ZIP declared as `image/png` lands in `files` as `application/zip`; PNG bytes declared as `application/octet-stream` land in `images` as `image/png`.

Touches the same two source files as #20383 in different regions; merge #20383 first and this branch rebases cleanly or with a trivial import-order resolution.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Attachments received through agent channels are now typed by their content rather than by the platform's declared type, and image files are always saved inside the session workspace with a safe extension.
```
