### PR TITLE
fix(claude-code): recover macOS high-fd spawn failures

### DIFF
--- a/src/main/ai/runtime/claudeCode/ClaudeCodeProcessManager.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeProcessManager.ts
@@ -44,12 +44,37 @@ export type SpawnProcess = (
     env: NodeJS.ProcessEnv
     signal: AbortSignal
     stdio: ['pipe', 'pipe', 'pipe']
+    uid?: number
     windowsHide: true
   }
 ) => SpawnedChildProcess
 
 type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void
 type ErrorListener = (error: Error) => void
+
+function logClaudeCodeProcessFailure(diagnostics: ClaudeCodeProcessDiagnostics): void {
+  logger.warn('Claude Code process failed', {
+    reference: diagnostics.reference,
+    category: diagnostics.category,
+    exitCode: diagnostics.exitCode,
+    exitSignal: diagnostics.exitSignal,
+    spawnFailed: diagnostics.spawnFailed
+  })
+}
+
+function recordSynchronousSpawnFailure(diagnostics: ClaudeCodeProcessDiagnostics, error: unknown): void {
+  if (!(error instanceof Error)) return
+  recordClaudeCodeSpawnError(diagnostics, error)
+  logClaudeCodeProcessFailure(diagnostics)
+}
+
+function macOsForkFallbackUid(error: unknown): number | undefined {
+  if (process.platform !== 'darwin' || typeof process.getuid !== 'function') return undefined
+  if (!(error instanceof Error) || (error as NodeJS.ErrnoException).code !== 'EBADF') return undefined
+
+  // Apple posix_spawn rejects pipe fds above 10239 (libuv#5204); same uid selects libuv's fork/exec path.
+  return process.getuid()
+}
 
 class ManagedClaudeCodeProcess implements SpawnedProcess {
   private readonly events = new EventEmitter()
@@ -84,7 +109,7 @@ class ManagedClaudeCodeProcess implements SpawnedProcess {
     })
     child.once('error', (error) => {
       recordClaudeCodeSpawnError(diagnostics, error)
-      this.logTerminalReason()
+      logClaudeCodeProcessFailure(diagnostics)
       this.events.emit('error', error)
     })
   }
@@ -145,19 +170,8 @@ class ManagedClaudeCodeProcess implements SpawnedProcess {
     this.pendingExit = undefined
     if (this.drainTimer) clearTimeout(this.drainTimer)
     recordClaudeCodeProcessExit(this.diagnostics, exit.code, exit.signal, this.stderrTail)
-    if (exit.code !== 0) this.logTerminalReason()
+    if (exit.code !== 0) logClaudeCodeProcessFailure(this.diagnostics)
     this.events.emit('exit', exit.code, exit.signal)
-  }
-
-  /** Correlate the renderer reference with structured diagnostics without persisting untrusted stderr. */
-  private logTerminalReason(): void {
-    logger.warn('Claude Code process failed', {
-      reference: this.diagnostics.reference,
-      category: this.diagnostics.category,
-      exitCode: this.diagnostics.exitCode,
-      exitSignal: this.diagnostics.exitSignal,
-      spawnFailed: this.diagnostics.spawnFailed
-    })
   }
 }
 
