### PR TITLE
fix(topic-list): keep pinned indicator visible without hover

### DIFF
--- a/src/renderer/components/chat/resourceList/base/ConversationRowStatus.tsx
+++ b/src/renderer/components/chat/resourceList/base/ConversationRowStatus.tsx
@@ -15,7 +15,8 @@ const CONVERSATION_ROW_APPROVAL_BADGE_CLASS =
   'pointer-events-none max-w-28 shrink-0 truncate rounded-full border border-warning-border bg-warning-subtle px-1.5 font-medium text-[10px] text-warning-subtle-foreground leading-4 transition-[max-width,padding,opacity] duration-150 group-hover:max-w-0 group-hover:px-0 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:max-w-0 group-has-[[data-resource-list-item-actions][data-active=true]]:max-w-0 group-has-[[data-resource-list-item-actions]:focus-within]:px-0 group-has-[[data-resource-list-item-actions][data-active=true]]:px-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0'
 
 const CONVERSATION_ROW_STREAM_INDICATOR_CLASS =
-  '-translate-y-1/2 pointer-events-none absolute top-1/2 right-1.5 flex size-5 shrink-0 items-center justify-center opacity-100 transition-opacity duration-150 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0'
+  // A pinned rail stays expanded at rest, so the overlay steps left into the title's yield instead of sitting under the pin.
+  '-translate-y-1/2 pointer-events-none absolute top-1/2 right-1.5 flex size-5 shrink-0 items-center justify-center opacity-100 transition-[opacity,right] duration-150 group-hover:opacity-0 group-has-[[data-resource-list-item-actions]:focus-within]:opacity-0 group-has-[[data-resource-list-item-actions][data-active=true]]:opacity-0 group-has-[[data-resource-list-item-actions][data-pinned=true]]:right-7'
 
 export function ConversationRowStatus({ status, testId }: ConversationRowStatusProps) {
   const { t } = useTranslation()

--- a/src/renderer/components/chat/resourceList/base/ResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceList.tsx
@@ -595,7 +595,7 @@ function ItemAction({ className, ref, type = 'button', ...props }: ItemActionPro
         'hover:bg-accent hover:text-accent-foreground!',
         'focus-visible:pointer-events-auto focus-visible:bg-accent focus-visible:text-accent-foreground! focus-visible:opacity-100 focus-visible:outline-none',
         RESOURCE_LIST_ROW_STATE_FOREGROUND_CLASS,
-        'group-hover:pointer-events-auto group-hover:opacity-100 data-[deleting=true]:pointer-events-auto data-[deleting=true]:opacity-100 aria-pressed:true:pointer-events-auto aria-pressed:true:opacity-100',
+        'group-hover:pointer-events-auto group-hover:opacity-100 data-[deleting=true]:pointer-events-auto data-[deleting=true]:opacity-100 aria-pressed:pointer-events-auto aria-pressed:opacity-100',
         className
       )}
       {...props}

--- a/src/renderer/components/chat/resourceList/base/ResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceList.tsx
@@ -595,7 +595,7 @@ function ItemAction({ className, ref, type = 'button', ...props }: ItemActionPro
         'hover:bg-accent hover:text-accent-foreground!',
         'focus-visible:pointer-events-auto focus-visible:bg-accent focus-visible:text-accent-foreground! focus-visible:opacity-100 focus-visible:outline-none',
         RESOURCE_LIST_ROW_STATE_FOREGROUND_CLASS,
-        'group-hover:pointer-events-auto group-hover:opacity-100 data-[deleting=true]:pointer-events-auto data-[deleting=true]:opacity-100',
+        'group-hover:pointer-events-auto group-hover:opacity-100 data-[deleting=true]:pointer-events-auto data-[deleting=true]:opacity-100 aria-pressed:true:pointer-events-auto aria-pressed:true:opacity-100',
         className
       )}
       {...props}
