### PR TITLE
fix(assistant-tools): expose prepare_diagnostic_report in default tool set

### DIFF
--- a/src/main/ai/agents/builtin/__tests__/builtinAgentCapabilities.test.ts
+++ b/src/main/ai/agents/builtin/__tests__/builtinAgentCapabilities.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { DEFAULT_ASSISTANT_TOOL_NAMES } from '@main/ai/toolApproval/assistantToolNames'
 import { BUILTIN_AGENT_ROLE } from '@shared/ai/builtinAgent'
 import { AGENT_TYPES, type AgentType } from '@shared/data/api/schemas/agents'
 
@@ -37,6 +38,7 @@ describe('resolveAgentCapabilities', () => {
   })
 
   it('keeps diagnostic draft preparation in the reusable channel-linked Support tool set', () => {
+    expect(DEFAULT_ASSISTANT_TOOL_NAMES).toContain('prepare_diagnostic_report')
     const support = resolveAgentCapabilities({ configuration: { builtin_role: BUILTIN_AGENT_ROLE.SUPPORT } })
     const assistant = resolveAgentCapabilities({ configuration: { builtin_role: BUILTIN_AGENT_ROLE.ASSISTANT } })
     const channelLinkedSupportTools = resolveHostTools(agentOf('claude-code', BUILTIN_AGENT_ROLE.SUPPORT), {

--- a/src/main/ai/agents/builtin/builtinAgentGuardRules.ts
+++ b/src/main/ai/agents/builtin/builtinAgentGuardRules.ts
@@ -83,6 +83,7 @@ export const BUILTIN_AGENT_TOOL_GUARD_RULES: readonly ToolGuardRule[] = [
   },
   {
     // The result is useful only when AgentChat can present its user-owned review dialog.
+    // Headless deny holds on Claude Code only until #18898 closes the Pi/DSH gap.
     id: 'support-diagnostic-draft',
     appliesTo: { roles: [BUILTIN_AGENT_ROLE.SUPPORT, BUILTIN_AGENT_ROLE.ASSISTANT] },
     match: { tool: 'mcp__assistant__prepare_diagnostic_report' },

--- a/src/main/ai/agents/builtin/builtinAgentGuardRules.ts
+++ b/src/main/ai/agents/builtin/builtinAgentGuardRules.ts
@@ -84,7 +84,7 @@ export const BUILTIN_AGENT_TOOL_GUARD_RULES: readonly ToolGuardRule[] = [
   {
     // The result is useful only when AgentChat can present its user-owned review dialog.
     id: 'support-diagnostic-draft',
-    appliesTo: { roles: [BUILTIN_AGENT_ROLE.SUPPORT] },
+    appliesTo: { roles: [BUILTIN_AGENT_ROLE.SUPPORT, BUILTIN_AGENT_ROLE.ASSISTANT] },
     match: { tool: 'mcp__assistant__prepare_diagnostic_report' },
     headless: {
       predicate: 'either',

--- a/src/main/ai/mcp/servers/__tests__/assistant.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/assistant.test.ts
@@ -440,7 +440,7 @@ describe('create_agent', () => {
 })
 
 describe('prepare_diagnostic_report', () => {
-  it('is exposed only by the explicit Cherry Support capability set', async () => {
+  it('is exposed by the default assistant tool set and callable through the packaged list path', async () => {
     const assistantClient = await connectAssistantClient()
     const supportClient = await connectAssistantClient(SUPPORT_ASSISTANT_TOOL_NAMES)
 
@@ -449,7 +449,8 @@ describe('prepare_diagnostic_report', () => {
       'diagnose',
       'product_info',
       'apply_setting',
-      'create_agent'
+      'create_agent',
+      'prepare_diagnostic_report'
     ])
 
     const supportTools = (await supportClient.listTools()).tools
@@ -470,7 +471,7 @@ describe('prepare_diagnostic_report', () => {
   })
 
   it('returns an editable normalized draft without performing submission', async () => {
-    const client = await connectAssistantClient(SUPPORT_ASSISTANT_TOOL_NAMES)
+    const client = await connectAssistantClient()
     const output = { ok: true, description: 'first\r\nsecond\r\nthird' }
 
     const result = await client.callTool({

--- a/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
@@ -435,6 +435,23 @@ describe('CLAUDE_TOOL_GUARD_RULES', () => {
       }
     })
 
+    it('denies the UI-backed draft tool on headless Assistant turns', async () => {
+      await expect(
+        evaluate(
+          makeCtx({
+            builtinRole: 'assistant',
+            toolName,
+            permissionMode: 'default',
+            interaction: HEADLESS
+          })
+        )
+      ).resolves.toMatchObject({ effect: 'deny', ruleId: 'support-diagnostic-draft' })
+    })
+
+    it('leaves the draft tool auto-approved on interactive Assistant turns', async () => {
+      await expect(evaluate(makeCtx({ builtinRole: 'assistant', toolName }))).resolves.toBeUndefined()
+    })
+
     it('leaves the draft tool auto-approved on interactive Support turns', async () => {
       await expect(evaluate(makeCtx({ builtinRole: 'support', toolName }))).resolves.toBeUndefined()
     })

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -2415,6 +2415,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     // Only read-only Assistant tools are pre-approved. Mutations and diagnose use per-call approval.
     expect(settings.allowedTools).toContain('mcp__assistant__navigate')
     expect(settings.allowedTools).toContain('mcp__assistant__product_info')
+    expect(settings.allowedTools).toContain('mcp__assistant__prepare_diagnostic_report')
     expect(settings.allowedTools).toContain('mcp__assistant-files__read_file')
     expect(settings.allowedTools).not.toContain('mcp__assistant__apply_setting')
     expect(settings.allowedTools).not.toContain('mcp__assistant__create_agent')
@@ -2426,6 +2427,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     const snapshotOptions = mocks.createToolPolicySnapshot.mock.calls.at(-1)?.[1]
     expect(snapshotOptions.autoAllowRuntimeNames).toContain('mcp__assistant__navigate')
     expect(snapshotOptions.autoAllowRuntimeNames).toContain('mcp__assistant__product_info')
+    expect(snapshotOptions.autoAllowRuntimeNames).toContain('mcp__assistant__prepare_diagnostic_report')
     expect(snapshotOptions.autoAllowRuntimeNames).not.toContain('mcp__assistant__apply_setting')
     expect(snapshotOptions.autoAllowRuntimeNames).not.toContain('mcp__assistant__create_agent')
     expect(snapshotOptions.autoAllowRuntimeNames).not.toContain('mcp__assistant__diagnose')

--- a/src/main/ai/toolApproval/assistantToolNames.ts
+++ b/src/main/ai/toolApproval/assistantToolNames.ts
@@ -12,9 +12,10 @@ export const DEFAULT_ASSISTANT_TOOL_NAMES = [
   'diagnose',
   'product_info',
   'apply_setting',
-  'create_agent'
+  'create_agent',
+  'prepare_diagnostic_report'
 ] as const
 
-const ASSISTANT_TOOL_NAMES = [...DEFAULT_ASSISTANT_TOOL_NAMES, 'prepare_diagnostic_report'] as const
+const ASSISTANT_TOOL_NAMES = [...DEFAULT_ASSISTANT_TOOL_NAMES] as const
 
 export type AssistantToolName = (typeof ASSISTANT_TOOL_NAMES)[number]

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -205,6 +205,9 @@ const AgentChat = ({
   const visibleWorkspace = sessionSnapshot?.workspace ?? null
   const activeAgent = conversationBootstrap.resources.agent
   const isSupportAgent = activeAgent?.configuration?.builtin_role === BUILTIN_AGENT_ROLE.SUPPORT
+  const isAssistantAgent = activeAgent?.configuration?.builtin_role === BUILTIN_AGENT_ROLE.ASSISTANT
+  // Assistant now exposes prepare_diagnostic_report, so it needs the same review dialog as Support.
+  const canReviewDiagnosticReport = isSupportAgent || isAssistantAgent
   const isActiveAgentLoading = conversationBootstrap.resources.agentLoading
   const activeModel = conversationBootstrap.resources.model
   const isActiveModelLoading = conversationBootstrap.resources.modelLoading
@@ -497,7 +500,7 @@ const AgentChat = ({
         onOpenCitationsPanel={handleOpenCitationsPanel}
         onCreateEmptySession={sessionAgentId && onCreateEmptySession ? handleCreateEmptySession : undefined}
         composerLaunchOptions={composerLaunchOptions}
-        openDiagnosticReport={isSupportAgent ? openDiagnosticReport : undefined}
+        openDiagnosticReport={canReviewDiagnosticReport ? openDiagnosticReport : undefined}
       />
     )
   }
@@ -535,7 +538,7 @@ const AgentChat = ({
   return (
     <>
       <AgentChatLayout {...layoutProps} />
-      {isSupportAgent && activeDiagnosticReportDraft ? (
+      {canReviewDiagnosticReport && activeDiagnosticReportDraft ? (
         <DiagnosticUploadDialog
           key={activeDiagnosticReportDraft.sessionId}
           initialDescription={activeDiagnosticReportDraft.description}


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Cherry Assistant bundles the `cherry-studio-feedback` skill, which instructs it to call `mcp__assistant__prepare_diagnostic_report`. The default assistant MCP tool set omitted that tool, so the built-in diagnostic workflow failed with `No such tool available` on 2.0.14.

After this PR:

`prepare_diagnostic_report` is part of `DEFAULT_ASSISTANT_TOOL_NAMES`, so Cherry Assistant lists and invokes it through the packaged `ListTools`/`CallTool` path. The headless diagnostic-draft guard now also covers the assistant role, keeping channel/scheduled turns on the manual feedback entry.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20404

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Extended the default tool set instead of adding an explicit per-role tool list, keeping one source of truth so bare `new AssistantServer()` sessions also expose the draft tool.

The following alternatives were considered:

- Explicit `tools: [...]` list on the ASSISTANT capability: rejected, duplicates the list and leaves the no-args server path broken.
- Removing the skill from the Assistant bundle: rejected, the feedback route is intentional and the acceptance criterion requires the workflow to complete.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `builtinToolPolicy` already auto-approves `assistantPrepareDiagnosticReport`; no approval change was needed.
- SUPPORT explicit list unchanged (still withholds `create_agent`).

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the built-in assistant diagnostic workflow failing with a missing-tool error for `prepare_diagnostic_report`.
```
