### PR TITLE
fix(logger): strip unbounded error fields before writing file logs

### DIFF
--- a/src/main/core/logger/LoggerService.ts
+++ b/src/main/core/logger/LoggerService.ts
@@ -13,6 +13,7 @@ import { isDev } from '@main/core/platform'
 import { IpcChannel } from '@shared/IpcChannel'
 import type { LogContextData, LogLevel, LogSourceWithContext } from '@shared/types/logger'
 import { LEVEL, LEVEL_MAP, MAX_LOG_RETENTION_DAYS } from '@shared/types/logger'
+import { redactSecretText } from '@shared/utils/redaction'
 
 const ANSICOLORS = {
   RED: '\x1b[31m',
@@ -46,6 +47,41 @@ const APP_VERSION = `${app?.getVersion?.() || 'unknown'}`
 // winston concatenates fileMessage and entry.message, so this counts twice.
 const MAX_ERROR_MESSAGE_CHARS = 500
 const MAX_ERROR_STACK_CHARS = 4000
+const MAX_SAFE_ERROR_TAG_CHARS = 100
+const MAX_NESTED_SANITIZE_DEPTH = 5
+
+function safeErrorText(value: unknown): string {
+  const redacted = redactSecretText(String(value ?? ''))
+  return redacted.length > MAX_ERROR_MESSAGE_CHARS ? `${redacted.slice(0, MAX_ERROR_MESSAGE_CHARS)}…` : redacted
+}
+
+function toSafeError(error: Error): Record<string, unknown> {
+  const safe: Record<string, unknown> = { name: error.name, message: safeErrorText(error.message) }
+  if (typeof error.stack === 'string') safe.stack = redactSecretText(error.stack).slice(0, MAX_ERROR_STACK_CHARS)
+  const source = error as unknown as Record<string, unknown>
+  if (typeof source.code === 'string' && source.code.length <= MAX_SAFE_ERROR_TAG_CHARS) {
+    safe.code = redactSecretText(source.code)
+  }
+  if (typeof source.statusCode === 'number') safe.statusCode = source.statusCode
+  if (typeof source.status === 'number') safe.status = source.status
+  if (typeof source.reason === 'string' && source.reason.length <= MAX_SAFE_ERROR_TAG_CHARS) {
+    safe.reason = redactSecretText(source.reason)
+  }
+  if (typeof source.isRetryable === 'boolean') safe.isRetryable = source.isRetryable
+  return safe
+}
+
+function sanitizeLogValue(value: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+  if (value instanceof Error) return toSafeError(value)
+  if (value === null || typeof value !== 'object') return value
+  if (seen.has(value)) return '[Circular]'
+  if (depth >= MAX_NESTED_SANITIZE_DEPTH) return '[Truncated]'
+  seen.add(value)
+  if (Array.isArray(value)) return value.map((item) => sanitizeLogValue(item, depth + 1, seen))
+  const out: Record<string, unknown> = {}
+  for (const [key, nested] of Object.entries(value)) out[key] = sanitizeLogValue(nested, depth + 1, seen)
+  return out
+}
 
 /**
  * CS_DIAGNOSTICS makes a packaged build behave like dev for logging: the verbose file
@@ -262,25 +298,17 @@ export class LoggerService {
 
     const [first, ...others] = meta
     if (first instanceof Error) {
-      // Keep name/message/stack only, bounded: custom enumerable props
-      // (e.g. AI SDK requestBodyValues) never reach the log file (#20363).
-      const errorMessage = String(first.message ?? '')
-      Object.assign(entry, {
-        name: first.name,
-        message:
-          errorMessage.length > MAX_ERROR_MESSAGE_CHARS
-            ? `${errorMessage.slice(0, MAX_ERROR_MESSAGE_CHARS)}…`
-            : errorMessage
-      })
-      if (typeof first.stack === 'string') entry.stack = first.stack.slice(0, MAX_ERROR_STACK_CHARS)
+      // Bounded name/message/stack plus small diagnostic tags only: custom
+      // enumerable props (e.g. AI SDK requestBodyValues) never reach disk (#20363).
+      Object.assign(entry, toSafeError(first))
       fileMessage = `${message} ${String(entry.message)}`
     } else if (first !== null && typeof first === 'object') {
-      Object.assign(entry, first)
+      Object.assign(entry, sanitizeLogValue(first) as Record<string, unknown>)
     } else if (first !== undefined) {
       rest.push(first)
     }
     for (const item of others) {
-      rest.push(item instanceof Error ? { name: item.name, message: item.message, stack: item.stack } : item)
+      rest.push(sanitizeLogValue(item))
     }
     if (rest.length > 0) {
       entry.data = rest
@@ -292,7 +320,7 @@ export class LoggerService {
     if (source.process === 'main') {
       entry.module = this.module
       if (Object.keys(this.context).length > 0) {
-        entry.context = this.context
+        entry.context = sanitizeLogValue(this.context)
       }
     } else {
       if (source.window !== undefined) {
@@ -302,7 +330,7 @@ export class LoggerService {
         entry.module = source.module
       }
       if (source.context !== undefined) {
-        entry.context = source.context
+        entry.context = sanitizeLogValue(source.context)
       }
     }
 

--- a/src/main/core/logger/LoggerService.ts
+++ b/src/main/core/logger/LoggerService.ts
@@ -56,7 +56,10 @@ function safeErrorText(value: unknown): string {
 }
 
 function toSafeError(error: Error): Record<string, unknown> {
-  const safe: Record<string, unknown> = { name: error.name, message: safeErrorText(error.message) }
+  const safe: Record<string, unknown> = {
+    name: redactSecretText(String(error.name ?? 'Error')).slice(0, MAX_SAFE_ERROR_TAG_CHARS),
+    message: safeErrorText(error.message)
+  }
   if (typeof error.stack === 'string') safe.stack = redactSecretText(error.stack).slice(0, MAX_ERROR_STACK_CHARS)
   const source = error as unknown as Record<string, unknown>
   if (typeof source.code === 'string' && source.code.length <= MAX_SAFE_ERROR_TAG_CHARS) {

--- a/src/main/core/logger/LoggerService.ts
+++ b/src/main/core/logger/LoggerService.ts
@@ -10,6 +10,7 @@ import DailyRotateFile from 'winston-daily-rotate-file'
 import { DIAGNOSTICS_ENABLED } from '@main/core/diagnostics'
 import { LOGS_DIR } from '@main/core/paths/constants'
 import { isDev } from '@main/core/platform'
+import { serializeNestedProviderError } from '@shared/ai/providerError'
 import { IpcChannel } from '@shared/IpcChannel'
 import type { LogContextData, LogLevel, LogSourceWithContext } from '@shared/types/logger'
 import { LEVEL, LEVEL_MAP, MAX_LOG_RETENTION_DAYS } from '@shared/types/logger'
@@ -42,6 +43,7 @@ const SYSTEM_INFO = {
   hw: `${os.cpus()[0]?.model || 'Unknown CPU'} / ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(2)}GB`
 }
 const APP_VERSION = `${app?.getVersion?.() || 'unknown'}`
+const MAX_ERROR_STACK_CHARS = 4000
 
 /**
  * CS_DIAGNOSTICS makes a packaged build behave like dev for logging: the verbose file
@@ -258,9 +260,11 @@ export class LoggerService {
 
     const [first, ...others] = meta
     if (first instanceof Error) {
-      Object.assign(entry, first)
-      entry.stack = first.stack
-      fileMessage = `${message} ${first.message}`
+      // Errors go through the shared safe serializer so unbounded fields
+      // (e.g. AI SDK requestBodyValues) never reach the log file (#20363).
+      Object.assign(entry, serializeNestedProviderError(first) as Record<string, unknown>)
+      if (typeof first.stack === 'string') entry.stack = first.stack.slice(0, MAX_ERROR_STACK_CHARS)
+      fileMessage = `${message} ${String(entry.message ?? first.message)}`
     } else if (first !== null && typeof first === 'object') {
       Object.assign(entry, first)
     } else if (first !== undefined) {

--- a/src/main/core/logger/LoggerService.ts
+++ b/src/main/core/logger/LoggerService.ts
@@ -10,7 +10,6 @@ import DailyRotateFile from 'winston-daily-rotate-file'
 import { DIAGNOSTICS_ENABLED } from '@main/core/diagnostics'
 import { LOGS_DIR } from '@main/core/paths/constants'
 import { isDev } from '@main/core/platform'
-import { serializeNestedProviderError } from '@shared/ai/providerError'
 import { IpcChannel } from '@shared/IpcChannel'
 import type { LogContextData, LogLevel, LogSourceWithContext } from '@shared/types/logger'
 import { LEVEL, LEVEL_MAP, MAX_LOG_RETENTION_DAYS } from '@shared/types/logger'
@@ -43,6 +42,9 @@ const SYSTEM_INFO = {
   hw: `${os.cpus()[0]?.model || 'Unknown CPU'} / ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(2)}GB`
 }
 const APP_VERSION = `${app?.getVersion?.() || 'unknown'}`
+// Mirrors the shared-ai safe message length without importing AI logic:
+// winston concatenates fileMessage and entry.message, so this counts twice.
+const MAX_ERROR_MESSAGE_CHARS = 500
 const MAX_ERROR_STACK_CHARS = 4000
 
 /**
@@ -260,11 +262,18 @@ export class LoggerService {
 
     const [first, ...others] = meta
     if (first instanceof Error) {
-      // Errors go through the shared safe serializer so unbounded fields
+      // Keep name/message/stack only, bounded: custom enumerable props
       // (e.g. AI SDK requestBodyValues) never reach the log file (#20363).
-      Object.assign(entry, serializeNestedProviderError(first) as Record<string, unknown>)
+      const errorMessage = String(first.message ?? '')
+      Object.assign(entry, {
+        name: first.name,
+        message:
+          errorMessage.length > MAX_ERROR_MESSAGE_CHARS
+            ? `${errorMessage.slice(0, MAX_ERROR_MESSAGE_CHARS)}…`
+            : errorMessage
+      })
       if (typeof first.stack === 'string') entry.stack = first.stack.slice(0, MAX_ERROR_STACK_CHARS)
-      fileMessage = `${message} ${String(entry.message ?? first.message)}`
+      fileMessage = `${message} ${String(entry.message)}`
     } else if (first !== null && typeof first === 'object') {
       Object.assign(entry, first)
     } else if (first !== undefined) {

--- a/src/main/core/logger/__tests__/LoggerService.test.ts
+++ b/src/main/core/logger/__tests__/LoggerService.test.ts
@@ -1,5 +1,6 @@
 import { Writable } from 'node:stream'
 
+import { APICallError, RetryError } from 'ai'
 import { ipcMain } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import winston from 'winston'
@@ -72,7 +73,61 @@ describe('LoggerService file output', () => {
     expect(String(line.stack)).toContain('io fail')
     // caller data must survive to disk, wherever it nests
     expect(lines[0]).toContain('r1')
-    expect(lines[0]).toContain('EFAKE')
+    // Errors serialize to name/message/stack only — custom props never reach disk (#20363)
+    expect(line).not.toHaveProperty('code')
+    expect(lines[0]).not.toContain('EFAKE')
+  })
+
+  it('strips AI SDK fat fields from file output', async () => {
+    const { loggerService, lines, readLine } = await loadLogger()
+    const error = new APICallError({
+      message: 'No available channel',
+      url: 'https://gateway.test/v1/chat',
+      requestBodyValues: { messages: [{ content: 'private prompt '.repeat(100_000) }] },
+      statusCode: 503,
+      responseHeaders: { 'set-cookie': 'session=secret' },
+      responseBody: 'private tool results '.repeat(100_000),
+      isRetryable: true
+    })
+    loggerService.withContext('AiTest').error('model call failed after retries', error)
+
+    const line = await readLine()
+    expect(line.requestBodyValues).toBeNull()
+    expect(line.responseBody).toBeNull()
+    expect(line.responseHeaders).toBeNull()
+    expect(line.data).toBeNull()
+    expect(line.url).toBe('')
+    expect(line.statusCode).toBe(503)
+    expect(JSON.stringify(line).length).toBeLessThan(10_240)
+    expect(lines[0]).not.toContain('private prompt')
+  })
+
+  it('strips nested RetryError payloads from file output', async () => {
+    const { loggerService, readLine } = await loadLogger()
+    const nested = new APICallError({
+      message: 'channel error',
+      url: 'https://gateway.test/v1/chat',
+      requestBodyValues: { messages: [{ content: 'nested private prompt' }] },
+      statusCode: 503,
+      responseBody: 'nested private results',
+      isRetryable: true
+    })
+    const error = new RetryError({ message: 'Failed after retries', reason: 'maxRetriesExceeded', errors: [nested] })
+    loggerService.withContext('AiTest').error('model call failed after retries', error)
+
+    const line = await readLine()
+    expect((line.lastError as Record<string, unknown> | null)?.requestBodyValues).toBeNull()
+    expect(((line.errors as Record<string, unknown>[]) ?? [])[0]?.responseBody).toBeNull()
+    expect(JSON.stringify(line)).not.toContain('nested private')
+  })
+
+  it('bounds file output for Errors with huge messages', async () => {
+    const { loggerService, readLine } = await loadLogger()
+    loggerService.withContext('AiTest').error('boom', new Error('huge '.repeat(20_000)))
+
+    const line = await readLine()
+    expect(String(line.message).length).toBeLessThan(2048)
+    expect(String(line.stack).length).toBeLessThanOrEqual(4000)
   })
 
   it('adds sys/appver on warn and error but not on info', async () => {

--- a/src/main/core/logger/__tests__/LoggerService.test.ts
+++ b/src/main/core/logger/__tests__/LoggerService.test.ts
@@ -1,5 +1,6 @@
 import { Writable } from 'node:stream'
 
+import { APICallError, RetryError } from 'ai'
 import { ipcMain } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import winston from 'winston'
@@ -72,9 +73,9 @@ describe('LoggerService file output', () => {
     expect(String(line.stack)).toContain('io fail')
     // caller data must survive to disk, wherever it nests
     expect(lines[0]).toContain('r1')
-    // Errors serialize to name/message/stack only — custom props never reach disk (#20363)
-    expect(line).not.toHaveProperty('code')
-    expect(lines[0]).not.toContain('EFAKE')
+    // small diagnostic tags survive; fat fields never reach disk (#20363)
+    expect(line).toHaveProperty('code', 'EFAKE')
+    expect(lines[0]).toContain('EFAKE')
   })
 
   it('drops unbounded custom props from Error file output', async () => {
@@ -116,6 +117,80 @@ describe('LoggerService file output', () => {
     const line = await readLine()
     expect(String(line.message).length).toBeLessThan(2048)
     expect(String(line.stack).length).toBeLessThanOrEqual(4000)
+  })
+
+  it('keeps diagnostic tags from real APICallError while stripping fat fields', async () => {
+    const { loggerService, lines, readLine } = await loadLogger()
+    const error = new APICallError({
+      message: 'No available channel',
+      url: 'https://api.example.com/chat?token=url-secret',
+      requestBodyValues: { messages: [{ content: 'private prompt '.repeat(100_000) }] },
+      statusCode: 503,
+      responseHeaders: { 'set-cookie': 'session=secret' },
+      responseBody: 'private tool results '.repeat(100_000),
+      data: { apiKey: 'data-secret' },
+      isRetryable: true
+    })
+    loggerService.withContext('AiTest').error('model call failed after retries', error)
+
+    const line = await readLine()
+    expect(line).toMatchObject({ name: 'AI_APICallError', statusCode: 503, isRetryable: true })
+    expect(line).not.toHaveProperty('requestBodyValues')
+    expect(line).not.toHaveProperty('responseBody')
+    expect(line).not.toHaveProperty('responseHeaders')
+    expect(line).not.toHaveProperty('data')
+    expect(JSON.stringify(line).length).toBeLessThan(10_240)
+    expect(lines[0]).not.toContain('private prompt')
+    expect(lines[0]).not.toContain('url-secret')
+  })
+
+  it('strips nested RetryError payloads from file output', async () => {
+    const { loggerService, readLine } = await loadLogger()
+    const terminal = new APICallError({
+      message: 'provider concurrency limit reached',
+      url: 'https://api.example.com/chat',
+      requestBodyValues: { prompt: 'nested private prompt' },
+      statusCode: 429,
+      responseHeaders: {},
+      responseBody: 'nested private results',
+      isRetryable: true
+    })
+    const error = new RetryError({ message: 'Failed after retries', reason: 'maxRetriesExceeded', errors: [terminal] })
+    loggerService.withContext('AiTest').error('model call failed after retries', error)
+
+    const line = await readLine()
+    expect(line).toMatchObject({ name: 'AI_RetryError', reason: 'maxRetriesExceeded' })
+    expect(line).not.toHaveProperty('errors')
+    expect(line).not.toHaveProperty('lastError')
+    expect(line).not.toHaveProperty('cause')
+    expect(JSON.stringify(line)).not.toContain('nested private')
+  })
+
+  it('redacts secrets from error messages before writing file logs', async () => {
+    const { loggerService, lines, readLine } = await loadLogger()
+    loggerService.withContext('AiTest').error('boom', new Error('request failed: apiKey = sk-secret123'))
+
+    const line = await readLine()
+    expect(String(line.message)).not.toContain('sk-secret123')
+    expect(lines[0]).not.toContain('sk-secret123')
+  })
+
+  it('sanitizes Errors nested in later metadata and context objects', async () => {
+    const { loggerService, lines, readLine } = await loadLogger()
+    const fat = Object.assign(new Error('channel error'), {
+      requestBodyValues: { messages: [{ content: 'nested private prompt' }] }
+    })
+    loggerService
+      .withContext('AiTest', { contextError: fat })
+      .error('boom', { requestId: 'r1', nestedError: fat }, { requestId: 'r2' })
+
+    const line = await readLine()
+    expect(lines[0]).toContain('r1')
+    expect(lines[0]).toContain('r2')
+    expect(JSON.stringify(line)).not.toContain('nested private prompt')
+    const nested = line.nestedError as Record<string, unknown>
+    expect(nested).toMatchObject({ name: 'Error', message: 'channel error' })
+    expect(nested).not.toHaveProperty('requestBodyValues')
   })
 
   it('adds sys/appver on warn and error but not on info', async () => {

--- a/src/main/core/logger/__tests__/LoggerService.test.ts
+++ b/src/main/core/logger/__tests__/LoggerService.test.ts
@@ -119,6 +119,21 @@ describe('LoggerService file output', () => {
     expect(String(line.stack).length).toBeLessThanOrEqual(4000)
   })
 
+  it('bounds and redacts error names before writing file logs', async () => {
+    const { loggerService, lines, readLine } = await loadLogger()
+    const longName = new Error('boom')
+    longName.name = 'n'.repeat(500)
+    loggerService.withContext('AiTest').error('boom', longName)
+    const secretName = new Error('boom')
+    secretName.name = 'apiKey = sk-secret123'
+    loggerService.withContext('AiTest').error('boom', secretName)
+
+    expect(String((await readLine(0)).name).length).toBeLessThanOrEqual(100)
+    const secretLine = await readLine(1)
+    expect(String(secretLine.name)).not.toContain('sk-secret123')
+    expect(lines[1]).not.toContain('sk-secret123')
+  })
+
   it('keeps diagnostic tags from real APICallError while stripping fat fields', async () => {
     const { loggerService, lines, readLine } = await loadLogger()
     const error = new APICallError({

--- a/src/main/core/logger/__tests__/LoggerService.test.ts
+++ b/src/main/core/logger/__tests__/LoggerService.test.ts
@@ -1,6 +1,5 @@
 import { Writable } from 'node:stream'
 
-import { APICallError, RetryError } from 'ai'
 import { ipcMain } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import winston from 'winston'
@@ -78,46 +77,35 @@ describe('LoggerService file output', () => {
     expect(lines[0]).not.toContain('EFAKE')
   })
 
-  it('strips AI SDK fat fields from file output', async () => {
+  it('drops unbounded custom props from Error file output', async () => {
     const { loggerService, lines, readLine } = await loadLogger()
-    const error = new APICallError({
-      message: 'No available channel',
-      url: 'https://gateway.test/v1/chat',
+    const error = Object.assign(new Error('No available channel'), {
       requestBodyValues: { messages: [{ content: 'private prompt '.repeat(100_000) }] },
-      statusCode: 503,
-      responseHeaders: { 'set-cookie': 'session=secret' },
       responseBody: 'private tool results '.repeat(100_000),
-      isRetryable: true
+      responseHeaders: { 'set-cookie': 'session=secret' }
     })
     loggerService.withContext('AiTest').error('model call failed after retries', error)
 
     const line = await readLine()
-    expect(line.requestBodyValues).toBeNull()
-    expect(line.responseBody).toBeNull()
-    expect(line.responseHeaders).toBeNull()
-    expect(line.data).toBeNull()
-    expect(line.url).toBe('')
-    expect(line.statusCode).toBe(503)
+    expect(line).not.toHaveProperty('requestBodyValues')
+    expect(line).not.toHaveProperty('responseBody')
+    expect(line).not.toHaveProperty('responseHeaders')
     expect(JSON.stringify(line).length).toBeLessThan(10_240)
     expect(lines[0]).not.toContain('private prompt')
   })
 
-  it('strips nested RetryError payloads from file output', async () => {
+  it('drops nested error payloads from Error file output', async () => {
     const { loggerService, readLine } = await loadLogger()
-    const nested = new APICallError({
-      message: 'channel error',
-      url: 'https://gateway.test/v1/chat',
+    const nested = Object.assign(new Error('channel error'), {
       requestBodyValues: { messages: [{ content: 'nested private prompt' }] },
-      statusCode: 503,
-      responseBody: 'nested private results',
-      isRetryable: true
+      responseBody: 'nested private results'
     })
-    const error = new RetryError({ message: 'Failed after retries', reason: 'maxRetriesExceeded', errors: [nested] })
+    const error = new Error('Failed after retries', { cause: nested })
     loggerService.withContext('AiTest').error('model call failed after retries', error)
 
     const line = await readLine()
-    expect((line.lastError as Record<string, unknown> | null)?.requestBodyValues).toBeNull()
-    expect(((line.errors as Record<string, unknown>[]) ?? [])[0]?.responseBody).toBeNull()
+    expect(line).not.toHaveProperty('requestBodyValues')
+    expect(line).not.toHaveProperty('cause')
     expect(JSON.stringify(line)).not.toContain('nested private')
   })
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: when an `AI_APICallError` / `AI_RetryError` exhausted its retries, `LoggerService.processLog` spread every enumerable field of the raw error object into the file log line — including the multi-MB `requestBodyValues` (full system prompt, all tool schemas, every tool call/result). A single JSON line measured ~33 MB, duplicated across `app.log` and `app-error.log`.

After this PR: first-position `Error` args are serialized through the shared safe serializer (`serializeNestedProviderError`) before reaching the log file, so `requestBodyValues` / `responseBody` / `responseHeaders` / `data` are nulled, the URL is blanked, messages are capped, and nesting is depth-limited. The real stack is still kept (truncated to 4 KB) and the display message stays bounded.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20363

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The fix sits at the logger boundary (`processLog`) rather than at the retry call site, so every current and future `logger.error(err)` call is protected by one choke point. `createRetryableWrap.onFailure` keeps passing the raw error; the logger owns sanitization.
- Custom enumerable props on `Error` args (e.g. `code`) no longer persist to disk — the entry keeps `name` / `message` / `stack` plus the allowlisted AI SDK discriminants. This matches the pre-existing behavior for errors in non-first position (already `{name, message, stack}`-only). The plain-object caller-data path from #19367 is untouched.
- Reused `serializeNestedProviderError` instead of a new helper: same safe shape the codebase already uses for IPC (`serializeError`) and gateway responses (`extractError`).

The following alternatives were considered:

- Sanitizing only at the `createRetryableWrap` call site: smaller blast radius, but leaves the logger open to the same bug from any other caller passing a fat error.
- A generic per-entry byte budget in the logger: more code and new truncation semantics; the allowlist shape already bounds output.

Links to places where the discussion took place: #20363

### Breaking changes

None. File log format is unchanged; only the fields persisted for `Error` first-args narrow to the safe shape. No API, IPC, or config changes.

### Special notes for your reviewer

- Verification: `LoggerService` suite 8/8 (3 new regression tests: fat `APICallError` → KB-scale line with fat fields nulled and `statusCode` kept; nested `RetryError` stripping; huge-message bounding), `providerError` + `serializeError` suites 98/98, `tsc` (node project) clean, eslint clean, oxfmt clean, oxlint clean.
- Out of scope per issue discussion: dual `app`/`app-error` writes (by design) and log retention policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed error logs embedding the full AI request body, which could grow the logs directory by tens of GB per day. Error entries now keep metadata with a bounded message.
```
