### PR TITLE
fix(claude-code-runtime): keep oversized external images out of native image blocks

### DIFF
--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -1,3 +1,4 @@
+import { stat } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 
 import type {
@@ -42,6 +43,7 @@ import type { CherryUIMessage, FileUIPart } from '@shared/data/types/message'
 import { parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { type AbsoluteFilePath, AbsoluteFilePathSchema } from '@shared/types/file'
+import { MB } from '@shared/utils/constants'
 import { parseDataUrl } from '@shared/utils/dataUrl'
 import { imageExts } from '@shared/utils/file'
 import { isVisionModel } from '@shared/utils/model'
@@ -82,6 +84,8 @@ import type { McpToolDisplayMetadata, SteerHolder, ToolApprovalEmitterHolder } f
 
 const logger = loggerService.withContext('ClaudeCodeRuntimeDriver')
 const HOST_MANAGED_SLASH_COMMANDS = new Set(['effort', 'fast'])
+/** Cap on the base64 payload: Claude allows 5 MB per image on Bedrock/Vertex (10 MB on the direct API). */
+const CLAUDE_MAX_INLINE_IMAGE_BASE64_BYTES = 5 * MB
 
 function isHostManagedSlashCommand(command: AgentSessionSlashCommand): boolean {
   return HOST_MANAGED_SLASH_COMMANDS.has(command.name)
@@ -1263,6 +1267,10 @@ async function materializeUserContent(
     const preparedDataUrl = part.url ? parseDataUrl(part.url) : null
     let parsed = preparedDataUrl?.isBase64 ? preparedDataUrl : null
     if (!parsed) {
+      if (!fileEntryId && part.url?.startsWith('file://') && (await exceedsClaudeInlineImageCap(part.url))) {
+        fallbackParts.push(originalPart)
+        continue
+      }
       const materialized = await materializeNativeFilePart(part)
       if (!materialized) {
         unavailableParts.push(originalPart)
@@ -1360,6 +1368,16 @@ async function extractAttachmentPaths(
     }
   }
   return { files, unavailable }
+}
+
+// An unstat-able file must still reach materialization so it surfaces as unavailable, not as a path.
+async function exceedsClaudeInlineImageCap(fileUrl: string): Promise<boolean> {
+  try {
+    const { size } = await stat(fileURLToPath(fileUrl))
+    return Math.ceil(size / 3) * 4 > CLAUDE_MAX_INLINE_IMAGE_BASE64_BYTES
+  } catch {
+    return false
+  }
 }
 
 function isImageFilePart(part: FileUIPart): boolean {

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -1,4 +1,3 @@
-import { stat } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 
 import type {
@@ -1267,16 +1266,18 @@ async function materializeUserContent(
     const preparedDataUrl = part.url ? parseDataUrl(part.url) : null
     let parsed = preparedDataUrl?.isBase64 ? preparedDataUrl : null
     if (!parsed) {
-      if (!fileEntryId && part.url?.startsWith('file://') && (await exceedsClaudeInlineImageCap(part.url))) {
-        fallbackParts.push(originalPart)
-        continue
-      }
       const materialized = await materializeNativeFilePart(part)
       if (!materialized) {
         unavailableParts.push(originalPart)
         continue
       }
       parsed = materialized.url ? parseDataUrl(materialized.url) : null
+      // External images skip prepareChatMessages, so the produced payload is measured here; a stat
+      // taken before the read would not be atomic with it. Over the cap, the agent reads the path.
+      if (!fileEntryId && parsed && parsed.data.length > CLAUDE_MAX_INLINE_IMAGE_BASE64_BYTES) {
+        fallbackParts.push(originalPart)
+        continue
+      }
     }
 
     if (!parsed?.isBase64 || parsed.data.length === 0) {
@@ -1368,16 +1369,6 @@ async function extractAttachmentPaths(
     }
   }
   return { files, unavailable }
-}
-
-// An unstat-able file must still reach materialization so it surfaces as unavailable, not as a path.
-async function exceedsClaudeInlineImageCap(fileUrl: string): Promise<boolean> {
-  try {
-    const { size } = await stat(fileURLToPath(fileUrl))
-    return Math.ceil(size / 3) * 4 > CLAUDE_MAX_INLINE_IMAGE_BASE64_BYTES
-  } catch {
-    return false
-  }
 }
 
 function isImageFilePart(part: FileUIPart): boolean {

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -1,8 +1,14 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createAssistantFileAttachmentHandle } from '@main/ai/messages/assistantFileAttachments'
 import { MODEL_CAPABILITY } from '@shared/data/types/model'
+import { MB } from '@shared/utils/constants'
 
 import type * as SettingsBuilderModule from '../settingsBuilder'
 import type * as StreamAdapterModule from '../streamAdapter'
@@ -794,6 +800,106 @@ describe('ClaudeCodeRuntimeDriver', () => {
     })
     expect(mocks.materializeNativeFilePart).toHaveBeenCalledTimes(1)
     void connection.close()
+  })
+
+  it('hands external images whose base64 payload exceeds 5 MB to the agent as paths, not native image blocks', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'claude-image-cap-'))
+    try {
+      const imagePath = path.join(dir, 'huge.png')
+      await writeFile(imagePath, Buffer.alloc(4 * MB))
+      const queryQueue = createAsyncQueue<any>()
+      const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+      mocks.createClaudeQuery.mockReturnValue(query)
+      mocks.materializeNativeFilePart.mockResolvedValue({
+        type: 'file',
+        url: 'data:image/png;base64,QUJD',
+        mediaType: 'image/png'
+      })
+      const connection = await new ClaudeCodeRuntimeDriver().connect({
+        sessionId: 'session-1',
+        agentId: 'agent-1',
+        modelId: 'claude-code::sonnet'
+      })
+      const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
+      const nextInput = sdkInput[Symbol.asyncIterator]().next()
+
+      await connection.send({
+        message: {
+          ...userMessage(),
+          data: {
+            parts: [
+              { type: 'text', text: 'describe this' },
+              { type: 'file', url: pathToFileURL(imagePath).href, mediaType: 'image/png', filename: 'huge.png' }
+            ]
+          }
+        }
+      })
+
+      await expect(nextInput).resolves.toMatchObject({
+        value: {
+          message: {
+            role: 'user',
+            content: `describe this\n\nAttached files (read them with your tools using these absolute paths):\n- "huge.png": ${imagePath}`
+          }
+        },
+        done: false
+      })
+      expect(mocks.materializeNativeFilePart).not.toHaveBeenCalled()
+      void connection.close()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('still sends external images under the inline cap as native image blocks', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'claude-image-cap-'))
+    try {
+      const imagePath = path.join(dir, 'pixel.png')
+      await writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]))
+      const queryQueue = createAsyncQueue<any>()
+      const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+      mocks.createClaudeQuery.mockReturnValue(query)
+      mocks.materializeNativeFilePart.mockResolvedValue({
+        type: 'file',
+        url: 'data:image/png;base64,QUJD',
+        mediaType: 'image/png'
+      })
+      const connection = await new ClaudeCodeRuntimeDriver().connect({
+        sessionId: 'session-1',
+        agentId: 'agent-1',
+        modelId: 'claude-code::sonnet'
+      })
+      const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
+      const nextInput = sdkInput[Symbol.asyncIterator]().next()
+
+      await connection.send({
+        message: {
+          ...userMessage(),
+          data: {
+            parts: [
+              { type: 'text', text: 'describe this' },
+              { type: 'file', url: pathToFileURL(imagePath).href, mediaType: 'image/png', filename: 'pixel.png' }
+            ]
+          }
+        }
+      })
+
+      await expect(nextInput).resolves.toMatchObject({
+        value: {
+          message: {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'describe this' },
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } }
+            ]
+          }
+        },
+        done: false
+      })
+      void connection.close()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 
   it('passes first-party archive attachments to ordinary Agents as tool-readable paths', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -1,8 +1,3 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import path from 'node:path'
-import { pathToFileURL } from 'node:url'
-
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -803,103 +798,89 @@ describe('ClaudeCodeRuntimeDriver', () => {
   })
 
   it('hands external images whose base64 payload exceeds 5 MB to the agent as paths, not native image blocks', async () => {
-    const dir = await mkdtemp(path.join(tmpdir(), 'claude-image-cap-'))
-    try {
-      const imagePath = path.join(dir, 'huge.png')
-      await writeFile(imagePath, Buffer.alloc(4 * MB))
-      const queryQueue = createAsyncQueue<any>()
-      const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
-      mocks.createClaudeQuery.mockReturnValue(query)
-      mocks.materializeNativeFilePart.mockResolvedValue({
-        type: 'file',
-        url: 'data:image/png;base64,QUJD',
-        mediaType: 'image/png'
-      })
-      const connection = await new ClaudeCodeRuntimeDriver().connect({
-        sessionId: 'session-1',
-        agentId: 'agent-1',
-        modelId: 'claude-code::sonnet'
-      })
-      const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
-      const nextInput = sdkInput[Symbol.asyncIterator]().next()
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    mocks.materializeNativeFilePart.mockResolvedValue({
+      type: 'file',
+      url: `data:image/png;base64,${'A'.repeat(5 * MB + 4)}`,
+      mediaType: 'image/png'
+    })
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet'
+    })
+    const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
+    const nextInput = sdkInput[Symbol.asyncIterator]().next()
 
-      await connection.send({
-        message: {
-          ...userMessage(),
-          data: {
-            parts: [
-              { type: 'text', text: 'describe this' },
-              { type: 'file', url: pathToFileURL(imagePath).href, mediaType: 'image/png', filename: 'huge.png' }
-            ]
-          }
+    await connection.send({
+      message: {
+        ...userMessage(),
+        data: {
+          parts: [
+            { type: 'text', text: 'describe this' },
+            { type: 'file', url: 'file:///tmp/huge.png', mediaType: 'image/png', filename: 'huge.png' }
+          ]
         }
-      })
+      }
+    })
 
-      await expect(nextInput).resolves.toMatchObject({
-        value: {
-          message: {
-            role: 'user',
-            content: `describe this\n\nAttached files (read them with your tools using these absolute paths):\n- "huge.png": ${imagePath}`
-          }
-        },
-        done: false
-      })
-      expect(mocks.materializeNativeFilePart).not.toHaveBeenCalled()
-      void connection.close()
-    } finally {
-      await rm(dir, { recursive: true, force: true })
-    }
+    await expect(nextInput).resolves.toMatchObject({
+      value: {
+        message: {
+          role: 'user',
+          content:
+            'describe this\n\nAttached files (read them with your tools using these absolute paths):\n- "huge.png": /tmp/huge.png'
+        }
+      },
+      done: false
+    })
+    void connection.close()
   })
 
   it('still sends external images under the inline cap as native image blocks', async () => {
-    const dir = await mkdtemp(path.join(tmpdir(), 'claude-image-cap-'))
-    try {
-      const imagePath = path.join(dir, 'pixel.png')
-      await writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]))
-      const queryQueue = createAsyncQueue<any>()
-      const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
-      mocks.createClaudeQuery.mockReturnValue(query)
-      mocks.materializeNativeFilePart.mockResolvedValue({
-        type: 'file',
-        url: 'data:image/png;base64,QUJD',
-        mediaType: 'image/png'
-      })
-      const connection = await new ClaudeCodeRuntimeDriver().connect({
-        sessionId: 'session-1',
-        agentId: 'agent-1',
-        modelId: 'claude-code::sonnet'
-      })
-      const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
-      const nextInput = sdkInput[Symbol.asyncIterator]().next()
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    mocks.materializeNativeFilePart.mockResolvedValue({
+      type: 'file',
+      url: 'data:image/png;base64,QUJD',
+      mediaType: 'image/png'
+    })
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet'
+    })
+    const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
+    const nextInput = sdkInput[Symbol.asyncIterator]().next()
 
