### PR TITLE
fix(ai): stabilize OpenRouter session routing

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -610,6 +610,47 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     )
   })
 
+  it('adds a stable opaque OpenRouter session header to direct Claude SDK requests', async () => {
+    mocks.getProviderByProviderId.mockReturnValue({
+      id: 'my-router',
+      presetProviderId: 'openrouter',
+      endpointConfigs: {
+        'anthropic-messages': { adapterFamily: 'anthropic', baseUrl: 'https://openrouter.ai/api' }
+      }
+    })
+
+    const first = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+    const repeated = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+    mocks.getSessionById.mockReturnValue({
+      id: 'session-2',
+      agentId: 'agent-1',
+      workspace: { type: 'user', path: '/workspace/project' }
+    })
+    const second = await buildClaudeCodeQueryRequestForAgentSession('session-2')
+
+    const firstHeader = first?.settings.env?.ANTHROPIC_CUSTOM_HEADERS
+    const repeatedHeader = repeated?.settings.env?.ANTHROPIC_CUSTOM_HEADERS
+    const secondHeader = second?.settings.env?.ANTHROPIC_CUSTOM_HEADERS
+    expect(firstHeader).toMatch(/^x-session-id: cherry-agent:[0-9a-f]{32}$/)
+    expect(firstHeader).not.toContain('session-1')
+    expect(repeatedHeader).toBe(firstHeader)
+    expect(secondHeader).not.toBe(firstHeader)
+  })
+
+  it('recognizes the OpenRouter adapter and preserves a case-insensitive explicit session header', async () => {
+    mocks.getProviderByProviderId.mockReturnValue({
+      id: 'custom-router',
+      endpointConfigs: {
+        'anthropic-messages': { adapterFamily: 'openrouter', baseUrl: 'https://openrouter.ai/api' }
+      },
+      settings: { extraHeaders: { 'X-Session-Id': 'chosen-session', 'x-tenant': 'tenant-1' } }
+    })
+
+    const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(request?.settings.env?.ANTHROPIC_CUSTOM_HEADERS).toBe('X-Session-Id: chosen-session\nx-tenant: tenant-1')
+  })
+
   it('uses the provider Anthropic endpoint directly when all selected models belong to that provider', async () => {
     mocks.getLastRuntimeResumeToken.mockReturnValue(null)
 

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -19,6 +19,7 @@ import {
   resolveLinkedNotifyChannel
 } from '@main/ai/runtime/agentMcpServers'
 import { getEffectiveAgentLanguage } from '@main/ai/utils/agentLanguage'
+import { deriveAgentSessionRoutingKey, usesOpenRouterSessionRouting } from '@main/ai/utils/agentSessionRouting'
 import { resolveKnowledgeBaseScope } from '@main/ai/utils/knowledgeScope'
 import { encodeReasoningInvocation, resolveReasoningInvocation } from '@main/ai/utils/reasoningSerializers'
 import { createAiUsagePricingSnapshot } from '@main/ai/utils/usageCapture'
@@ -807,11 +808,18 @@ async function resolveClaudeCodeRuntimeRoute(
       const resolvedApiKey = providerService.resolveApiKey(primaryProvider.id)
       const runtimeApiKey =
         resolvedApiKey.value || (isOllamaProvider(primaryProvider) ? OLLAMA_PLACEHOLDER_AUTH_TOKEN : '')
+      const sessionRoutingHeaders = usesOpenRouterSessionRouting(
+        primaryProvider,
+        resolveEffectiveEndpoint(primaryProvider, primaryModel, ENDPOINT_TYPE.ANTHROPIC_MESSAGES).endpointType
+      )
+        ? { 'x-session-id': deriveAgentSessionRoutingKey(sessionId) }
+        : undefined
       return {
         ...facts,
         apiKey: runtimeApiKey,
         customHeaders: mergeAnthropicCustomHeaders(
           getProviderAppHeaders(primaryProvider),
+          sessionRoutingHeaders,
           getExtraHeaders(primaryProvider)
         ),
         usageCapture: {

--- a/src/main/ai/runtime/dsh/__tests__/modelInjection.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/modelInjection.test.ts
@@ -296,6 +296,73 @@ describe('resolveDshProviderInjectionFromSnapshot', () => {
     expect(mocks.resolveApiGatewayRuntime).not.toHaveBeenCalled()
   })
 
+  it('adds a stable opaque session header to copied OpenRouter preset routes', async () => {
+    const provider = {
+      ...nativeProvider,
+      id: 'my-router',
+      presetProviderId: 'openrouter',
+      defaultChatEndpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: {
+          adapterFamily: 'anthropic',
+          baseUrl: 'https://openrouter.ai/api'
+        }
+      }
+    } as unknown as Provider
+    const model = makeModel({
+      id: 'my-router::anthropic/claude-sonnet-4',
+      providerId: 'my-router',
+      apiModelId: 'anthropic/claude-sonnet-4',
+      endpointTypes: [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+    })
+
+    const first = await resolveDshProviderInjectionFromSnapshot('session-1', provider, model)
+    const repeated = await resolveDshProviderInjectionFromSnapshot('session-1', provider, model)
+    const second = await resolveDshProviderInjectionFromSnapshot('session-2', provider, model)
+
+    const key = first.headers?.['x-session-id']
+    expect(key).toMatch(/^cherry-agent:[0-9a-f]{32}$/)
+    expect(key).not.toContain('session-1')
+    expect(repeated.headers?.['x-session-id']).toBe(key)
+    expect(second.headers?.['x-session-id']).not.toBe(key)
+  })
+
+  it('recognizes an OpenRouter adapter and preserves an explicit header regardless of casing', async () => {
+    const provider = {
+      ...nativeProvider,
+      id: 'custom-router',
+      presetProviderId: undefined,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+          adapterFamily: 'openrouter',
+          baseUrl: 'https://openrouter.ai/api/v1'
+        }
+      }
+    } as unknown as Provider
+    const model = makeModel({
+      id: 'custom-router::openai/gpt-5.6',
+      providerId: 'custom-router',
+      apiModelId: 'openai/gpt-5.6',
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+
+    const injected = await resolveDshProviderInjectionFromSnapshot('session-1', provider, model)
+    const explicit = await resolveDshProviderInjectionFromSnapshot(
+      'session-1',
+      {
+        ...provider,
+        settings: { extraHeaders: { 'X-Session-Id': 'chosen-session', 'x-tenant': 'tenant-1' } }
+      },
+      model
+    )
+
+    expect(injected.headers?.['x-session-id']).toMatch(/^cherry-agent:[0-9a-f]{32}$/)
+    expect(explicit.headers).toEqual({
+      'X-Session-Id': 'chosen-session',
+      'x-tenant': 'tenant-1'
+    })
+  })
+
   it('falls back to the gateway without consuming native key rotation', async () => {
     const injection = await resolveDshProviderInjectionFromSnapshot('session-1', vertexProvider, makeModel())
 

--- a/src/main/ai/runtime/dsh/modelInjection.ts
+++ b/src/main/ai/runtime/dsh/modelInjection.ts
@@ -14,6 +14,7 @@ import type { ReasoningEffort } from '@cherrystudio/provider-registry'
 import type { AiUsageCredentialReceipt } from '@data/services/AiUsageRecordService'
 import { modelService } from '@data/services/ModelService'
 import { providerService } from '@data/services/ProviderService'
+import { deriveAgentSessionRoutingKey, usesOpenRouterSessionRouting } from '@main/ai/utils/agentSessionRouting'
 import { getExtraHeaders } from '@main/ai/utils/provider'
 import { createAiUsagePricingSnapshot } from '@main/ai/utils/usageCapture'
 import { type DshApi, mapEndpointToDshApi, resolveDshEndpointType } from '@shared/ai/dshModelCompatibility'
@@ -321,13 +322,24 @@ export async function resolveDshProviderInjectionFromSnapshot(
   if (enabledApiKeys && !enabledApiKeys.some((entry) => entry.key === resolvedApiKey.value)) {
     throw new Error(`dsh provider credentials changed during materialization: ${provider.id}`)
   }
-  return buildDshProviderInjection(
+  const injection = buildDshProviderInjection(
     provider,
     model,
     resolvedApiKey.value,
     resolvedApiKey.apiKeySelection,
     reasoningEffort
   )
+  const resolvedEndpoint = resolveDshEndpoint(provider, model)
+  if (
+    usesOpenRouterSessionRouting(provider, resolvedEndpoint.endpointType) &&
+    !Object.keys(injection.headers ?? {}).some((name) => name.toLowerCase() === 'x-session-id')
+  ) {
+    injection.headers = {
+      ...injection.headers,
+      'x-session-id': deriveAgentSessionRoutingKey(sessionId)
+    }
+  }
+  return injection
 }
 
 /**

--- a/src/main/ai/runtime/pi/modelInjection.test.ts
+++ b/src/main/ai/runtime/pi/modelInjection.test.ts
@@ -635,6 +635,56 @@ describe('OpenCode Pi session headers', () => {
   })
 })
 
+describe('OpenRouter Pi session headers', () => {
+  beforeEach(() => {
+    serviceMocks.resolveApiKey.mockReturnValue({ value: REAL_KEY })
+  })
+
+  afterEach(() => {
+    serviceMocks.resolveApiKey.mockReset()
+  })
+
+  const provider = makeProvider({
+    id: 'my-router',
+    presetProviderId: 'openrouter',
+    defaultChatEndpoint: 'openai-chat-completions',
+    endpointConfigs: {
+      'openai-chat-completions': { adapterFamily: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1' }
+    }
+  })
+  const model = makeModel({
+    providerId: provider.id,
+    endpointTypes: ['openai-chat-completions']
+  })
+
+  it('keeps an opaque session header stable and isolates sessions', async () => {
+    const first = await resolvePiProviderInjectionForSession('session-1', provider, model)
+    const repeated = await resolvePiProviderInjectionForSession('session-1', provider, model)
+    const second = await resolvePiProviderInjectionForSession('session-2', provider, model)
+
+    const key = first.providerConfig.headers?.['x-session-id']
+    expect(key).toMatch(/^cherry-agent:[0-9a-f]{32}$/)
+    expect(key).not.toContain('session-1')
+    expect(repeated.providerConfig.headers?.['x-session-id']).toBe(key)
+    expect(second.providerConfig.headers?.['x-session-id']).not.toBe(key)
+  })
+
+  it('recognizes the OpenRouter adapter and preserves an explicit header regardless of casing', async () => {
+    const configured = {
+      ...provider,
+      id: 'custom-router',
+      presetProviderId: undefined,
+      settings: { extraHeaders: { 'X-Session-Id': 'chosen-session', 'x-tenant': 'tenant-1' } }
+    }
+    const injection = await resolvePiProviderInjectionForSession('session-1', configured, model)
+
+    expect(injection.providerConfig.headers).toEqual({
+      'X-Session-Id': 'chosen-session',
+      'x-tenant': 'tenant-1'
+    })
+  })
+})
+
 describe('Cherry Cloud Pi injection', () => {
   const provider = makeProvider({
     id: CHERRY_CLOUD_PROVIDER_ID,

--- a/src/main/ai/runtime/pi/modelInjection.ts
+++ b/src/main/ai/runtime/pi/modelInjection.ts
@@ -16,6 +16,7 @@ import { application } from '@application'
 import type { AiUsageCredentialReceipt } from '@data/services/AiUsageRecordService'
 import { modelService } from '@data/services/ModelService'
 import { providerService } from '@data/services/ProviderService'
+import { deriveAgentSessionRoutingKey, usesOpenRouterSessionRouting } from '@main/ai/utils/agentSessionRouting'
 import { getExtraHeaders } from '@main/ai/utils/provider'
 import { createAiUsagePricingSnapshot } from '@main/ai/utils/usageCapture'
 import { mapEndpointToPiApi, type PiApi } from '@shared/ai/piModelCompatibility'
@@ -328,11 +329,20 @@ export async function resolvePiProviderInjectionForSession(
   if (!usesPiGateway(provider)) {
     const injection = resolvePiProviderInjectionFromSnapshot(provider, model, enabledApiKeys)
     const headers = injection.providerConfig.headers
+    const resolvedEndpoint = resolvePiEndpoint(provider, model)
     if (
       matchesPreset(provider, SystemProviderIds.opencode) &&
       !Object.keys(headers ?? {}).some((name) => name.toLowerCase() === 'x-opencode-session')
     ) {
       injection.providerConfig.headers = { ...headers, ...toPiHeaders({ 'x-opencode-session': sessionId }) }
+    } else if (
+      usesOpenRouterSessionRouting(provider, resolvedEndpoint.endpointType) &&
+      !Object.keys(headers ?? {}).some((name) => name.toLowerCase() === 'x-session-id')
+    ) {
+      injection.providerConfig.headers = {
+        ...headers,
+        ...toPiHeaders({ 'x-session-id': deriveAgentSessionRoutingKey(sessionId) })
+      }
     }
     return injection
   }

--- a/src/main/ai/utils/agentSessionRouting.ts
+++ b/src/main/ai/utils/agentSessionRouting.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'node:crypto'
+
+import type { EndpointType } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+import { matchesPreset } from '@shared/utils/provider'
+import { SystemProviderIds } from '@shared/utils/systemProviderId'
+
+export function deriveAgentSessionRoutingKey(sessionId: string): string {
+  const digest = createHash('sha256').update(sessionId).digest('hex')
+  return `cherry-agent:${digest.slice(0, 32)}`
+}
+
+export function usesOpenRouterSessionRouting(provider: Provider, endpointType: EndpointType | undefined): boolean {
+  return (
+    matchesPreset(provider, SystemProviderIds.openrouter) ||
+    (endpointType !== undefined &&
+      provider.endpointConfigs?.[endpointType]?.adapterFamily === SystemProviderIds.openrouter)
+  )
+}

--- a/src/main/features/apiGateway/__tests__/promptCacheKey.test.ts
+++ b/src/main/features/apiGateway/__tests__/promptCacheKey.test.ts
@@ -1,5 +1,6 @@
 import { createOpenAI } from '@ai-sdk/openai'
-import { generateText } from 'ai'
+import { createOpenRouter } from '@openrouter/ai-sdk-provider'
+import { generateText, streamText } from 'ai'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ENDPOINT_TYPE, type EndpointType, type Model } from '@shared/data/types/model'
@@ -34,6 +35,8 @@ const SESSION_ID = '018f2f45-agent-session'
 
 const openaiProvider = provider('my-openai', ENDPOINT_TYPE.OPENAI_RESPONSES, 'openai')
 const openaiModel = model('my-openai', ENDPOINT_TYPE.OPENAI_RESPONSES)
+const openRouterProvider = provider('my-router', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, 'openrouter')
+const openRouterModel = model('my-router', ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS)
 
 describe('applyAgentPromptCacheKey', () => {
   it('derives a stable opaque key for the same session and distinct keys across sessions', () => {
@@ -80,6 +83,25 @@ describe('applyAgentPromptCacheKey', () => {
     expect(applyAgentPromptCacheKey(anthropicProvider, anthropicModel, options, SESSION_ID)).toBe(options)
   })
 
+  it('derives a stable opaque OpenRouter session_id without overriding explicit options', () => {
+    const first = applyAgentPromptCacheKey(openRouterProvider, openRouterModel, {}, SESSION_ID)
+    const repeated = applyAgentPromptCacheKey(openRouterProvider, openRouterModel, {}, SESSION_ID)
+    const other = applyAgentPromptCacheKey(openRouterProvider, openRouterModel, {}, 'another-session')
+    const explicit = applyAgentPromptCacheKey(
+      openRouterProvider,
+      openRouterModel,
+      { openrouter: { session_id: 'caller-session', reasoning: { effort: 'high' } } },
+      SESSION_ID
+    )
+
+    const key = first.openrouter?.session_id
+    expect(key).toMatch(/^cherry-agent:[0-9a-f]{32}$/)
+    expect(key).not.toContain(SESSION_ID)
+    expect(repeated.openrouter?.session_id).toBe(key)
+    expect(other.openrouter?.session_id).not.toBe(key)
+    expect(explicit.openrouter).toEqual({ session_id: 'caller-session', reasoning: { effort: 'high' } })
+  })
+
   // Contract tripwire against @ai-sdk/openai: the options object OUR helper
   // produces must reach the wire as `prompt_cache_key`. Catches both a wrong
   // namespace on our side and an SDK upgrade that stops serializing the field.
@@ -114,5 +136,51 @@ describe('applyAgentPromptCacheKey', () => {
 
     const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string)
     expect(body.prompt_cache_key).toBe(providerOptions.openai.promptCacheKey)
+  })
+
+  it('is serialized as session_id on the OpenRouter Chat wire', async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: 'gen-1',
+            created: 1,
+            model: 'openai/gpt-5.6',
+            choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    )
+    const openrouter = createOpenRouter({ apiKey: 'test-key', fetch: fetchMock as unknown as typeof fetch })
+    const providerOptions = applyAgentPromptCacheKey(openRouterProvider, openRouterModel, {}, SESSION_ID)
+
+    await generateText({ model: openrouter.chat('openai/gpt-5.6'), prompt: 'ping', providerOptions })
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string)
+    expect(body.session_id).toBe(providerOptions.openrouter.session_id)
+  })
+
+  it('is serialized as session_id on the streaming OpenRouter Chat wire', async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          [
+            'data: {"id":"gen-1","created":1,"model":"openai/gpt-5.6","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}',
+            'data: {"id":"gen-1","created":1,"model":"openai/gpt-5.6","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}',
+            'data: [DONE]',
+            ''
+          ].join('\n\n'),
+          { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+        )
+    )
+    const openrouter = createOpenRouter({ apiKey: 'test-key', fetch: fetchMock as unknown as typeof fetch })
+    const providerOptions = applyAgentPromptCacheKey(openRouterProvider, openRouterModel, {}, SESSION_ID)
+
+    const result = streamText({ model: openrouter.chat('openai/gpt-5.6'), prompt: 'ping', providerOptions })
+    await result.text
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string)
+    expect(body.session_id).toBe(providerOptions.openrouter.session_id)
   })
 })

--- a/src/main/features/apiGateway/__tests__/proxyStream.promptCacheKey.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.promptCacheKey.test.ts
@@ -10,11 +10,19 @@ import { createUniqueModelId, ENDPOINT_TYPE } from '@shared/data/types/model'
  * external requests must not.
  */
 
-const { mockStreamPrompt, mockGetProvider, mockListModels, mockGetAgentSessionId, captured } = vi.hoisted(() => ({
+const {
+  mockStreamPrompt,
+  mockGetProvider,
+  mockListModels,
+  mockGetAgentSessionId,
+  mockExtractProviderOptions,
+  captured
+} = vi.hoisted(() => ({
   mockStreamPrompt: vi.fn(),
   mockGetProvider: vi.fn(),
   mockListModels: vi.fn(),
   mockGetAgentSessionId: vi.fn(),
+  mockExtractProviderOptions: vi.fn(),
   captured: {
     opts: undefined as
       | { listener?: StreamListener; callOverrides?: { providerOptions?: Record<string, Record<string, unknown>> } }
@@ -52,7 +60,7 @@ vi.mock('../adapters', () => ({
       toUIMessages: () => [],
       toAiSdkTools: () => undefined,
       extractStreamOptions: () => ({}),
-      extractProviderOptions: () => undefined
+      extractProviderOptions: mockExtractProviderOptions
     })
   },
   StreamAdapterFactory: {
@@ -74,6 +82,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   captured.opts = undefined
   mockGetAgentSessionId.mockReturnValue(undefined)
+  mockExtractProviderOptions.mockReturnValue(undefined)
   mockGetProvider.mockReturnValue({
     id: PROVIDER_ID,
     name: PROVIDER_ID,
@@ -96,10 +105,10 @@ beforeEach(() => {
   })
 })
 
-async function resolveRequest(): Promise<Record<string, Record<string, unknown>> | undefined> {
+async function resolveRequest(stream = false): Promise<Record<string, Record<string, unknown>> | undefined> {
   captured.opts = undefined
   const promise = processMessage({
-    params: { model: `${PROVIDER_ID}:${MODEL_ID}`, messages: [] },
+    params: { model: `${PROVIDER_ID}:${MODEL_ID}`, messages: [], stream },
     inputFormat: 'openai',
     outputFormat: 'openai',
     requestHeaders: new Headers()
@@ -138,5 +147,77 @@ describe('processMessage internal Agent prompt cache key', () => {
     const providerOptions = await resolveRequest()
 
     expect(providerOptions?.openai?.promptCacheKey).toBeUndefined()
+  })
+})
+
+describe('processMessage internal Agent OpenRouter session routing', () => {
+  beforeEach(() => {
+    mockGetProvider.mockReturnValue({
+      id: PROVIDER_ID,
+      name: PROVIDER_ID,
+      isEnabled: true,
+      presetProviderId: 'openrouter',
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+          baseUrl: 'https://openrouter.ai/api/v1',
+          adapterFamily: 'openrouter'
+        }
+      }
+    })
+    mockListModels.mockReturnValue([
+      {
+        id: createUniqueModelId(PROVIDER_ID, MODEL_ID),
+        providerId: PROVIDER_ID,
+        apiModelId: MODEL_ID,
+        capabilities: [],
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+      }
+    ])
+  })
+
+  it.each([false, true])('adds stable opaque session_id for authenticated stream=%s requests', async (stream) => {
+    mockGetAgentSessionId.mockReturnValue('agent-session-1')
+
+    const first = await resolveRequest(stream)
+    const repeated = await resolveRequest(stream)
+
+    const key = first?.openrouter?.session_id
+    expect(key).toMatch(/^cherry-agent:[0-9a-f]{32}$/)
+    expect(key).not.toContain('agent-session-1')
+    expect(repeated?.openrouter?.session_id).toBe(key)
+  })
+
+  it('isolates sessions and preserves caller-provided OpenRouter options', async () => {
+    mockExtractProviderOptions.mockReturnValue({ openrouter: { reasoning: { effort: 'high' } } })
+    mockGetAgentSessionId.mockReturnValue('agent-session-1')
+    const first = await resolveRequest()
+
+    mockGetAgentSessionId.mockReturnValue('agent-session-2')
+    const second = await resolveRequest()
+
+    expect(first?.openrouter?.reasoning).toEqual({ effort: 'high' })
+    expect(second?.openrouter?.session_id).not.toBe(first?.openrouter?.session_id)
+
+    mockExtractProviderOptions.mockReturnValue({ openrouter: { session_id: 'caller-session' } })
+    expect((await resolveRequest())?.openrouter?.session_id).toBe('caller-session')
+  })
+
+  it('adds no session_id for sessionless requests or unrelated providers', async () => {
+    expect((await resolveRequest())?.openrouter?.session_id).toBeUndefined()
+
+    mockGetProvider.mockReturnValue({
+      id: PROVIDER_ID,
+      name: PROVIDER_ID,
+      isEnabled: true,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+          baseUrl: 'https://example.invalid/v1',
+          adapterFamily: 'openai-compatible'
+        }
+      }
+    })
+    mockGetAgentSessionId.mockReturnValue('agent-session-1')
+
+    expect((await resolveRequest())?.openrouter?.session_id).toBeUndefined()
   })
 })

--- a/src/main/features/apiGateway/utils/promptCacheKey.ts
+++ b/src/main/features/apiGateway/utils/promptCacheKey.ts
@@ -8,19 +8,17 @@
  * derives an opaque key from the validated Agent session id — same session,
  * same key — without letting the raw session id leave the process.
  */
-import { createHash } from 'node:crypto'
-
 import type { ProviderOptions } from '@ai-sdk/provider-utils'
 
 import { resolveEffectiveEndpoint, resolveEndpointProviderOptionsKey } from '@main/ai/provider/endpoint'
+import { deriveAgentSessionRoutingKey, usesOpenRouterSessionRouting } from '@main/ai/utils/agentSessionRouting'
 import { ENDPOINT_TYPE, type Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 
 /**
- * Merge a session-derived `promptCacheKey` into the providerOptions namespace
- * the resolved adapter reads (the same resolution chain reasoning options use).
- * No-op for non-Responses endpoints; never overrides an existing key and keeps
- * the namespace's other options intact.
+ * Merge a session-derived routing key into the providerOptions namespace the
+ * resolved adapter reads. OpenAI Responses consumes `promptCacheKey`, while
+ * OpenRouter Chat forwards `session_id` verbatim to its request body.
  */
 export function applyAgentPromptCacheKey(
   provider: Provider,
@@ -29,15 +27,21 @@ export function applyAgentPromptCacheKey(
   agentSessionId: string
 ): ProviderOptions {
   const resolvedEndpoint = resolveEffectiveEndpoint(provider, model)
-  if (resolvedEndpoint.endpointType !== ENDPOINT_TYPE.OPENAI_RESPONSES) return providerOptions
+  const optionName =
+    resolvedEndpoint.endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES
+      ? 'promptCacheKey'
+      : resolvedEndpoint.endpointType === ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS &&
+          usesOpenRouterSessionRouting(provider, resolvedEndpoint.endpointType)
+        ? 'session_id'
+        : undefined
+  if (!optionName) return providerOptions
 
   const providerOptionsKey = resolveEndpointProviderOptionsKey(provider, resolvedEndpoint)
   const namespace = providerOptions[providerOptionsKey]
-  if (namespace?.promptCacheKey !== undefined) return providerOptions
+  if (namespace?.[optionName] !== undefined) return providerOptions
 
-  const digest = createHash('sha256').update(agentSessionId).digest('hex')
   return {
     ...providerOptions,
-    [providerOptionsKey]: { ...namespace, promptCacheKey: `cherry-agent:${digest.slice(0, 32)}` }
+    [providerOptionsKey]: { ...namespace, [optionName]: deriveAgentSessionRoutingKey(agentSessionId) }
   }
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

OpenRouter agent requests did not carry a stable provider routing key. Gateway Chat requests were outside the Responses-only `promptCacheKey` path, while direct Claude Code, Pi, and DSH routes bypassed that gateway path entirely. A long-running session could therefore be routed without a stable session identity even when Cherry already had a verified session ID.

After this PR:

- Gateway OpenRouter Chat requests send an opaque, session-stable `providerOptions.openrouter.session_id`.
- Direct Claude Code, Pi, and DSH OpenRouter routes send the same opaque identity as `x-session-id`.
- Explicit caller options and headers remain authoritative, including differently cased `X-Session-Id` headers.
- Other providers, sessionless or untrusted gateway requests, and the existing OpenAI Responses cache-key behavior are unchanged.

Fixes #20432

### Why we need it and why it was done in this way

OpenRouter supports `session_id` and `x-session-id` as stable routing identities. Cherry already has a trusted session boundary, so the implementation derives a deterministic SHA-256-based opaque key instead of forwarding the raw internal session ID.

The following tradeoffs were made:

- The key is stable within one Cherry session and isolated across sessions, but it does not expose the original session identifier.
- Provider detection uses the existing preset and endpoint-adapter metadata so copied OpenRouter presets are covered without relying on mutable display names.
- Gateway and direct runtime paths share the same derivation helper while retaining their native wire formats.

The following alternatives were considered:

- Reusing `promptCacheKey` was rejected because the pinned OpenRouter provider forwards snake_case `session_id` on its Chat wire path.
- Reordering the shared agent prompt was not used because #19297 already owns prompt-prefix ordering and does not provide a stable upstream routing identity.
- The separate Pi Anthropic cache-marker behavior is intentionally outside this change.

Links to places where the discussion took place: #20432, #18343, #19297

### Breaking changes

None.

### Special notes for your reviewer

The regression suite exercises the pinned OpenRouter SDK's actual non-streaming and streaming fetch payloads, plus the direct Claude Code, Pi, and DSH header boundaries.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: The shared routing helper keeps the provider-specific branches small and explicit
- [x] Refactor: The existing Responses behavior and caller override semantics are preserved
- [x] Upgrade: No migration or upgrade action is required
- [x] Documentation: No user-guide change is required for this internal routing correction
- [x] Self-review: The complete diff and provider-boundary regressions were reviewed before submission

Validation:

- 151 focused Vitest tests across five modified suites
- `pnpm typecheck`
- `pnpm typecheck:node` after the final DSH adjustment
- `pnpm test:lint` (0 errors)
- changed-file `oxfmt --check`
- `git diff --check`

### Release note

```release-note
Stabilize OpenRouter prompt-cache routing across long-running agent sessions.
```
