### PR TITLE
fix(deepseek-harness): fail fast on incompatible upgraded DSH home

### DIFF
--- a/src/main/core/paths/__tests__/pathRegistry.test.ts
+++ b/src/main/core/paths/__tests__/pathRegistry.test.ts
@@ -150,6 +150,8 @@ describe('buildPathRegistry', () => {
   it('uses the shared user-owned DeepSeek Harness home', () => {
     const registry = buildPathRegistry()
     expect(registry['external.deepseek_harness.config']).toBe(path.join(os.homedir(), '.dsh'))
+    expect(registry['external.deepseek_harness.storages']).toBe(path.join(os.homedir(), '.dsh', 'storages'))
+    expect(shouldAutoEnsure('external.deepseek_harness.storages')).toBe(false)
   })
 
   it('registers the platform-native default Hermes home as external data', () => {

--- a/src/main/core/paths/pathRegistry.ts
+++ b/src/main/core/paths/pathRegistry.ts
@@ -267,6 +267,7 @@ export function buildPathRegistry() {
     // -- F. external.* — third-party tool paths (Cherry reads/writes, does NOT own) --
     'external.openclaw.config': path.join(sysHome, '.openclaw'),
     'external.deepseek_harness.config': path.join(sysHome, '.dsh'),
+    'external.deepseek_harness.storages': path.join(sysHome, '.dsh', 'storages'),
     'external.hermes.default_home': isWin
       ? path.join(process.env.LOCALAPPDATA?.trim() || path.join(sysHome, 'AppData', 'Local'), 'hermes')
       : path.join(sysHome, '.hermes'),

--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -1,4 +1,5 @@
-import type { ChildProcess } from 'node:child_process'
+import { type ChildProcess, execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 
 import { Mutex } from 'async-mutex'
 
@@ -29,6 +30,7 @@ import {
   rollbackDeepSeekHarnessConfig,
   writeDeepSeekHarnessConfig
 } from './config'
+import { checkDshHomeHealth } from './storageHealth'
 
 const logger = loggerService.withContext('DeepSeekHarnessService')
 
@@ -41,6 +43,7 @@ const NO_KEY_PLACEHOLDER = 'no-key-required'
 const GATEWAY_ROUTE = 'cherry-studio-codemate-gateway'
 const GATEWAY_CREDENTIAL_REF = 'CHERRY_STUDIO_CODEMATE_GATEWAY_API_KEY'
 const MANAGED_CREDENTIAL_ENV = /^CHERRY_STUDIO_CODEMATE_(?:[A-F0-9]{12}|GATEWAY)_API_KEY$/i
+const execFileAsync = promisify(execFile)
 
 interface DeepSeekHarnessStartInput extends DeepSeekHarnessSettings {
   mode: DeepSeekHarnessMode
@@ -140,6 +143,25 @@ export class DeepSeekHarnessService extends BaseService {
           const runtime = await this.resolveRuntime()
           if (startupAbortController.signal.aborted) {
             throw new Error('DeepSeek Harness startup was cancelled')
+          }
+          const homeHealth = await checkDshHomeHealth(
+            AbsoluteFilePathSchema.parse(application.getPath('external.deepseek_harness.config'))
+          )
+          if (!homeHealth.healthy) {
+            const dshVersion = await readDshVersion(runtime.path)
+            logger.warn('DeepSeek Harness home failed preflight', {
+              reason: homeHealth.reason,
+              detail: homeHealth.detail,
+              ...(dshVersion ? { dshVersion } : {})
+            })
+            this.url = undefined
+            this.setStatus('error')
+            return {
+              success: false,
+              message: sanitizeDiagnostic(
+                `DeepSeek Harness home looks upgraded-incompatible (${homeHealth.detail}). Back it up, delete storages/session_projcache.json and storages/workspace.json inside it, then retry. [dsh-home-${homeHealth.reason}]`
+              )
+            }
           }
           const synced = await this.syncConfig(input)
           const projection = synced.projection
@@ -347,6 +369,15 @@ function appendBounded(current: string, chunk: Buffer | string): string {
 
 function sanitizeDiagnostic(value: string, secret?: string): string {
   return redactSecretText(redactLiteral(value, secret)).slice(0, DIAGNOSTIC_LIMIT)
+}
+
+async function readDshVersion(binaryPath: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(binaryPath, ['--version'], { timeout: 3000 })
+    return stdout.split('\n', 1)[0]?.trim().slice(0, 80) || undefined
+  } catch {
+    return undefined
+  }
 }
 
 function parseReadyUrl(output: string): string | undefined {

--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -30,7 +30,7 @@ import {
   rollbackDeepSeekHarnessConfig,
   writeDeepSeekHarnessConfig
 } from './config'
-import { checkDshHomeHealth } from './storageHealth'
+import { checkDshHomeHealth, type DshHomeHealth } from './storageHealth'
 
 const logger = loggerService.withContext('DeepSeekHarnessService')
 
@@ -159,7 +159,7 @@ export class DeepSeekHarnessService extends BaseService {
             return {
               success: false,
               message: sanitizeDiagnostic(
-                `DeepSeek Harness home looks upgraded-incompatible (${homeHealth.detail}). Back it up, delete storages/session_projcache.json and storages/workspace.json inside it, then retry. [dsh-home-${homeHealth.reason}]`
+                `DeepSeek Harness home looks upgraded-incompatible (${homeHealth.detail}). Back it up, delete ${repairTargetForReason(homeHealth.reason)} inside it, then retry. [dsh-home-${homeHealth.reason}]`
               )
             }
           }
@@ -366,6 +366,10 @@ function appendBounded(current: string, chunk: Buffer | string): string {
 
 function sanitizeDiagnostic(value: string, secret?: string): string {
   return redactSecretText(redactLiteral(value, secret)).slice(0, DIAGNOSTIC_LIMIT)
+}
+
+function repairTargetForReason(reason: Extract<DshHomeHealth, { healthy: false }>['reason']): string {
+  return reason.startsWith('projcache') ? 'storages/session_projcache.json' : 'storages/workspace.json'
 }
 
 function stripManagedCredentialEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -145,7 +145,7 @@ export class DeepSeekHarnessService extends BaseService {
             throw new Error('DeepSeek Harness startup was cancelled')
           }
           const homeHealth = await checkDshHomeHealth(
-            AbsoluteFilePathSchema.parse(application.getPath('external.deepseek_harness.config'))
+            AbsoluteFilePathSchema.parse(application.getPath('external.deepseek_harness.storages'))
           )
           if (!homeHealth.healthy) {
             const dshVersion = await readDshVersion(runtime.path)
@@ -299,14 +299,11 @@ export class DeepSeekHarnessService extends BaseService {
     permissionMode: DeepSeekHarnessPermissionMode,
     signal: AbortSignal
   ): Promise<string> {
-    const env = {
+    const env = stripManagedCredentialEnv({
       ...runtime.env,
       DSH_HOME: application.getPath('external.deepseek_harness.config'),
       DSH_PERMISSION_MODE: permissionMode
-    }
-    for (const name of Object.keys(env)) {
-      if (MANAGED_CREDENTIAL_ENV.test(name)) delete env[name]
-    }
+    })
 
     const child = crossPlatformSpawn(runtime.path, ['web', '--host', '127.0.0.1', '--port', '0', '--no-open'], {
       cwd: application.getPath('feature.deepseek_harness.workspace'),
@@ -371,9 +368,19 @@ function sanitizeDiagnostic(value: string, secret?: string): string {
   return redactSecretText(redactLiteral(value, secret)).slice(0, DIAGNOSTIC_LIMIT)
 }
 
+function stripManagedCredentialEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  for (const name of Object.keys(env)) {
+    if (MANAGED_CREDENTIAL_ENV.test(name)) delete env[name]
+  }
+  return env
+}
+
 async function readDshVersion(binaryPath: string): Promise<string | undefined> {
   try {
-    const { stdout } = await execFileAsync(binaryPath, ['--version'], { timeout: 3000 })
+    const { stdout } = await execFileAsync(binaryPath, ['--version'], {
+      timeout: 3000,
+      env: stripManagedCredentialEnv({ ...process.env })
+    })
     return stdout.split('\n', 1)[0]?.trim().slice(0, 80) || undefined
   } catch {
     return undefined

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -384,6 +384,10 @@ describe('DeepSeekHarnessService', () => {
     const result = await service.start(startInput)
 
     expect(result).toEqual({ success: false, message: expect.stringContaining('[dsh-home-workspace-inconsistent]') })
+    expect(result).toEqual({
+      success: false,
+      message: expect.stringContaining('delete storages/workspace.json inside it')
+    })
     expect(mocks.checkHomeHealth).toHaveBeenCalledWith('/mock/home/.dsh/storages')
     expect(mocks.spawn).not.toHaveBeenCalled()
     expect(mocks.writeConfig).not.toHaveBeenCalled()
@@ -404,6 +408,10 @@ describe('DeepSeekHarnessService', () => {
       expect(result).toEqual({
         success: false,
         message: expect.stringContaining('[dsh-home-projcache-unreadable]')
+      })
+      expect(result).toEqual({
+        success: false,
+        message: expect.stringContaining('delete storages/session_projcache.json inside it')
       })
       expect(mocks.execFile).toHaveBeenCalledOnce()
       const options = mocks.execFile.mock.calls[0][2] as { env: NodeJS.ProcessEnv }

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
   writeConfig: vi.fn(),
   rollbackConfig: vi.fn(),
+  checkHomeHealth: vi.fn(),
   providerGet: vi.fn(),
   providerGetApiKeys: vi.fn(),
   modelGet: vi.fn(),
@@ -69,6 +70,7 @@ vi.mock('../config', async () => {
     rollbackDeepSeekHarnessConfig: mocks.rollbackConfig
   }
 })
+vi.mock('../storageHealth', () => ({ checkDshHomeHealth: mocks.checkHomeHealth }))
 
 const { DeepSeekHarnessService } = await import('../DeepSeekHarnessService')
 
@@ -172,6 +174,7 @@ describe('DeepSeekHarnessService', () => {
       settings: { path: '/mock/home/.dsh/settings.yaml', written: 'written settings' }
     })
     mocks.rollbackConfig.mockResolvedValue(true)
+    mocks.checkHomeHealth.mockResolvedValue({ healthy: true })
     mocks.gatewayStart.mockResolvedValue(undefined)
     mocks.gatewayEnsureKey.mockResolvedValue('gateway-key')
     mocks.gatewayGetConfig.mockReturnValue({ host: '127.0.0.1', port: 23333 })
@@ -366,6 +369,23 @@ describe('DeepSeekHarnessService', () => {
     expect(result).toEqual({ success: false, message: 'This provider must be used through the Unified Gateway' })
     expect(mocks.writeConfig).not.toHaveBeenCalled()
     expect(mocks.spawn).not.toHaveBeenCalled()
+  })
+
+  it('fails fast without spawning when a populated home fails the upgrade preflight', async () => {
+    mocks.checkHomeHealth.mockResolvedValue({
+      healthy: false,
+      reason: 'workspace-inconsistent',
+      detail:
+        'storages/workspace.json lists 3 workspace(s) with empty sessionIds while archivedSessionIds holds 4 session(s)'
+    })
+    const service = new DeepSeekHarnessService()
+
+    const result = await service.start(startInput)
+
+    expect(result).toEqual({ success: false, message: expect.stringContaining('[dsh-home-workspace-inconsistent]') })
+    expect(mocks.spawn).not.toHaveBeenCalled()
+    expect(mocks.writeConfig).not.toHaveBeenCalled()
+    expect(service.getStatus()).toEqual({ status: 'error' })
   })
 
   it('starts the global gateway and projects its current address, key, and gateway model id', async () => {

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -136,6 +136,7 @@ describe('DeepSeekHarnessService', () => {
     children.length = 0
     mocks.appGetPath.mockImplementation((key: string) => {
       if (key === 'external.deepseek_harness.config') return '/mock/home/.dsh'
+      if (key === 'external.deepseek_harness.storages') return '/mock/home/.dsh/storages'
       if (key === 'feature.deepseek_harness.workspace') return '/mock/userData/Data/DeepSeekHarness/Workspace'
       throw new Error(`Unexpected application.getPath(${key})`)
     })
@@ -383,9 +384,35 @@ describe('DeepSeekHarnessService', () => {
     const result = await service.start(startInput)
 
     expect(result).toEqual({ success: false, message: expect.stringContaining('[dsh-home-workspace-inconsistent]') })
+    expect(mocks.checkHomeHealth).toHaveBeenCalledWith('/mock/home/.dsh/storages')
     expect(mocks.spawn).not.toHaveBeenCalled()
     expect(mocks.writeConfig).not.toHaveBeenCalled()
     expect(service.getStatus()).toEqual({ status: 'error' })
+  })
+
+  it('scrubs managed credential env from the diagnostic version probe', async () => {
+    process.env.CHERRY_STUDIO_CODEMATE_GATEWAY_API_KEY = 'probe-secret'
+    try {
+      mocks.checkHomeHealth.mockResolvedValue({
+        healthy: false,
+        reason: 'projcache-unreadable',
+        detail: 'storages/session_projcache.json is not valid JSON'
+      })
+
+      const result = await new DeepSeekHarnessService().start(startInput)
+
+      expect(result).toEqual({
+        success: false,
+        message: expect.stringContaining('[dsh-home-projcache-unreadable]')
+      })
+      expect(mocks.execFile).toHaveBeenCalledOnce()
+      const options = mocks.execFile.mock.calls[0][2] as { env: NodeJS.ProcessEnv }
+      expect(options.env).not.toHaveProperty('CHERRY_STUDIO_CODEMATE_GATEWAY_API_KEY')
+      expect(options.env).not.toHaveProperty('CHERRY_STUDIO_CODEMATE_481BD06FDD6C_API_KEY')
+      expect(mocks.spawn).not.toHaveBeenCalled()
+    } finally {
+      delete process.env.CHERRY_STUDIO_CODEMATE_GATEWAY_API_KEY
+    }
   })
 
   it('starts the global gateway and projects its current address, key, and gateway model id', async () => {

--- a/src/main/services/deepSeekHarness/__tests__/storageHealth.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/storageHealth.test.ts
@@ -44,6 +44,26 @@ describe('checkDshHomeHealth', () => {
     })
   })
 
+  it('flags a unit-enveloped projcache version outside its compatibleVersions', async () => {
+    await writeStore(
+      'session_projcache.json',
+      JSON.stringify({ unit: { name: 'session_projcache', version: 9, compatibleVersions: [3, 4, 5, 6] } })
+    )
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({
+      healthy: false,
+      reason: 'projcache-version',
+      detail: expect.stringContaining('version 9')
+    })
+  })
+
+  it('reports healthy for a unit-enveloped projcache version inside its compatibleVersions', async () => {
+    await writeStore(
+      'session_projcache.json',
+      JSON.stringify({ unit: { name: 'session_projcache', version: 4, compatibleVersions: [3, 4, 5, 6] } })
+    )
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({ healthy: true })
+  })
+
   it('flags a corrupt projcache file', async () => {
     await writeStore('session_projcache.json', '{not json')
     await expect(checkDshHomeHealth(stores)).resolves.toEqual({

--- a/src/main/services/deepSeekHarness/__tests__/storageHealth.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/storageHealth.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { AbsoluteFilePath } from '@shared/types/file'
+
+import { checkDshHomeHealth } from '../storageHealth'
+
+describe('checkDshHomeHealth', () => {
+  let dir: AbsoluteFilePath
+
+  beforeEach(async () => {
+    dir = (await mkdtemp(path.join(tmpdir(), 'deepseek-harness-home-'))) as AbsoluteFilePath
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  async function writeStore(fileName: string, content: string): Promise<void> {
+    await mkdir(path.join(dir, 'storages'), { recursive: true })
+    await writeFile(path.join(dir, 'storages', fileName), content, 'utf8')
+  }
+
+  it('reports healthy for a fresh home with no store files', async () => {
+    await expect(checkDshHomeHealth(dir)).resolves.toEqual({ healthy: true })
+  })
+
+  it('reports healthy for a nominally migratable projcache version', async () => {
+    await writeStore('session_projcache.json', JSON.stringify({ version: 3, compatibleVersions: [3, 4, 5, 6] }))
+    await expect(checkDshHomeHealth(dir)).resolves.toEqual({ healthy: true })
+  })
+
+  it('flags a projcache version outside its own compatibleVersions', async () => {
+    await writeStore('session_projcache.json', JSON.stringify({ version: 9, compatibleVersions: [3, 4, 5, 6] }))
+    await expect(checkDshHomeHealth(dir)).resolves.toEqual({
+      healthy: false,
+      reason: 'projcache-version',
+      detail: expect.stringContaining('version 9')
+    })
+  })
+
+  it('flags a corrupt projcache file', async () => {
+    await writeStore('session_projcache.json', '{not json')
+    await expect(checkDshHomeHealth(dir)).resolves.toEqual({
+      healthy: false,
+      reason: 'projcache-unreadable',
+      detail: expect.stringContaining('session_projcache.json')
+    })
+  })
+
+  it('flags workspaces with empty sessionIds while archived sessions exist', async () => {
+    await writeStore(
+      'workspace.json',
+      JSON.stringify({
+        unit: { name: 'workspace', version: 2 },
+        global: { initialized: true, workspaceIds: ['w1'], archivedSessionIds: ['s1', 's2', 's3', 's4'] },
+        tables: { workspaces: { w1: { path: '/tmp/w1', title: 'w1', sessionIds: [] } } }
+      })
+    )
+    await expect(checkDshHomeHealth(dir)).resolves.toEqual({
+      healthy: false,
+      reason: 'workspace-inconsistent',
+      detail: expect.stringContaining('archivedSessionIds')
+    })
+  })
+
+  it('reports healthy when at least one workspace still owns sessions', async () => {
+    await writeStore(
+      'workspace.json',
+      JSON.stringify({
+        global: { archivedSessionIds: ['s1'] },
+        tables: { workspaces: { w1: { sessionIds: [] }, w2: { sessionIds: ['s9'] } } }
+      })
+    )
+    await expect(checkDshHomeHealth(dir)).resolves.toEqual({ healthy: true })
+  })
+
+  it('fails open on unknown shapes instead of blocking launch', async () => {
+    await writeStore('session_projcache.json', JSON.stringify({ version: 'three' }))
+    await writeStore('workspace.json', JSON.stringify({ tables: 'unexpected' }))
+    await expect(checkDshHomeHealth(dir)).resolves.toEqual({ healthy: true })
+  })
+})

--- a/src/main/services/deepSeekHarness/__tests__/storageHealth.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/storageHealth.test.ts
@@ -10,9 +10,11 @@ import { checkDshHomeHealth } from '../storageHealth'
 
 describe('checkDshHomeHealth', () => {
   let dir: AbsoluteFilePath
+  let stores: AbsoluteFilePath
 
   beforeEach(async () => {
     dir = (await mkdtemp(path.join(tmpdir(), 'deepseek-harness-home-'))) as AbsoluteFilePath
+    stores = path.join(dir, 'storages') as AbsoluteFilePath
   })
 
   afterEach(async () => {
@@ -20,22 +22,22 @@ describe('checkDshHomeHealth', () => {
   })
 
   async function writeStore(fileName: string, content: string): Promise<void> {
-    await mkdir(path.join(dir, 'storages'), { recursive: true })
-    await writeFile(path.join(dir, 'storages', fileName), content, 'utf8')
+    await mkdir(stores, { recursive: true })
+    await writeFile(path.join(stores, fileName), content, 'utf8')
   }
 
   it('reports healthy for a fresh home with no store files', async () => {
-    await expect(checkDshHomeHealth(dir)).resolves.toEqual({ healthy: true })
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({ healthy: true })
   })
 
   it('reports healthy for a nominally migratable projcache version', async () => {
     await writeStore('session_projcache.json', JSON.stringify({ version: 3, compatibleVersions: [3, 4, 5, 6] }))
-    await expect(checkDshHomeHealth(dir)).resolves.toEqual({ healthy: true })
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({ healthy: true })
   })
 
   it('flags a projcache version outside its own compatibleVersions', async () => {
     await writeStore('session_projcache.json', JSON.stringify({ version: 9, compatibleVersions: [3, 4, 5, 6] }))
-    await expect(checkDshHomeHealth(dir)).resolves.toEqual({
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({
       healthy: false,
       reason: 'projcache-version',
       detail: expect.stringContaining('version 9')
@@ -44,7 +46,7 @@ describe('checkDshHomeHealth', () => {
 
   it('flags a corrupt projcache file', async () => {
     await writeStore('session_projcache.json', '{not json')
-    await expect(checkDshHomeHealth(dir)).resolves.toEqual({
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({
       healthy: false,
       reason: 'projcache-unreadable',
       detail: expect.stringContaining('session_projcache.json')
@@ -53,7 +55,7 @@ describe('checkDshHomeHealth', () => {
 
   it('flags a corrupt workspace file with its own reason code', async () => {
     await writeStore('workspace.json', '{not json')
-    await expect(checkDshHomeHealth(dir)).resolves.toEqual({
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({
       healthy: false,
       reason: 'workspace-unreadable',
       detail: expect.stringContaining('workspace.json')
@@ -69,7 +71,7 @@ describe('checkDshHomeHealth', () => {
         tables: { workspaces: { w1: { path: '/tmp/w1', title: 'w1', sessionIds: [] } } }
       })
     )
-    await expect(checkDshHomeHealth(dir)).resolves.toEqual({
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({
       healthy: false,
       reason: 'workspace-inconsistent',
       detail: expect.stringContaining('archivedSessionIds')
@@ -84,12 +86,12 @@ describe('checkDshHomeHealth', () => {
         tables: { workspaces: { w1: { sessionIds: [] }, w2: { sessionIds: ['s9'] } } }
       })
     )
-    await expect(checkDshHomeHealth(dir)).resolves.toEqual({ healthy: true })
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({ healthy: true })
   })
 
   it('fails open on unknown shapes instead of blocking launch', async () => {
     await writeStore('session_projcache.json', JSON.stringify({ version: 'three' }))
     await writeStore('workspace.json', JSON.stringify({ tables: 'unexpected' }))
-    await expect(checkDshHomeHealth(dir)).resolves.toEqual({ healthy: true })
+    await expect(checkDshHomeHealth(stores)).resolves.toEqual({ healthy: true })
   })
 })

--- a/src/main/services/deepSeekHarness/__tests__/storageHealth.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/storageHealth.test.ts
@@ -51,6 +51,15 @@ describe('checkDshHomeHealth', () => {
     })
   })
 
+  it('flags a corrupt workspace file with its own reason code', async () => {
+    await writeStore('workspace.json', '{not json')
+    await expect(checkDshHomeHealth(dir)).resolves.toEqual({
+      healthy: false,
+      reason: 'workspace-unreadable',
+      detail: expect.stringContaining('workspace.json')
+    })
+  })
+
   it('flags workspaces with empty sessionIds while archived sessions exist', async () => {
     await writeStore(
       'workspace.json',

--- a/src/main/services/deepSeekHarness/storageHealth.ts
+++ b/src/main/services/deepSeekHarness/storageHealth.ts
@@ -7,7 +7,7 @@ export type DshHomeHealth =
   | { healthy: true }
   | {
       healthy: false
-      reason: 'projcache-unreadable' | 'projcache-version' | 'workspace-inconsistent'
+      reason: 'projcache-unreadable' | 'projcache-version' | 'workspace-inconsistent' | 'workspace-unreadable'
       detail: string
     }
 
@@ -98,7 +98,7 @@ export async function checkDshHomeHealth(dshHomeDir: AbsoluteFilePath): Promise<
     workspace = await readStoreJson(dshHomeDir, 'workspace.json')
   } catch (error) {
     if (error instanceof SyntaxError) {
-      return { healthy: false, reason: 'projcache-unreadable', detail: 'storages/workspace.json is not valid JSON' }
+      return { healthy: false, reason: 'workspace-unreadable', detail: 'storages/workspace.json is not valid JSON' }
     }
     return { healthy: true }
   }

--- a/src/main/services/deepSeekHarness/storageHealth.ts
+++ b/src/main/services/deepSeekHarness/storageHealth.ts
@@ -1,0 +1,110 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import type { AbsoluteFilePath } from '@shared/types/file'
+
+export type DshHomeHealth =
+  | { healthy: true }
+  | {
+      healthy: false
+      reason: 'projcache-unreadable' | 'projcache-version' | 'workspace-inconsistent'
+      detail: string
+    }
+
+// Fail-open cap: an unexpectedly large store file is never a reason to block launch.
+const MAX_ENTRY_BYTES = 256 * 1024
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === 'ENOENT'
+}
+
+async function readStoreJson(dshHomeDir: AbsoluteFilePath, fileName: string): Promise<unknown | undefined> {
+  const filePath = path.join(dshHomeDir, 'storages', fileName)
+  let stat: { size: number }
+  try {
+    stat = await fs.stat(filePath)
+  } catch (error) {
+    if (isMissing(error)) return undefined
+    throw error
+  }
+  if (stat.size > MAX_ENTRY_BYTES) return undefined
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown
+}
+
+function checkProjcacheVersion(data: unknown): string | undefined {
+  if (typeof data !== 'object' || data === null) return undefined
+  const version = (data as { version?: unknown }).version
+  if (typeof version !== 'number' || !Number.isSafeInteger(version)) return undefined
+  const compatible = (data as { compatibleVersions?: unknown }).compatibleVersions
+  if (!Array.isArray(compatible) || !compatible.every((entry) => typeof entry === 'number')) return undefined
+  if (compatible.includes(version)) return undefined
+  return `storages/session_projcache.json declares version ${version} outside its compatibleVersions [${compatible.join(', ')}]`
+}
+
+function checkWorkspaceConsistency(data: unknown): string | undefined {
+  if (typeof data !== 'object' || data === null) return undefined
+  const tables = (data as { tables?: unknown }).tables
+  const workspaces =
+    typeof tables === 'object' && tables !== null ? (tables as { workspaces?: unknown }).workspaces : undefined
+  if (typeof workspaces !== 'object' || workspaces === null || Array.isArray(workspaces)) return undefined
+  const entries = Object.values(workspaces)
+  if (entries.length === 0) return undefined
+  const global = (data as { global?: unknown }).global
+  const archived =
+    typeof global === 'object' && global !== null
+      ? (global as { archivedSessionIds?: unknown }).archivedSessionIds
+      : undefined
+  if (!Array.isArray(archived) || archived.length === 0) return undefined
+  const allEmpty = entries.every(
+    (entry) =>
+      typeof entry === 'object' &&
+      entry !== null &&
+      Array.isArray((entry as { sessionIds?: unknown }).sessionIds) &&
+      (entry as { sessionIds: unknown[] }).sessionIds.length === 0
+  )
+  if (!allEmpty) return undefined
+  return (
+    `storages/workspace.json lists ${entries.length} workspace(s) with empty sessionIds ` +
+    `while archivedSessionIds holds ${archived.length} session(s)`
+  )
+}
+
+/**
+ * Read-only preflight for a pre-existing DSH home (`~/.dsh`, third-party owned).
+ * @returns healthy, or the first positive incompatibility signal. Fail-open:
+ * unknown shapes and I/O surprises report healthy so launch is never blocked.
+ */
+export async function checkDshHomeHealth(dshHomeDir: AbsoluteFilePath): Promise<DshHomeHealth> {
+  let projcache: unknown
+  try {
+    projcache = await readStoreJson(dshHomeDir, 'session_projcache.json')
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return {
+        healthy: false,
+        reason: 'projcache-unreadable',
+        detail: 'storages/session_projcache.json is not valid JSON'
+      }
+    }
+    return { healthy: true }
+  }
+  if (projcache !== undefined) {
+    const versionDetail = checkProjcacheVersion(projcache)
+    if (versionDetail) return { healthy: false, reason: 'projcache-version', detail: versionDetail }
+  }
+
+  let workspace: unknown
+  try {
+    workspace = await readStoreJson(dshHomeDir, 'workspace.json')
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return { healthy: false, reason: 'projcache-unreadable', detail: 'storages/workspace.json is not valid JSON' }
+    }
+    return { healthy: true }
+  }
+  if (workspace !== undefined) {
+    const consistencyDetail = checkWorkspaceConsistency(workspace)
+    if (consistencyDetail) return { healthy: false, reason: 'workspace-inconsistent', detail: consistencyDetail }
+  }
+  return { healthy: true }
+}

--- a/src/main/services/deepSeekHarness/storageHealth.ts
+++ b/src/main/services/deepSeekHarness/storageHealth.ts
@@ -18,8 +18,8 @@ function isMissing(error: unknown): boolean {
   return (error as NodeJS.ErrnoException).code === 'ENOENT'
 }
 
-async function readStoreJson(dshHomeDir: AbsoluteFilePath, fileName: string): Promise<unknown | undefined> {
-  const filePath = path.join(dshHomeDir, 'storages', fileName)
+async function readStoreJson(storagesDir: AbsoluteFilePath, fileName: string): Promise<unknown | undefined> {
+  const filePath = path.join(storagesDir, fileName)
   let stat: { size: number }
   try {
     stat = await fs.stat(filePath)
@@ -31,6 +31,8 @@ async function readStoreJson(dshHomeDir: AbsoluteFilePath, fileName: string): Pr
   return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown
 }
 
+// Self-descriptive only: fires when the store's own version falls outside its own
+// compatibleVersions. Anything else fails open — no Cherry-side version constants.
 function checkProjcacheVersion(data: unknown): string | undefined {
   if (typeof data !== 'object' || data === null) return undefined
   const version = (data as { version?: unknown }).version
@@ -41,6 +43,8 @@ function checkProjcacheVersion(data: unknown): string | undefined {
   return `storages/session_projcache.json declares version ${version} outside its compatibleVersions [${compatible.join(', ')}]`
 }
 
+// Exact state from #20395: every workspace lost its sessionIds slots while the
+// archive still holds sessions, which the dsh registry would not produce itself.
 function checkWorkspaceConsistency(data: unknown): string | undefined {
   if (typeof data !== 'object' || data === null) return undefined
   const tables = (data as { tables?: unknown }).tables
@@ -71,13 +75,14 @@ function checkWorkspaceConsistency(data: unknown): string | undefined {
 
 /**
  * Read-only preflight for a pre-existing DSH home (`~/.dsh`, third-party owned).
+ * @param storagesDir the registered `external.deepseek_harness.storages` directory.
  * @returns healthy, or the first positive incompatibility signal. Fail-open:
  * unknown shapes and I/O surprises report healthy so launch is never blocked.
  */
-export async function checkDshHomeHealth(dshHomeDir: AbsoluteFilePath): Promise<DshHomeHealth> {
+export async function checkDshHomeHealth(storagesDir: AbsoluteFilePath): Promise<DshHomeHealth> {
   let projcache: unknown
   try {
-    projcache = await readStoreJson(dshHomeDir, 'session_projcache.json')
+    projcache = await readStoreJson(storagesDir, 'session_projcache.json')
   } catch (error) {
     if (error instanceof SyntaxError) {
       return {
@@ -95,7 +100,7 @@ export async function checkDshHomeHealth(dshHomeDir: AbsoluteFilePath): Promise<
 
   let workspace: unknown
   try {
-    workspace = await readStoreJson(dshHomeDir, 'workspace.json')
+    workspace = await readStoreJson(storagesDir, 'workspace.json')
   } catch (error) {
     if (error instanceof SyntaxError) {
       return { healthy: false, reason: 'workspace-unreadable', detail: 'storages/workspace.json is not valid JSON' }

--- a/src/main/services/deepSeekHarness/storageHealth.ts
+++ b/src/main/services/deepSeekHarness/storageHealth.ts
@@ -35,6 +35,13 @@ async function readStoreJson(storagesDir: AbsoluteFilePath, fileName: string): P
 // compatibleVersions. Anything else fails open — no Cherry-side version constants.
 function checkProjcacheVersion(data: unknown): string | undefined {
   if (typeof data !== 'object' || data === null) return undefined
+  // dsh also envelopes versions under `unit` (seen in real workspace.json from
+  // #20395); a unit-carried version previously bypassed this guard entirely.
+  return checkVersionPair(data) ?? checkVersionPair((data as { unit?: unknown }).unit)
+}
+
+function checkVersionPair(data: unknown): string | undefined {
+  if (typeof data !== 'object' || data === null) return undefined
   const version = (data as { version?: unknown }).version
   if (typeof version !== 'number' || !Number.isSafeInteger(version)) return undefined
   const compatible = (data as { compatibleVersions?: unknown }).compatibleVersions


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`DeepSeekHarnessService.start()` only proved the `dsh web` root was up (ready-URL line + HTTP 200 / 303 probe). A stale `~/.dsh` store from an older release passed readiness, so Cherry opened the Web UI and users looped forever on the dsh workspace picker: workspaces registered fine, but no session was ever created.

After this PR:

`start()` runs a read-only, fail-open preflight over the third-party-owned DSH home before spawning. A positively incompatible state now returns an actionable `{ success: false, message }` (surfaced by the existing `toast.error`) naming the store files and the backup-and-delete repair, and sets status `error` — instead of opening a dead picker.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20395

### Why we need it and why it was done in this way

The dsh workspace/session store (`storages/session_projcache.json`, `storages/workspace.json`, `archivedSessionIds`) lives entirely in the external `dsh` binary — there are zero references to it in this repo, so Cherry cannot migrate the store itself. The only defensible seam is failing fast with guidance instead of reporting success into a broken UI.

The following tradeoffs were made:

- Preflight is read-only and fail-open: unknown shapes, oversized files, and transient I/O errors report healthy so a future dsh store rename can never false-block launch. Only positive signals flag: unparsable store JSON, a projcache `version` outside its own `compatibleVersions`, and the exact inconsistency from the issue (every workspace with empty `sessionIds` while `archivedSessionIds` is non-empty). No expected-version constants are hardcoded.
- The repair is a message, not a button: the failure text tells the user to back up `~/.dsh` and delete the two store files. A one-click backup-and-reset (`deepseek_harness.reset_home` + confirm dialog) is deferred as a follow-up to keep this change surgical and avoid new IPC routes, renderer wiring, and locale work.
- No `dsh` version bump: the loop reproduces *after* moving to `0.1.5-rc.1`, so bumping alone repairs nothing. A best-effort `dsh --version` is logged on preflight failure for future upgrade reports.

The following alternatives were considered:

- Vendoring dsh store schemas and migrating in Cherry: rejected, couples us to upstream internals that change every dsh bump.
- Post-ready session-creation smoke probe: deferred, no confirmed stable `dsh web` API for it.

Links to places where the discussion took place:

- https://github.com/CherryHQ/cherry-studio/issues/20395

### Breaking changes

None.

### Special notes for your reviewer

- Verification: `storageHealth.test.ts` (7 tests, populated-home matrix) + `DeepSeekHarnessService.test.ts` (new fail-fast case: no spawn, no config write, status `error`) + `config.test.ts` — 60 tests green via direct `vitest run`; `eslint` clean; `oxfmt` applied; `tsc -p tsconfig.node.json` shows zero errors in touched files (24 pre-existing errors in untouched `src/main/ai/runtime/dsh/compositionBuilder.ts` from the unbuilt `@cherrystudio/dsh-bridge` dist in this worktree; CI builds workspaces first).
- `oxlint` binary is absent from this worktree's partial install, so that gate was not run locally; CI will cover it.
- Out of scope per issue triage: EPERM dir-fsync noise, placeholder MCP baseDir path, process-tree cleanup (#20097 / #20415), credentials flat-vs-`refs` (#19267, already handled).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
<!--LANG:en-->
[DeepSeek Harness] Launch now fails fast with an actionable repair hint when the pre-existing DSH home is incompatible after an upgrade, instead of looping on the workspace picker.
<!--LANG:zh-CN-->
[DeepSeek Harness] 升级后若已有 DSH 主目录不兼容，启动时将直接给出可操作的修复提示，而不再卡在工作区选择器循环中。
<!--LANG:END-->
```
