### PR TITLE
docs(migrations): correct the stale package manager in the migrations README

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -7,4 +7,4 @@ The chain was consolidated into a single initial migration and shipped with `v2.
 - Table schemas are defined in `src\main\data\db\schemas`
 - `migrations/sqlite-drizzle` contains auto-generated migration data. Please **DO NOT** modify it.
 - If table structure changes, we should run migrations.
-- To generate migrations, use the command `yarn run db:migrations:generate`
+- To generate migrations, use the command `pnpm db:migrations:generate`


### PR DESCRIPTION
### What this PR does

Before this PR:

`migrations/README.md` told contributors to generate migrations with a yarn command:

> - To generate migrations, use the command `yarn run db:migrations:generate`

That command belongs to the toolchain this repository no longer uses. The move from yarn to pnpm
landed in #12260 (`refactor/switch-yarn-to-pnpm`, merged 2026-01-05, 58 files) — it rewrote the
install and run instructions in `CLAUDE.md`, `docs/en/guides/development.md`,
`docs/zh/guides/development.md` and the package READMEs, but it never touched `migrations/README.md`.
The file has been pointing at yarn ever since.

Anyone who follows it today is told to use a package manager this repo has not declared for eight
months. The current state of the repository says pnpm on every axis:

- `package.json` declares `"packageManager": "pnpm@11.8.0+sha512.…"`, and `engines` pins Node.
- The only lockfiles and workspace/config files present are `pnpm-lock.yaml`, `pnpm-workspace.yaml`
  and `.npmrc`. There is no `yarn.lock`.
- A repo-wide search finds no `yarn` invocation in `.github/workflows/**` or `scripts/**`.

After this PR:

The bullet reads the command that actually works:

> - To generate migrations, use the command `pnpm db:migrations:generate`

`db:migrations:generate` is a real root script (`package.json`), and `pnpm <script>` is the form the
rest of this repo's Markdown already uses — the string `pnpm run ` appears in zero Markdown files
here, so the fix follows the existing convention rather than introducing a new one.

The rest of the file is byte-for-byte unchanged. Net `+1 / -1`.

### Why we need it and why it was done in this way

The migrations README is the entry point for anyone adding a schema change, and it is the one file in
`migrations/` a contributor is expected to read. Sending them to a package manager that the repo does
not declare is a documentation defect with a one-token fix, so the change is deliberately narrowed to
that token.

This is the leftover of a completed migration rather than a deliberate choice: #12260 swept 58 files
including every other developer-facing command reference, and `migrations/README.md` simply was not in
its list. The same file's sibling facts (the driver, the ORM, `migrations/sqlite-drizzle` as generated
output) were re-verified while preparing this PR and are all still accurate, so nothing else needed to
change.

The following tradeoffs were made:

Replacing the whole command text (`yarn run db:migrations:generate` → `pnpm db:migrations:generate`)
rather than only the executable (`yarn` → `pnpm`, keeping `run`). Keeping `run` would work, but it
would be the only `pnpm run …` in the repository's Markdown; matching the surrounding convention keeps
the corpus internally consistent, which is the point of the fix.

The following alternatives were considered:

- Rewriting the bullet into a longer "how to regenerate the schema" paragraph. Rejected: that is a
  content change, not a correction, and it would balloon a one-line fix.
- Leaving the file alone because yarn still exists as a tool. Rejected: the README's job is to state
  how *this* repository is operated; `package.json` pins pnpm via `packageManager`, so yarn is not an
  equivalent path here.

Links to places where the discussion took place:

- https://github.com/CherryHQ/cherry-studio/pull/12260 — `refactor/switch-yarn-to-pnpm` (merged
  2026-01-05), the migration that missed this file

### Breaking changes

None. Documentation only: no code, dependency, API, or user-visible behavior change.

### Special notes for your reviewer

- Scope: 1 file, `+1 / -1`, one bullet. No new dependencies, no refactor.
- The two other Markdown occurrences of yarn were deliberately left alone, because both live in
  `src/renderer/routes/`, which open PR #19104 (`feat(navigation): add configurable sidebar and tab
  layouts`) is actively editing: `src/renderer/routes/README.md:24` and
  `src/renderer/routes/README.zh-CN.md:24` ("After running `yarn dev`"). Both are the same class of
  leftover and are one-word fixes — I would rather land this file cleanly than create overlap on a
  directory another PR owns. Happy to send them as a follow-up once #19104 is in, or to fold them in
  here if you prefer; say the word.
- Every other `yarn` hit in the repo was checked and is correct as written: `.gitignore` /
  `.gitattributes` / `oxfmt` / `oxlint` / `eslint` ignore patterns and `.vscode` settings, the yarn
  command *detectors* in `src/main/ai/toolApproval/dependencyGuard.ts` and
  `packages/dsh-bridge/src/policy.ts`, a vendored patch under `patches/`, and a lockfile name used as
  an example in `resources/**/hooks-patterns.md`. None of those are instructions to a contributor.
- Conflict check: `migrations/README.md` is touched by none of the currently open PRs (451 sampled),
  none of the recently merged PRs (60 sampled, 839 distinct files), and none of my previous PRs here —
  #19237, #20295, #20305, #20409. Zero overlap. (Open PRs do add files under
  `migrations/sqlite-drizzle/`, but not this README.)
- No gate covers this file, verified rather than assumed: `scripts/check-doc-links.ts` scans `docs`,
  `src`, `packages`, `.agents` plus root-level Markdown (`migrations/` is not in that list, and this
  file contains no links anyway); `scripts/verify-doc-frontmatter.ts` scans `docs/references` and
  `docs/contrib`; `scripts/gen-doc-index.ts` only writes `docs/README.md`; and `.oxfmtrc.json` ignores
  both `**/*.md` and `migrations/**`. So no formatter or doc gate applies to this edit.
- No test added: the change is Markdown-only and no test asserts on documentation prose.
- Local verification: `git diff` reviewed line by line — exactly 1 file, `+1 / -1`, line endings
  unchanged (LF), and the 27 unrelated paths that a checkout glitch removed from my working tree were
  restored before staging, so the index contains this file and nothing else.
- Local limitation, stated plainly: I could not run `pnpm docs:check` or the test suite here — this
  environment has no reachable npm registry, so pnpm's dependency status check aborts before any check
  starts. The failure is the network, not this change. Also note that running
  `pnpm db:migrations:generate` itself is deliberately *not* part of the verification: it writes new
  files into `migrations/sqlite-drizzle/`. The script's existence and name were verified against
  `package.json` instead.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: kept to the one-line correction; no surrounding rewording
- [x] Refactor: left the file cleaner than found, with nothing else touched
- [x] Upgrade: no upgrade impact — documentation only
- [x] Documentation: this PR *is* a documentation fix; no user-guide (docs.cherry-ai.com) update needed
- [x] Self-review: reviewed my own diff (`git diff`) line by line before requesting review

### Release note

```release-note
NONE
```
