### PR TITLE
fix(process-manager): escalate failed Windows process-tree cleanup

### DIFF
--- a/src/main/services/HermesDashboardService.ts
+++ b/src/main/services/HermesDashboardService.ts
@@ -230,8 +230,8 @@ export class HermesDashboardService extends BaseService {
     }
     this.stoppingChild = child
     try {
-      await terminateProcessTree(child, false, 'Hermes Dashboard')
-      if (await waitForProcessExit(child, GRACEFUL_STOP_TIMEOUT_MS)) return
+      const gracefulStopSucceeded = await terminateProcessTree(child, false, 'Hermes Dashboard')
+      if (gracefulStopSucceeded && (await waitForProcessExit(child, GRACEFUL_STOP_TIMEOUT_MS))) return
 
       await terminateProcessTree(child, true, 'Hermes Dashboard')
       if (!(await waitForProcessExit(child, FORCE_STOP_TIMEOUT_MS))) {

--- a/src/main/services/__tests__/HermesDashboardService.test.ts
+++ b/src/main/services/__tests__/HermesDashboardService.test.ts
@@ -1,3 +1,4 @@
+import type * as NodeChildProcess from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import type * as NodeFsPromises from 'node:fs/promises'
 
@@ -9,6 +10,7 @@ import type * as ProcessRunner from '@main/utils/processRunner'
 const mocks = vi.hoisted(() => ({
   appGet: vi.fn(),
   cacheSetShared: vi.fn(),
+  execFile: vi.fn(),
   getHermesHome: vi.fn(),
   getRawShellEnv: vi.fn(),
   isWin: false,
@@ -20,6 +22,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock('node:fs/promises', async (importOriginal) => ({
   ...(await importOriginal<typeof NodeFsPromises>()),
   realpath: mocks.realpath
+}))
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeChildProcess>()),
+  execFile: mocks.execFile
 }))
 
 vi.mock('@application', () => ({ application: { get: mocks.appGet } }))
@@ -81,6 +87,14 @@ describe('HermesDashboardService', () => {
     mocks.realpath.mockRejectedValue(new Error('ENOENT'))
     mocks.refreshShellEnv.mockResolvedValue({ PATH: '/managed/bin' })
     mocks.spawn.mockReturnValue(child)
+    mocks.execFile.mockImplementation(
+      (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => callback(null, '', '')
+    )
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => ({
@@ -222,6 +236,52 @@ describe('HermesDashboardService', () => {
     } as unknown as Response)
 
     await expect(new HermesDashboardService().start()).resolves.toMatchObject({ success: true })
+  })
+
+  it('forces the Windows process tree after graceful cleanup fails', async () => {
+    mocks.isWin = true
+    mocks.execFile
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: string[],
+          _options: object,
+          callback: (error: Error | null, stdout: string, stderr: string) => void
+        ) => {
+          child.close('SIGTERM')
+          callback(new Error('taskkill exited with code 128'), '', '')
+        }
+      )
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: string[],
+          _options: object,
+          callback: (error: Error | null, stdout: string, stderr: string) => void
+        ) => {
+          callback(null, '', '')
+        }
+      )
+    const service = new HermesDashboardService()
+    await expect(service.start()).resolves.toMatchObject({ success: true })
+
+    await service.stop()
+
+    expect(mocks.execFile).toHaveBeenNthCalledWith(
+      1,
+      'taskkill',
+      ['/PID', String(child.pid), '/T'],
+      { windowsHide: true },
+      expect.any(Function)
+    )
+    expect(mocks.execFile).toHaveBeenNthCalledWith(
+      2,
+      'taskkill',
+      ['/PID', String(child.pid), '/T', '/F'],
+      { windowsHide: true },
+      expect.any(Function)
+    )
+    expect(service.getStatus()).toEqual({ status: 'stopped' })
   })
 
   it('reports a missing Hermes binary without spawning a process', async () => {

--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -331,8 +331,8 @@ export class DeepSeekHarnessService extends BaseService {
     const child = this.child
     if (!child) return
     this.stoppingChild = child
-    await terminateProcessTree(child, false, 'DeepSeek Harness')
-    if (await waitForProcessExit(child, GRACEFUL_STOP_TIMEOUT_MS)) return
+    const gracefulStopSucceeded = await terminateProcessTree(child, false, 'DeepSeek Harness')
+    if (gracefulStopSucceeded && (await waitForProcessExit(child, GRACEFUL_STOP_TIMEOUT_MS))) return
 
     await terminateProcessTree(child, true, 'DeepSeek Harness')
     if (!(await waitForProcessExit(child, FORCE_STOP_TIMEOUT_MS))) {

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -474,6 +474,57 @@ describe('DeepSeekHarnessService', () => {
     expect(processKill).not.toHaveBeenCalled()
   })
 
+  it('forces the Windows process tree after graceful cleanup fails', async () => {
+    vi.useFakeTimers()
+    mocks.isWin = true
+    const child = spawnChild((process) => process.stdout.write('dsh web: http://127.0.0.1:43123\n'))
+    mocks.execFile
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: string[],
+          _options: object,
+          callback: (error: Error | null, stdout: string, stderr: string) => void
+        ) => {
+          child.close(null, 'SIGTERM')
+          callback(new Error('taskkill exited with code 128'), '', '')
+        }
+      )
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: string[],
+          _options: object,
+          callback: (error: Error | null, stdout: string, stderr: string) => void
+        ) => {
+          child.close(null, 'SIGKILL')
+          callback(null, '', '')
+        }
+      )
+    const service = new DeepSeekHarnessService()
+    await expect(service.start(startInput)).resolves.toMatchObject({ success: true })
+
+    const stop = service.stop()
+    await vi.advanceTimersByTimeAsync(3000)
+    await stop
+
+    expect(mocks.execFile).toHaveBeenNthCalledWith(
+      1,
+      'taskkill',
+      ['/PID', String(child.pid), '/T'],
+      { windowsHide: true },
+      expect.any(Function)
+    )
+    expect(mocks.execFile).toHaveBeenNthCalledWith(
+      2,
+      'taskkill',
+      ['/PID', String(child.pid), '/T', '/F'],
+      { windowsHide: true },
+      expect.any(Function)
+    )
+    expect(service.getStatus()).toEqual({ status: 'stopped' })
+  })
+
   it('bounds graceful and forced termination below the lifecycle stop ceiling', async () => {
     vi.useFakeTimers()
     const child = spawnChild((process) => process.stdout.write('dsh web: http://127.0.0.1:43123\n'))

--- a/src/main/utils/processRunner.ts
+++ b/src/main/utils/processRunner.ts
@@ -128,21 +128,23 @@ export function killProcessTree(child: ChildProcess): void {
  * Unlike `killProcessTree` (fire-and-forget SIGTERM), this awaits `taskkill` so a
  * caller can pair it with `waitForProcessExit` for graceful-then-forced escalation.
  * `force=false` sends SIGTERM / `taskkill /T`; `force=true` sends SIGKILL /
- * `taskkill /T /F`. Best-effort: a graceful failure against a still-live tree is
- * logged (`label` names the owner in the warning) and a forced failure rethrows;
+ * `taskkill /T /F`. The boolean result reports whether the termination command
+ * succeeded, so callers can escalate even if the wrapper exits before its tree.
  * POSIX signals the negative PID (the detached child's process group) and swallows
  * ESRCH (the group is already gone).
  */
-export async function terminateProcessTree(child: ChildProcess, force: boolean, label: string): Promise<void> {
-  if (!child.pid) return
+export async function terminateProcessTree(child: ChildProcess, force: boolean, label: string): Promise<boolean> {
+  if (!child.pid) return true
   if (isWin) {
     const args = ['/PID', String(child.pid), '/T', ...(force ? ['/F'] : [])]
-    await execFileAsync('taskkill', args, { windowsHide: true }).catch((error) => {
-      if (child.exitCode !== null || child.signalCode !== null) return
+    try {
+      await execFileAsync('taskkill', args, { windowsHide: true })
+      return true
+    } catch (error) {
       if (force) throw error
       logger.warn(`Failed to gracefully stop the managed ${label} process tree`, error as Error)
-    })
-    return
+      return false
+    }
   }
 
   try {
@@ -150,6 +152,7 @@ export async function terminateProcessTree(child: ChildProcess, force: boolean, 
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
   }
+  return true
 }
 
 /** Resolve true once the child exits within `timeoutMs` (or has already exited); false on timeout. */


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A failed graceful Windows `taskkill /PID <pid> /T` could be treated as complete when the managed wrapper had already exited, so forced process-tree cleanup was skipped.

After this PR:

The process-tree helper preserves graceful command failure, allowing DeepSeek Harness and Hermes Dashboard to escalate to `taskkill /PID <pid> /T /F` and surface forced-cleanup failures.

Fixes #20097

### Why we need it and why it was done in this way

The process runner owns platform-specific termination commands, while each lifecycle owns the decision to wait and escalate. Returning the graceful command result keeps that boundary explicit and prevents wrapper exit from hiding a failed tree cleanup command.

The following tradeoffs were made:

The change remains scoped to the managed PID tree and preserves the existing graceful-then-forced lifecycle. Real Windows nested-process validation remains an upstream CI or manual-environment concern.

The following alternatives were considered:

Name-based process termination was rejected because cleanup must remain scoped to the managed PID tree.

Links to places where the discussion took place: #20097

### Breaking changes

None.

### Special notes for your reviewer

The Linux regression fixtures verify graceful-to-forced escalation at the Windows command boundary; they do not establish real Windows descendant liveness.

### Reviewers

@suyao, @kangfenmao, @zhibisora

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Windows managed process trees now escalate failed graceful cleanup instead of treating wrapper exit as successful cleanup.
```