@@ -605,18 +605,20 @@ function ItemAction({ className, ref, type = 'button', ...props }: ItemActionPro
 
 type ItemActionsProps = ComponentProps<'div'> & {
   active?: boolean
+  pinned?: boolean
   ref?: Ref<HTMLDivElement>
 }
 
-function ItemActions({ active, children, className, ref, ...props }: ItemActionsProps) {
+function ItemActions({ active, children, className, pinned, ref, ...props }: ItemActionsProps) {
   return (
     <div
       ref={ref}
       data-active={active || undefined}
+      data-pinned={pinned || undefined}
       data-resource-list-item-actions="true"
       className={cn(
         '-ml-1.5 -mr-1 pointer-events-none grid shrink-0 grid-cols-[0fr] opacity-0 transition-[grid-template-columns,opacity] duration-150 group-has-[[data-resource-list-leading-slot=true]]:mr-0 motion-reduce:transition-none',
-        'focus-within:pointer-events-auto focus-within:grid-cols-[1fr] focus-within:opacity-100 group-hover:pointer-events-auto group-hover:grid-cols-[1fr] group-hover:opacity-100 data-[active=true]:pointer-events-auto data-[active=true]:grid-cols-[1fr] data-[active=true]:opacity-100',
+        'focus-within:pointer-events-auto focus-within:grid-cols-[1fr] focus-within:opacity-100 group-hover:pointer-events-auto group-hover:grid-cols-[1fr] group-hover:opacity-100 data-[active=true]:pointer-events-auto data-[active=true]:grid-cols-[1fr] data-[active=true]:opacity-100 data-[pinned=true]:pointer-events-auto data-[pinned=true]:grid-cols-[1fr] data-[pinned=true]:opacity-100',
         className
       )}
       {...props}>

--- a/src/renderer/components/chat/resourceList/base/__tests__/ConversationRowStatus.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ConversationRowStatus.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import type * as ReactI18next from 'react-i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ConversationRowStatus } from '../ConversationRowStatus'
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactI18next>()),
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+describe('ConversationRowStatus', () => {
+  it('steps the stream overlay aside when the action rail is pinned', () => {
+    render(<ConversationRowStatus status="pending" testId="row-status" />)
+
+    // A pinned rail stays expanded at rest; without this offset the overlay
+    // would sit underneath the pin button.
+    expect(screen.getByTestId('row-status')).toHaveClass(
+      'group-has-[[data-resource-list-item-actions][data-pinned=true]]:right-7'
+    )
+  })
+})

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -2910,5 +2910,9 @@ describe('ResourceList', () => {
     expect(unpinButton).toHaveAttribute('aria-pressed', 'true')
     // The pinned rail reserves space at rest; unpinned rows keep the hover-only rail.
     expect(unpinButton.closest('[data-resource-list-item-actions]')).toHaveAttribute('data-pinned', 'true')
+    // The toggle itself must carry valid visible-at-rest variants; an unknown
+    // variant (e.g. `aria-pressed:true:`) compiles to no CSS and leaves it hidden.
+    expect(unpinButton).toHaveClass('aria-pressed:opacity-100')
+    expect(unpinButton).toHaveClass('aria-pressed:pointer-events-auto')
   })
 })

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -2883,4 +2883,32 @@ describe('ResourceList', () => {
       unmount()
     }
   })
+
+  it('keeps the pinned action rail expanded at rest without hover', () => {
+    const Provider = ResourceList.Provider<TestItem>
+
+    render(
+      <Provider items={[ITEMS[0]]}>
+        <ResourceList.Frame>
+          <ResourceList.VirtualItems<TestItem>
+            renderItem={(item) => (
+              <ResourceList.Item item={item} data-testid="resource-row">
+                <ResourceList.ItemTitle>{item.name}</ResourceList.ItemTitle>
+                <ResourceList.ItemActions pinned>
+                  <ResourceList.ItemAction aria-label="Unpin item" aria-pressed>
+                    #
+                  </ResourceList.ItemAction>
+                </ResourceList.ItemActions>
+              </ResourceList.Item>
+            )}
+          />
+        </ResourceList.Frame>
+      </Provider>
+    )
+
+    const unpinButton = screen.getByRole('button', { name: 'Unpin item' })
+    expect(unpinButton).toHaveAttribute('aria-pressed', 'true')
+    // The pinned rail reserves space at rest; unpinned rows keep the hover-only rail.
+    expect(unpinButton.closest('[data-resource-list-item-actions]')).toHaveAttribute('data-pinned', 'true')
+  })
 })

--- a/src/renderer/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/pages/agents/components/SessionItem.tsx
@@ -326,11 +326,12 @@ const SessionItem = ({
         />
       )}
 