@@ -176,14 +190,34 @@ export class ClaudeCodeProcessManager extends BaseService {
 
   spawn(options: SpawnOptions, diagnostics = createClaudeCodeProcessDiagnostics()): SpawnedProcess {
     resetClaudeCodeProcessDiagnostics(diagnostics)
-    const rawChild = this.spawnProcess(options.command, options.args, {
+    const spawnOptions: Parameters<SpawnProcess>[2] = {
       cwd: options.cwd,
       env: options.env,
       signal: options.signal,
       // Keeping stdin a pipe is also what makes the CLI exit on its own once this app dies.
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true
-    })
+    }
+    let rawChild: SpawnedChildProcess
+    try {
+      rawChild = this.spawnProcess(options.command, options.args, spawnOptions)
+    } catch (error) {
+      const uid = macOsForkFallbackUid(error)
+      if (uid === undefined) {
+        recordSynchronousSpawnFailure(diagnostics, error)
+        throw error
+      }
+
+      logger.warn('Retrying Claude Code process spawn through macOS fork fallback', {
+        reference: diagnostics.reference
+      })
+      try {
+        rawChild = this.spawnProcess(options.command, options.args, { ...spawnOptions, uid })
+      } catch (retryError) {
+        recordSynchronousSpawnFailure(diagnostics, retryError)
+        throw retryError
+      }
+    }
     const child = new ManagedClaudeCodeProcess(rawChild, diagnostics) as TrackedSpawnedProcess
     this.processes.add(child)
     // Untracked on the raw exit, not the wrapper's — no reason to hold a dead handle through the drain.

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeProcessManager.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeProcessManager.test.ts
@@ -155,6 +155,83 @@ describe('ClaudeCodeProcessManager', () => {
     expect(child.kill).not.toHaveBeenCalled()
   })
 
+  it('recovers repeated startup and cleanup after macOS rejects high pipe descriptors', () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!
+    const getuidDescriptor = Object.getOwnPropertyDescriptor(process, 'getuid')
+    const recovered = createFakeChild()
+    const next = createFakeChild()
+    const spawnError = Object.assign(new Error('spawn EBADF'), { code: 'EBADF' })
+    const spawnProcess = vi
+      .fn<SpawnProcess>()
+      .mockImplementationOnce(() => {
+        throw spawnError
+      })
+      .mockReturnValueOnce(recovered.process)
+      .mockReturnValueOnce(next.process)
+    const manager = new TestProcessManager(spawnProcess)
+
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    Object.defineProperty(process, 'getuid', { value: () => 501, configurable: true })
+
+    try {
+      manager.spawn(spawnOptions)
+      expect(spawnProcess).toHaveBeenNthCalledWith(2, spawnOptions.command, spawnOptions.args, {
+        env: spawnOptions.env,
+        signal: spawnOptions.signal,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        uid: 501,
+        windowsHide: true
+      })
+      recovered.emitExit()
+
+      manager.spawn(spawnOptions)
+      next.emitExit()
+      manager.killAll('SIGTERM')
+
+      expect(recovered.kill).not.toHaveBeenCalled()
+      expect(next.kill).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(process, 'platform', platformDescriptor)
+      if (getuidDescriptor) Object.defineProperty(process, 'getuid', getuidDescriptor)
+      else Reflect.deleteProperty(process, 'getuid')
+    }
+  })
+
+  it('records a failed macOS fallback without logging the private executable path', () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!
+    const getuidDescriptor = Object.getOwnPropertyDescriptor(process, 'getuid')
+    const initialError = Object.assign(new Error('spawn EBADF'), { code: 'EBADF' })
+    const retryError = Object.assign(new Error('spawn /Users/alice/private/claude EBADF'), { code: 'EBADF' })
+    const spawnProcess = vi
+      .fn<SpawnProcess>()
+      .mockImplementationOnce(() => {
+        throw initialError
+      })
+      .mockImplementationOnce(() => {
+        throw retryError
+      })
+    const manager = new TestProcessManager(spawnProcess)
+    const diagnostics = createClaudeCodeProcessDiagnostics('diagnostic-ref')
+
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    Object.defineProperty(process, 'getuid', { value: () => 501, configurable: true })
+
+    try {
+      expect(() => manager.spawn(spawnOptions, diagnostics)).toThrow(retryError)
+
+      expect(diagnostics).toMatchObject({ category: 'unknown', spawnFailed: true })
+      const logged = mockMainLoggerService.warn.mock.calls.findLast(
+        ([message]) => message === 'Claude Code process failed'
+      )?.[1]
+      expect(logged).toMatchObject({ reference: 'diagnostic-ref', category: 'unknown', spawnFailed: true })
+      expect(JSON.stringify(logged)).not.toContain('/Users/alice/private')
+    } finally {
+      Object.defineProperty(process, 'platform', platformDescriptor)
+      if (getuidDescriptor) Object.defineProperty(process, 'getuid', getuidDescriptor)
+      else Reflect.deleteProperty(process, 'getuid')
+    }
+  })
+
   it('drains a bounded stderr tail before delivering exit diagnostics', async () => {
     const child = createFakeChild()
     const manager = new TestProcessManager(vi.fn(() => child.process))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

On macOS, Apple `posix_spawn` rejects otherwise valid pipe descriptors above 10239 with `EBADF`. A Claude Code Agent session could therefore fail synchronously while creating its three stdio pipes after Cherry Studio had accumulated enough open file descriptors. The synchronous throw also bypassed the existing child-process `error` diagnostics.

After this PR:

`ClaudeCodeProcessManager` retries a synchronous macOS `EBADF` once with Cherry Studio's unchanged current UID, which selects libuv's fork/exec path while preserving the existing stdin/stdout/stderr pipe contract. If either a non-recoverable initial spawn or the fallback still fails, the existing structured diagnostics record the spawn phase without logging raw executable paths.

Refs #20407

### Why we need it and why it was done in this way

The failure is caused by the open libuv/macOS limitation tracked in [libuv#5204](https://github.com/libuv/libuv/issues/5204), not by an invalid Cherry descriptor. Keeping stdin piped is also required for the Claude CLI to observe parent shutdown, while stdout and stderr are part of the SDK transport and diagnostics contract. Passing the unchanged current UID is the narrowest available Node/libuv option that selects fork/exec only after the proven macOS failure.

The following tradeoffs were made:

- Normal startup still uses `posix_spawn`; the fallback is limited to a synchronous `EBADF` on macOS and retries only once.
- The retry uses the current UID, so it does not change the child's identity or the three-pipe transport contract.
- This PR covers the Claude Code boundary that Cherry owns directly. The public diagnostic does not identify which registered Agent runtime failed, so it links to #20407 without changing the issue state.

The following alternatives were considered:

- Removing or redirecting a stdio pipe was rejected because it would break the Claude SDK transport, diagnostics, or parent-death behavior.
- Forcing every macOS spawn through fork/exec was rejected because the workaround is only needed after the specific `posix_spawn` failure.
- Patching DSH downstream was not included: `@deepseek-ai/dsh-sdk-client` currently owns its direct three-pipe spawn and exposes no spawn injection or spawn-options hook. Upstream master has the same boundary, so DSH coverage requires an upstream API or a separately reviewed dependency patch.
- Pi runtime startup is in-process. Its Bash tool has a separate operation-scoped spawn boundary and is not changed here.

Links to places where the discussion took place: #20407, https://github.com/libuv/libuv/issues/5204

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A.

### Special notes for your reviewer

This is a main-process runtime fix with no UI surface, so screenshots are not applicable.

Validation performed on macOS arm64:

- 134 focused tests passed across `ClaudeCodeProcessManager`, process-exit diagnostics, the Claude runtime driver, warm-query manager, and query options.
- A bundled Electron 41.8.0 / Node 24.16.0 probe opened descriptors through fd 10241, observed the initial `EBADF`, used the fallback, and started a child that exited 0 with empty stderr.
- `pnpm test:lint` passed with zero errors (47 unrelated existing advisory warnings).
- `pnpm lint` passed, including Node/Web/AI Core type checks, i18n validation, and formatting.
- Regression tests cover recovered repeated startup/cleanup and a failed fallback whose structured logs exclude a private executable path.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this transparent recovery fix
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Claude Code Agent sessions failing to start on macOS when Cherry Studio has many open file descriptors.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the main-process Claude Code spawn path and adds a macOS-only retry; incorrect fallback logic could affect agent startup, though scope is limited to synchronous EBADF.
> 
> **Overview**
> Fixes Claude Code Agent sessions that fail to start on macOS when `posix_spawn` rejects high file-descriptor pipe stdio with **`EBADF`** (libuv#5204).
> 
> **`ClaudeCodeProcessManager.spawn`** now catches synchronous spawn throws, and on **darwin** + **`EBADF`** retries once with the current **`uid`** so Node/libuv uses fork/exec while keeping the three-pipe stdio contract. Non-recoverable or failed retry paths call **`recordSynchronousSpawnFailure`**, so spawn-phase failures get the same structured diagnostics and **`Claude Code process failed`** logging as async child errors—without pulling raw executable paths into logs.
> 
> Failure logging moves from **`ManagedClaudeCodeProcess.logTerminalReason`** to shared module helpers. Tests cover successful retry/cleanup and a failed fallback that asserts diagnostics without private paths in logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8af6780146871d8e884d77e8218c8cf40eb7931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->