### PR TITLE
fix(agent-runtime): classify Claude Code API result failures

### DIFF
--- a/src/main/ai/utils/__tests__/serializeError.test.ts
+++ b/src/main/ai/utils/__tests__/serializeError.test.ts
@@ -4,6 +4,22 @@ import { describe, expect, it } from 'vitest'
 import { serializeError } from '../serializeError'
 
 describe('serializeError', () => {
+  it('preserves safe classification fields from a Claude Code API result error', () => {
+    const error = Object.assign(new Error('API Error: 400 Internal server error'), {
+      name: 'ClaudeCodeResultError',
+      apiErrorStatus: 400,
+      errors: ['API Error: 400 Internal server error'],
+      terminalReason: 'api_error'
+    })
+
+    expect(serializeError(error)).toMatchObject({
+      name: 'ClaudeCodeResultError',
+      message: 'API Error: 400 Internal server error',
+      providerErrorCategory: 'server',
+      statusCode: 400
+    })
+  })
+
   it('retains quota diagnosis in serialized retry errors without retaining the payload', () => {
     const error = new APICallError({
       message: 'Rate limit exceeded',

--- a/src/main/ai/utils/serializeError.ts
+++ b/src/main/ai/utils/serializeError.ts
@@ -3,7 +3,7 @@ import { APICallError, RetryError } from 'ai'
 import { getSafeProviderErrorMessage, serializeNestedProviderError } from '@shared/ai/providerError'
 import type { SerializedError } from '@shared/types/error'
 import type { Serializable } from '@shared/types/serializable'
-import { isErrorCategory } from '@shared/utils/errorCategory'
+import { classifyErrorCategory, isErrorCategory } from '@shared/utils/errorCategory'
 
 /** Lenient JSON serialization with circular-reference safety.
  *  Returns null for absent values so callers can preserve the `string | null`
@@ -45,6 +45,20 @@ export function serializeError(error: unknown): SerializedError {
       message: isRetryError ? getSafeProviderErrorMessage({ message: error.message }) : error.message,
       stack: isRetryError ? null : (error.stack ?? null),
       cause: e.cause != null ? String(e.cause) : null
+    }
+
+    if (error.name === 'ClaudeCodeResultError') {
+      const status = typeof e.apiErrorStatus === 'number' ? e.apiErrorStatus : undefined
+      const details = Array.isArray(e.errors)
+        ? e.errors.filter((value): value is string => typeof value === 'string')
+        : []
+      serialized.providerErrorCategory = classifyErrorCategory({
+        text: [error.message, ...details, e.terminalReason]
+          .filter((value): value is string => typeof value === 'string')
+          .join('\n'),
+        status
+      })
+      if (status !== undefined) serialized.statusCode = status
     }
 
     if ('url' in e) serialized.url = String(e.url ?? '')


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Claude Code API result errors lost their HTTP status during serialization, leaving the renderer with an opaque generic error.

After this PR:
The serializer preserves the numeric API status and derives the existing provider error category without exposing provider payloads.

Fixes #20094

### Why we need it and why it was done in this way

The serializer owns the safe renderer-facing error shape, so this change restores the existing status and classification fields at that boundary. Automatic replay is not included because a failed multi-step Agent task may already have performed tool side effects.

The following tradeoffs were made:

The change preserves safe diagnostic discriminants while leaving task recovery for a separate checkpoint and side-effect design.

The following alternatives were considered:

Automatically replaying the whole Agent task could repeat completed tool side effects.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Suggested reviewers: Siin Xu, jd, and suyao.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Improved Claude Code Agent error classification for upstream API failures.
```
