### PR TITLE
docs(references): fix dead heading anchors in the reference docs

### DIFF
--- a/docs/references/lan-transfer/README.md
+++ b/docs/references/lan-transfer/README.md
@@ -18,13 +18,13 @@ This document defines the LAN file transfer protocol between the Cherry Studio d
 1. [Protocol Overview](#1-protocol-overview)
 2. [Service Discovery (Bonjour/mDNS)](#2-service-discovery-bonjourmdns)
 3. [TCP Connection and Handshake](#3-tcp-connection-and-handshake)
-4. [Message Format Specification](#4-message-format-specification)
+4. [Message Format Specification (Mixed Protocol)](#4-message-format-specification-mixed-protocol)
 5. [File Transfer Protocol](#5-file-transfer-protocol)
 6. [Heartbeat and Keep-alive](#6-heartbeat-and-keep-alive)
 7. [Error Handling](#7-error-handling)
 8. [Constants and Configuration](#8-constants-and-configuration)
 9. [Complete Sequence Diagram](#9-complete-sequence-diagram)
-10. [Mobile Implementation Guide](#10-mobile-implementation-guide)
+10. [Mobile Implementation Guide (v1)](#10-mobile-implementation-guide-v1)
 
 ---
 

--- a/docs/references/window-manager/window-manager-api-reference.md
+++ b/docs/references/window-manager/window-manager-api-reference.md
@@ -144,9 +144,9 @@ For non-pooled windows, the same two endpoints apply without any intermediate st
 | `onWindowCreatedByType(type, listener)` | `(type, listener) => Disposable` | Convenience variant of `onWindowCreated` that filters to a single `WindowType`. Equivalent to `onWindowCreated` + an inline `if (managed.type === type)` guard, but avoids the boilerplate at every call site. Prefer this for single-type subscriptions (the typical consumer case). |
 | `onWindowDestroyedByType(type, listener)` | `(type, listener) => Disposable` | Type-filtered counterpart to `onWindowDestroyed`. Same filtering semantics as `onWindowCreatedByType`. |
 
-The intermediate Released and Recycled stages have no dedicated lifecycle events — side effects on `hide` / `close` / `show` should be expressed as declarative [Platform Quirks](./window-manager-platform.md#platform-quirks), and per-session data on recycle is delivered via the `window.reused` IpcApi payload (see [Init Data](#init-data)).
+The intermediate Released and Recycled stages have no dedicated lifecycle events — side effects on `hide` / `close` / `show` should be expressed as declarative [OS Quirks](./window-manager-platform.md#os-quirks), and per-session data on recycle is delivered via the `window.reused` IpcApi payload (see [Init Data](#init-data)).
 
 **Usage notes for pooled windows:**
 
 - **Do NOT set `paintWhenInitiallyHidden: false`** on pooled windows — it suppresses the native `ready-to-show` event, breaking the pool's fresh-window auto-show path (`showMode === 'auto'` listens for `ready-to-show`). It is NOT an acceptable workaround for "show only when content ready" — use `showMode: 'manual'` + consumer-driven show for that, or rely on the reuse-path `Reused` payload to ensure the renderer has data before `.show()` is called.
-- **macOS focus / hover / always-on-top workarounds** are declarative — see [Platform Quirks](./window-manager-platform.md#platform-quirks).
+- **macOS focus / hover / always-on-top workarounds** are declarative — see [OS Quirks](./window-manager-platform.md#os-quirks).


### PR DESCRIPTION
### What this PR does

Before this PR:

Four in-page links under `docs/references/` point at heading anchors that no longer match their headings, so they resolve to nothing:

- `docs/references/lan-transfer/README.md:21` — the TOC entry for section 4 links to `#4-message-format-specification`, but the heading is `## 4. Message Format Specification (Mixed Protocol)`, whose GitHub anchor is `#4-message-format-specification-mixed-protocol`.
- `docs/references/lan-transfer/README.md:27` — the TOC entry for section 10 links to `#10-mobile-implementation-guide`, but the heading is `## 10. Mobile Implementation Guide (v1)`, anchor `#10-mobile-implementation-guide-v1`.
- `docs/references/window-manager/window-manager-api-reference.md:147` and `:152` — two links to `./window-manager-platform.md#platform-quirks`, but that heading is now `## OS Quirks`, anchor `#os-quirks`.

Nothing catches this today: `scripts/check-doc-links.ts:65` strips the fragment (`rawLink.split('#')[0]`) and only asserts that the target file exists, and `:61` skips anchor-only links entirely.

After this PR:

All four links resolve. The two `lan-transfer` TOC entries now carry the same parenthetical qualifiers as their headings, matching the convention already used by entry 2 of that same TOC (`2. [Service Discovery (Bonjour/mDNS)](#2-service-discovery-bonjourmdns)`). The two `window-manager` links now read `[OS Quirks](.../window-manager-platform.md#os-quirks)`.

A repo-wide scan of every `](...#fragment)` link across all 415 tracked markdown files now reports zero unresolved anchors inside `docs/`.

### Why we need it and why it was done in this way

`docs/references/` is the developer-facing entry point for the LAN transfer protocol and for the window manager. A dead anchor is invisible in CI but user-visible: clicking a table-of-contents entry does nothing, and anyone following a cross-reference lands at the top of the wrong page.

The window-manager drift is confirmed by history rather than guessed: commit `62d39d41f7` (`refactor(window-manager): split metadata into windowOptions/behavior/quirks`, 2026-04-19) renamed `## Platform Quirks` to `## OS Quirks` in `window-manager-platform.md` **and modified `window-manager-api-reference.md` in the same commit** — yet the two inbound anchors were left behind, so those links have been broken since that day. The `lan-transfer` drift is older still: the TOC already omitted the qualifiers before the file was moved to `docs/references/lan-transfer/README.md` in #18848.

The following tradeoffs were made:

Fixing the links instead of renaming the headings back. The headings are the source of truth, and the stale side is unambiguously the link — no content depends on the old anchor names.

The following alternatives were considered:

Adding an anchor check to `check-doc-links.ts`. Deliberately not done here, to keep this PR documentation-only and because a naive anchor check can false-positive on headings whose slugs are generated outside this repo. Happy to open that separately if the maintainers want it.

Links to places where the discussion took place: N/A

### Breaking changes

None — documentation only.

### Special notes for your reviewer

**Scope, and what was deliberately left out.** The same scan turns up three more dead anchors that this PR does not touch, to keep the change inside `docs/`:

- `CLAUDE.md:168` and `CONTRIBUTING.md:67` — both files are currently modified by open PRs, so editing them would create avoidable overlap.
- `src/shared/data/presets/README.md:14` — lives under `src/`, so it is kept out to leave this PR in the docs lane.

Happy to send any of these as a follow-up once the in-flight PRs land.

**Why the other doc gates are unaffected.** Both files are inside the `docs/` scan set, so here is the per-gate reasoning:

- `docs:check-links` — the edited links still point at files that exist; only the fragments changed, and fragments are stripped before the existence check.
- `docs:check-frontmatter` / `docs:check-structure` — no frontmatter key and no reference domain was changed.
- `docs:check-index` — only validates the generated `docs/README.md`; the two pages edited here are hand-written and not part of that generated index.
- `oxfmt` does not format markdown (`.oxfmtrc.json` → `ignorePatterns` includes `**/*.md`).

No line endings were touched either — `git diff` shows exactly four changed lines, with no file rewritten end to end.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every-programmer-should-know/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
