### PR TITLE
fix(claude-code): preserve Linux desktop session bus

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -3,7 +3,7 @@ import type * as NodeModule from 'node:module'
 import os from 'node:os'
 import path from 'node:path'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   listBuiltinToolPolicies,
@@ -74,7 +74,7 @@ const mocks = vi.hoisted(() => ({
   createAgentsMdLoader: vi.fn(),
   loadAgentsMdInitialContext: vi.fn(),
   agentsMdHook: vi.fn(async () => ({})),
-  platform: { isMac: false },
+  platform: { isLinux: false, isMac: false },
   isWin: false
 }))
 
@@ -191,7 +191,9 @@ vi.mock('@application', () => ({
 }))
 
 vi.mock('@main/core/platform', () => ({
-  isLinux: false,
+  get isLinux() {
+    return mocks.platform.isLinux
+  },
   get isWin() {
     return mocks.isWin
   },
@@ -284,6 +286,10 @@ function systemPromptText(systemPrompt: unknown): string {
 }
 
 describe('buildClaudeCodeSessionSettings', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.approvalRegister.mockReturnValue(true)
@@ -348,6 +354,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     // test's instance. Must run after the application.get implementation above is in place.
     disposeToolPolicySnapshot('session-1')
     mocks.applicationGetPath.mockImplementation((key: string) => `/app/${key}`)
+    mocks.platform.isLinux = false
     mocks.platform.isMac = false
     mocks.getShellEnv.mockResolvedValue({})
     mocks.refreshShellEnv.mockResolvedValue({})
@@ -394,6 +401,40 @@ describe('buildClaudeCodeSessionSettings', () => {
       MISE_STATE_DIR: '/managed/state',
       MISE_SHIMS_DIR: '/managed/shims'
     })
+  })
+
+  it('preserves the running Linux desktop session bus when the login shell omits it', async () => {
+    mocks.platform.isLinux = true
+    mocks.getShellEnv.mockResolvedValue({ PATH: '/usr/bin' })
+    vi.stubEnv('DBUS_SESSION_BUS_ADDRESS', 'unix:path=/flatpak/session-bus')
+
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never
+    )
+
+    expect(settings.env!.DBUS_SESSION_BUS_ADDRESS).toBe('unix:path=/flatpak/session-bus')
+  })
+
+  it('does not invent a Linux desktop session bus when neither environment provides one', async () => {
+    mocks.platform.isLinux = true
+    mocks.getShellEnv.mockResolvedValue({ PATH: '/usr/bin' })
+    vi.stubEnv('DBUS_SESSION_BUS_ADDRESS', undefined)
+
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never
+    )
+
+    expect(settings.env).not.toHaveProperty('DBUS_SESSION_BUS_ADDRESS')
   })
 
   it.each(['PostToolUse', 'PostToolUseFailure'] as const)(

--- a/src/main/ai/runtime/claudeCode/environment.ts
+++ b/src/main/ai/runtime/claudeCode/environment.ts
@@ -134,7 +134,12 @@ export async function getClaudeCodeLoginShellEnvironment(
   if (hasStaleCherryProxyMarkers(loginShellEnv, currentProxyEnvironment)) {
     loginShellEnv = await refreshShellEnv()
   }
-  return stripInheritedCherryProxyMarkers(loginShellEnv)
+  const env = stripInheritedCherryProxyMarkers(loginShellEnv)
+  // A login shell can drop the desktop-session bus inherited by packaged Electron.
+  if (isLinux && process.env.DBUS_SESSION_BUS_ADDRESS) {
+    env.DBUS_SESSION_BUS_ADDRESS = process.env.DBUS_SESSION_BUS_ADDRESS
+  }
+  return env
 }
 
 export async function buildEnvironment(


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- Claude Code Agent settings replaced Electron's inherited environment with the login-shell environment.
- On packaged Linux desktops, a login shell can omit `DBUS_SESSION_BUS_ADDRESS` even though Electron inherited a working session bus. The Agent child then falls back to unavailable X11 D-Bus autolaunch, and zypak exits before JSON-RPC starts.

After this PR:

- Linux Agent settings preserve the running Electron process's `DBUS_SESSION_BUS_ADDRESS` after loading login-shell paths.
- Environments with no session-bus address remain unchanged; Cherry Studio does not invent a bus endpoint.
- Regression coverage exercises both cases.

Refs #20369

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The desktop process is the authority for the live session bus, while the login shell remains the authority for CLI paths and related shell-managed variables.
- The change is limited to Linux and to the Claude Code subprocess environment.

The following alternatives were considered:

- Inferring a D-Bus socket path was rejected because runtime-directory and sandbox layouts vary and a guessed endpoint can target the wrong session.
- Relying on X11 D-Bus autolaunch was rejected because the reported packaged environment does not provide it.

Links to places where the discussion took place: #20369

### Breaking changes

None.

### Special notes for your reviewer

- Focused main-process tests: 130 passed before and after the full gates.
- `pnpm lint` passed, including typecheck, i18n validation, and formatting.
- `CI=1 pnpm test:lint` passed with the repository's existing unrelated warnings.
- Validation used the repository-supported Node 24.15.0 runtime.
- This is a non-visual process-environment change. A trustworthy packaged Linux runtime was not available in this macOS workspace, so no runtime screenshot was produced.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Claude Code Agent startup in packaged Linux desktop sessions when login shells omit the inherited D-Bus address.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linux-only, single-env-var merge in Claude Code subprocess setup; no auth or data-path changes, with focused unit tests.
> 
> **Overview**
> Fixes Claude Code Agent startup on packaged Linux when the login-shell environment replaces Electron’s inherited env but drops **`DBUS_SESSION_BUS_ADDRESS`**, which could break D-Bus (e.g. zypak) before JSON-RPC starts.
> 
> **`getClaudeCodeLoginShellEnvironment`** now, on Linux only, re-applies the running Electron process’s **`DBUS_SESSION_BUS_ADDRESS`** after login-shell/proxy cleanup. If neither the desktop process nor the shell provides an address, nothing is synthesized.
> 
> **`settingsBuilder.test.ts`** adds regression tests (stub env + togglable **`isLinux`** mock) and resets stubbed envs between cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea6ac19a5fb5fcd83c5f3e169d694fdc85f269a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->