### PR TITLE
docs(skills): add the missing language switcher to the skills README pair

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,5 +1,7 @@
 # Skills Management
 
+English | [中文](README.zh.md)
+
 This directory is the single source of truth for repository skills.
 
 ## Add a New Skill

--- a/.agents/skills/README.zh.md
+++ b/.agents/skills/README.zh.md
@@ -1,5 +1,7 @@
 # Skills 管理说明
 
+[English](README.md) | 中文
+
 本目录是仓库内 skills 的唯一维护来源（single source of truth）。
 
 ## 新增 Skill 流程


### PR DESCRIPTION
### What this PR does

Before this PR:

`.agents/skills/README.zh.md` is a complete Chinese translation of `.agents/skills/README.md`, but
neither file links to the other. The Chinese page therefore has no inbound navigation link anywhere
in the repository: it is reachable only by knowing the exact filename.

Every other Chinese counterpart in the tree — the three pairs under `.agents/notes/` — opens with a
language switcher line:

```
.agents/notes/README.md:3                                    English | [中文](README.zh.md)
.agents/notes/README.zh.md:3                                 [English](README.md) | 中文
.agents/notes/implemented/process/…outcomes.md:5             English | [中文](…outcomes.zh.md)
.agents/notes/implemented/process/…outcomes.zh.md:5          [English](…outcomes.md) | 中文
.agents/notes/proposed/process/…spec-workflow.md:5           English | [中文](…spec-workflow.zh.md)
.agents/notes/proposed/process/…spec-workflow.zh.md:5        [English](…spec-workflow.md) | 中文
```

The skills pair is the odd one out.

After this PR:

Both sides of the pair open with the same switcher line the `.agents/notes/` pairs already use:

```
.agents/skills/README.md:3        English | [中文](README.zh.md)
.agents/skills/README.zh.md:3     [English](README.md) | 中文
```

Nothing else changes. Net `+4 / -0` across two files.

Fixes #

### Why we need it and why it was done in this way

A full Chinese translation exists and is actively maintained, and yet nothing in the repository
points at it. The pairing is not vestigial and not accidental:

- `scripts/skills-check.ts:17-19` defines `isAgentsReadmeFile` as `/^\.agents\/skills\/README(?:\.[a-z0-9-]+)?\.md$/i`.
  The `(?:\.[a-z0-9-]+)?` group exists precisely so localized `README.<lang>.md` files are treated
  as first-class tracked files rather than stray content — the tooling already expects what this PR
  simply makes reachable.
- Commit `fe0678a206` ("chore: migrate .claude/skills to directory symlinks", #13486) edits
  `.agents/skills/README.md` (`+13/-4`) and `.agents/skills/README.zh.md` (`+13/-4`) in the same
  commit, so both sides are kept current side by side.
- The two files are structurally identical today — same section count, same number of list items,
  same number of code fences — so the only thing that was ever missing is navigation.

`docs:check-links` scans `.agents/`, but it only asserts that link targets resolve; it cannot detect
a page that exists and resolves while nothing links *to* it. That is the blind spot this fixes.

The following tradeoffs were made:

Patching both sides rather than only the English one. A one-way link would send Chinese readers to
the English page but leave them unable to come back, which is worse than no link. The cost is one
extra line.

The following alternatives were considered:

- Rewriting or expanding the Chinese README. Rejected: the translation is already faithful and
  structurally identical to the original, so there is no content gap to close. Adding prose would
  also mean inventing wording, which this PR deliberately avoids.
- Restructuring the README into a bilingual single file. Rejected: the repository's convention is
  side-by-side `foo.md` + `foo.zh.md` with a switcher line, and the governance proposal commits to
  the pairing model rather than a merged document.
- Fixing every pair with the same gap in one PR. Rejected to keep scope minimal (see the notes for
  the reviewer on the two pairs deliberately left out).

Links to places where the discussion took place:

- `.agents/notes/README.md:3` and `.agents/notes/README.zh.md:3` — the convention being followed
- `scripts/skills-check.ts:17-19` — the localized-README whitelist
- Commit `fe0678a206` — the previous update that touched both sides of this pair

### Breaking changes

None. Two Markdown lines are added to two documentation files. No code, no dependency, no API, no
user-facing behavior change.

### Special notes for your reviewer

- Scope: 2 files, `+4 / -0`. Both added lines are byte-for-byte the format already used at
  `.agents/notes/README.md:3` and `.agents/notes/README.zh.md:3`, so no new wording or style enters
  the corpus.
- Two other pairs have the same gap and are deliberately **not** touched here:
  `.claude/skills/README.md` / `README.zh.md` (the `.claude/skills/` tree is a generated mirror
  managed by `pnpm skills:sync`, and its README is a short mirror note) and
  `src/renderer/routes/README.zh-CN.md` (that directory is being rewritten by open PR #19104, so a
  change there would only create overlap). Both are two-line fixes; happy to send them as a
  follow-up if you want them.
- Gate impact, checked by reading each script:
  - `docs:check-links` scans `.agents/`; the new relative targets (`README.zh.md` / `README.md`)
    already exist next to the source files, so they resolve.
  - `verify-doc-structure`, `verify-doc-frontmatter` and `gen-doc-index` only scan
    `docs/references/**` and `docs/README.md`, so they are unaffected.
  - `oxfmt` does not format these files: `.oxfmtrc.json` lists `**/*.md` in `ignorePatterns`.
  - `skills:check` is unaffected: no skill directory, `.gitignore`, symlink or `public-skills.txt`
    entry changes, and `README*.md` is whitelisted by `isAgentsReadmeFile`.
- Local verification was limited: this machine has no reachable npm registry, so `pnpm docs:check`
  cannot run here. What was done instead is static — link-target existence, the gate scan-scope
  inspection above, a before/after structural comparison of the two files (equal on every counter),
  and a byte-level diff of the added lines against the `notes` pairs.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: The change is two Markdown lines; no code is touched
- [x] Refactor: No refactor; the diff is additive only
- [x] Upgrade: No impact on upgrade flows
- [x] Documentation: Developer-facing docs only; no user-guide update required
- [x] Self-review: Reviewed the diff, the gate scripts, and the surrounding file conventions

### Release note

```release-note
NONE
```
