### PR TITLE
fix(model-list): list all LM Studio models

### DIFF
--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -93,6 +93,16 @@ function makeGeminiProvider() {
   })
 }
 
+function makeLmStudioProvider() {
+  return makeProvider({
+    id: 'lmstudio',
+    defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'http://lmstudio.test:1234' }
+    }
+  })
+}
+
 describe('listModels — default grouping', () => {
   it('surfaces strict listing errors without writing provider error details to logs', async () => {
     const apiKey = 'sk-should-not-reach-logs'
@@ -216,6 +226,85 @@ describe('listModels — TokenDance protocol routing', () => {
 
     expect(models[0].endpointTypes).toEqual([ENDPOINT_TYPE.ANTHROPIC_MESSAGES])
   })
+})
+
+describe('listModels — LM Studio', () => {
+  it("lists the complete catalog from LM Studio's model endpoint", async () => {
+    aiSdkGetFromApiMock.mockResolvedValueOnce({
+      value: {
+        data: [{ id: 'loaded-model' }, { id: 'downloaded-but-not-loaded-model' }]
+      }
+    })
+
+    const models = await listModels(makeLmStudioProvider())
+
+    expect(aiSdkGetFromApiMock.mock.calls[0][0]).toMatchObject({
+      url: 'http://lmstudio.test:1234/api/v0/models'
+    })
+    expect(models.map((model) => model.apiModelId)).toEqual(['loaded-model', 'downloaded-but-not-loaded-model'])
+  })
+
+  it('maps embedding and vision metadata from the LM Studio catalog', async () => {
+    aiSdkGetFromApiMock.mockResolvedValueOnce({
+      value: {
+        data: [
+          { id: 'embedding-model', type: 'embeddings', max_context_length: 2048 },
+          { id: 'vision-model', type: 'vlm', max_context_length: 32768 }
+        ]
+      }
+    })
+
+    const models = await listModels(makeLmStudioProvider())
+
+    expect(models[0]).toMatchObject({
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_EMBEDDINGS],
+      capabilities: [MODEL_CAPABILITY.EMBEDDING],
+      contextWindow: 2048
+    })
+    expect(models[1]).toMatchObject({
+      capabilities: [MODEL_CAPABILITY.IMAGE_RECOGNITION],
+      contextWindow: 32768
+    })
+  })
+
+  it('falls back to /v1/models for older LM Studio servers', async () => {
+    aiSdkGetFromApiMock.mockRejectedValueOnce(new Error('404 Not Found'))
+    aiSdkGetFromApiMock.mockResolvedValueOnce({ value: { data: [{ id: 'legacy-model' }] } })
+
+    const models = await listModels(makeLmStudioProvider())
+
+    expect(aiSdkGetFromApiMock.mock.calls[0][0]).toMatchObject({
+      url: 'http://lmstudio.test:1234/api/v0/models'
+    })
+    expect(aiSdkGetFromApiMock.mock.calls[1][0]).toMatchObject({
+      url: 'http://lmstudio.test:1234/v1/models'
+    })
+    expect(models[0]).toMatchObject({ apiModelId: 'legacy-model' })
+  })
+
+  it.each(['http://lmstudio.test:1234/api/v0', 'http://lmstudio.test:1234/v1/', 'http://lmstudio.test:1234#'])(
+    'normalizes %s to the server root',
+    async (baseUrl) => {
+      const provider = makeProvider({
+        id: 'lmstudio',
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl }
+        }
+      })
+      aiSdkGetFromApiMock.mockRejectedValueOnce(new Error('404 Not Found'))
+      aiSdkGetFromApiMock.mockResolvedValueOnce({ value: { data: [{ id: 'legacy-model' }] } })
+
+      await listModels(provider)
+
+      expect(aiSdkGetFromApiMock.mock.calls[0][0]).toMatchObject({
+        url: 'http://lmstudio.test:1234/api/v0/models'
+      })
+      expect(aiSdkGetFromApiMock.mock.calls[1][0]).toMatchObject({
+        url: 'http://lmstudio.test:1234/v1/models'
+      })
+    }
+  )
 })
 
 describe('listModels — Ollama capabilities', () => {

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -51,6 +51,7 @@ import {
   AnthropicModelsResponseSchema,
   CopilotModelsResponseSchema,
   GeminiModelsResponseSchema,
+  LMStudioModelsResponseSchema,
   NewApiModelsResponseSchema,
   OllamaShowResponseSchema,
   OllamaTagsResponseSchema,
@@ -806,6 +807,52 @@ const openAICompatibleFetcher: ModelFetcher = {
   }
 }
 
+const lmStudioFetcher: ModelFetcher = {
+  match: (p) => matchesPreset(p, SystemProviderIds.lmstudio),
+  fetch: async (provider, signal) => {
+    const root = withoutTrailingApiVersion(formatApiHost(getBaseUrl(provider), false).replace(/\/api\/v0$/, ''))
+    let response: z.infer<typeof LMStudioModelsResponseSchema>
+    try {
+      response = await getFromApi({
+        url: `${root}/api/v0/models`,
+        headers: defaultHeaders(provider),
+        responseSchema: LMStudioModelsResponseSchema,
+        abortSignal: signal
+      })
+    } catch (error) {
+      logger.warn('LM Studio /api/v0/models failed; falling back to /v1/models', {
+        providerId: provider.id,
+        errorType: getErrorType(error)
+      })
+      const baseUrl = formatApiHost(root)
+      const fallback = await getFromApi({
+        url: `${baseUrl}/models`,
+        headers: defaultHeaders(provider),
+        responseSchema: OpenAIModelsResponseSchema,
+        abortSignal: signal
+      })
+      return dedup(fallback.data, (m) => m.id).map((m) =>
+        toModel(m.id, provider, { name: m.name || m.id, ownedBy: m.owned_by })
+      )
+    }
+
+    return dedup(response.data, (m) => m.id).map((m) => {
+      const type = m.type?.toLowerCase()
+      const endpointTypes = type?.startsWith('embedding') ? [ENDPOINT_TYPE.OPENAI_EMBEDDINGS] : undefined
+      const capability =
+        endpointImpliedCapability(endpointTypes?.[0]) ??
+        (type === 'vlm' ? MODEL_CAPABILITY.IMAGE_RECOGNITION : undefined)
+
+      return toModel(m.id, provider, {
+        ownedBy: m.publisher,
+        ...(endpointTypes ? { endpointTypes } : {}),
+        ...(capability ? { capabilities: [capability] } : {}),
+        ...(m.max_context_length ? { contextWindow: m.max_context_length } : {})
+      })
+    })
+  }
+}
+
 // ── Ollama probe ──
 
 /** Lightweight model-existence check for Ollama — avoids loading the model into memory. */
@@ -840,6 +887,7 @@ export async function probeOllamaModel(
 const fetchers: ModelFetcher[] = [
   aiHubMixFetcher,
   ollamaFetcher,
+  lmStudioFetcher,
   geminiFetcher,
   vertexFetcher,
   copilotFetcher,

--- a/src/main/ai/provider/listModelsSchemas.ts
+++ b/src/main/ai/provider/listModelsSchemas.ts
@@ -22,6 +22,32 @@ export const OpenAIModelsResponseSchema = z.object({
   object: z.string().optional()
 })
 
+/**
+ * `GET /api/v0/models` lists loaded and downloaded LM Studio models, unlike `/v1/models`.
+ */
+export const LMStudioModelsResponseSchema = z.object({
+  data: z.array(
+    z.looseObject({
+      id: z.string(),
+      type: z
+        .string()
+        .nullable()
+        .optional()
+        .transform((v) => v ?? undefined),
+      publisher: z
+        .string()
+        .nullable()
+        .optional()
+        .transform((v) => v ?? undefined),
+      max_context_length: z
+        .number()
+        .nullable()
+        .optional()
+        .transform((v) => v ?? undefined)
+    })
+  )
+})
+
 // === GitHub Copilot (/models) ===
 export const CopilotModelsResponseSchema = z.object({
   data: z.array(


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: LM Studio model synchronization queried the generic `/v1/models` endpoint, which can omit available models.

After this PR: LM Studio synchronization queries `/api/v0/models`, maps its catalog metadata, and falls back to `/v1/models` for older servers.

Fixes #20274

### Why we need it and why it was done in this way

The LM Studio catalog endpoint represents the complete model list while the generic endpoint can be partial under loading settings.

The following tradeoffs were made: provider-specific endpoint selection is used for LM Studio, while the older endpoint remains available for older servers.

The following alternatives were considered: changing the generic OpenAI-compatible path or repairing the list after discovery.

Links to places where the discussion took place: Issue #20274

### Breaking changes

None.

### Special notes for your reviewer

The malformed-entry continuation and UI skip-reason behavior described in the issue are not changed by this PR.

### Reviewers

SuYao, Phantom, Dante

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix incomplete LM Studio model synchronization.
```
