### PR TITLE
fix(agent-runtime): carry the Windows system env into the dsh child

### DIFF
--- a/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
+++ b/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
@@ -25,7 +25,7 @@ import { wrapSteerReminder } from '@main/ai/steerReminder'
 import { toolApprovalRegistry } from '@main/ai/toolApproval/ToolApprovalRegistry'
 import { evaluateUserDataSqliteGuard } from '@main/ai/toolApproval/userDataSqliteGuard'
 import { resolveKnowledgeBaseScope } from '@main/ai/utils/knowledgeScope'
-import { mergeBinaryExecutionEnv } from '@main/utils/binaryEnv'
+import { mergeBinaryExecutionEnv, pickSystemEnvironment } from '@main/utils/binaryEnv'
 import { getPathFromEnvironment, getShellEnv } from '@main/utils/shellEnv'
 import type { AgentSessionContextUsage } from '@shared/ai/agentSessionContextUsage'
 import {
@@ -396,6 +396,10 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
         cwd: workspacePath,
         env: {
           ...binaryExecutionEnv,
+          // ...plus the platform's own baseline, which the scoping above must not
+          // withhold: on Windows the runtime process cannot start without it and
+          // exits with a Windows exception code seconds after spawn (#19753).
+          ...pickSystemEnvironment(loginShellEnv),
           ...(loginShellEnv.HOME !== undefined
             ? { HOME: loginShellEnv.HOME }
             : process.env.HOME !== undefined

--- a/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.windows.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.windows.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentRuntimeConnectInput } from '../../types'
+
+// Pin the Windows code path. This cannot live in DshRuntimeConnection.trace.test.ts:
+// mocking the platform module there flips the PATH separator to `;` and breaks that
+// file's own PATH assertions.
+vi.mock('@main/core/platform', () => ({
+  isWin: true,
+  isMac: false,
+  isLinux: false,
+  isDev: false,
+  isPortable: false,
+  isDarwinX64: false,
+  isWinArm64: false
+}))
+
+const mocks = vi.hoisted(() => ({
+  harnessOptions: undefined as Record<string, any> | undefined,
+  getShellEnv: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('../dshConnectionSignature', () => ({
+  DshInvalidConnectionSnapshotError: class extends Error {},
+  captureDshConnectionSnapshot: vi.fn(() =>
+    Promise.resolve({
+      signature: 'sig-1',
+      agent: { id: 'agent-1', configuration: {}, disabledTools: [] },
+      session: { agentId: 'agent-1', workspace: { path: 'C:\\workspace' } },
+      provider: {},
+      model: {},
+      enabledApiKeys: [],
+      additionalSkillPaths: [],
+      mcpServerSnapshots: [],
+      linkedChannel: null
+    })
+  )
+}))
+vi.mock('../modelInjection', () => ({
+  resolveDshProviderInjectionFromSnapshot: vi.fn(() => ({
+    providerName: 'deepseek',
+    api: 'openai-completions',
+    baseUrl: 'https://api.deepseek.com',
+    modelId: 'deepseek-chat',
+    apiKey: 'key',
+    modelConfig: { id: 'deepseek-chat', contextWindow: 128_000, maxTokens: 8192 },
+    usageCapture: { owner: 'provider-calls' }
+  })),
+  usesDshGateway: vi.fn(() => false)
+}))
+vi.mock('../compositionBuilder', () => ({
+  buildDshCompositionYaml: vi.fn(() => 'plugins: []'),
+  resolveDshRuntimeBinPath: vi.fn(() => 'C:\\dsh\\bin')
+}))
+vi.mock('../DshBridgeServer', () => ({
+  DshBridgeServer: vi.fn(function DshBridgeServerMock() {
+    return {
+      socketPath: '\\\\.\\pipe\\dsh',
+      authenticationToken: 'bridge-token',
+      listen: vi.fn().mockResolvedValue(undefined),
+      whenReady: vi.fn().mockResolvedValue(undefined),
+      request: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined)
+    }
+  })
+}))
+vi.mock('../DshCherryToolBridge', () => ({
+  buildDshCherryToolBridge: vi.fn().mockResolvedValue({
+    tools: [],
+    callTool: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined)
+  }),
+  buildDshCherryToolName: (server: string, tool: string) => `mcp__${server}__${tool}`,
+  warmDshMcpToolCatalogs: vi.fn().mockResolvedValue(undefined),
+  DSH_AUTO_APPROVED_BRIDGED_TOOLS: new Set<string>(),
+  DSH_APPROVAL_REQUIRED_BRIDGED_TOOLS: new Set<string>(),
+  DSH_NON_BYPASSABLE_APPROVAL_BRIDGED_TOOLS: new Set<string>()
+}))
+vi.mock('../dshSdk', () => ({
+  loadDshSdk: vi.fn().mockResolvedValue({
+    HarnessClient: vi.fn(function HarnessClientMock(options: Record<string, unknown>) {
+      mocks.harnessOptions = options
+      return {
+        start: vi.fn(),
+        initialize: vi.fn().mockResolvedValue(undefined),
+        subscribe: vi.fn(() => ({ async *[Symbol.asyncIterator]() {}, close: vi.fn() })),
+        close: vi.fn().mockResolvedValue(undefined)
+      }
+    })
+  })
+}))
+vi.mock('@main/utils/shellEnv', () => ({
+  getShellEnv: mocks.getShellEnv,
+  getPathFromEnvironment: (env: Record<string, string | undefined>) =>
+    Object.entries(env).find(([key]) => key.toLowerCase() === 'path')?.[1]
+}))
+vi.mock('@main/ai/agents/agentDataDirectory', () => ({
+  ensureAgentDataDirectory: vi.fn().mockResolvedValue('C:\\agent-data')
+}))
+vi.mock('@main/ai/runtime/agentPrompt', () => ({
+  buildAgentRuntimePrompt: vi.fn().mockResolvedValue({ base: { kind: 'native' }, append: '' })
+}))
+vi.mock('@main/ai/runtime/agentMcpServers', () => ({ buildAgentMcpServers: vi.fn(() => []) }))
+vi.mock('@main/ai/runtime/citationsGuidance', () => ({ buildCitationsGuidance: vi.fn(() => '') }))
+vi.mock('@main/ai/steerReminder', () => ({ wrapSteerReminder: vi.fn((text: string) => text) }))
+
+const { DshRuntimeConnection } = await import('../DshRuntimeConnection')
+
+// No `trace` field: the connection only records spans when the host supplies a
+// trace context, and this test is about the spawn env.
+const connectInput = {
+  sessionId: 'session-1',
+  agentId: 'agent-1',
+  modelId: 'deepseek::deepseek-chat'
+} as unknown as AgentRuntimeConnectInput
+
+beforeEach(() => {
+  mocks.harnessOptions = undefined
+  mocks.getShellEnv.mockReset().mockResolvedValue({
+    Path: 'C:\\Users\\tester\\bin;C:\\Windows\\system32',
+    SystemRoot: 'C:\\Windows',
+    SystemDrive: 'C:',
+    ComSpec: 'C:\\Windows\\system32\\cmd.exe',
+    PATHEXT: '.COM;.EXE;.BAT',
+    TEMP: 'C:\\Users\\tester\\Temp',
+    USERPROFILE: 'C:\\Users\\tester',
+    DEEPSEEK_API_KEY: 'do-not-forward'
+  })
+})
+
+describe('DshRuntimeConnection on Windows', () => {
+  it('spawns the runtime with the Windows system baseline', async () => {
+    // Without it the child - process.execPath under ELECTRON_RUN_AS_NODE - cannot
+    // resolve the system DLLs and exits with a Windows exception code seconds after
+    // spawn, which is the crash in #19753.
+    const connection = await new DshRuntimeConnection(connectInput).start()
+    const env = mocks.harnessOptions?.env as NodeJS.ProcessEnv
+
+    expect(env).toMatchObject({
+      SystemRoot: 'C:\\Windows',
+      SystemDrive: 'C:',
+      ComSpec: 'C:\\Windows\\system32\\cmd.exe',
+      PATHEXT: '.COM;.EXE;.BAT',
+      TEMP: 'C:\\Users\\tester\\Temp',
+      USERPROFILE: 'C:\\Users\\tester'
+    })
+    await connection.close()
+  })
+
+  it('still keeps the rest of the host environment out of the child', async () => {
+    // The baseline is a fixed list, not a passthrough: the scoping the surrounding
+    // code calls deliberate has to survive it.
+    const connection = await new DshRuntimeConnection(connectInput).start()
+    const env = mocks.harnessOptions?.env as NodeJS.ProcessEnv
+
+    expect(env).not.toHaveProperty('DEEPSEEK_API_KEY')
+    expect(env.CHERRY_DSH_API_KEY).toBe('key')
+    await connection.close()
+  })
+})

--- a/src/main/utils/__tests__/binaryEnv.test.ts
+++ b/src/main/utils/__tests__/binaryEnv.test.ts
@@ -6,7 +6,8 @@ import {
   getBinaryShimsDir,
   mergeBinaryExecutionEnv,
   mergePathPrefixes,
-  mergePathSuffixes
+  mergePathSuffixes,
+  pickSystemEnvironment
 } from '../binaryEnv'
 
 // Real `node:path` (posix on CI) — the dedup's canonicalization runs against
@@ -81,5 +82,14 @@ describe('getBinaryIsolatedHomeEnv', () => {
     expect(env['HOME']).toBe('/mock/feature.binary.data/home')
     expect(env['LOCALAPPDATA']).toBeUndefined()
     expect(env['APPDATA']).toBeUndefined()
+  })
+})
+
+describe('pickSystemEnvironment', () => {
+  it('adds nothing off Windows, where the child inherits no comparable baseline', () => {
+    // Posix children need no baseline beyond what their caller already builds, so
+    // the replacement env must come back untouched even if the host happens to
+    // carry Windows-shaped keys. The Windows side lives in binaryEnv.windows.test.ts.
+    expect(pickSystemEnvironment({ SystemRoot: 'C:_WINDOWS', HOME: '/Users/tester' })).toEqual({})
   })
 })

--- a/src/main/utils/__tests__/binaryEnv.windows.test.ts
+++ b/src/main/utils/__tests__/binaryEnv.windows.test.ts
@@ -28,7 +28,12 @@ vi.mock('@application', () => ({
 
 vi.mock('path')
 
-import { getBinaryIsolatedHomeEnv, mergeBinaryExecutionEnv, mergePathSuffixes } from '../binaryEnv'
+import {
+  getBinaryIsolatedHomeEnv,
+  mergeBinaryExecutionEnv,
+  mergePathSuffixes,
+  pickSystemEnvironment
+} from '../binaryEnv'
 
 describe('mergeBinaryExecutionEnv (Windows)', () => {
   beforeEach(async () => {
@@ -102,5 +107,48 @@ describe('mergeBinaryExecutionEnv (Windows)', () => {
     const env = getBinaryIsolatedHomeEnv()
     expect(env['LOCALAPPDATA']).toBe('C:\\data\\binary-manager\\localappdata')
     expect(env['APPDATA']).toBe('C:\\data\\binary-manager\\appdata')
+  })
+})
+
+describe('pickSystemEnvironment (Windows)', () => {
+  const hostEnv = {
+    SystemRoot: 'C:\\Windows',
+    SystemDrive: 'C:',
+    windir: 'C:\\Windows',
+    ComSpec: 'C:\\Windows\\system32\\cmd.exe',
+    PATHEXT: '.COM;.EXE;.BAT',
+    TEMP: 'C:\\Users\\tester\\AppData\\Local\\Temp',
+    TMP: 'C:\\Users\\tester\\AppData\\Local\\Temp',
+    USERPROFILE: 'C:\\Users\\tester'
+  }
+
+  it('carries the whole baseline a replacement child env cannot start without', () => {
+    // A child spawned without SystemRoot cannot resolve the system DLLs and dies
+    // with a Windows exception exit code before running any of its own code.
+    expect(pickSystemEnvironment(hostEnv)).toEqual(hostEnv)
+  })
+
+  it('reads the baseline whatever case the host spells it in', () => {
+    // Windows env keys are case-insensitive, so a captured host env can carry any
+    // spelling; the child must receive the canonical one either way.
+    expect(pickSystemEnvironment({ SYSTEMROOT: 'C:\\Windows', Pathext: '.EXE' })).toEqual({
+      SystemRoot: 'C:\\Windows',
+      PATHEXT: '.EXE'
+    })
+  })
+
+  it('forwards nothing else from the host environment', () => {
+    // The point of a replacement env is that unrelated host variables stay out of
+    // the child. Widening the baseline must not become a way back in.
+    const picked = pickSystemEnvironment({ ...hostEnv, DEEPSEEK_API_KEY: 'secret', Path: 'C:\\bin' })
+
+    expect(picked).not.toHaveProperty('DEEPSEEK_API_KEY')
+    expect(picked).not.toHaveProperty('Path')
+  })
+
+  it('skips variables the host does not define', () => {
+    expect(pickSystemEnvironment({ SystemRoot: 'C:\\Windows', TEMP: undefined })).toEqual({
+      SystemRoot: 'C:\\Windows'
+    })
   })
 })

--- a/src/main/utils/binaryEnv.ts
+++ b/src/main/utils/binaryEnv.ts
@@ -130,6 +130,53 @@ export function getBinaryIsolatedHomeEnv(): Record<string, string> {
   return env
 }
 
+/**
+ * The Windows variables a child process cannot start without, plus the two that
+ * decide where it reads and writes:
+ * - `SystemRoot`, `windir`, `SystemDrive`, `ComSpec`, `PATHEXT` — the system baseline
+ *   `utilityProcess/host/environment.ts` already forwards to its children;
+ *   `BinaryManager`'s `MISE_PASSTHROUGH_ENV` forwards all of them but `SystemDrive`.
+ *   Without `SystemRoot` a Windows process cannot resolve the system DLLs at all.
+ * - `TEMP`, `TMP` — a writable scratch dir. The utility-process host substitutes a
+ *   Cherry-scoped one instead of forwarding these; here there is none to substitute.
+ * - `USERPROFILE` — Windows' `HOME`, which neither list carries because neither
+ *   child needs a home. Callers here hand the child `HOME` on posix, so this is the
+ *   same value under the name Windows uses for it.
+ *
+ * None of them is a credential or a user-configured setting, so forwarding them
+ * does not widen what a deliberately scoped child env exposes.
+ */
+const WIN32_SYSTEM_ENV_KEYS = [
+  'SystemRoot',
+  'SystemDrive',
+  'windir',
+  'ComSpec',
+  'PATHEXT',
+  'TEMP',
+  'TMP',
+  'USERPROFILE'
+]
+
+/**
+ * The platform's mandatory system variables, read out of `source`.
+ *
+ * Callers that hand a child a *replacement* env — one that does not start from the
+ * host environment — must fold this in. On Windows an env without it kills the
+ * child before it runs any of its own code: a process spawned without `SystemRoot`
+ * cannot resolve the system DLLs, and dies with a Windows exception exit code and
+ * no crash report. Posix has no comparable baseline, so this is empty there.
+ */
+export function pickSystemEnvironment(source: Record<string, string | undefined>): Record<string, string> {
+  if (!isWin) return {}
+  const picked: Record<string, string> = {}
+  for (const name of WIN32_SYSTEM_ENV_KEYS) {
+    // Windows env keys are case-insensitive, so the source may spell them any way.
+    const match = Object.entries(source).find(([key]) => key.toLowerCase() === name.toLowerCase())
+    if (match?.[1] !== undefined) picked[name] = match[1]
+  }
+  return picked
+}
+
 function mergePathEntries(
   env: Record<string, string>,
   prefixes: string[],


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

On Windows, a DeepSeek Harness Agent session dies a few seconds in with `TransportClosedError: DeepSeek Harness runtime exited`, a Windows exception exit code and `crashpad: not connected`.

`DshRuntimeConnection` starts the runtime with a complete replacement env — deliberately, so the child only sees the managed binary dirs, the routed API key and the bridge socket. But that env keeps nothing from the host except `PATH` and `HOME`, and on Windows `HOME` is usually not set at all. The child is `process.execPath` under `ELECTRON_RUN_AS_NODE`, and a Windows process spawned without `SystemRoot`/`SystemDrive` cannot resolve the system DLLs, so it exits before it runs any of its own code — which is also why nothing useful is reported: the crash handler never comes up either.

It is the only runtime that builds its env this way. Claude Code spreads the whole login-shell env, Pi merges onto the caller's, and the utility-process host and the mise install subprocess both forward an explicit Windows baseline. That matches the report that switching the Agent to a non-DeepSeek provider avoids the crash.

After this PR:

The dsh child env carries the platform's mandatory system variables (`SystemRoot`, `SystemDrive`, `windir`, `ComSpec`, `PATHEXT`, `TEMP`, `TMP`, `USERPROFILE`) on Windows, and nothing else changes. Posix is unaffected.

Fixes #19753

### Why we need it and why it was done in this way

The new `pickSystemEnvironment()` lives in `binaryEnv.ts`, next to the other "what Cherry injects into a child process's env" primitives, and branches on `isWin` like everything else in that module. Its five system keys are the ones `utilityProcess/host/environment.ts` already forwards; `TEMP`/`TMP` and `USERPROFILE` are the two additions, and the docstring says why each is there.

`DshRuntimeConnection.windows.test.ts` pins the wiring — it captures the options the runtime is spawned with and asserts the baseline reaches the child while a host API key still does not — and `binaryEnv.windows.test.ts` / `binaryEnv.test.ts` cover the helper on each platform.

The following tradeoffs were made:

The scoping of the dsh child env is intentional and I did not want to loosen it, so this forwards a fixed list of system variables instead of passing the host env through. None of them is a credential, and the test pins that nothing else comes along.

The following alternatives were considered:

Spreading the login-shell env the way the Claude Code runtime does would fix the crash too, but it undoes the deliberate scoping from #19259 and hands the child every unrelated host variable.

Reusing `createUtilityProcessEnvironment()` was not workable: it forces its own `NODE_ENV`/`TMPDIR` and throws on any addition that overlaps its baseline, so the `PATH` this env already carries would be rejected.

### Breaking changes

None.

### Special notes for your reviewer

This addresses the root cause only. The issue and the follow-up comments also ask for actionable crash diagnostics and a recoverable session state when the runtime does go down; that is worth doing on its own and I have deliberately left it out of this PR.

I have not been able to reproduce the crash first-hand — it needs the Harness runtime and a DeepSeek key on Windows — so the diagnosis rests on the code and the exit signature. `SystemRoot`/`SystemDrive`/`windir`/`ComSpec`/`PATHEXT` are the set the utility-process host already forwards (the mise install subprocess forwards all but `SystemDrive`); `TEMP`/`TMP` and `USERPROFILE` are the two additions. If you would rather see `APPDATA`/`LOCALAPPDATA` in there too, say so and I will add them.

The new `DshRuntimeConnection.windows.test.ts` is a separate file rather than a case in `DshRuntimeConnection.trace.test.ts` because mocking `@main/core/platform` flips the PATH separator to `;` and would break that file's existing PATH assertions.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required — no user-facing feature or behavior change beyond the fix itself.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix DeepSeek Harness Agent sessions crashing on Windows shortly after the runtime starts.
```
