### PR TITLE
fix(model-list): keep valid models after malformed entries

### DIFF
--- a/src/main/ai/provider/__tests__/listModels.integration.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.integration.test.ts
@@ -1,0 +1,130 @@
+import { createServer, type Server } from 'node:http'
+
+import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import { SystemProviderIds } from '@shared/utils/systemProviderId'
+
+import { makeProvider } from '../../__tests__/fixtures/provider'
+
+const { getRotatedApiKeyMock } = vi.hoisted(() => ({
+  getRotatedApiKeyMock: vi.fn<() => string>()
+}))
+
+vi.mock('@main/data/services/ProviderService', () => ({
+  providerService: {
+    getRotatedApiKey: getRotatedApiKeyMock
+  }
+}))
+
+vi.mock('@main/data/services/ProviderRegistryService', () => ({
+  providerRegistryService: {
+    isRegistryProvider: vi.fn(() => false)
+  }
+}))
+
+vi.mock('@main/services/VertexAiService', () => ({
+  vertexAiService: {
+    getAuthHeaders: vi.fn()
+  }
+}))
+
+vi.mock('@main/services/CopilotService', () => ({
+  copilotService: {
+    getToken: vi.fn()
+  }
+}))
+
+const { listModels } = await import('../listModels')
+
+const servers: Server[] = []
+
+async function listen(server: Server): Promise<number> {
+  servers.push(server)
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('test server did not expose a TCP port')
+  return address.port
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getRotatedApiKeyMock.mockReturnValue('')
+})
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()))
+        })
+    )
+  )
+})
+
+describe('listModels - LM Studio response isolation', () => {
+  it('keeps valid models in order when one response row is malformed', async () => {
+    const server = createServer((request, response) => {
+      response.setHeader('content-type', 'application/json')
+      if (request.url === '/api/v0/models') {
+        response.statusCode = 404
+        response.end(JSON.stringify({ error: { message: 'not supported by this test server' } }))
+        return
+      }
+
+      response.end(
+        JSON.stringify({
+          data: [
+            { id: 'first-model', name: 'First Model' },
+            'malformed-row-payload',
+            { id: 'second-model', owned_by: 'lmstudio' },
+            { id: 'first-model', name: 'Duplicate Model' }
+          ]
+        })
+      )
+    })
+    const port = await listen(server)
+    const provider = makeProvider({
+      id: SystemProviderIds.lmstudio,
+      presetProviderId: SystemProviderIds.lmstudio,
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: `http://127.0.0.1:${port}/v1` }
+      }
+    })
+
+    const models = await listModels(provider)
+
+    expect(models.map((model) => model.apiModelId)).toEqual(['first-model', 'second-model'])
+    expect(models[0]?.name).toBe('First Model')
+    expect(
+      mockMainLoggerService.warn.mock.calls.filter(
+        ([message]) => message === 'Skipped malformed OpenAI-compatible model entries'
+      )
+    ).toEqual([
+      [
+        'Skipped malformed OpenAI-compatible model entries',
+        { providerId: SystemProviderIds.lmstudio, skippedModelCount: 1 }
+      ]
+    ])
+    const logs = JSON.stringify([
+      ...mockMainLoggerService.error.mock.calls,
+      ...mockMainLoggerService.warn.mock.calls,
+      ...mockMainLoggerService.info.mock.calls
+    ])
+    for (const payloadValue of [
+      'malformed-row-payload',
+      'first-model',
+      'second-model',
+      'First Model',
+      'Duplicate Model'
+    ]) {
+      expect(logs).not.toContain(payloadValue)
+    }
+  })
+})

--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -140,6 +140,87 @@ describe('listModels — default grouping', () => {
   )
 })
 
