### PR TITLE
fix(composer-tokens): render knowledge refs as compact in-composer chips

### DIFF
--- a/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
@@ -1153,6 +1153,53 @@ describe('ComposerToken', () => {
     expect(onRemove).toHaveBeenCalledTimes(1)
   })
 
+  it('renders no knowledge chip when no knowledge reference is selected', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'skill:pdf',
+          kind: 'skill',
+          label: 'PDF Reader',
+          description: 'Read and summarize PDF files.'
+        }}
+      />
+    )
+
+    expect(container.querySelector('[data-composer-token-kind="knowledge"]')).toBeNull()
+    expect(container.querySelector('[data-composer-token-remove]')).toBeNull()
+  })
+
+  it('renders multiple knowledge chips with independent remove actions', async () => {
+    const user = userEvent.setup()
+    const onRemoveFirst = vi.fn()
+    const onRemoveSecond = vi.fn()
+    render(
+      <>
+        <ComposerToken
+          token={{ id: 'knowledge:base-1', kind: 'knowledge', label: 'Product Docs' }}
+          onRemove={onRemoveFirst}
+          removeLabel="Remove Product Docs"
+        />
+        <ComposerToken
+          token={{ id: 'knowledge:base-2', kind: 'knowledge', label: 'API Guide' }}
+          onRemove={onRemoveSecond}
+          removeLabel="Remove API Guide"
+        />
+      </>
+    )
+
+    expect(screen.getByText('Product Docs')).toBeInTheDocument()
+    expect(screen.getByText('API Guide')).toBeInTheDocument()
+
+    const removeButtons = screen.getAllByRole('button', { name: /remove/i })
+    expect(removeButtons).toHaveLength(2)
+
+    await user.click(screen.getByRole('button', { name: 'Remove Product Docs' }))
+    expect(onRemoveFirst).toHaveBeenCalledTimes(1)
+    expect(onRemoveSecond).not.toHaveBeenCalled()
+    expect(screen.getByText('API Guide')).toBeInTheDocument()
+  })
+
   it.each([
     [
       'skill',

--- a/src/renderer/components/composer/tokenView/ComposerToken.tsx
+++ b/src/renderer/components/composer/tokenView/ComposerToken.tsx
@@ -931,10 +931,52 @@ export function FolderComposerToken(props: ComposerTokenProps) {
 }
 
 export function KnowledgeComposerToken(props: ComposerTokenProps) {
-  return renderActiveComposerTokenElement({
-    ...props,
-    icon: tokenIconByKind.knowledge
-  })
+  const removeLabel = props.removeLabel ?? 'Remove'
+
+  const chipElement = (
+    <span
+      className={cn(
+        'group/composer-token mx-0.5 my-0.5 inline-flex h-6 max-w-[calc(100%_-_0.25rem)] select-none items-center gap-1 overflow-hidden rounded-md border px-1.5 align-baseline font-medium text-foreground text-xs leading-[inherit] transition-[color,box-shadow,border-color]',
+        'group-focus-visible:border-primary',
+        props.readOnly && 'focus-visible:border-primary focus-visible:outline-none',
+        'border-border bg-background hover:bg-accent',
+        props.selected && 'border-primary ring-1 ring-primary/40',
+        props.className
+      )}
+      title={props.token.description ? undefined : props.token.label}
+      data-composer-token-kind={props.token.kind}
+      onMouseDown={props.onMouseDown}>
+      <span
+        className="inline-flex size-4.5 shrink-0 items-center justify-center rounded-[5px] border-0 bg-accent text-muted-foreground leading-none"
+        data-knowledge-token-icon="">
+        <InlineTokenIconSlot
+          icon={props.token.icon ? props.token.icon : <Boxes className={tokenIconClassName} aria-hidden />}
+          removeLabel={removeLabel}
+          onRemove={props.onRemove}
+          removeButtonClassName="size-full rounded-[5px]"
+          removeIconClassName="size-3"
+        />
+      </span>
+      {props.children ?? (
+        <span className={cn('whitespace-nowrap! min-w-0 max-w-full truncate break-normal', props.maxWidthClassName)}>
+          {props.token.label}
+        </span>
+      )}
+    </span>
+  )
+
+  if (!props.token.description) return chipElement
+
+  return (
+    <NormalTooltip
+      content={props.token.description}
+      side="top"
+      sideOffset={6}
+      delayDuration={300}
+      triggerProps={props.readOnly ? { tabIndex: 0, 'aria-label': props.token.label } : undefined}>
+      {chipElement}
+    </NormalTooltip>
+  )
 }
 
 export function ReferenceComposerToken(props: ComposerTokenProps) {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: knowledge-base references selected through the composer used the generic inline text presentation, which reads as detached from the draft and — per the 2.0.9 report in #20392 — felt like a separate panel obscuring the conversation.

After this PR: selected knowledge bases render as compact boxed chips inside the composer (same pattern as folder tokens), wrapping with the draft text. The message list stays visible; each chip is individually removable by click and keyboard.

Fixes #20392

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Copied the existing FolderComposerToken boxed-chip pattern instead of adding a new component or tooltip/popover surface — keeps the change surgical and preserves the inline-atom layout that grows the dock inset instead of overlaying messages.
- Native title now uses the base label rather than the long model instruction in promptText, so hover text stays compact.

The following alternatives were considered:
- A separate selected-refs strip above the composer (topContent) — rejected: it would reintroduce the obscuring panel from the report and bypass the inset measurement.

### Breaking changes

NONE

### Special notes for your reviewer

- Existing keyboard/focus behavior (Backspace/Delete removal, focus return, inline remove button) is unchanged; only the chip visuals changed.
- Tests: ComposerToken.test.tsx (52 passed), knowledgeBaseTool + useComposerKnowledgeBaseScope + ComposerDockTransitionFrame (19 passed); ESLint clean.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: human-readable, minimal change
- [x] Self-review: reviewed via gh pr diff

### Release note

```release-note
Fixed knowledge-base references covering the conversation: selected bases now show as compact chips inside the composer.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)