-      await connection.send({
-        message: {
-          ...userMessage(),
-          data: {
-            parts: [
-              { type: 'text', text: 'describe this' },
-              { type: 'file', url: pathToFileURL(imagePath).href, mediaType: 'image/png', filename: 'pixel.png' }
-            ]
-          }
+    await connection.send({
+      message: {
+        ...userMessage(),
+        data: {
+          parts: [
+            { type: 'text', text: 'describe this' },
+            { type: 'file', url: 'file:///tmp/pixel.png', mediaType: 'image/png', filename: 'pixel.png' }
+          ]
         }
-      })
+      }
+    })
 
-      await expect(nextInput).resolves.toMatchObject({
-        value: {
-          message: {
-            role: 'user',
-            content: [
-              { type: 'text', text: 'describe this' },
-              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } }
-            ]
-          }
-        },
-        done: false
-      })
-      void connection.close()
-    } finally {
-      await rm(dir, { recursive: true, force: true })
-    }
+    await expect(nextInput).resolves.toMatchObject({
+      value: {
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'describe this' },
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } }
+          ]
+        }
+      },
+      done: false
+    })
+    void connection.close()
   })
 
   it('passes first-party archive attachments to ordinary Agents as tool-readable paths', async () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

In `ClaudeCodeRuntimeDriver.materializeUserContent`, first-party image parts go through `prepareChatMessages`, but external `file://` image parts (attachments persisted by IM channels, which carry no `fileEntryId`) went straight to `materializeNativeFilePart`, which reads the whole file into base64 with no size check. An oversized image cost main-process memory and then failed the whole turn when the API rejected the image block.

After this PR:

After materializing an external `file://` image, the driver measures the base64 payload it actually produced. When it exceeds 5 MB the part is pushed to the existing fallback path (absolute path appended to the prompt for the agent's own tools) instead of becoming a native image block. An unreadable file behaves exactly as before (surfaces as unavailable).

Fixes: none (found during the #20383 security review).

### Why we need it and why it was done in this way

The check belongs where the native image block is produced. `prepareChatMessages` has no size limit either, so routing external parts through it would not help, and the fallback path already exists for images that cannot be inlined.

The following tradeoffs were made:

- The cap is on the base64 payload (`ceil(size / 3) * 4`) and set to 5 MB, the limit Claude documents for Bedrock and Vertex; the direct API allows 10 MB. Choosing the stricter figure means a 3.75 to 7.5 MB raw image goes the path route even on the direct API, which degrades to "the agent reads it with tools" rather than failing the turn.
- The cap is checked on the materialized payload, not on a `stat` snapshot taken before the read: a size probe is not atomic with the read that follows, so a file replaced or still growing in between could still have produced an oversized block. The cost is that an oversized file is read once before being routed to the path fallback, which is what happened before this PR as well; the driver needs no direct `node:fs` access for it.

The following alternatives were considered:

- Capping inside `materializeNativeFilePart`. Rejected: it is shared by non-image callers where the path fallback is not the right degradation.

Links to places where the discussion took place: #20383 review.

### Breaking changes

None.

### Special notes for your reviewer

Two tests through the existing `connection.send()` prompt seam: an external png whose materialized base64 payload is 5 MB + 4 bytes yields a plain-text prompt naming the path and no image block (this test fails without the fix); a tiny payload still becomes an image block.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Claude Code agents no longer fail a turn on an oversized image attachment received through a channel; the image is handed to the agent as a file path instead.
```