+describe('listModels — malformed OpenAI-compatible rows', () => {
+  it.each([
+    {
+      name: 'OpenRouter',
+      providerId: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      responses: [
+        { data: [{ id: 'openrouter-chat' }], skippedModelCount: 1 },
+        { data: [{ id: 'openrouter-embedding' }], skippedModelCount: 2 },
+        { data: [{ id: 'openrouter-image' }], skippedModelCount: 3 }
+      ],
+      expectedModelIds: ['openrouter-chat', 'openrouter-embedding', 'openrouter-image'],
+      expectedSkippedModelCount: 6
+    },
+    {
+      name: 'PPIO',
+      providerId: 'ppio',
+      baseUrl: 'https://api.ppio.com/v1',
+      responses: [
+        { data: [{ id: 'ppio-chat' }], skippedModelCount: 1 },
+        { data: [{ id: 'ppio-embedding' }], skippedModelCount: 2 },
+        { data: [{ id: 'ppio-reranker' }], skippedModelCount: 3 }
+      ],
+      expectedModelIds: ['ppio-chat', 'ppio-embedding', 'ppio-reranker'],
+      expectedSkippedModelCount: 6
+    },
+    {
+      name: 'Jina',
+      providerId: 'jina',
+      baseUrl: 'https://api.jina.ai',
+      responses: [{ data: [{ id: 'jina-ai/jina-valid' }], skippedModelCount: 2 }],
+      expectedModelIds: ['jina-valid'],
+      expectedSkippedModelCount: 2
+    },
+    {
+      name: 'OpenAI',
+      providerId: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      responses: [{ data: [{ id: 'gpt-4o' }], skippedModelCount: 2 }],
+      expectedModelIds: ['gpt-4o'],
+      expectedSkippedModelCount: 2
+    },
+    {
+      name: 'generic fallback',
+      providerId: 'custom-openai-compatible',
+      baseUrl: 'https://models.example.com/v1',
+      responses: [{ data: [{ id: 'fallback-valid' }], skippedModelCount: 2 }],
+      expectedModelIds: ['fallback-valid'],
+      expectedSkippedModelCount: 2
+    }
+  ])(
+    'keeps valid $name models and emits one aggregate warning',
+    async ({ providerId, baseUrl, responses, expectedModelIds, expectedSkippedModelCount }) => {
+      const provider = makeProvider({
+        id: providerId,
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl }
+        }
+      })
+      let responseIndex = 0
+      aiSdkGetFromApiMock.mockImplementation(() => Promise.resolve({ value: responses[responseIndex++] }))
+
+      const models = await listModels(provider)
+
+      expect(models.map((model) => model.apiModelId)).toEqual(expectedModelIds)
+      expect(aiSdkGetFromApiMock).toHaveBeenCalledTimes(responses.length)
+      expect(
+        mockMainLoggerService.warn.mock.calls.filter(
+          ([message]) => message === 'Skipped malformed OpenAI-compatible model entries'
+        )
+      ).toEqual([
+        [
+          'Skipped malformed OpenAI-compatible model entries',
+          { providerId: provider.id, skippedModelCount: expectedSkippedModelCount }
+        ]
+      ])
+    }
+  )
+})
+
 describe('listModels — TokenDance protocol routing', () => {
   function makeTokenDanceProvider(id = 'tokendance') {
     return makeProvider({

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -96,6 +96,16 @@ function recoverOptionalModelListFailure<T>(error: unknown, context: Record<stri
   return { data: [] }
 }
 
+function warnSkippedOpenAIModelEntries(
+  providerId: string,
+  ...responses: Array<{ data: unknown[]; skippedModelCount?: number }>
+): void {
+  const skippedModelCount = responses.reduce((total, response) => total + (response.skippedModelCount ?? 0), 0)
+  if (skippedModelCount > 0) {
+    logger.warn('Skipped malformed OpenAI-compatible model entries', { providerId, skippedModelCount })
+  }
+}
+
 // ── API Layer ──
 
 const ApiErrorSchema = z.object({
@@ -599,6 +609,7 @@ const openRouterFetcher: ModelFetcher = {
         })
       )
     ])
+    warnSkippedOpenAIModelEntries(provider.id, modelsResponse, embedModelsResponse, imageModelsResponse)
     const imageModelsById = new Map(imageModelsResponse.data.map((model) => [model.id, model]))
     const all = [...modelsResponse.data, ...embedModelsResponse.data, ...imageModelsResponse.data]
     return dedup(all, (m) => m.id).map((m) => {
@@ -652,6 +663,7 @@ const ppioFetcher: ModelFetcher = {
         })
       )
     ])
+    warnSkippedOpenAIModelEntries(provider.id, chat, embed, reranker)
     const modelsById = new Map<string, Partial<Model>>()
     const mergeModel = (model: OpenAIModelResponseItem, capability?: (typeof MODEL_CAPABILITY.RERANK)[]) => {
       const id = model.id?.trim()
@@ -764,6 +776,7 @@ const jinaFetcher: ModelFetcher = {
       responseSchema: OpenAIModelsResponseSchema,
       abortSignal: signal
     })
+    warnSkippedOpenAIModelEntries(provider.id, response)
     return dedup(response.data, (m) => m.id).map((m) => {
       const apiModelId = m.id.replace(/^jina-ai\//, '')
       return toModel(apiModelId, provider, { name: m.name || apiModelId, ownedBy: m.owned_by })
@@ -781,6 +794,7 @@ const openAIFetcher: ModelFetcher = {
       responseSchema: OpenAIModelsResponseSchema,
       abortSignal: signal
     })
+    warnSkippedOpenAIModelEntries(provider.id, response)
     return dedup(response.data, (m) => m.id)
       .filter((m) => isSupportedOpenAIModel(m.id))
       .map((m) => toModel(m.id, provider, { ownedBy: m.owned_by }))
@@ -797,12 +811,7 @@ const openAICompatibleFetcher: ModelFetcher = {
       responseSchema: OpenAIModelsResponseSchema,
       abortSignal: signal
     })
-    if (response.skippedModelCount > 0) {
-      logger.warn('Skipped malformed OpenAI-compatible model entries', {
-        providerId: provider.id,
-        skippedModelCount: response.skippedModelCount
-      })
-    }
+    warnSkippedOpenAIModelEntries(provider.id, response)
     return dedup(response.data, (m) => m.id).map((m) =>
       toModel(m.id, provider, {
         name: m.name || m.id,

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -797,6 +797,12 @@ const openAICompatibleFetcher: ModelFetcher = {
       responseSchema: OpenAIModelsResponseSchema,
       abortSignal: signal
     })
+    if (response.skippedModelCount > 0) {
+      logger.warn('Skipped malformed OpenAI-compatible model entries', {
+        providerId: provider.id,
+        skippedModelCount: response.skippedModelCount
+      })
+    }
     return dedup(response.data, (m) => m.id).map((m) =>
       toModel(m.id, provider, {
         name: m.name || m.id,

--- a/src/main/ai/provider/listModelsSchemas.ts
+++ b/src/main/ai/provider/listModelsSchemas.ts
@@ -9,18 +9,32 @@ import * as z from 'zod'
 
 // === OpenAI-compatible (also used by OpenRouter, PPIO, etc.) ===
 
-export const OpenAIModelsResponseSchema = z.object({
-  data: z.array(
-    z.looseObject({
-      id: z.string(),
-      name: z.string().optional(),
-      object: z.string().optional().default('model'),
-      created: z.number().optional(),
-      owned_by: z.string().optional()
-    })
-  ),
-  object: z.string().optional()
+const OpenAIModelSchema = z.looseObject({
+  id: z.string(),
+  name: z.string().optional(),
+  object: z.string().optional().default('model'),
+  created: z.number().optional(),
+  owned_by: z.string().optional()
 })
+
+const OpenAIModelItemSchema = z.unknown().transform((model) => {
+  const parsed = OpenAIModelSchema.safeParse(model)
+  return parsed.success ? parsed.data : undefined
+})
+
+export const OpenAIModelsResponseSchema = z
+  .object({
+    data: z.array(OpenAIModelItemSchema),
+    object: z.string().optional()
+  })
+  .transform((response) => {
+    const data = response.data.filter((model): model is z.output<typeof OpenAIModelSchema> => model !== undefined)
+    return {
+      ...response,
+      data,
+      skippedModelCount: response.data.length - data.length
+    }
+  })
 
 // === GitHub Copilot (/models) ===
 export const CopilotModelsResponseSchema = z.object({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

One malformed row in an OpenAI-compatible `/models` response failed validation for the complete response, discarding every valid model returned around it.

After this PR:

OpenAI-compatible model responses validate each row independently, retain valid models in their original order, preserve first-wins deduplication, and log only the provider ID and skipped-row count.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Refs #20345
Refs #20274

### Why we need it and why it was done in this way

The model-list wire boundary is the earliest shared point that can isolate a malformed row without changing endpoint selection, model mapping, or import behavior.

The following tradeoffs were made:

Skipped entries produce a structural warning without row contents, model IDs, or names. The UI does not yet expose a per-entry skip reason.

The following alternatives were considered:

An LM Studio-specific parser fork was rejected because `/v1/models` uses the shared OpenAI-compatible response shape and the same failure mode can affect other compatible providers.

Links to places where the discussion took place: #20345, #20274, #20429

### Breaking changes

None.

### Special notes for your reviewer

This is complementary to #20429: that PR changes LM Studio endpoint selection and fallback, while this PR only isolates malformed rows in the shared OpenAI-compatible schema. It does not duplicate or change the LM Studio fetcher. The patches are adjacent in `listModelsSchemas.ts` and may require ordinary stacking if #20429 merges first.

This is a nonvisual parsing fix, and screenshots were omitted at the user's request.

Validation:

- `pnpm test:main src/main/ai/provider/__tests__/listModels.integration.test.ts src/main/ai/provider/__tests__/listModels.test.ts` (51 tests passed, including aggregate warning coverage for all five OpenAI-compatible fetch paths)
- `pnpm lint`
- `pnpm test:lint`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Keep valid LM Studio models when one catalog entry is malformed.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared model-list parsing for every OpenAI-compatible provider; behavior is more permissive (partial success) but should reduce total listing failures.
> 
> **Overview**
> **OpenAI-compatible `/models` parsing no longer fails the whole catalog when a single `data[]` row is invalid.** `OpenAIModelsResponseSchema` now validates each entry with `safeParse`, drops bad rows while keeping valid ones in order, and attaches a `skippedModelCount` on the parsed response.
> 
> `listModels` adds `warnSkippedOpenAIModelEntries`, which emits one aggregate warning (`Skipped malformed OpenAI-compatible model entries`) with **only** `providerId` and total skipped count—no model IDs or malformed payload text. That hook runs on OpenRouter (chat/embed/image), PPIO, Jina, official OpenAI, and the generic OpenAI-compatible path (including LM Studio’s `/v1/models` fallback). Existing first-wins dedup behavior is unchanged.
> 
> Coverage adds parameterized unit tests for those fetch paths and an HTTP integration test that asserts LM Studio still lists valid models and does not leak row contents into logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309588e1814a8a9008bf92d7e6edc81f3c4d0c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->