### PR TITLE
docs(main): drop the stale bootstrap.ts cleanup note from core README

### DIFF
--- a/src/main/core/README.md
+++ b/src/main/core/README.md
@@ -37,9 +37,6 @@ terminology across the codebase.
 The lifecycle stages (Background / BeforeReady / WhenReady) run *inside*
 the bootstrap phase, not as separate top-level phases.
 
-The legacy file `src/main/bootstrap.ts` predates this vocabulary and is
-no longer imported anywhere. It will be removed in a follow-up cleanup PR.
-
 ## Current modules
 
 | Module | Description | Reference Docs |


### PR DESCRIPTION
### What this PR does

Before this PR:

`src/main/core/README.md` §"Startup phases" ended with a note about a file that no longer exists:

> The legacy file `src/main/bootstrap.ts` predates this vocabulary and is no longer imported anywhere.
> It will be removed in a follow-up cleanup PR.

That promise is stale. `src/main/bootstrap.ts` **was** removed — commit `a917ecd6a1`
("refactor(cleanup): remove deprecated bootstrap and init files", 2026-04-08) deleted it together with
`src/main/utils/init.ts`, migrating their responsibilities to `resolveUserDataLocation()` in
`src/main/core/preboot/userDataLocation.ts`. The paragraph was added one day earlier by `ed694a19cf`,
so it has been stating a pending cleanup for roughly five months after the cleanup actually landed.
A reader following it today finds no such file and no pending work.

After this PR:

The two-sentence note is gone. The surrounding section is untouched: the three-phase table, the
explicit statement that `bootstrap` means only `application.bootstrap()` in this codebase, and the
clarification that lifecycle stages run inside the bootstrap phase all remain, so the terminology the
paragraph existed to disambiguate is still documented. Net `-3` lines, no additions.

### Why we need it and why it was done in this way

This is the leftover of a completed cleanup rather than a deliberate note. `a917ecd6a1` touched exactly
three files — `src/main/bootstrap.ts`, `src/main/utils/init.ts` and `src/main/ipc.ts` — and did not
update this README, which is how the future-tense promise survived the deletion it was announcing.

The following tradeoffs were made:

Deletion rather than rewriting it into the past tense ("was removed in a917ecd6a1"). The paragraph's
only job was to flag a legacy file that was still present and about to go; once the file is gone there
is nothing left for it to say, and a commit hash in prose ages badly. Deletion also matches how this
repo handled the equivalent stale paragraph in `packages/ui/docs/design-token-system.md`, which
`82d06345b8` removed outright when the command it documented was deleted.

The following alternatives were considered:

- Keep it as a past-tense history note. Rejected above — but if reviewers would rather preserve the
  "bootstrap used to mean a file too" nuance, I am happy to restore it in the past tense; the deletion
  is easy to convert.
- Leave it. Rejected: it reads as an open TODO and points contributors at a file that does not exist.

Links to places where the discussion took place:

- `ed694a19cf` — docs(main): mark bootstrap.ts and config.ts as v2-deprecated legacy (added the note)
- `a917ecd6a1` — refactor(cleanup): remove deprecated bootstrap and init files (fulfilled it)

### Breaking changes

None. Documentation only: no code, dependency, API, or behavior change.

### Special notes for your reviewer

- Scope: 1 file, `-3 / +0`. No new dependencies, no refactor.
- Confirmed this is the **only** stale reference: a repo-wide search for `main/bootstrap.ts` across
  Markdown returns this single hit. `src/main/utils/init.ts`, the other file deleted by `a917ecd6a1`,
  is not referenced from any doc, so there is nothing else to clean up.
- Conflict check: `src/main/core/README.md` appears in none of the recently merged PRs (50 sampled),
  none of the currently open PRs (100 sampled), and none of my previous PRs in this repo — #19237
  (`docs/contrib/development.md`), #20295 (`CONTRIBUTING.md`) and #20305
  (`packages/ui/docs/design-token-system.md`). Zero overlap with all three.
- No test added: the change is Markdown-only and no test asserts on documentation prose.
- Local verification: `git diff` reviewed line by line (1 file, `-3`, LF endings unchanged); the
  repo-wide reference search above re-run after the edit.
- Local limitation, stated plainly: I could not run `pnpm docs:check` or the test suite here. This
  environment has no reachable npm registry, so pnpm's dependency status check aborts before any test
  or doc check starts — the failure is the network, not this change. I am relying on CI for those
  gates and will re-run them if anything comes back red.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: kept to the minimum deletion that removes the stale promise
- [x] Refactor: left the surrounding section as found; only the stale paragraph is gone
- [x] Upgrade: no upgrade impact — documentation only
- [x] Documentation: this PR *is* a documentation fix; no user-guide (docs.cherry-ai.com) update needed
- [x] Self-review: reviewed my own diff (`git diff`) line by line before requesting review

### Release note

```release-note
NONE
```
