### PR TITLE
docs(claude): fix the mistyped Write Serialization anchor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ Scope:
 
 Database: SQLite via **better-sqlite3** + Drizzle ORM — the driver is **synchronous** (queries and transactions run inline with no `await`, unlike the app's otherwise-async data layers), so `getDb()` queries and `withWriteTx(fn)` callbacks must be written synchronously. Schemas in `src/main/data/db/schemas/`, migrations via `pnpm db:migrations:generate`
 
-**Write atomicity**: use `application.get('DbService').withWriteTx(fn)` to commit multiple writes (or a read-then-write) all-or-nothing in one synchronous `BEGIN IMMEDIATE` transaction; `fn` must be synchronous. A single write doesn't need it — better-sqlite3 runs each statement atomically on its one connection. See [Database Patterns — Write Serialization](docs/references/data/database-patterns.md#write-serialization-dbservicewritewritetx).
+**Write atomicity**: use `application.get('DbService').withWriteTx(fn)` to commit multiple writes (or a read-then-write) all-or-nothing in one synchronous `BEGIN IMMEDIATE` transaction; `fn` must be synchronous. A single write doesn't need it — better-sqlite3 runs each statement atomically on its one connection. See [Database Patterns — Write Serialization](docs/references/data/database-patterns.md#write-serialization-dbservicewithwritetx).
 
 **DataApi boundary rule**: DataApi is for SQLite-backed business data only. No database table → no DataApi endpoint; use IPC instead. See [Scope & Boundaries](docs/references/data/api-design-guidelines.md#dataapi-scope--boundaries).
 


### PR DESCRIPTION
### What this PR does

Before this PR:

`CLAUDE.md:168` points at the `DbService.withWriteTx` contract with a mistyped in-page fragment:

```
[Database Patterns — Write Serialization](docs/references/data/database-patterns.md#write-serialization-dbservicewritewritetx)
```

The slug says `dbservicewritewritetx`; the heading it targets — `## Write Serialization (`DbService.withWriteTx`)` at `docs/references/data/database-patterns.md:357` — produces `write-serialization-dbservicewithwritetx`. Because the fragment does not exist, following the link silently lands the reader at the top of the target page instead of the section.

After this PR:

The fragment is corrected to `dbservicewithwritetx`, so the link resolves to the section it names. Only the fragment changed; the link text and the surrounding paragraph are untouched.

Fixes #

### Why we need it and why it was done in this way

`CLAUDE.md` is the file agents and contributors are told to read first, and it is the entry point for the SQLite write-atomicity rule — the paragraph ends with this link as the "read the full contract" pointer. A dead fragment there sends readers to the wrong place with no error.

`docs/references/data/database-patterns.md`'s heading is the correct side of the inconsistency, so the link is what has to move. Three independent lines of evidence agree:

1. **The target exists and is spelled the other way.** `docs/references/data/database-patterns.md:357` is `## Write Serialization (\`DbService.withWriteTx\`)`.
2. **Every other call site already uses the correct slug.** The same section is linked from `docs/references/data/README.md:30`, `docs/references/data/data-api-overview.md:123`, `docs/references/job-and-scheduler/concurrency-and-locks.md:37` and `src/main/data/services/README.md:15` — all four spell it `#write-serialization-dbservicewithwritetx`. `CLAUDE.md` is the only outlier.
3. **The mechanism is visible in the typo itself.** The source symbol is `withWriteTx`; the broken slug reads `writeWriteTx`, i.e. `with` was mistyped as `write`.

The following tradeoffs were made:

Rewriting the heading in the target document was rejected, since that heading is referenced correctly by four other files and the slug is derived from the real symbol name `DbService.withWriteTx`.

The following alternatives were considered:

Saying nothing about the four other call sites was not an option for a correctness claim — they are the evidence that the fragment, not the heading, is the wrong side.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

None. Documentation link fragment only.

### Special notes for your reviewer

**Verification.** `check-doc-links.ts` only validates that link *targets* exist (`rawLink.split('#')[0]` then `fs.existsSync`), and `ci:basic-check` does not run it — so a broken in-page fragment passes CI forever. Verification was done with a scanner that applies GitHub's slug algorithm to every heading in the repo and checks each `](...#fragment)` against it:

- before: `unresolved anchors: 3`
- after: `unresolved anchors: 2`

The remaining two are out of scope here and are not regressions:

- `CONTRIBUTING.md:67` links `README.md#-community`, but `README.md` has no Community heading (checked at `a83f98fd24`, `ce93b462ba`, `443b24a819` — the fragment never resolved, so it is a different root cause: a link that never worked rather than a renamed heading).
- `src/shared/data/presets/README.md:14` is fixed in #20419, which is still open and not yet in `main`.

**Overlap note.** `CLAUDE.md` is touched by three open PRs (#18920, #20140, #20264), but their hunks are all in lines 30–77 while this change is at line 168 — no overlap, and any merge order is safe.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
