### PR TITLE
test(agent): cover unsupported reasoning summary parameters

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -1249,6 +1249,42 @@ describe('buildAgentParams assistant-less reasoning', () => {
     })
   })
 
+  it('omits reasoning.summary for a Responses endpoint without explicit support', async () => {
+    resolveProviderAiSdkConfigMock.mockResolvedValue({
+      config: { providerId: 'newapi', providerSettings: {} },
+      credentialReceipt: { attribution: 'unknown' }
+    })
+    const provider = makeProvider({
+      id: 'new-api',
+      presetProviderId: 'new-api',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+      endpointConfigs: { [ENDPOINT_TYPE.OPENAI_RESPONSES]: { adapterFamily: 'newapi' } }
+    })
+    const model = makeModel({
+      id: 'new-api::gpt-5.6-sol',
+      providerId: 'new-api',
+      apiModelId: 'gpt-5.6-sol',
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES],
+      capabilities: [MODEL_CAPABILITY.REASONING],
+      reasoning: {
+        controls: [{ kind: 'effort', values: ['low', 'medium', 'high'] }],
+        selectableEfforts: ['low', 'medium', 'high']
+      }
+    })
+    const assistant = makeAssistant({ settings: { reasoning_effort: 'high', reasoning_summary: 'detailed' } })
+
+    const result = await buildAgentParams({
+      request: { conversation: CONVERSATION },
+      signal: undefined,
+      provider,
+      model,
+      assistant
+    })
+
+    expect(result.options.providerOptions?.openai).toMatchObject({ reasoningEffort: 'high' })
+    expect(result.options.providerOptions?.openai).not.toHaveProperty('reasoningSummary')
+  })
+
   const makeOffCapableSetup = () => {
     resolveProviderAiSdkConfigMock.mockResolvedValue({
       config: {


### PR DESCRIPTION
### What this PR does

Before this PR:

The unsupported Responses endpoint case lacked Agent-level regression coverage.

After this PR:

An Agent parameter test verifies that reasoning summary is omitted unless the endpoint explicitly supports it.

Fixes #20364

### Why we need it and why it was done in this way

The following tradeoffs were made:

The production capability gate is unchanged; this adds focused coverage at the Agent request-construction boundary.

The following alternatives were considered:

Stripping the field in the final serializer was not selected because it would also remove explicitly supported endpoint configurations.

Links to places where the discussion took place: #20364

### Breaking changes

No breaking changes.

### Special notes for your reviewer

The base already contains the capability-aware behavior; this contribution adds the missing negative regression test. Suggested reviewers: Dante, SuYao, Phantom.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
