### PR TITLE
fix(knowledge): prevent startup freeze during delete recovery

### DIFF
--- a/src/main/features/knowledge/ingestion/subtreePurge.ts
+++ b/src/main/features/knowledge/ingestion/subtreePurge.ts
@@ -14,11 +14,14 @@ import { deleteKnowledgeItemVectors } from '../pipeline/vectorstore/vectorCleanu
  * delete job keeps only `deleting` rows; replace passes the conflicting roots'
  * subtrees), then run vector cleanup before DB deletion so a retry can still
  * discover affected ids.
+ * `allowPartialMaterialProgress` is only safe when every row is already
+ * `deleting` and a durable delete job will retry an interrupted purge.
  */
 export async function purgeKnowledgeSubtreeWithinLock(
   base: KnowledgeBase,
   subtreeItems: KnowledgeItem[],
-  logContext: Record<string, unknown>
+  logContext: Record<string, unknown>,
+  options: { allowPartialMaterialProgress?: boolean } = {}
 ): Promise<void> {
   const subtreeItemIds = subtreeItems.map((item) => item.id)
   if (subtreeItemIds.length === 0) {
@@ -27,7 +30,7 @@ export async function purgeKnowledgeSubtreeWithinLock(
   const leafItemIds = subtreeItems.filter((item) => isIndexableKnowledgeItem(item)).map((item) => item.id)
 
   // Vector cleanup precedes DB deletion so a retry can still discover affected item ids.
-  await deleteKnowledgeItemVectors(base, leafItemIds)
+  await deleteKnowledgeItemVectors(base, leafItemIds, options)
   // Best-effort: a file-removal failure must not abort the row deletion below,
   // which would otherwise strand rows after their vectors are gone.
   await deleteKnowledgeItemFilesBestEffort(base.id, subtreeItems, logContext)

--- a/src/main/features/knowledge/pipeline/vectorstore/__tests__/vectorCleanup.test.ts
+++ b/src/main/features/knowledge/pipeline/vectorstore/__tests__/vectorCleanup.test.ts
@@ -75,17 +75,20 @@ describe('deleteKnowledgeItemVectors', () => {
   })
 
   it('deletes all deduplicated item ids in a single batch call', async () => {
-    // The whole folder's ids go to deleteMaterials in ONE call (one transaction, one GC
-    // pass) — not one call per id, which was the O(N × table) folder-delete freeze.
+    // The whole folder's ids go to deleteMaterials in one call, not one call per id.
     await deleteKnowledgeItemVectors(createBase(), ['note-1', 'note-1', 'note-2'])
 
     expect(deleteMaterialsMock).toHaveBeenCalledTimes(1)
     expect(deleteMaterialsMock).toHaveBeenCalledWith(['note-1', 'note-2'])
   })
 
+  it('forwards partial-material progress only for a caller with durable recovery', async () => {
+    await deleteKnowledgeItemVectors(createBase(), ['note-1'], { allowPartialMaterialProgress: true })
+
+    expect(deleteMaterialsMock).toHaveBeenCalledWith(['note-1'], { allowPartialMaterialProgress: true })
+  })
+
   it('propagates the error when the batch delete fails', async () => {
-    // The batch is atomic: a failure rolls the whole transaction back and throws its root
-    // cause, so a retry re-discovers every affected id. No per-item aggregation to do.
     deleteMaterialsMock.mockRejectedValueOnce(new Error('batch delete failed'))
 
     await expect(deleteKnowledgeItemVectors(createBase(), ['note-1', 'note-2'])).rejects.toThrow('batch delete failed')

--- a/src/main/features/knowledge/pipeline/vectorstore/indexStore/KnowledgeIndexStore.ts
+++ b/src/main/features/knowledge/pipeline/vectorstore/indexStore/KnowledgeIndexStore.ts
@@ -36,12 +36,15 @@ const EMBEDDING_HASH_QUERY_BATCH = 500
 
 /**
  * How long {@link KnowledgeIndexStore.deleteMaterials} may run consecutive
- * per-material transactions before handing the main-process event loop back to
- * the OS message pump (see the method doc for why). Tuned well under the
+ * transactions before handing the main-process event loop back to the
+ * OS message pump (see the method doc for why). Tuned well under the
  * multi-second window that surfaces the macOS beachball, while large enough
  * that the yields add no measurable overhead to a small delete.
  */
 const DELETE_YIELD_BUDGET_MS = 50
+
+/** Bound each resumable delete transaction before returning to Electron's event loop. */
+const DELETE_BATCH_SIZE = 50
 
 /**
  * Engine-neutral store over a per-base `index.sqlite`. Written once; the storage
@@ -218,62 +221,130 @@ export class KnowledgeIndexStore {
   }
 
   /**
-   * Delete many materials — each in its OWN short transaction — then sweep
-   * orphaned `embedding` / `content` rows with a SINGLE {@link collectIndexGarbage}
-   * pass in a final transaction.
-   *
-   * Removing each material row cascades to its `search_unit`; the units' body
-   * `search_text` is deleted explicitly first (no FK), which also clears the FTS
-   * index via the delete trigger.
-   *
-   * collectIndexGarbage runs two FULL-TABLE anti-join scans, so calling it once
-   * per material (an old per-material delete+GC loop) made a bulk delete
-   * O(materials × table): deleting a folder of N files scanned the whole
-   * `embedding`/`content` table N times. With a large index (e.g. a folder of
-   * PDFs chunked into tens of thousands of rows) that blocked the main-process
-   * event loop for seconds — the folder-delete UI freeze. Deleting the rows up
-   * front and GCing once makes it O(N + table).
-   *
-   * Batching the GC removes the super-linear cost, but the per-material row
-   * deletes are still linear in chunks: each `search_text` delete fires the FTS
-   * delete trigger, which the driver runs synchronously on the main process.
-   * Tens of thousands of rows still sum to a multi-second block, and because
-   * Electron drives the window from this same loop that block IS the macOS
-   * beachball (the renderer thread never stalls). A driver transaction must run
-   * fully synchronously (no event-loop yield inside `BEGIN`..`COMMIT` — see
-   * {@link SqliteDriver.transaction}), so each material gets its own transaction
-   * and the loop yields to the OS message pump BETWEEN them whenever it has run
-   * for {@link DELETE_YIELD_BUDGET_MS}: the total work is unchanged, but no single
-   * uninterrupted block is long enough to freeze the window.
-   *
-   * This is no longer one all-or-nothing batch — a failure partway leaves the
-   * materials deleted so far committed. That is safe: every caller (subtreePurge.ts)
-   * deletes vectors before the corresponding `knowledge_item` DB rows, so those rows
-   * still exist after a partial failure and a retry re-discovers exactly the
-   * materials still left (re-deleting an already-gone one is a harmless no-op).
+   * Delete materials and their derived rows, yielding between transactions. Each
+   * material is atomic by default so callers without durable recovery never expose
+   * a partial material. Callers whose owning rows are `deleting` may opt into bounded
+   * per-material batches because their delete job safely resumes partial progress.
    */
-  async deleteMaterials(materialIds: string[]): Promise<void> {
+  async deleteMaterials(
+    materialIds: string[],
+    options: { allowPartialMaterialProgress?: boolean } = {}
+  ): Promise<void> {
     const uniqueMaterialIds = [...new Set(materialIds)]
     if (uniqueMaterialIds.length === 0) {
       return
     }
-    // performance.now() is monotonic — a wall-clock step (NTP/manual) mid-batch
-    // must not make the delta negative and silently disable the yields for the
-    // rest of a large delete, reintroducing the freeze this loop prevents.
+
     let lastYieldAt = performance.now()
-    for (const materialId of uniqueMaterialIds) {
-      this.driver.transaction((tx) => {
-        this.deleteMaterialSearchText(tx, materialId)
-        tx.execute(`DELETE FROM material WHERE material_id = ?`, [materialId])
-      })
-      if (performance.now() - lastYieldAt >= DELETE_YIELD_BUDGET_MS) {
-        await new Promise<void>((resolve) => setImmediate(resolve))
-        lastYieldAt = performance.now()
-      }
+    const yieldIfNeeded = async () => {
+      if (performance.now() - lastYieldAt < DELETE_YIELD_BUDGET_MS) return
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      lastYieldAt = performance.now()
     }
-    this.driver.transaction((tx) => {
-      this.collectIndexGarbage(tx)
+
+    for (const materialId of uniqueMaterialIds) {
+      if (options.allowPartialMaterialProgress) {
+        while (this.deleteMaterialUnitsBatch(materialId) === DELETE_BATCH_SIZE) {
+          await yieldIfNeeded()
+        }
+        this.driver.transaction((tx) => tx.execute(`DELETE FROM material WHERE material_id = ?`, [materialId]))
+      } else {
+        this.driver.transaction((tx) => {
+          this.deleteMaterialSearchText(tx, materialId)
+          tx.execute(`DELETE FROM material WHERE material_id = ?`, [materialId])
+        })
+      }
+      await yieldIfNeeded()
+    }
+
+    await this.collectIndexGarbageInBatches(yieldIfNeeded)
+  }
+
+  private deleteMaterialUnitsBatch(materialId: string): number {
+    return this.driver.transaction((tx) => {
+      const unitIds = tx
+        .execute(
+          `SELECT unit_id FROM search_unit
+           WHERE material_id = ?
+           ORDER BY unit_id
+           LIMIT ?`,
+          [materialId, DELETE_BATCH_SIZE]
+        )
+        .rows.map((row) => row.unit_id as string)
+      if (unitIds.length === 0) {
+        return 0
+      }
+
+      const placeholders = unitIds.map(() => '?').join(', ')
+      tx.execute(
+        `DELETE FROM search_text
+         WHERE target_type = 'search_unit' AND target_id IN (${placeholders})`,
+        unitIds
+      )
+      tx.execute(`DELETE FROM search_unit WHERE unit_id IN (${placeholders})`, unitIds)
+      return unitIds.length
     })
+  }
+
+  private async collectIndexGarbageInBatches(yieldIfNeeded: () => Promise<void>): Promise<void> {
+    let embeddingCursor = ''
+    while (true) {
+      const page = this.driver.transaction((tx) => {
+        const rows = tx.execute(
+          `SELECT e.embedding_text_hash,
+                  EXISTS (
+                    SELECT 1 FROM search_text st
+                    WHERE st.embedding_text_hash = e.embedding_text_hash
+                  ) AS referenced
+           FROM embedding e
+           WHERE e.embedding_text_hash > ?
+           ORDER BY e.embedding_text_hash
+           LIMIT ?`,
+          [embeddingCursor, DELETE_BATCH_SIZE]
+        ).rows
+        const orphanIds = rows
+          .filter((row) => Number(row.referenced) === 0)
+          .map((row) => row.embedding_text_hash as string)
+        if (orphanIds.length > 0) {
+          tx.execute(
+            `DELETE FROM embedding WHERE embedding_text_hash IN (${orphanIds.map(() => '?').join(', ')})`,
+            orphanIds
+          )
+        }
+        return rows
+      })
+      if (page.length < DELETE_BATCH_SIZE) break
+      const lastRow = page.at(-1)
+      if (!lastRow) break
+      embeddingCursor = lastRow.embedding_text_hash as string
+      await yieldIfNeeded()
+    }
+
+    let contentCursor = ''
+    while (true) {
+      const page = this.driver.transaction((tx) => {
+        const rows = tx.execute(
+          `SELECT c.content_hash,
+                  EXISTS (SELECT 1 FROM material m WHERE m.current_content_hash = c.content_hash)
+                    OR EXISTS (SELECT 1 FROM search_unit su WHERE su.content_hash = c.content_hash) AS referenced
+           FROM content c
+           WHERE c.content_hash > ?
+           ORDER BY c.content_hash
+           LIMIT ?`,
+          [contentCursor, DELETE_BATCH_SIZE]
+        ).rows
+        const orphanIds = rows.filter((row) => Number(row.referenced) === 0).map((row) => row.content_hash as string)
+        if (orphanIds.length > 0) {
+          tx.execute(`DELETE FROM content WHERE content_hash IN (${orphanIds.map(() => '?').join(', ')})`, orphanIds)
+        }
+        return rows
+      })
+      if (page.length < DELETE_BATCH_SIZE) break
+      const lastRow = page.at(-1)
+      if (!lastRow) break
+      contentCursor = lastRow.content_hash as string
+      await yieldIfNeeded()
+    }
   }
 
   /**

--- a/src/main/features/knowledge/pipeline/vectorstore/indexStore/__tests__/KnowledgeIndexStore.test.ts
+++ b/src/main/features/knowledge/pipeline/vectorstore/indexStore/__tests__/KnowledgeIndexStore.test.ts
@@ -34,6 +34,18 @@ function buildInput(
   }
 }
 
+function buildBm25Input(unitCount: number): RebuildMaterialInput {
+  const words = Array.from({ length: unitCount }, (_, index) => `chunk-${index}`)
+  const text = words.join(' ')
+  const ranges: Array<[number, number]> = []
+  let offset = 0
+  for (const word of words) {
+    ranges.push([offset, offset + word.length])
+    offset += word.length + 1
+  }
+  return { ...buildInput(text, ranges), usesEmbeddings: false, embeddings: [] }
+}
+
 describe('KnowledgeIndexStore', () => {
   let tempDir: string
   let driver: BetterSqlite3Driver
@@ -387,15 +399,14 @@ describe('KnowledgeIndexStore', () => {
     expect(await count('content')).toBe(2) // shared (m1+m3) + unique (m2)
     expect(await count('embedding')).toBe(2)
 
-    // Duplicate id must be de-duped; the whole batch deletes in one transaction with a
-    // single GC pass — the path a folder delete takes (one deleteMaterials over N files).
+    // Duplicate ids are de-duped; the bounded deletion still reaches the same final state.
     await store.deleteMaterials(['m1', 'm2', 'm1'])
 
     expect(driver.execute(`SELECT material_id FROM material`).rows.map((r) => r.material_id)).toEqual(['m3'])
     expect(store.listMaterialUnits('m1')).toEqual([])
     expect(store.listMaterialUnits('m2')).toEqual([])
-    // The single end-of-batch GC must sweep m2's now-orphaned body/embedding/content while
-    // keeping the body m3 still references — i.e. the same end state N per-material GCs gave.
+    // The end-of-batch GC must sweep m2's now-orphaned body/embedding/content while
+    // keeping the body m3 still references.
     expect(await count('content')).toBe(1)
     expect(await count('embedding')).toBe(1)
 
@@ -445,6 +456,57 @@ describe('KnowledgeIndexStore', () => {
     expect(await count('material')).toBe(0)
     expect(await count('search_text')).toBe(0)
     expect(await count('embedding')).toBe(0)
+  })
+
+  it('yields the main-process event loop while deleting many units from one material', async () => {
+    store.rebuildMaterial('large-material', buildBm25Input(120))
+
+    let clock = 0
+    const perfNow = vi.spyOn(performance, 'now').mockImplementation(() => (clock += 100))
+    const observedUnitCounts: number[] = []
+    const scheduleImmediate = global.setImmediate
+    const immediate = vi.spyOn(global, 'setImmediate').mockImplementation((callback, ...args) => {
+      observedUnitCounts.push(store.listMaterialUnits('large-material').length)
+      return scheduleImmediate(callback, ...args)
+    })
+    let yields = 0
+    try {
+      await store.deleteMaterials(['large-material'], { allowPartialMaterialProgress: true })
+      yields = immediate.mock.calls.length
+    } finally {
+      perfNow.mockRestore()
+      immediate.mockRestore()
+    }
+
+    expect(yields).toBeGreaterThan(1)
+    expect(observedUnitCounts.some((count) => count > 0)).toBe(true)
+    expect(await count('material')).toBe(0)
+    expect(await count('search_unit')).toBe(0)
+    expect(await count('search_text')).toBe(0)
+    expect(await count('embedding')).toBe(0)
+    expect(await count('content')).toBe(0)
+  })
+
+  it('keeps a material atomic for callers without durable delete recovery', async () => {
+    store.rebuildMaterial('large-material', buildBm25Input(120))
+
+    let clock = 0
+    const perfNow = vi.spyOn(performance, 'now').mockImplementation(() => (clock += 100))
+    const observedUnitCounts: number[] = []
+    const scheduleImmediate = global.setImmediate
+    const immediate = vi.spyOn(global, 'setImmediate').mockImplementation((callback, ...args) => {
+      observedUnitCounts.push(store.listMaterialUnits('large-material').length)
+      return scheduleImmediate(callback, ...args)
+    })
+    try {
+      await store.deleteMaterials(['large-material'])
+    } finally {
+      perfNow.mockRestore()
+      immediate.mockRestore()
+    }
+
+    expect(observedUnitCounts.length).toBeGreaterThan(0)
+    expect(observedUnitCounts.every((count) => count === 0)).toBe(true)
   })
 
   it('does not yield when a small batch stays within the time budget', async () => {

--- a/src/main/features/knowledge/pipeline/vectorstore/vectorCleanup.ts
+++ b/src/main/features/knowledge/pipeline/vectorstore/vectorCleanup.ts
@@ -4,7 +4,11 @@ import type { KnowledgeBase } from '@shared/data/types/knowledge'
 
 const logger = loggerService.withContext('KnowledgeVectorCleanup')
 
-export async function deleteKnowledgeItemVectors(base: KnowledgeBase, itemIds: string[]): Promise<void> {
+export async function deleteKnowledgeItemVectors(
+  base: KnowledgeBase,
+  itemIds: string[],
+  options: { allowPartialMaterialProgress?: boolean } = {}
+): Promise<void> {
   const uniqueItemIds = [...new Set(itemIds)]
   if (uniqueItemIds.length === 0) {
     return
@@ -16,15 +20,16 @@ export async function deleteKnowledgeItemVectors(base: KnowledgeBase, itemIds: s
     return
   }
 
-  // Delete every id with a single collectIndexGarbage pass at the end (each material's
-  // row delete is its own short transaction; see KnowledgeIndexStore.deleteMaterials).
+  // Delete every id with one end-of-delete garbage-collection traversal.
   // The old per-id Promise.allSettled loop ran the two full-table GC scans once per item,
   // so deleting a folder of N files scanned the whole embedding/content table N times —
-  // the multi-second main-process freeze on large (PDF-heavy) folders. A failure partway
-  // leaves whatever was already deleted committed; that is safe because this call always
-  // precedes the knowledge_item DB row deletion (see subtreePurge.ts), so a retry
-  // re-discovers exactly the materials still left.
-  await store.deleteMaterials(uniqueItemIds)
+  // the multi-second main-process freeze on large (PDF-heavy) folders. Partial material
+  // progress is reserved for delete jobs whose `deleting` rows and durable retry make it safe.
+  if (options.allowPartialMaterialProgress) {
+    await store.deleteMaterials(uniqueItemIds, { allowPartialMaterialProgress: true })
+  } else {
+    await store.deleteMaterials(uniqueItemIds)
+  }
 }
 
 /**

--- a/src/main/features/knowledge/tasks/__tests__/deleteSubtreeJobHandler.test.ts
+++ b/src/main/features/knowledge/tasks/__tests__/deleteSubtreeJobHandler.test.ts
@@ -64,7 +64,7 @@ describe('delete-subtree job handler', () => {
     expect(cancelMock).toHaveBeenCalledWith('check-job', 'knowledge-delete-subtree')
     expect(cancelMock).toHaveBeenCalledWith('fp-job-1', 'knowledge-delete-subtree')
     expect(cancelMock).not.toHaveBeenCalledWith('unrelated-job', expect.anything())
-    expect(deleteMaterialsMock).toHaveBeenCalledWith(['note-1'])
+    expect(deleteMaterialsMock).toHaveBeenCalledWith(['note-1'], { allowPartialMaterialProgress: true })
     expect(deleteItemsByIdsMock).toHaveBeenCalledWith('kb-1', ['dir-1', 'note-1'])
     // The freed index pages are reclaimed once, after the purge.
     expect(reclaimSpaceMock).toHaveBeenCalledTimes(1)

--- a/src/main/features/knowledge/tasks/deleteSubtreeJobHandler.ts
+++ b/src/main/features/knowledge/tasks/deleteSubtreeJobHandler.ts
@@ -56,7 +56,12 @@ export function createDeleteSubtreeJobHandler(
         const subtreeItems = knowledgeItemService
           .getSubtreeItems(baseId, rootItemIds, { includeRoots: true })
           .filter((item) => item.status === 'deleting')
-        await purgeKnowledgeSubtreeWithinLock(base, subtreeItems, { baseId, jobId: ctx.jobId })
+        await purgeKnowledgeSubtreeWithinLock(
+          base,
+          subtreeItems,
+          { baseId, jobId: ctx.jobId },
+          { allowPartialMaterialProgress: true }
+        )
         // Return the freed pages to the OS (best-effort, large deletes only). Inside the
         // lock so the VACUUM never races an indexer write on this base's index.
         await reclaimKnowledgeIndexSpace(base)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Recovering an interrupted knowledge subtree deletion could synchronously delete thousands of SQLite/FTS rows and stall Electron's main process.

After this PR: Recoverable deletions commit bounded batches and yield to the event loop, while other callers retain per-material atomicity.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: An interrupted recoverable job may leave partial derived-index cleanup, but its owning rows remain `deleting` and the durable job safely resumes it.

The following alternatives were considered: Moving index cleanup to a utility process was rejected as a substantially larger architectural change than bounding the synchronous work directly.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Diagnostics repeatedly recovered the same `knowledge.delete-subtree` job after startup; 53 focused main-process tests, `pnpm lint`, and `pnpm test:lint` pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
<!--LANG:en-->
[Knowledge Base] Prevent interrupted deletion recovery from freezing the app during startup.
<!--LANG:zh-CN-->
[知识库] 防止中断的删除任务在启动恢复时导致应用卡死。
<!--LANG:END-->
```
