### PR TITLE
fix(stream-manager): wait for terminal dispatch before admitting a follow-up stream

### DIFF
--- a/docs/references/ai/stream-manager.md
+++ b/docs/references/ai/stream-manager.md
@@ -270,10 +270,13 @@ a listener) so it inlines the loop instead of going through
 Consumers that gate further admission on `onDone` (the channel completion
 sentinel, for example) must be `cleanup`-phased: unphased listeners run
 before the runtime terminal listener marks the session idle, so a follow-up
-they release would be refused as busy. `startAgentSessionRun` also awaits
-`whenTerminalDispatchSettled(topicId)` before admitting a run, so a
-follow-up released by one cleanup listener cannot evict the stream while
-later cleanup listeners are still running — the stale-generation guard
+they release would be refused as busy. Every admission path — `dispatch()`
+(renderer opens, approval continues, steer continuations),
+`startAgentSessionRun`, and the delivery service's `dispatchOne` — awaits
+`whenTerminalDispatchSettled(topicId)` under the dispatch lock, so a
+follow-up released by one cleanup listener (or a renderer submit landing
+right after its `done` chunk) cannot evict the stream while later cleanup
+listeners are still running — the stale-generation guard
 would otherwise skip that stream's terminal lifecycle (`done` status
 broadcast and `onConversationCompleted`). The inverse invariant follows:
 a terminal listener must never await the topic's dispatch lock, or the

--- a/docs/references/ai/stream-manager.md
+++ b/docs/references/ai/stream-manager.md
@@ -267,6 +267,18 @@ them by `terminalPhase` (`persistence` → notification → `cleanup`), and then
 a listener) so it inlines the loop instead of going through
 `dispatchToListeners`, but the dead-listener cleanup is the same.
 
+Consumers that gate further admission on `onDone` (the channel completion
+sentinel, for example) must be `cleanup`-phased: unphased listeners run
+before the runtime terminal listener marks the session idle, so a follow-up
+they release would be refused as busy. `startAgentSessionRun` also awaits
+`whenTerminalDispatchSettled(topicId)` before admitting a run, so a
+follow-up released by one cleanup listener cannot evict the stream while
+later cleanup listeners are still running — the stale-generation guard
+would otherwise skip that stream's terminal lifecycle (`done` status
+broadcast and `onConversationCompleted`). The inverse invariant follows:
+a terminal listener must never await the topic's dispatch lock, or the
+admission waiting on that dispatch would deadlock with it.
+
 ### PersistenceListener — strategy pattern
 
 One listener + four backends:

--- a/src/main/ai/agentSession/AgentSessionDeliveryService.ts
+++ b/src/main/ai/agentSession/AgentSessionDeliveryService.ts
@@ -351,6 +351,10 @@ export class AgentSessionDeliveryService extends BaseService {
     let outcome: 'blocked' | 'started' | 'settled' | 'revalidate' | 'stale' = 'stale'
 
     await manager.withDispatchLock(topicId, async () => {
+      // The idle kick lands mid-dispatch; admitting before it settles evicts the stream and skips
+      // its terminal lifecycle (see startAgentSessionRun).
+      await manager.whenTerminalDispatchSettled(topicId)
+
       if (this.isShuttingDown || this.isWriteQuiesced || manager.isWriteQuiesced) {
         this.suppressedSessionIds.add(message.sessionId)
         outcome = 'blocked'

--- a/src/main/ai/agentSession/__tests__/AgentSessionDeliveryService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionDeliveryService.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   hasLiveStream: vi.fn(),
   pauseRuntimeTurn: vi.fn(),
   hasTerminalPersistenceInFlight: vi.fn(),
+  whenTerminalDispatchSettled: vi.fn(),
   runtimeBusy: vi.fn(),
   closeSession: vi.fn(),
   terminalListeners: new Set<(event: any) => void>(),
@@ -103,6 +104,7 @@ const manager = {
   hasLiveStream: mocks.hasLiveStream,
   pauseRuntimeTurn: mocks.pauseRuntimeTurn,
   hasTerminalPersistenceInFlight: mocks.hasTerminalPersistenceInFlight,
+  whenTerminalDispatchSettled: mocks.whenTerminalDispatchSettled,
   send: mocks.send
 }
 const dbService = {
@@ -156,6 +158,7 @@ describe('AgentSessionDeliveryService', () => {
     mocks.listRecoverable.mockReturnValue([])
     mocks.hasLiveStream.mockReturnValue(false)
     mocks.hasTerminalPersistenceInFlight.mockReturnValue(false)
+    mocks.whenTerminalDispatchSettled.mockResolvedValue(undefined)
     mocks.runtimeBusy.mockReturnValue(false)
     mocks.closeSession.mockResolvedValue(undefined)
     mocks.getMessage.mockReturnValue(accepted)
@@ -200,6 +203,28 @@ describe('AgentSessionDeliveryService', () => {
   })
 
   afterEach(() => BaseService.resetInstances())
+
+  it('waits for the previous terminal dispatch to settle before checking liveness', async () => {
+    const service = new AgentSessionDeliveryService()
+    await service._doInit()
+    let release!: () => void
+    mocks.whenTerminalDispatchSettled.mockReturnValue(
+      new Promise<void>((resolve) => {
+        release = resolve
+      })
+    )
+    mocks.listAccepted.mockReturnValueOnce([accepted]).mockReturnValue([])
+
+    service.kick('target')
+    await flush()
+    expect(mocks.hasLiveStream).not.toHaveBeenCalled()
+    expect(mocks.validateDispatch).not.toHaveBeenCalled()
+
+    release()
+    await service.drainInFlight({ timeoutMs: 100 })
+    expect(mocks.hasLiveStream).toHaveBeenCalled()
+    expect(mocks.send).toHaveBeenCalled()
+  })
 
   it('keeps an accepted row durable while the target is busy, then starts it on idle', async () => {
     const service = new AgentSessionDeliveryService()

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -354,6 +354,9 @@ export class AiStreamManager extends BaseService {
   /** Terminal persistence listeners currently writing by topic. Unlike `hasLiveStream`, this remains
    *  true after terminal status is published and clears before runtime/renderer terminal listeners run. */
   private readonly terminalPersistenceCounts = new Map<string, number>()
+  /** Terminal dispatch + lifecycle still running by topic. Admission waits on it: a follow-up released
+   *  by a cleanup listener must not evict the stream before its terminal lifecycle has run. */
+  private readonly terminalDispatchInFlight = new Map<string, Promise<void>>()
   /** Steer continuations suppressed by the write-quiesce gate; the last hold's disposal re-kicks
    *  them (mirrors JobManager's suppressed-fires sets). */
   private readonly suppressedChatContinuationTopicIds = new Set<string>()
@@ -990,6 +993,11 @@ export class AiStreamManager extends BaseService {
     return (this.terminalPersistenceCounts.get(topicId) ?? 0) > 0
   }
 
+  /** Resolves once this topic's in-flight terminal dispatch (listeners + lifecycle) has settled. */
+  whenTerminalDispatchSettled(topicId: string): Promise<void> {
+    return this.terminalDispatchInFlight.get(topicId) ?? Promise.resolve()
+  }
+
   /**
    * Wait until a failed execution has finished notifying/persisting its terminal event, then decide
    * whether a retry can replace that exact slot or should start a fresh one-model stream because the
@@ -1396,19 +1404,24 @@ export class AiStreamManager extends BaseService {
       application.get('AgentSessionRuntimeService').willContinueTopic(topicId)
     const chaining = chatChaining || agentChaining
 
-    await this.broadcastExecutionDone(stream, exec, topicDone && !chaining)
+    const settleTerminalDispatch = this.beginTerminalDispatch(topicId)
+    try {
+      await this.broadcastExecutionDone(stream, exec, topicDone && !chaining)
 
-    // The awaited dispatch can outlive this stream's registry slot — a new stream for
-    // the topic may have replaced it while listeners ran. Everything below belongs to
-    // the current stream generation only; a stale callback must not touch it.
-    if (this.activeStreams.get(topicId) !== stream) return
+      // The awaited dispatch can outlive this stream's registry slot — a new stream for
+      // the topic may have replaced it while listeners ran. Everything below belongs to
+      // the current stream generation only; a stale callback must not touch it.
+      if (this.activeStreams.get(topicId) !== stream) return
 
-    if (chatChaining) this.scheduleNextChatTurn(topicId)
-    else if (topicDone && !chaining) {
-      // A sibling errored/aborted (this exec finished clean but the topic didn't): drop the queue,
-      // matching onExecutionError/onExecutionPaused. A clean 'done' or an approval-park keeps it.
-      if (stream.status === 'error' || stream.status === 'aborted') this.dropPendingSteers(topicId, stream.status)
-      this.runTerminalLifecycle(stream)
+      if (chatChaining) this.scheduleNextChatTurn(topicId)
+      else if (topicDone && !chaining) {
+        // A sibling errored/aborted (this exec finished clean but the topic didn't): drop the queue,
+        // matching onExecutionError/onExecutionPaused. A clean 'done' or an approval-park keeps it.
+        if (stream.status === 'error' || stream.status === 'aborted') this.dropPendingSteers(topicId, stream.status)
+        this.runTerminalLifecycle(stream)
+      }
+    } finally {
+      settleTerminalDispatch()
     }
   }
 
@@ -1439,16 +1452,21 @@ export class AiStreamManager extends BaseService {
     // the dropped approval anchor must reach the shared cache on its own.
     if (hadPendingApprovals && !isTopicDone) stream.lifecycle.onApprovalPendingChanged(stream)
 
-    await this.broadcastExecutionPaused(stream, exec, isTopicDone)
+    const settleTerminalDispatch = this.beginTerminalDispatch(topicId)
+    try {
+      await this.broadcastExecutionPaused(stream, exec, isTopicDone)
 
-    // See onExecutionDone: awaited terminal dispatch may outlive this stream's registry slot.
-    if (this.activeStreams.get(topicId) !== stream) return
+      // See onExecutionDone: awaited terminal dispatch may outlive this stream's registry slot.
+      if (this.activeStreams.get(topicId) !== stream) return
 
-    if (isTopicDone) {
-      // Aborted (stop button / idle timeout), not a clean steer-yield — drop any queued steer
-      // instead of chaining. Its persisted user row stays as a dangling message the user can resend.
-      this.dropPendingSteers(topicId, 'aborted')
-      this.runTerminalLifecycle(stream)
+      if (isTopicDone) {
+        // Aborted (stop button / idle timeout), not a clean steer-yield — drop any queued steer
+        // instead of chaining. Its persisted user row stays as a dangling message the user can resend.
+        this.dropPendingSteers(topicId, 'aborted')
+        this.runTerminalLifecycle(stream)
+      }
+    } finally {
+      settleTerminalDispatch()
     }
   }
 
@@ -1497,15 +1515,20 @@ export class AiStreamManager extends BaseService {
       runtimeTiming: exec.runtimeTiming.snapshot()
     }
 
-    await this.dispatchToListeners(stream, 'onError', (listener) => listener.onError(result))
+    const settleTerminalDispatch = this.beginTerminalDispatch(topicId)
+    try {
+      await this.dispatchToListeners(stream, 'onError', (listener) => listener.onError(result))
 
-    // See onExecutionDone: awaited terminal dispatch may outlive this stream's registry slot.
-    if (this.activeStreams.get(topicId) !== stream) return
+      // See onExecutionDone: awaited terminal dispatch may outlive this stream's registry slot.
+      if (this.activeStreams.get(topicId) !== stream) return
 
-    if (isTopicDone) {
-      // Errored turn — drop any queued steer rather than chaining onto a failed turn.
-      this.dropPendingSteers(topicId, 'error')
-      this.runTerminalLifecycle(stream)
+      if (isTopicDone) {
+        // Errored turn — drop any queued steer rather than chaining onto a failed turn.
+        this.dropPendingSteers(topicId, 'error')
+        this.runTerminalLifecycle(stream)
+      }
+    } finally {
+      settleTerminalDispatch()
     }
   }
 
@@ -1587,6 +1610,20 @@ export class AiStreamManager extends BaseService {
     }
     stream.status = 'error'
     this.runTerminalLifecycle(stream)
+  }
+
+  /** Marks the topic's terminal dispatch in flight; the returned release settles it. Synchronous on
+   *  both ends so the terminal handlers keep their microtask timing. */
+  private beginTerminalDispatch(topicId: string): () => void {
+    let release!: () => void
+    const inFlight = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    this.terminalDispatchInFlight.set(topicId, inFlight)
+    return () => {
+      if (this.terminalDispatchInFlight.get(topicId) === inFlight) this.terminalDispatchInFlight.delete(topicId)
+      release()
+    }
   }
 
   /** Chat defers 30 s, prompt evicts immediately. */

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -415,6 +415,10 @@ export class AiStreamManager extends BaseService {
     // stream opened in the boot window before reconcile finished.
     await this.reconciled
     return this.withDispatchLock(req.topicId, async () => {
+      // A renderer submit can land while the previous turn's terminal dispatch is still running;
+      // admitting now would evict that stream before its terminal lifecycle ran (see startAgentSessionRun).
+      await this.whenTerminalDispatchSettled(req.topicId)
+
       // Write-quiesce admission gate, re-checked under the lock so a pause landing while this
       // dispatch waited on the mutex still rejects it — the gate must sit before `prepareDispatch`
       // writes the user/pending-assistant rows. `steer-continuation` is exempt: it only originates

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -354,9 +354,12 @@ export class AiStreamManager extends BaseService {
   /** Terminal persistence listeners currently writing by topic. Unlike `hasLiveStream`, this remains
    *  true after terminal status is published and clears before runtime/renderer terminal listeners run. */
   private readonly terminalPersistenceCounts = new Map<string, number>()
-  /** Terminal dispatch + lifecycle still running by topic. Admission waits on it: a follow-up released
-   *  by a cleanup listener must not evict the stream before its terminal lifecycle has run. */
-  private readonly terminalDispatchInFlight = new Map<string, Promise<void>>()
+  /** Terminal dispatches still running by topic (counted, so multi-model siblings settle together).
+   *  Admission waits on it so a follow-up cannot evict a stream before its terminal lifecycle ran. */
+  private readonly terminalDispatchInFlight = new Map<
+    string,
+    { pending: number; settled: Promise<void>; release: () => void }
+  >()
   /** Steer continuations suppressed by the write-quiesce gate; the last hold's disposal re-kicks
    *  them (mirrors JobManager's suppressed-fires sets). */
   private readonly suppressedChatContinuationTopicIds = new Set<string>()
@@ -995,7 +998,7 @@ export class AiStreamManager extends BaseService {
 
   /** Resolves once this topic's in-flight terminal dispatch (listeners + lifecycle) has settled. */
   whenTerminalDispatchSettled(topicId: string): Promise<void> {
-    return this.terminalDispatchInFlight.get(topicId) ?? Promise.resolve()
+    return this.terminalDispatchInFlight.get(topicId)?.settled ?? Promise.resolve()
   }
 
   /**
@@ -1612,17 +1615,28 @@ export class AiStreamManager extends BaseService {
     this.runTerminalLifecycle(stream)
   }
 
-  /** Marks the topic's terminal dispatch in flight; the returned release settles it. Synchronous on
-   *  both ends so the terminal handlers keep their microtask timing. */
+  /** Counts a terminal dispatch in flight for the topic; the returned release settles the topic once every
+   *  counted dispatch has released. Synchronous on both ends so the terminal handlers keep their timing. */
   private beginTerminalDispatch(topicId: string): () => void {
-    let release!: () => void
-    const inFlight = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    this.terminalDispatchInFlight.set(topicId, inFlight)
+    let gate = this.terminalDispatchInFlight.get(topicId)
+    if (!gate) {
+      let release!: () => void
+      const settled = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      gate = { pending: 0, settled, release }
+      this.terminalDispatchInFlight.set(topicId, gate)
+    }
+    const inFlight = gate
+    inFlight.pending += 1
+    let released = false
     return () => {
+      if (released) return
+      released = true
+      inFlight.pending -= 1
+      if (inFlight.pending > 0) return
       if (this.terminalDispatchInFlight.get(topicId) === inFlight) this.terminalDispatchInFlight.delete(topicId)
-      release()
+      inFlight.release()
     }
   }
 

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -1465,6 +1465,47 @@ describe('AiStreamManager', () => {
       ])
     })
 
+    it('settles the terminal dispatch only after every execution of a multi-model topic has dispatched', async () => {
+      const topicId = 'multi-terminal'
+      const first = 'provider-a::model-a'
+      const last = 'provider-b::model-b'
+      let releaseFirst!: () => void
+      const cleanup = new FakeListener('cleanup:multi-terminal', 'cleanup')
+      cleanup.onDoneImpl = (result) => {
+        if (result.modelId !== first) return
+        return new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+      }
+      mgr.send({
+        topicId,
+        models: [
+          { modelId: first, request: req(topicId) },
+          { modelId: last, request: req(topicId) }
+        ],
+        listeners: [cleanup],
+        isPersistentConversation: true
+      })
+
+      // The first execution's dispatch is parked on its cleanup listener while the last one ends the topic.
+      const firstTerminal = mgr.onExecutionDone(topicId, first)
+      await vi.advanceTimersByTimeAsync(0)
+      await mgr.onExecutionDone(topicId, last)
+      expect(conversationCompletedEvents).toHaveLength(1)
+
+      let settled = false
+      const settledPromise = mgr.whenTerminalDispatchSettled(topicId).then(() => {
+        settled = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(settled).toBe(false)
+
+      releaseFirst()
+      await settledPromise
+      await firstTerminal
+      expect(conversationCompletedEvents).toHaveLength(1)
+    })
+
     it('keeps the previous turn terminal lifecycle when a follow-up is admitted after the dispatch settles', async () => {
       let releaseB!: () => void
       const a = new FakeListener('cleanup-a:a', 'cleanup')

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -24,7 +24,7 @@ import type {
 
 class FakeListener implements StreamListener {
   readonly id: string
-  readonly terminalPhase?: 'persistence'
+  readonly terminalPhase?: 'persistence' | 'cleanup'
   chunks: UIMessageChunk[] = []
   /** Second argument of each onChunk call, indexed by chunk position. */
   chunkSources: Array<string | undefined> = []
@@ -36,7 +36,7 @@ class FakeListener implements StreamListener {
   onPausedImpl?: (result: StreamPausedResult) => void | Promise<void>
   onErrorImpl?: (result: StreamErrorResult) => void | Promise<void>
 
-  constructor(id: string, terminalPhase?: 'persistence') {
+  constructor(id: string, terminalPhase?: 'persistence' | 'cleanup') {
     this.id = id
     this.terminalPhase = terminalPhase
   }
@@ -1424,6 +1424,87 @@ describe('AiStreamManager', () => {
       await terminal
       expect(renderer.doneResults).toHaveLength(1)
       expect(mgr.hasTerminalPersistenceInFlight('a')).toBe(false)
+    })
+
+    it('keeps the terminal dispatch in flight until every cleanup listener settles', async () => {
+      let releaseB!: () => void
+      const a = new FakeListener('cleanup-a:a', 'cleanup')
+      const aDone = new Promise<void>((resolve) => {
+        a.onDoneImpl = () => resolve()
+      })
+      const b = new FakeListener('cleanup-b:a', 'cleanup')
+      b.onDoneImpl = () =>
+        new Promise<void>((resolve) => {
+          releaseB = resolve
+        })
+      startSingle(mgr, {
+        topicId: 'a',
+        modelId: 'provider-a::model-a',
+        request: req('a'),
+        listeners: [a, b],
+        isPersistentConversation: true
+      })
+
+      const terminal = mgr.onExecutionDone('a', 'provider-a::model-a')
+      await aDone
+
+      let settled = false
+      const settledPromise = mgr.whenTerminalDispatchSettled('a').then(() => {
+        settled = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(b.doneResults).toHaveLength(1)
+      expect(settled).toBe(false)
+      expect(conversationCompletedEvents).toEqual([])
+
+      releaseB()
+      await settledPromise
+      await terminal
+      expect(conversationCompletedEvents).toEqual([
+        { topicId: 'a', turnId: expect.stringMatching(/^\d+:\d+$/), completedAt: expect.any(Number) }
+      ])
+    })
+
+    it('keeps the previous turn terminal lifecycle when a follow-up is admitted after the dispatch settles', async () => {
+      let releaseB!: () => void
+      const a = new FakeListener('cleanup-a:a', 'cleanup')
+      const aDone = new Promise<void>((resolve) => {
+        a.onDoneImpl = () => resolve()
+      })
+      const b = new FakeListener('cleanup-b:a', 'cleanup')
+      b.onDoneImpl = () =>
+        new Promise<void>((resolve) => {
+          releaseB = resolve
+        })
+      startSingle(mgr, {
+        topicId: 'a',
+        modelId: 'provider-a::model-a',
+        request: req('a'),
+        listeners: [a, b],
+        isPersistentConversation: true
+      })
+      const previousTurnId = (sharedCacheStore.get('topic.stream.statuses.a') as { turnId: string }).turnId
+
+      const terminal = mgr.onExecutionDone('a', 'provider-a::model-a')
+      await aDone
+
+      const next = new FakeListener('wc:next:a')
+      const followUp = mgr
+        .whenTerminalDispatchSettled('a')
+        .then(() =>
+          startSingle(mgr, { topicId: 'a', modelId: 'provider-a::model-a', request: req('a'), listeners: [next] })
+        )
+      releaseB()
+      await followUp
+      await terminal
+
+      expect(conversationCompletedEvents).toEqual([
+        { topicId: 'a', turnId: previousTurnId, completedAt: expect.any(Number) }
+      ])
+      expect(fakeCacheService.setShared.mock.calls.map(([, value]) => value)).toContainEqual(
+        expect.objectContaining({ status: 'done', turnId: previousTurnId })
+      )
+      expect(mgr.inspect('a')).toMatchObject({ status: 'pending', listenerIds: [next.id] })
     })
 
     it('suppresses the original terminal notification after persistence surfaced an error', async () => {

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -10,6 +10,7 @@ import type { SerializedError } from '@shared/types/error'
 import type { ApprovalRequestedEvent } from '../../types'
 import type { AiStreamRequest } from '../../types/requests'
 import { AiStreamAdmissionError } from '../admission'
+import type * as DispatchModule from '../context/dispatch'
 import type {
   AiStreamManagerConfig,
   CherryUIMessage,
@@ -70,6 +71,14 @@ class FakeListener implements StreamListener {
 
 const mockAbortPendingTurn = vi.fn<(sessionId: string, reason: string) => boolean>(() => false)
 const mockGetMessageById = vi.hoisted(() => vi.fn())
+
+// Real by default (steer continuations reach it through `dispatch()`); a test swaps it to observe admission.
+const mockDispatchStreamRequest = vi.hoisted(() => vi.fn())
+vi.mock('../context/dispatch', async (importOriginal) => {
+  const actual = await importOriginal<typeof DispatchModule>()
+  mockDispatchStreamRequest.mockImplementation(actual.dispatchStreamRequest)
+  return { ...actual, dispatchStreamRequest: mockDispatchStreamRequest }
+})
 
 vi.mock('@main/data/services/MessageService', () => ({
   messageService: {
@@ -1537,6 +1546,53 @@ describe('AiStreamManager', () => {
         )
       releaseB()
       await followUp
+      await terminal
+
+      expect(conversationCompletedEvents).toEqual([
+        { topicId: 'a', turnId: previousTurnId, completedAt: expect.any(Number) }
+      ])
+      expect(fakeCacheService.setShared.mock.calls.map(([, value]) => value)).toContainEqual(
+        expect.objectContaining({ status: 'done', turnId: previousTurnId })
+      )
+      expect(mgr.inspect('a')).toMatchObject({ status: 'pending', listenerIds: [next.id] })
+    })
+
+    it('dispatch() admits a renderer follow-up only after the previous terminal dispatch settles', async () => {
+      ;(mgr as unknown as { markReconciled(): void }).markReconciled()
+      let releaseB!: () => void
+      const a = new FakeListener('cleanup-a:a', 'cleanup')
+      const aDone = new Promise<void>((resolve) => {
+        a.onDoneImpl = () => resolve()
+      })
+      const b = new FakeListener('cleanup-b:a', 'cleanup')
+      b.onDoneImpl = () =>
+        new Promise<void>((resolve) => {
+          releaseB = resolve
+        })
+      startSingle(mgr, {
+        topicId: 'a',
+        modelId: 'provider-a::model-a',
+        request: req('a'),
+        listeners: [a, b],
+        isPersistentConversation: true
+      })
+      const previousTurnId = (sharedCacheStore.get('topic.stream.statuses.a') as { turnId: string }).turnId
+
+      const terminal = mgr.onExecutionDone('a', 'provider-a::model-a')
+      await aDone
+
+      const next = new FakeListener('wc:next:a')
+      mockDispatchStreamRequest.mockImplementationOnce(async () => {
+        startSingle(mgr, { topicId: 'a', modelId: 'provider-a::model-a', request: req('a'), listeners: [next] })
+        return { mode: 'started' }
+      })
+      const followUp = mgr.dispatch(next, { trigger: 'submit-message', topicId: 'a' } as never)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockDispatchStreamRequest).not.toHaveBeenCalled()
+      expect(conversationCompletedEvents).toEqual([])
+
+      releaseB()
+      await expect(followUp).resolves.toEqual({ mode: 'started' })
       await terminal
 
       expect(conversationCompletedEvents).toEqual([

--- a/src/main/ai/streamManager/api/__tests__/startAgentSessionRun.test.ts
+++ b/src/main/ai/streamManager/api/__tests__/startAgentSessionRun.test.ts
@@ -172,6 +172,35 @@ describe('startAgentSessionRun — per-topic dispatch serialization', () => {
     expect(sendSpy).not.toHaveBeenCalled()
   })
 
+  it('waits for the previous terminal dispatch to settle before checking liveness', async () => {
+    const manager = managerHolder.current as ManagerInstance
+    let releaseTerminal!: () => void
+    vi.spyOn(manager, 'whenTerminalDispatchSettled').mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseTerminal = resolve
+      })
+    )
+    const hasLiveStream = vi.spyOn(manager, 'hasLiveStream').mockReturnValue(false)
+
+    const run = startAgentSessionRun({
+      sessionId: 's',
+      userParts: [text('queued')],
+      listeners: [listener('task')],
+      requireIdle: { expectedAgentId: 'agent-1' }
+    })
+    await flush()
+    expect(hasLiveStream).not.toHaveBeenCalled()
+    expect(runtimeBusy).not.toHaveBeenCalled()
+    expect(events).toEqual([])
+
+    releaseTerminal()
+    await flush()
+    expect(events).toEqual(['prepare:agent-session:s:0'])
+    prepareResolvers[0]()
+    await expect(run).resolves.toEqual({ mode: 'started' })
+    expect(events).toEqual(['prepare:agent-session:s:0', 'send:agent-session:s'])
+  })
+
   it('returns busy when the runtime becomes active during preparation', async () => {
     prepareDispatchMock.mockRejectedValueOnce(
       DataApiErrorFactory.resourceLocked('Agent session', 's', 'an active turn')

--- a/src/main/ai/streamManager/api/startAgentSessionRun.ts
+++ b/src/main/ai/streamManager/api/startAgentSessionRun.ts
@@ -38,6 +38,10 @@ export async function startAgentSessionRun(input: {
   let result: StartAgentSessionRunResult = { mode: 'not-started', reason: 'session-invalid' }
 
   await manager.withDispatchLock(topicId, async () => {
+    // A cleanup listener of the previous turn may release this caller mid-dispatch; admitting now
+    // would evict that stream before its terminal lifecycle ran (stale-generation guard skips it).
+    await manager.whenTerminalDispatchSettled(topicId)
+
     if (manager.isWriteQuiesced) {
       throw new Error(
         'AiStreamManager is write-quiesced (backup restore in progress); refusing a new agent-session turn'


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`AiStreamManager.onExecutionDone` / `onExecutionPaused` / `onExecutionError` await the terminal dispatch to listeners and then run the stream's terminal lifecycle behind a stale-generation guard (`activeStreams.get(topicId) !== stream → return`). A cleanup-phase listener can release its consumer while later cleanup listeners (for example `TraceFlushListener` awaiting `saveSpans`) are still running. If that consumer admitted a new stream immediately, `send()` evicted the old stream and the guard then skipped its terminal lifecycle: no `done` status broadcast and no `onConversationCompleted` for that turn. Three admission paths can do this: a channel follow-up through `startAgentSessionRun` (once #20383 phases the channel sentinel as `cleanup`), a cross-session delivery kicked by `onRuntimeIdle`, which fires inside the runtime terminal listener mid-dispatch, and a renderer submit through `AiStreamManager.dispatch()` landing right after the window received its `done` chunk while later cleanup listeners are still running.

After this PR:

The manager tracks the in-flight terminal dispatch per topic (`terminalDispatchInFlight`, registered synchronously before the first await and released in `finally`) and exposes `whenTerminalDispatchSettled(topicId)`. Every admission path (`dispatch()`, `startAgentSessionRun` and `AgentSessionDeliveryService.dispatchOne`) awaits it inside the dispatch lock, ahead of the liveness checks, so a follow-up can no longer evict a stream whose lifecycle has not run. The stream-manager doc states the two resulting invariants: consumers gating admission on `onDone` must be `cleanup`-phased, and a terminal listener must never await the topic's dispatch lock.

Fixes: none (found during the #20383 architecture review).

### Why we need it and why it was done in this way

The stale-generation guard is correct and stays; the missing piece was that admission had no way to know a terminal dispatch was still running. Mirroring the existing `terminalPersistenceCounts` / `hasTerminalPersistenceInFlight` bookkeeping keeps the change local to the manager and its admission callers, and `send()` keeps its synchronous signature.

The following tradeoffs were made:

- The deferred is registered and released synchronously rather than wrapping the section in an async closure: the closure form added microtask hops before the terminal handlers resolved and broke the existing steer-chaining test.
- Only the most recent execution's dispatch promise is stored per topic. A waiter that captured an earlier one is still stopped by `hasLiveStream` while a sibling execution streams, so per-execution bookkeeping was not added.

The following alternatives were considered:

- Running `runTerminalLifecycle` for the evicted stream anyway. Rejected: its `done` broadcast would land after the new stream's `pending`, which is exactly the ordering the guard exists to prevent.

Links to places where the discussion took place: #20383 review.

### Breaking changes

None.

### Special notes for your reviewer

Tests, each verified to fail without the fix: the dispatch promise stays pending until every cleanup listener settles and `onConversationCompleted` fires only then; a follow-up `send()` issued after the wait keeps the previous turn's `done` write and completion event while the new stream registers as `pending`; `dispatch()` parks a renderer follow-up until the cleanup listeners settle and then admits it with the previous turn's `done` write and completion event intact; `startAgentSessionRun` and `AgentSessionDeliveryService` both await the wait before any liveness check (mocked manager, call-order contract).

Verified no current terminal listener awaits the dispatch lock: the delivery service's listener callbacks are no-ops and its `dispatchOne` is driven by a detached `kick`; the steer continuation reaches `dispatch()` from a microtask queued after the terminal handler released its dispatch count; the remaining lock user is `abortAndDrain`.

Independent of #20383 at the file level; it complements it.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
A turn immediately followed by a new message, a queued message or a cross-session delivery now always reports its completion; previously its done status and completion notification could be skipped.
```

