### PR TITLE
fix(v2-migration): surface the driver reason behind a failed schema migration

### DIFF
--- a/src/main/core/preboot/__tests__/v2MigrationGate.test.ts
+++ b/src/main/core/preboot/__tests__/v2MigrationGate.test.ts
@@ -70,10 +70,14 @@ const defaultResolveResult = {
 
 function stubMigrationV2() {
   vi.doMock('@data/migration/v2', async () => {
-    // The gate now imports the version-policy fns and isSchemaOutOfSyncError through
-    // the barrel, so they live on this mock. isSchemaOutOfSyncError is a pure predicate —
-    // keep the real implementation so schemaOutOfSyncError() fixtures are still detected.
-    const { isSchemaOutOfSyncError } = (await vi.importActual('@data/migration/v2/core/migrationErrors')) as {
+    // The gate now imports the version-policy fns and the error helpers through the
+    // barrel, so they live on this mock. Both helpers are pure — keep the real
+    // implementations so schemaOutOfSyncError() fixtures are still detected and the
+    // dialogs carry the real flattened cause chain.
+    const { describeErrorChain, isSchemaOutOfSyncError } = (await vi.importActual(
+      '@data/migration/v2/core/migrationErrors'
+    )) as {
+      describeErrorChain: (error: unknown) => string
       isSchemaOutOfSyncError: (error: unknown) => boolean
     }
     return {
@@ -97,7 +101,8 @@ function stubMigrationV2() {
       setDataLocationNotice: setDataLocationNoticeMock,
       evaluateCandidateVersion: evaluateCandidateVersionMock,
       getBlockMessage: getBlockMessageMock,
-      isSchemaOutOfSyncError
+      isSchemaOutOfSyncError,
+      describeErrorChain
     }
   })
 }

--- a/src/main/core/preboot/v2MigrationGate.ts
+++ b/src/main/core/preboot/v2MigrationGate.ts
@@ -15,6 +15,7 @@ import { app, dialog } from 'electron'
 
 import { application } from '@application'
 import {
+  describeErrorChain,
   evaluateCandidateVersion,
   getAllMigrators,
   getBlockMessage,
@@ -154,7 +155,10 @@ export async function runV2MigrationGate(): Promise<V2MigrationGateResult> {
     needsMigration = await migrationEngine.needsMigration()
     logger.info('Migration status check result', { needsMigration })
   } catch (error) {
-    logger.error('Migration status check failed', error as Error)
+    // The driver reason lives in `.cause`, which neither `error.message` nor the
+    // winston serializer carries — flatten it or the failure is undiagnosable.
+    const reason = describeErrorChain(error)
+    logger.error(`Migration status check failed: ${reason}`, error as Error)
     await app.whenReady()
 
     // Dev-only: when the disposable migration SQL is regenerated/deleted but
@@ -172,7 +176,7 @@ export async function runV2MigrationGate(): Promise<V2MigrationGateResult> {
           `  ${paths.databaseFile}\n\n` +
           `Or run:\n  rm -f "${paths.databaseFile}"\n\n` +
           `Then start the app again (pnpm dev).\n\n` +
-          `Original error: ${(error as Error).message}`
+          `Original error: ${reason}`
       )
       logger.error('Exiting application due to schema out of sync (dev)')
       application.quit()
@@ -188,7 +192,7 @@ export async function runV2MigrationGate(): Promise<V2MigrationGateResult> {
       dialog.showErrorBox(
         'Migration Failed (Dev) - Application Cannot Start',
         `Startup migration failed while applying schema changes:\n\n` +
-          `  ${(error as Error).message}\n\n` +
+          `  ${reason}\n\n` +
           `In development this is usually one of:\n\n` +
           `  1. Your local database predates a schema change (incompatible legacy data). ` +
           `If this is throwaway dev data, reset it and restart:\n` +
@@ -201,7 +205,7 @@ export async function runV2MigrationGate(): Promise<V2MigrationGateResult> {
     } else {
       dialog.showErrorBox(
         'Migration Failed - Application Cannot Start',
-        `Could not complete data migration:\n\n  ${(error as Error).message}\n\n` +
+        `Could not complete data migration:\n\n  ${reason}\n\n` +
           `The application will now exit. Please try again, and contact support if the problem persists.`
       )
     }

--- a/src/main/data/migration/v2/core/MigrationDbService.ts
+++ b/src/main/data/migration/v2/core/MigrationDbService.ts
@@ -17,6 +17,7 @@ import { applyMigrations } from '@data/db/applyMigrations'
 import type { DbType } from '@data/db/types'
 import { loggerService } from '@logger'
 
+import { describeErrorChain } from './migrationErrors'
 import type { MigrationPaths } from './MigrationPaths'
 
 const logger = loggerService.withContext('MigrationDbService')
@@ -71,8 +72,7 @@ export class MigrationDbService {
       } catch {
         // Best-effort — the original error is more important.
       }
-      const msg = error instanceof Error ? error.message : String(error)
-      throw new Error(`Database schema migration failed: ${msg}`, { cause: error })
+      throw new Error(`Database schema migration failed: ${describeErrorChain(error)}`, { cause: error })
     }
 
     // Keep foreign keys OFF for the ENTIRE migration. better-sqlite3's single persistent

--- a/src/main/data/migration/v2/core/__tests__/migrationErrors.test.ts
+++ b/src/main/data/migration/v2/core/__tests__/migrationErrors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isSchemaOutOfSyncError } from '../migrationErrors'
+import { describeErrorChain, isSchemaOutOfSyncError } from '../migrationErrors'
 
 /**
  * Build an Error carrying an optional SQLite `code` and `.cause`, mirroring how
@@ -65,5 +65,46 @@ describe('isSchemaOutOfSyncError', () => {
       chain = makeError('wrapper', { code: 'SQLITE_ERROR', cause: chain })
     }
     expect(isSchemaOutOfSyncError(chain)).toBe(false)
+  })
+})
+
+describe('describeErrorChain', () => {
+  it('surfaces the driver reason and code that DrizzleQueryError.message omits', () => {
+    // The real shape behind "Migration Failed": drizzle names the statement, the
+    // wrapped SqliteError is the only thing that says why it could not run.
+    const driver = makeError('database or disk is full', { code: 'SQLITE_FULL' })
+    const drizzle = makeError(
+      'Failed query: CREATE INDEX `agent_session_message_created_at_id_idx` ON `agent_session_message`\nparams: ',
+      { cause: driver }
+    )
+
+    const described = describeErrorChain(drizzle)
+
+    expect(described).toContain('SQLITE_FULL')
+    expect(described).toContain('database or disk is full')
+  })
+
+  it('keeps every link of a multi-level chain', () => {
+    const driver = makeError('database is locked', { code: 'SQLITE_BUSY' })
+    const drizzle = makeError('Failed query: CREATE INDEX ...', { cause: driver })
+    const wrapper = new Error('Database schema migration failed', { cause: drizzle })
+
+    const described = describeErrorChain(wrapper)
+
+    expect(described).toContain('Database schema migration failed')
+    expect(described).toContain('Failed query: CREATE INDEX ...')
+    expect(described).toContain('[SQLITE_BUSY] database is locked')
+  })
+
+  it('falls back to the value itself when it is not an Error', () => {
+    expect(describeErrorChain('boom')).toBe('boom')
+  })
+
+  it('terminates on a cyclic cause chain', () => {
+    const a = makeError('a')
+    const b = makeError('b', { cause: a })
+    a.cause = b
+
+    expect(describeErrorChain(a).split('caused by:')).toHaveLength(5)
   })
 })

--- a/src/main/data/migration/v2/core/migrationErrors.ts
+++ b/src/main/data/migration/v2/core/migrationErrors.ts
@@ -7,7 +7,8 @@
  * exist and the driver throws `SQLITE_ERROR: ... already exists`.
  * `isSchemaOutOfSyncError` recognizes that specific failure so the gate can
  * show a developer-targeted "reset your local DB" dialog instead of the
- * generic connectivity error.
+ * generic connectivity error. `describeErrorChain` reports the driver reason
+ * behind any other migration failure.
  *
  * This file lives inside migration/v2/ so it is removed when migration is
  * deleted.
@@ -37,4 +38,27 @@ export function isSchemaOutOfSyncError(error: unknown): boolean {
     current = (current as { cause?: unknown }).cause
   }
   return false
+}
+
+/**
+ * Flatten an error and its `.cause` chain into one human-readable string,
+ * prefixing each link with its SQLite `code` when the driver set one.
+ *
+ * `DrizzleQueryError.message` is only `Failed query: <sql>` — the driver's
+ * actual reason (`SQLITE_BUSY: database is locked`, `SQLITE_FULL: database or
+ * disk is full`, `SQLITE_ERROR: index ... already exists`) sits one level down
+ * in `.cause`. Reporting `error.message` alone therefore names the statement
+ * that failed but never why, which is unusable for both the migration error
+ * dialog and the log (winston serializes `message` + `stack`, never `cause`).
+ */
+export function describeErrorChain(error: unknown): string {
+  const links: string[] = []
+  let current: unknown = error
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    if (!(current instanceof Error)) break
+    const code = (current as { code?: string }).code
+    links.push(code ? `[${code}] ${current.message}` : current.message)
+    current = (current as { cause?: unknown }).cause
+  }
+  return links.length > 0 ? links.join('\ncaused by: ') : String(error)
 }

--- a/src/main/data/migration/v2/index.ts
+++ b/src/main/data/migration/v2/index.ts
@@ -5,7 +5,7 @@
 // Core
 export { createMigrationContext, type MigrationContext } from './core/MigrationContext'
 export { MigrationEngine, migrationEngine } from './core/MigrationEngine'
-export { isSchemaOutOfSyncError } from './core/migrationErrors'
+export { describeErrorChain, isSchemaOutOfSyncError } from './core/migrationErrors'
 export {
   type MigrationPaths,
   type MigrationPathsResult,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A failed startup schema migration told the user (and the log) only which statement failed, never why:

```
Could not complete data migration:

  Failed to run the query 'CREATE INDEX `agent_session_message_created_at_id_idx` ON `agent_session_message` ("created_at" desc,"id" asc);'
```

The driver's actual reason lives in `.cause` (better-sqlite3 / drizzle wrap the real `SqliteError`), which `MigrationDbService` dropped by formatting `error.message` alone, and which the winston serializer never records either (`LoggerService` keeps `message` + `stack` only). A boot-blocking failure was therefore undiagnosable from a screenshot, a log, or a diagnostics bundle.

After this PR:

```
Could not complete data migration:

  Failed to run the query 'CREATE INDEX `agent_session_message_created_at_id_idx` ON `agent_session_message` ("created_at" desc,"id" asc);'
caused by: [SQLITE_ERROR] index agent_session_message_created_at_id_idx already exists
```

`describeErrorChain()` flattens the `.cause` chain (reusing the existing depth-5 cycle guard) and tags each link with its SQLite `code`. It now feeds the error thrown by `MigrationDbService`, the gate's `logger.error` line, and all three gate dialogs (dev schema-out-of-sync, dev migration-failed, production migration-failed).

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The chain is folded into the message string rather than fixing `LoggerService` to serialize `cause`. That would be the root fix and would cover every `logger.error(msg, err)` call in the repo, but it changes the log schema globally — out of scope here, and noted for follow-up.
- The dialog gets longer. For a boot-blocking error that is the right trade: the extra line is the only actionable part of it.

The following alternatives were considered:

- Logging the cause separately from the dialog — rejected: the screenshot is what users actually send, so the reason has to be in the dialog too.
- Parsing/classifying the SQLite code into friendlier copy — deliberately not done here; this PR only stops discarding information. Whether the production path should also act on `isSchemaOutOfSyncError` (today it is `isDev`-gated) is a separate behavior change.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Verified against a real failure rather than a mock: applying migrations `0000..0017` to a scratch DB while recording `__drizzle_migrations` only up to `0016` reproduces the reported dialog byte-for-byte, and produces the `caused by: [SQLITE_ERROR] ...` line with this change.

Worth knowing while reviewing: every v2 user's release-to-release schema migration currently runs inside this temporary v1→v2 gate (`MigrationEngine.initialize()` opens and migrates the DB before `needsMigration()` is even consulted), so an ordinary migration failure is reported as "data migration failed" and hard-quits. That is tracked separately as v2 cleanup, not changed here.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Startup] The "Migration Failed" dialog now reports the underlying database error (e.g. "database is locked", "disk is full") instead of only the SQL statement that failed.
```