-      <ResourceList.ItemActions active={isConfirmingDeletion}>
+      <ResourceList.ItemActions active={isConfirmingDeletion} pinned={pinned && showPinAction}>
         {showPinAction && (
           <Tooltip title={pinned ? t('agent.session.unpin.title') : t('agent.session.pin.title')} delay={500}>
             <ResourceList.ItemAction
               aria-label={pinned ? t('agent.session.unpin.title') : t('agent.session.pin.title')}
+              aria-pressed={pinned}
               className={cn(pinned && 'text-foreground')}
               onClick={handleTogglePinClick}>
               <PinIcon size={14} className={cn('size-3.5!', pinned && 'fill-current')} />

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -2294,6 +2294,8 @@ describe('Sessions', () => {
     expect(pinnedRow).not.toBeNull()
     const unpinButton = within(pinnedRow as HTMLElement).getByLabelText('Unpin task')
     expect(unpinButton).toBeInTheDocument()
+    expect(unpinButton).toHaveAttribute('aria-pressed', 'true')
+    expect(unpinButton.closest('[data-resource-list-item-actions="true"]')).toHaveAttribute('data-pinned', 'true')
     expect(unpinButton.closest('[data-resource-list-item-actions="true"]')).toBeInTheDocument()
     expect(
       pinnedRow?.querySelector('[data-resource-list-leading-slot="true"] [aria-label="Unpin task"]') ?? null

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1907,11 +1907,12 @@ const TopicRow = memo(function TopicRow({
           status={conversationRowStatus}
         />
       )}
-      <ResourceList.ItemActions active={isConfirmingDeletion}>
+      <ResourceList.ItemActions active={isConfirmingDeletion} pinned={topic.pinned && showPinAction}>
         {showPinAction && (
           <Tooltip title={topic.pinned ? t('chat.topics.unpin') : t('chat.topics.pin')} delay={500}>
             <ResourceList.ItemAction
               aria-label={topic.pinned ? t('chat.topics.unpin') : t('chat.topics.pin')}
+              aria-pressed={topic.pinned}
               className={cn(topic.pinned && 'text-foreground')}
               onClick={(event) => {
                 event.stopPropagation()

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -1005,6 +1005,8 @@ describe('Topics', () => {
     const unpinButton = pinnedRow?.querySelector('[aria-label="Unpin Conversation"]')
     expect(unpinButton ?? null).toBeInTheDocument()
     expect(unpinButton).not.toHaveAttribute('data-active')
+    expect(unpinButton).toHaveAttribute('aria-pressed', 'true')
+    expect(unpinButton?.closest('[data-resource-list-item-actions="true"]')).toHaveAttribute('data-pinned', 'true')
     expect(pinnedRow?.querySelector('[data-resource-list-leading-slot="true"]') ?? null).not.toBeInTheDocument()
     expect(pinnedRow?.querySelector('[aria-label="Delete"]') ?? null).not.toBeInTheDocument()
     expect(
@@ -1344,6 +1346,7 @@ describe('Topics', () => {
     const alphaRow = getByText('Alpha topic').closest('[data-testid="topic-list-row"]')
     const pinButton = alphaRow?.querySelector('[aria-label="Pin Conversation"]')
     expect(pinButton ?? null).toBeInTheDocument()
+    expect(pinButton).toHaveAttribute('aria-pressed', 'false')
     expect(pinButton?.closest('[data-resource-list-item-actions="true"]')).toBeInTheDocument()
     expect(
       alphaRow?.querySelector('[data-resource-list-leading-slot="true"] [aria-label="Pin Conversation"]') ?? null


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: pinned conversations only showed their pin indicator while the row was hovered. Once the pointer left the row, the indicator disappeared, so the list could not be scanned for pinned state.

After this PR: a pinned row keeps its pin toggle visible at rest (quiet persistent treatment: `text-foreground` + filled pin). Hover/focus still adds the existing action treatment (`hover:bg-accent`, focus ring). Unpinned rows keep the hover-only rail. The same fix covers pinned agent sessions, which share the `ResourceList` infrastructure.

Fixes #20391

### Why we need it and why it was done in this way

The pin toggle lived inside `ResourceList.ItemActions` / `ItemAction`, which collapse to zero width and `opacity-0` until `group-hover` / `focus-within` / `data-active`. Pin state itself (`usePins` + `useResourceListPinnedState`, DataApi `/pins`) was already correct, so the fix is presentation-only: a `pinned` variant on the shared rail plus `aria-pressed` on the toggle, opted in by both row types.

The following tradeoffs were made:

- One persistent toggle instead of a separate badge + hover action, so there is a single tab stop, single accessible name, and no double layout shift.
- `aria-pressed` doubles as the styling hook, so toggle state and visibility cannot drift.

The following alternatives were considered:

- A persistent badge outside `ItemActions` plus the existing hover action: rejected, duplicates the control and its accessible name.

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

- No i18n changes (reuses `chat.topics.pin` / `unpin` and `agent.session.pin/unpin.title`); no new colors or components.
- Verified: `ResourceList.test.tsx` (60 passed), `Topics.test.tsx` (109 passed), `Sessions.test.tsx` (100 passed); `oxfmt --check` and `eslint` clean on changed files. Full `pnpm lint` was not run in the worktree (pre-commit/oxlint hooks break under `.claude/worktrees`; equivalent checks were run via direct binaries) — CI will run the full gate.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (`git diff`, targeted tests) before requesting review from others

### Release note

```release-note
Fixed pinned conversations losing their pin indicator when the row is not hovered; pinned state now stays visible at rest.
```
