### PR TITLE
feat(pi-runtime): expose browser code mode facade

### DIFF
--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -680,6 +680,9 @@ Browser MCP tools with unambiguous logical method names are also callable as
 both original MCP wire tools remain available through `tools.invoke`. Nested MCP
 image parts are forwarded as `tool_exec` image content; nested calls without an
 output schema omit those image parts from their returned value.
+Each `tool_exec` execution allows at most 32 images and 64 MiB of base64 data
+across forwarded results and explicit `emitImage` calls; exceeding either limit
+fails the whole execution instead of returning partial images.
 
 This executor is an orchestration boundary, not a security sandbox:
 `worker_threads` isolates scheduling but retains the app's Node.js authority.

--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -675,6 +675,12 @@ MCP catalog, including Cherry autonomy tools, is exposed through four native cus
   approvals are presented one at a time because the outer Pi tool part carries one
   active approval card; accepted calls may still execute concurrently.
 
+Browser MCP tools with unambiguous logical method names are also callable as
+`browser.<method>(params)` inside `tool_exec`; colliding aliases are omitted while
+both original MCP wire tools remain available through `tools.invoke`. Nested MCP
+image parts are forwarded as `tool_exec` image content; nested calls without an
+output schema omit those image parts from their returned value.
+
 This executor is an orchestration boundary, not a security sandbox:
 `worker_threads` isolates scheduling but retains the app's Node.js authority.
 Move it to a capability-isolated executor before allowing untrusted code without

--- a/src/main/ai/runtime/agentMcpServers.ts
+++ b/src/main/ai/runtime/agentMcpServers.ts
@@ -39,6 +39,7 @@ export interface AgentNotificationContext {
 
 export interface AgentMcpServer {
   name: string
+  logicalName?: string
   instance: McpServer
 }
 
@@ -64,7 +65,11 @@ export function buildAgentMcpServers(
       if (mcpServerSnapshots && !serverSnapshot) {
         throw new Error(`MCP server not found in request snapshot: ${mcpId}`)
       }
-      servers[mcpId] = { name: mcpId, instance: createMcpBridgeServer(mcpId, serverSnapshot) }
+      servers[mcpId] = {
+        name: mcpId,
+        logicalName: serverSnapshot?.name,
+        instance: createMcpBridgeServer(mcpId, serverSnapshot)
+      }
     } catch (error) {
       logger.error(`Failed to create MCP bridge for ${mcpId}`, { error })
     }

--- a/src/main/ai/runtime/pi/piCodeMode.test.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.test.ts
@@ -260,6 +260,34 @@ describe('createPiCodeModeTools', () => {
     })
   })
 
+  it('reveals a browser alias when a colliding tool is disabled after catalog creation', async () => {
+    const enabled = browserTool({ name: 'mcp__browser-a__open', label: 'open' })
+    const other = browserTool({ name: 'mcp__browser-b__open', label: 'open' })
+    const disabled = new Set<string>()
+    const tools = codeModeTools([enabled, other], disabled)
+    const search = tools.find((item) => item.name === PI_TOOL_SEARCH_TOOL_NAME)!
+    const exec = tools.find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
+
+    const before = await search.execute('search-1', { query: 'browser' }, undefined, undefined, {} as never)
+    expect(before.content[0]).toMatchObject({ type: 'text', text: expect.not.stringMatching(/\bopen\(params:/) })
+
+    disabled.add(other.name)
+    const after = await search.execute('search-2', { query: 'browser' }, undefined, undefined, {} as never)
+    expect(after.content[0]).toMatchObject({ type: 'text', text: expect.stringMatching(/\bopen\(params:/) })
+
+    const result = await exec.execute(
+      'outer-1',
+      { code: 'return await browser.open({ query: "example" })' },
+      undefined,
+      undefined,
+      {} as never
+    )
+    expect(result.details).toEqual({
+      result: { content: [{ type: 'text', text: 'ok' }], details: { ok: true } },
+      logs: undefined
+    })
+  })
+
   it('forwards images returned by browser facade methods as tool_exec image content', async () => {
     const screenshot = browserTool({
       name: 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__screenshot',

--- a/src/main/ai/runtime/pi/piCodeMode.test.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.test.ts
@@ -213,11 +213,25 @@ describe('createPiCodeModeTools', () => {
     )
   })
 
-  it('rejects duplicate browser facade method names', () => {
+  it('omits ambiguous browser facade methods while keeping the original tools callable', async () => {
     const first = browserTool({ name: 'mcp__browser-a__open', label: 'open' })
     const second = browserTool({ name: 'mcp__browser-b__open', label: 'open' })
+    const screenshot = browserTool({ name: 'mcp__browser-a__screenshot', label: 'screenshot' })
+    const tools = codeModeTools([first, second, screenshot])
+    const search = tools.find((item) => item.name === PI_TOOL_SEARCH_TOOL_NAME)!
+    const call = tools.find((item) => item.name === PI_TOOL_CALL_TOOL_NAME)!
 
-    expect(() => codeModeTools([first, second])).toThrow('Duplicate browser facade method: browser.open')
+    const discovery = await search.execute('search-1', { query: 'browser' }, undefined, undefined, {} as never)
+    const text = discovery.content[0].type === 'text' ? discovery.content[0].text : ''
+    expect(text).toContain('mcp__browser-a__open')
+    expect(text).toContain('mcp__browser-b__open')
+    expect(text).not.toMatch(/\bopen\(params:/)
+    expect(text).toMatch(/\bscreenshot\(params:/)
+
+    for (const name of [first.name, second.name]) {
+      const result = await call.execute('call-1', { name, params: {} }, undefined, undefined, {} as never)
+      expect(result.details).toEqual({ ok: true })
+    }
   })
 
   it('forwards images returned by browser facade methods as tool_exec image content', async () => {

--- a/src/main/ai/runtime/pi/piCodeMode.test.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.test.ts
@@ -29,6 +29,13 @@ function tool(overrides: Partial<ToolDefinition> & Pick<ToolDefinition, 'name'>)
   }
 }
 
+function browserTool(overrides: Partial<ToolDefinition> & Pick<ToolDefinition, 'name' | 'label'>): PiMcpToolDefinition {
+  return {
+    ...tool(overrides),
+    source: { serverName: '@cherry/browser', toolName: overrides.label }
+  }
+}
+
 function codeModeTools(
   catalog: PiMcpToolDefinition[],
   disabled = new Set<string>(),
@@ -150,7 +157,7 @@ describe('createPiCodeModeTools', () => {
   })
 
   it('generates a typed browser facade and dispatches its methods through the shared authorization boundary', async () => {
-    const name = 'mcp__browser__open'
+    const name = 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__open'
     const execute = vi.fn<ToolDefinition['execute']>(async () => ({
       content: [{ type: 'text' as const, text: '{"title":"Example"}' }],
       details: { title: 'Example' }
@@ -166,6 +173,7 @@ describe('createPiCodeModeTools', () => {
         },
         execute
       }),
+      source: { serverName: '@cherry/browser', toolName: 'open' },
       outputSchema: { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] }
     }
     const authorize = vi.fn<PiToolAuthorizer>(async () => undefined)
@@ -206,8 +214,9 @@ describe('createPiCodeModeTools', () => {
   })
 
   it('forwards images returned by browser facade methods as tool_exec image content', async () => {
-    const screenshot = tool({
-      name: 'mcp__browser__screenshot',
+    const screenshot = browserTool({
+      name: 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__screenshot',
+      label: 'screenshot',
       execute: vi.fn(async () => ({
         content: [{ type: 'image' as const, data: 'base64-png', mimeType: 'image/png' }],
         details: undefined
@@ -230,7 +239,7 @@ describe('createPiCodeModeTools', () => {
   })
 
   it('keeps browser facade calls behind the nested approval gate', async () => {
-    const reset = tool({ name: 'mcp__browser__reset' })
+    const reset = browserTool({ name: 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__reset', label: 'reset' })
     const authorize = vi.fn<PiToolAuthorizer>(async () => ({ block: true, reason: 'User denied browser control.' }))
     const exec = codeModeTools([reset], new Set(), authorize).find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
 
@@ -238,7 +247,11 @@ describe('createPiCodeModeTools', () => {
       exec.execute('outer-1', { code: 'return await browser.reset({})' }, undefined, undefined, {} as never)
     ).rejects.toThrow('User denied browser control.')
     expect(authorize).toHaveBeenCalledWith(
-      expect.objectContaining({ toolName: 'mcp__browser__reset', toolCallId: 'outer-1', input: {} })
+      expect.objectContaining({
+        toolName: 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__reset',
+        toolCallId: 'outer-1',
+        input: {}
+      })
     )
     expect(reset.execute).not.toHaveBeenCalled()
   })

--- a/src/main/ai/runtime/pi/piCodeMode.test.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.test.ts
@@ -392,6 +392,30 @@ describe('createPiCodeModeTools', () => {
     expect(result.content[0]).not.toMatchObject({ text: expect.stringContaining('content') })
   })
 
+  it('decodes schema-bearing MCP text when structuredContent is absent', async () => {
+    const name = 'mcp__browser__open'
+    const inner = tool({
+      name,
+      execute: vi.fn(async () => ({
+        content: [{ type: 'text' as const, text: '{"title":"Example"}' }],
+        details: null
+      }))
+    })
+    const exec = codeModeTools([
+      { ...inner, outputSchema: { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] } }
+    ]).find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
+
+    const result = await exec.execute(
+      'outer-1',
+      { code: `return await tools.invoke('${name}', {})` },
+      undefined,
+      undefined,
+      {} as never
+    )
+
+    expect(result.details).toEqual({ result: { title: 'Example' }, logs: undefined })
+  })
+
   it('decodes the one text result when a structured MCP response also includes an attachment', async () => {
     const name = 'mcp__browser__open'
     const inner = tool({

--- a/src/main/ai/runtime/pi/piCodeMode.test.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.test.ts
@@ -213,6 +213,13 @@ describe('createPiCodeModeTools', () => {
     )
   })
 
+  it('rejects duplicate browser facade method names', () => {
+    const first = browserTool({ name: 'mcp__browser-a__open', label: 'open' })
+    const second = browserTool({ name: 'mcp__browser-b__open', label: 'open' })
+
+    expect(() => codeModeTools([first, second])).toThrow('Duplicate browser facade method: browser.open')
+  })
+
   it('forwards images returned by browser facade methods as tool_exec image content', async () => {
     const screenshot = browserTool({
       name: 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__screenshot',
@@ -236,6 +243,31 @@ describe('createPiCodeModeTools', () => {
       { type: 'text', text: '"captured"' },
       { type: 'image', data: 'base64-png', mimeType: 'image/png' }
     ])
+  })
+
+  it('emits images once when code returns a raw MCP result', async () => {
+    const screenshot = browserTool({
+      name: 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__screenshot',
+      label: 'screenshot',
+      execute: vi.fn(async () => ({
+        content: [{ type: 'image' as const, data: 'base64-png', mimeType: 'image/png' }],
+        details: undefined
+      }))
+    })
+    const exec = codeModeTools([screenshot]).find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
+
+    const result = await exec.execute(
+      'outer-1',
+      { code: 'return await browser.screenshot({})' },
+      undefined,
+      undefined,
+      {} as never
+    )
+
+    expect(result.content).toHaveLength(2)
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.not.stringContaining('base64-png') })
+    expect(result.content[1]).toEqual({ type: 'image', data: 'base64-png', mimeType: 'image/png' })
+    expect(result.details).toMatchObject({ result: { content: [] } })
   })
 
   it('keeps browser facade calls behind the nested approval gate', async () => {

--- a/src/main/ai/runtime/pi/piCodeMode.test.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.test.ts
@@ -149,6 +149,111 @@ describe('createPiCodeModeTools', () => {
     expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('found') })
   })
 
+  it('generates a typed browser facade and dispatches its methods through the shared authorization boundary', async () => {
+    const name = 'mcp__browser__open'
+    const execute = vi.fn<ToolDefinition['execute']>(async () => ({
+      content: [{ type: 'text' as const, text: '{"title":"Example"}' }],
+      details: { title: 'Example' }
+    }))
+    const browserOpen: PiMcpToolDefinition = {
+      ...tool({
+        name,
+        description: 'Open a browser page',
+        parameters: {
+          type: 'object',
+          properties: { url: { type: 'string' } },
+          required: ['url']
+        },
+        execute
+      }),
+      outputSchema: { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] }
+    }
+    const authorize = vi.fn<PiToolAuthorizer>(async () => undefined)
+    const tools = codeModeTools([browserOpen], new Set(), authorize)
+    const search = tools.find((item) => item.name === PI_TOOL_SEARCH_TOOL_NAME)!
+    const exec = tools.find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
+
+    const discovery = await search.execute('search-1', { query: 'browser' }, undefined, undefined, {} as never)
+    const result = await exec.execute(
+      'outer-1',
+      { code: "return await browser.open({ url: 'https://example.com' })" },
+      undefined,
+      undefined,
+      {} as never
+    )
+
+    expect(discovery.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringMatching(
+        /declare const browser[\s\S]*open\(params: \{ url: string \}\): Promise<\{ title: string \}>/
+      )
+    })
+    expect(result.details).toEqual({ result: { title: 'Example' }, logs: undefined })
+    expect(authorize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: name,
+        toolCallId: 'outer-1',
+        input: { url: 'https://example.com' }
+      })
+    )
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringMatching(/^outer-1::exec::/),
+      { url: 'https://example.com' },
+      expect.any(AbortSignal),
+      undefined,
+      expect.anything()
+    )
+  })
+
+  it('forwards images returned by browser facade methods as tool_exec image content', async () => {
+    const screenshot = tool({
+      name: 'mcp__browser__screenshot',
+      execute: vi.fn(async () => ({
+        content: [{ type: 'image' as const, data: 'base64-png', mimeType: 'image/png' }],
+        details: undefined
+      }))
+    })
+    const exec = codeModeTools([screenshot]).find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
+
+    const result = await exec.execute(
+      'outer-1',
+      { code: "await browser.screenshot({}); return 'captured'" },
+      undefined,
+      undefined,
+      {} as never
+    )
+
+    expect(result.content).toEqual([
+      { type: 'text', text: '"captured"' },
+      { type: 'image', data: 'base64-png', mimeType: 'image/png' }
+    ])
+  })
+
+  it('keeps browser facade calls behind the nested approval gate', async () => {
+    const reset = tool({ name: 'mcp__browser__reset' })
+    const authorize = vi.fn<PiToolAuthorizer>(async () => ({ block: true, reason: 'User denied browser control.' }))
+    const exec = codeModeTools([reset], new Set(), authorize).find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
+
+    await expect(
+      exec.execute('outer-1', { code: 'return await browser.reset({})' }, undefined, undefined, {} as never)
+    ).rejects.toThrow('User denied browser control.')
+    expect(authorize).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: 'mcp__browser__reset', toolCallId: 'outer-1', input: {} })
+    )
+    expect(reset.execute).not.toHaveBeenCalled()
+  })
+
+  it('guides browser tool_exec calls to batch actions and capture one final state', () => {
+    const exec = codeModeTools([]).find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
+
+    expect(exec.promptGuidelines).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/batch/i),
+        expect.stringMatching(/one final (snapshot|screenshot)/i)
+      ])
+    )
+  })
+
   it('decodes a structured MCP result for tool_exec without leaking the MCP content envelope', async () => {
     const name = 'mcp__browser__open'
     const inner = tool({

--- a/src/main/ai/runtime/pi/piCodeMode.test.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.test.ts
@@ -234,6 +234,32 @@ describe('createPiCodeModeTools', () => {
     }
   })
 
+  it('keeps an enabled browser alias when its colliding tool is disabled', async () => {
+    const enabled = browserTool({ name: 'mcp__browser-a__open', label: 'open' })
+    const disabled = browserTool({ name: 'mcp__browser-b__open', label: 'open' })
+    const tools = codeModeTools([enabled, disabled], new Set([disabled.name]))
+    const search = tools.find((item) => item.name === PI_TOOL_SEARCH_TOOL_NAME)!
+    const exec = tools.find((item) => item.name === PI_TOOL_EXEC_TOOL_NAME)!
+
+    const discovery = await search.execute('search-1', { query: 'browser' }, undefined, undefined, {} as never)
+    const text = discovery.content[0].type === 'text' ? discovery.content[0].text : ''
+    expect(text).toContain(enabled.name)
+    expect(text).not.toContain(disabled.name)
+    expect(text).toMatch(/\bopen\(params:/)
+
+    const result = await exec.execute(
+      'outer-1',
+      { code: 'return await browser.open({ query: "example" })' },
+      undefined,
+      undefined,
+      {} as never
+    )
+    expect(result.details).toEqual({
+      result: { content: [{ type: 'text', text: 'ok' }], details: { ok: true } },
+      logs: undefined
+    })
+  })
+
   it('forwards images returned by browser facade methods as tool_exec image content', async () => {
     const screenshot = browserTool({
       name: 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__screenshot',

--- a/src/main/ai/runtime/pi/piCodeMode.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.ts
@@ -67,7 +67,7 @@ export function createPiCodeModeTools(
   authorizeTool: PiToolAuthorizer
 ): ToolDefinition[] {
   const catalog = new Map(tools.map((tool) => [tool.name, tool]))
-  const browserFacade = buildBrowserFacade(tools.filter((tool) => !isDisabled(tool.name)))
+  const getBrowserFacade = () => buildBrowserFacade(tools.filter((tool) => !isDisabled(tool.name)))
   const invokeTargetTool = async (
     executionToolCallId: string,
     approvalToolCallId: string,
@@ -187,7 +187,7 @@ export function createPiCodeModeTools(
       const serializeAuthorization = createSerializedAuthorizer(authorizeTool)
       const result = await runExecCode(code, {
         abortSignal: signal,
-        facades: { browser: browserFacade },
+        facades: { browser: getBrowserFacade() },
         onExecutionStarted({ pauseTimeout, resumeTimeout }) {
           pauseExecutionTimeout = pauseTimeout
           resumeExecutionTimeout = resumeTimeout
@@ -217,6 +217,7 @@ export function createPiCodeModeTools(
   return [searchTool, describeTool, callTool, execTool]
 
   function declarationsForTools(discovered: readonly PiMcpToolDefinition[]): string {
+    const browserFacade = getBrowserFacade()
     const declarations = toolsToTypeScript(
       discovered.map((tool) => ({
         name: tool.name,

--- a/src/main/ai/runtime/pi/piCodeMode.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.ts
@@ -227,7 +227,7 @@ export function createPiCodeModeTools(
     )
     const browserTools = discovered.flatMap((tool) => {
       const methodName = browserMethodName(tool)
-      return methodName
+      return methodName && browserFacade[methodName] === tool.name
         ? [
             {
               methodName,
@@ -252,10 +252,15 @@ function browserMethodName(tool: PiMcpToolDefinition): string | undefined {
 
 function buildBrowserFacade(tools: readonly PiMcpToolDefinition[]): Record<string, string> {
   const methods = new Map<string, string>()
+  const ambiguousMethods = new Set<string>()
   for (const tool of tools) {
     const methodName = browserMethodName(tool)
-    if (!methodName) continue
-    if (methods.has(methodName)) throw new Error(`Duplicate browser facade method: browser.${methodName}`)
+    if (!methodName || ambiguousMethods.has(methodName)) continue
+    if (methods.has(methodName)) {
+      methods.delete(methodName)
+      ambiguousMethods.add(methodName)
+      continue
+    }
     methods.set(methodName, tool.name)
   }
   return Object.fromEntries(methods)

--- a/src/main/ai/runtime/pi/piCodeMode.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.ts
@@ -8,6 +8,7 @@ import {
   PI_TOOL_EXEC_TOOL_NAME,
   PI_TOOL_SEARCH_TOOL_NAME
 } from '@shared/ai/piBuiltinTools'
+import { BuiltinMcpServerNames } from '@shared/utils/mcp'
 
 import type { PiToolAuthorizationRequest, PiToolAuthorizer } from './approvalExtension'
 import type { PiMcpToolDefinition } from './piMcpToolAdapter'
@@ -19,8 +20,6 @@ type SerializedAuthorizer = (request: PiToolAuthorizationRequest) => ReturnType<
 const SEARCH_RESULT_LIMIT = 20
 const BM25_K1 = 1.2
 const BM25_B = 0.75
-const BROWSER_TOOL_PREFIX = 'mcp__browser__'
-
 const searchParameters = {
   type: 'object',
   properties: {
@@ -70,7 +69,7 @@ export function createPiCodeModeTools(
   const catalog = new Map(tools.map((tool) => [tool.name, tool]))
   const browserFacade = Object.fromEntries(
     tools.flatMap((tool) => {
-      const methodName = browserMethodName(tool.name)
+      const methodName = browserMethodName(tool)
       return methodName ? [[methodName, tool.name]] : []
     })
   )
@@ -232,7 +231,7 @@ export function createPiCodeModeTools(
       }))
     )
     const browserTools = discovered.flatMap((tool) => {
-      const methodName = browserMethodName(tool.name)
+      const methodName = browserMethodName(tool)
       return methodName
         ? [
             {
@@ -251,9 +250,9 @@ export function createPiCodeModeTools(
   }
 }
 
-function browserMethodName(toolName: string): string | undefined {
-  if (!toolName.startsWith(BROWSER_TOOL_PREFIX)) return undefined
-  return toolName.slice(BROWSER_TOOL_PREFIX.length) || undefined
+function browserMethodName(tool: PiMcpToolDefinition): string | undefined {
+  if (tool.source?.serverName !== BuiltinMcpServerNames.browser) return undefined
+  return tool.source.toolName || undefined
 }
 
 function imageContent(result: ToolResult): ExecImage[] | undefined {

--- a/src/main/ai/runtime/pi/piCodeMode.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.ts
@@ -335,7 +335,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function decodeToolResult(result: ToolResult, outputSchema: unknown, toolName: string): unknown {
   if (!outputSchema) return { ...result, content: result.content.filter((part) => part.type !== 'image') }
-  if (result.details !== undefined) return result.details
+  if (result.details != null) return result.details
 
   const textContent = result.content.filter((part) => part.type === 'text')
   if (textContent.length === 0) {

--- a/src/main/ai/runtime/pi/piCodeMode.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.ts
@@ -1,7 +1,7 @@
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
 
-import { runExecCode } from '@main/ai/tools/codeMode/runtime'
-import { toolsToTypeScript, toolToTypeScript } from '@main/ai/tools/codeMode/schemaToTypeScript'
+import { type ExecImage, type ExecResult, runExecCode } from '@main/ai/tools/codeMode/runtime'
+import { toolFacadeToTypeScript, toolsToTypeScript, toolToTypeScript } from '@main/ai/tools/codeMode/schemaToTypeScript'
 import {
   PI_TOOL_CALL_TOOL_NAME,
   PI_TOOL_DESCRIBE_TOOL_NAME,
@@ -19,6 +19,7 @@ type SerializedAuthorizer = (request: PiToolAuthorizationRequest) => ReturnType<
 const SEARCH_RESULT_LIMIT = 20
 const BM25_K1 = 1.2
 const BM25_B = 0.75
+const BROWSER_TOOL_PREFIX = 'mcp__browser__'
 
 const searchParameters = {
   type: 'object',
@@ -67,6 +68,12 @@ export function createPiCodeModeTools(
   authorizeTool: PiToolAuthorizer
 ): ToolDefinition[] {
   const catalog = new Map(tools.map((tool) => [tool.name, tool]))
+  const browserFacade = Object.fromEntries(
+    tools.flatMap((tool) => {
+      const methodName = browserMethodName(tool.name)
+      return methodName ? [[methodName, tool.name]] : []
+    })
+  )
   const invokeTargetTool = async (
     executionToolCallId: string,
     approvalToolCallId: string,
@@ -100,33 +107,23 @@ export function createPiCodeModeTools(
     async execute(_toolCallId, params) {
       const input = params as Record<string, unknown>
       const query = typeof input.query === 'string' ? input.query : ''
-      const matches = rankTools(
+      const matchedTools = rankTools(
         [...catalog.values()].filter((tool) => !isDisabled(tool.name)),
         query
-      )
-        .slice(0, SEARCH_RESULT_LIMIT)
-        .map((tool) => ({
-          name: tool.name,
-          description: tool.description,
-          declaration: toolToTypeScript(
-            tool.name,
-            tool.description,
-            tool.parameters,
-            catalog.get(tool.name)?.outputSchema
-          )
-        }))
+      ).slice(0, SEARCH_RESULT_LIMIT)
+      const matches = matchedTools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        declaration: toolToTypeScript(
+          tool.name,
+          tool.description,
+          tool.parameters,
+          catalog.get(tool.name)?.outputSchema
+        )
+      }))
 
       const text =
-        matches.length > 0
-          ? toolsToTypeScript(
-              matches.map((match) => ({
-                name: match.name,
-                description: match.description,
-                inputSchema: catalog.get(match.name)?.parameters,
-                outputSchema: catalog.get(match.name)?.outputSchema
-              }))
-            )
-          : 'No tools matched. Broaden the query or omit it.'
+        matches.length > 0 ? declarationsForTools(matchedTools) : 'No tools matched. Broaden the query or omit it.'
       return {
         content: [{ type: 'text', text }],
         details: { matchedNamespaces: matches.length > 0 ? [{ namespace: 'pi', tools: matches }] : [] }
@@ -145,16 +142,17 @@ export function createPiCodeModeTools(
       const name = typeof input.name === 'string' ? input.name : ''
       const tool = catalog.get(name)
       if (!tool || isDisabled(name)) throw new Error(`Tool not found: ${name}`)
+      const declaration = declarationsForTools([tool])
       return {
         content: [
           {
             type: 'text',
-            text: `${tool.description}\n\n${toolToTypeScript(tool.name, tool.description, tool.parameters, tool.outputSchema)}`
+            text: `${tool.description}\n\n${declaration}`
           }
         ],
         details: {
           name: tool.name,
-          declaration: toolToTypeScript(tool.name, tool.description, tool.parameters, tool.outputSchema)
+          declaration
         }
       }
     }
@@ -182,7 +180,9 @@ export function createPiCodeModeTools(
     promptSnippet: 'Execute JavaScript that orchestrates multiple tools',
     promptGuidelines: [
       'Use tool_search before tool_exec when you do not already know the exact tool name and TypeScript signature.',
-      'tool_exec runs JavaScript, not TypeScript syntax. Explicitly return the final value.'
+      'tool_exec runs JavaScript, not TypeScript syntax. Explicitly return the final value.',
+      'Batch related browser actions in one tool_exec call instead of making one outer call per action.',
+      'End each browser batch with one final snapshot or screenshot so the resulting page state is available.'
     ],
     parameters: execParameters,
     async execute(toolCallId, params, signal) {
@@ -193,26 +193,26 @@ export function createPiCodeModeTools(
       const serializeAuthorization = createSerializedAuthorizer(authorizeTool)
       const result = await runExecCode(code, {
         abortSignal: signal,
+        facades: { browser: browserFacade },
         onExecutionStarted({ pauseTimeout, resumeTimeout }) {
           pauseExecutionTimeout = pauseTimeout
           resumeExecutionTimeout = resumeTimeout
         },
         async executeTool(name, input, requestId, childSignal) {
           const nestedToolCallId = `${toolCallId}::exec::${requestId}`
-          return (
-            await invokeTargetTool(
-              nestedToolCallId,
-              toolCallId,
-              name,
-              input,
-              childSignal,
-              () => {
-                pauseExecutionTimeout?.()
-                return () => resumeExecutionTimeout?.()
-              },
-              serializeAuthorization
-            )
-          ).value
+          const invoked = await invokeTargetTool(
+            nestedToolCallId,
+            toolCallId,
+            name,
+            input,
+            childSignal,
+            () => {
+              pauseExecutionTimeout?.()
+              return () => resumeExecutionTimeout?.()
+            },
+            serializeAuthorization
+          )
+          return { value: invoked.value, images: imageContent(invoked.raw) }
         }
       })
 
@@ -221,6 +221,46 @@ export function createPiCodeModeTools(
   }
 
   return [searchTool, describeTool, callTool, execTool]
+
+  function declarationsForTools(discovered: readonly PiMcpToolDefinition[]): string {
+    const declarations = toolsToTypeScript(
+      discovered.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.parameters,
+        outputSchema: tool.outputSchema
+      }))
+    )
+    const browserTools = discovered.flatMap((tool) => {
+      const methodName = browserMethodName(tool.name)
+      return methodName
+        ? [
+            {
+              methodName,
+              name: tool.name,
+              description: tool.description,
+              inputSchema: tool.parameters,
+              outputSchema: tool.outputSchema
+            }
+          ]
+        : []
+    })
+    return browserTools.length > 0
+      ? `${declarations}\n\n${toolFacadeToTypeScript('browser', browserTools)}`
+      : declarations
+  }
+}
+
+function browserMethodName(toolName: string): string | undefined {
+  if (!toolName.startsWith(BROWSER_TOOL_PREFIX)) return undefined
+  return toolName.slice(BROWSER_TOOL_PREFIX.length) || undefined
+}
+
+function imageContent(result: ToolResult): ExecImage[] | undefined {
+  const images = result.content.filter(
+    (part): part is Extract<(typeof result.content)[number], { type: 'image' }> => part.type === 'image'
+  )
+  return images.length > 0 ? images.map(({ data, mimeType }) => ({ data, mimeType })) : undefined
 }
 
 function rankTools(tools: readonly ToolDefinition[], query: string): ToolDefinition[] {
@@ -306,7 +346,7 @@ function isStringSchema(schema: unknown): boolean {
   return isRecord(schema) && schema.type === 'string'
 }
 
-function toPiResult(result: { result: unknown; logs?: string[]; error?: string; isError?: boolean }): ToolResult {
+function toPiResult(result: ExecResult): ToolResult {
   if (result.isError) {
     throw new Error(withLogs(result.error ?? 'tool_exec failed', result.logs))
   }
@@ -323,7 +363,10 @@ function toPiResult(result: { result: unknown; logs?: string[]; error?: string; 
     throw new Error(withLogs(message, result.logs))
   }
   return {
-    content: [{ type: 'text', text: output }],
+    content: [
+      { type: 'text', text: output },
+      ...(result.images?.map(({ data, mimeType }) => ({ type: 'image' as const, data, mimeType })) ?? [])
+    ],
     details: { result: JSON.parse(output), logs: result.logs }
   }
 }

--- a/src/main/ai/runtime/pi/piCodeMode.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.ts
@@ -67,12 +67,7 @@ export function createPiCodeModeTools(
   authorizeTool: PiToolAuthorizer
 ): ToolDefinition[] {
   const catalog = new Map(tools.map((tool) => [tool.name, tool]))
-  const browserFacade = Object.fromEntries(
-    tools.flatMap((tool) => {
-      const methodName = browserMethodName(tool)
-      return methodName ? [[methodName, tool.name]] : []
-    })
-  )
+  const browserFacade = buildBrowserFacade(tools)
   const invokeTargetTool = async (
     executionToolCallId: string,
     approvalToolCallId: string,
@@ -255,6 +250,17 @@ function browserMethodName(tool: PiMcpToolDefinition): string | undefined {
   return tool.source.toolName || undefined
 }
 
+function buildBrowserFacade(tools: readonly PiMcpToolDefinition[]): Record<string, string> {
+  const methods = new Map<string, string>()
+  for (const tool of tools) {
+    const methodName = browserMethodName(tool)
+    if (!methodName) continue
+    if (methods.has(methodName)) throw new Error(`Duplicate browser facade method: browser.${methodName}`)
+    methods.set(methodName, tool.name)
+  }
+  return Object.fromEntries(methods)
+}
+
 function imageContent(result: ToolResult): ExecImage[] | undefined {
   const images = result.content.filter(
     (part): part is Extract<(typeof result.content)[number], { type: 'image' }> => part.type === 'image'
@@ -322,7 +328,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function decodeToolResult(result: ToolResult, outputSchema: unknown, toolName: string): unknown {
-  if (!outputSchema) return result
+  if (!outputSchema) return { ...result, content: result.content.filter((part) => part.type !== 'image') }
   if (result.details !== undefined) return result.details
 
   const textContent = result.content.filter((part) => part.type === 'text')

--- a/src/main/ai/runtime/pi/piCodeMode.ts
+++ b/src/main/ai/runtime/pi/piCodeMode.ts
@@ -67,7 +67,7 @@ export function createPiCodeModeTools(
   authorizeTool: PiToolAuthorizer
 ): ToolDefinition[] {
   const catalog = new Map(tools.map((tool) => [tool.name, tool]))
-  const browserFacade = buildBrowserFacade(tools)
+  const browserFacade = buildBrowserFacade(tools.filter((tool) => !isDisabled(tool.name)))
   const invokeTargetTool = async (
     executionToolCallId: string,
     approvalToolCallId: string,

--- a/src/main/ai/runtime/pi/piMcpToolAdapter.test.ts
+++ b/src/main/ai/runtime/pi/piMcpToolAdapter.test.ts
@@ -121,6 +121,19 @@ describe('buildMcpToolDefinitions', () => {
     await bridge.close()
   })
 
+  it('keeps logical browser identity separate from its stored wire namespace', async () => {
+    const browser = createServer([tool('open')], async () => ({ content: [] }))
+    const bridge = await buildMcpToolDefinitions({
+      'browser-id': { name: '4b1884f6-78ad-4c2f-a523-8f0d7e784640', logicalName: '@cherry/browser', instance: browser }
+    })
+
+    expect(bridge.tools[0]).toMatchObject({
+      name: 'mcp__4b1884f6-78ad-4c2f-a523-8f0d7e784640__open',
+      source: { serverName: '@cherry/browser', toolName: 'open' }
+    })
+    await bridge.close()
+  })
+
   it('proxies calls, structured details, and MCP content through the in-memory transport', async () => {
     const call = vi.fn(async () => ({
       content: [

--- a/src/main/ai/runtime/pi/piMcpToolAdapter.ts
+++ b/src/main/ai/runtime/pi/piMcpToolAdapter.ts
@@ -16,7 +16,10 @@ const logger = loggerService.withContext('PiMcpToolAdapter')
 type PiToolContent = { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
 
 /** MCP keeps result schemas separately from tool-call parameters. Preserve that distinction for code-mode declarations. */
-export type PiMcpToolDefinition = ToolDefinition & { outputSchema?: unknown }
+export type PiMcpToolDefinition = ToolDefinition & {
+  outputSchema?: unknown
+  source?: { serverName: string; toolName: string }
+}
 
 class PiMcpToolIdentityError extends Error {}
 
@@ -63,7 +66,9 @@ export async function buildMcpToolDefinitions(servers: Record<string, AgentMcpSe
       await server.instance.connect(serverTransport)
       await client.connect(clientTransport)
       const result = await client.listTools()
-      const serverTools = result.tools.map((tool) => toPiToolDefinition(server.name, tool, client))
+      const serverTools = result.tools.map((tool) =>
+        toPiToolDefinition(server.name, server.logicalName ?? server.name, tool, client)
+      )
       const existingNames = new Set(tools.map((tool) => tool.name))
       const serverNames = new Set<string>()
       for (const tool of serverTools) {
@@ -92,12 +97,18 @@ export async function buildMcpToolDefinitions(servers: Record<string, AgentMcpSe
   }
 }
 
-function toPiToolDefinition(serverName: string, tool: Tool, client: Client): PiMcpToolDefinition {
+function toPiToolDefinition(
+  serverName: string,
+  logicalServerName: string,
+  tool: Tool,
+  client: Client
+): PiMcpToolDefinition {
   return {
     name: buildPiMcpToolName(serverName, tool.name),
     label: tool.name,
     description: tool.description ?? '',
     parameters: tool.inputSchema,
+    source: { serverName: logicalServerName, toolName: tool.name },
     ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
     async execute(_toolCallId, params, signal) {
       const result = (await client.callTool(

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolExec.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolExec.test.ts
@@ -1,0 +1,66 @@
+import { jsonSchema } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { ToolRegistry } from '../../registry'
+import { createToolExecTool } from '../toolExec'
+
+describe('tool_exec model output', () => {
+  it('keeps JSON output for code without nested images', async () => {
+    const tool = createToolExecTool(new ToolRegistry())
+    if (!tool.execute) throw new Error('tool_exec must be executable')
+
+    const input = { code: 'return 42' }
+    const output = await tool.execute(input, { toolCallId: 'outer-1', messages: [] })
+
+    expect(output).toEqual({ result: 42 })
+    expect(tool.toModelOutput?.({ toolCallId: 'outer-1', input, output })).toEqual({
+      type: 'json',
+      value: { result: 42 }
+    })
+  })
+
+  it('passes a nested MCP image to the model alongside the code result', async () => {
+    const registry = new ToolRegistry()
+    registry.register({
+      name: 'mcp__s1__screenshot',
+      namespace: 'mcp:s1',
+      description: 'Capture a screenshot',
+      defer: 'auto',
+      tool: {
+        type: 'function',
+        inputSchema: jsonSchema({ type: 'object' }),
+        execute: async () => ({
+          content: [
+            { type: 'text', text: 'captured' },
+            { type: 'image', data: 'base64-png', mimeType: 'image/png' }
+          ]
+        })
+      }
+    })
+    const tool = createToolExecTool(registry)
+    if (!tool.execute) throw new Error('tool_exec must be executable')
+
+    const input = {
+      code: "const response = await tools.invoke('mcp__s1__screenshot', {}); if (response.content[1].data !== 'base64-png') throw new Error('image missing in worker'); return response"
+    }
+    const output = await tool.execute(input, { toolCallId: 'outer-1', messages: [] })
+    const modelOutput = tool.toModelOutput?.({ toolCallId: 'outer-1', input, output })
+
+    expect(output).toEqual({
+      result: {
+        content: [
+          { type: 'text', text: 'captured' },
+          { type: 'image', data: 'base64-png', mimeType: 'image/png' }
+        ]
+      },
+      images: [{ data: 'base64-png', mimeType: 'image/png' }]
+    })
+    expect(modelOutput).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: JSON.stringify({ result: { content: [{ type: 'text', text: 'captured' }] } }) },
+        { type: 'image-data', data: 'base64-png', mediaType: 'image/png' }
+      ]
+    })
+  })
+})

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolExec.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolExec.test.ts
@@ -63,4 +63,74 @@ describe('tool_exec model output', () => {
       ]
     })
   })
+
+  it('omits forwarded images from composed model text without changing the worker result', async () => {
+    const registry = new ToolRegistry()
+    registry.register({
+      name: 'mcp__s1__screenshot',
+      namespace: 'mcp:s1',
+      description: 'Capture a screenshot',
+      defer: 'auto',
+      tool: {
+        type: 'function',
+        inputSchema: jsonSchema({ type: 'object' }),
+        execute: async () => ({
+          content: [
+            { type: 'text', text: 'captured' },
+            { type: 'image', data: 'base64-png', mimeType: 'image/png' }
+          ]
+        })
+      }
+    })
+    const tool = createToolExecTool(registry)
+    if (!tool.execute) throw new Error('tool_exec must be executable')
+
+    const input = {
+      code: "const screenshot = await tools.invoke('mcp__s1__screenshot', {}); if (screenshot.content[1].data !== 'base64-png') throw new Error('image missing in worker'); return { captures: [{ screenshot }], other: { content: [{ type: 'image', data: 'not-forwarded', mimeType: 'image/png' }, { type: 'image', data: null, mimeType: 'image/png' }] } }"
+    }
+    const output = await tool.execute(input, { toolCallId: 'outer-1', messages: [] })
+    const modelOutput = tool.toModelOutput?.({ toolCallId: 'outer-1', input, output })
+
+    expect(output).toEqual({
+      result: {
+        captures: [
+          {
+            screenshot: {
+              content: [
+                { type: 'text', text: 'captured' },
+                { type: 'image', data: 'base64-png', mimeType: 'image/png' }
+              ]
+            }
+          }
+        ],
+        other: {
+          content: [
+            { type: 'image', data: 'not-forwarded', mimeType: 'image/png' },
+            { type: 'image', data: null, mimeType: 'image/png' }
+          ]
+        }
+      },
+      images: [{ data: 'base64-png', mimeType: 'image/png' }]
+    })
+    expect(modelOutput).toEqual({
+      type: 'content',
+      value: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            result: {
+              captures: [{ screenshot: { content: [{ type: 'text', text: 'captured' }] } }],
+              other: {
+                content: [
+                  { type: 'image', data: 'not-forwarded', mimeType: 'image/png' },
+                  { type: 'image', data: null, mimeType: 'image/png' }
+                ]
+              }
+            }
+          })
+        },
+        { type: 'image-data', data: 'base64-png', mediaType: 'image/png' }
+      ]
+    })
+  })
 })

--- a/src/main/ai/tools/adapters/aiSdk/meta/exec/__tests__/runtime.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/exec/__tests__/runtime.test.ts
@@ -58,6 +58,24 @@ describe('runExec / handleToolCall', () => {
     expect(execute.mock.calls[0][0]).toEqual({ foo: 'bar' })
   })
 
+  it('forwards nested MCP image content through the exec result', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      content: [
+        { type: 'text', text: 'captured' },
+        { type: 'image', data: 'base64-png', mimeType: 'image/png' }
+      ]
+    })
+    const reg = registryWith({ name: 'mcp__s1__screenshot', tool: toolWith({ execute }) })
+
+    const out = await runExec("await tools.invoke('mcp__s1__screenshot', {}); return 'done'", {
+      registry: reg,
+      parentOptions: makeOptions()
+    })
+
+    expect(out.result).toBe('done')
+    expect(out.images).toEqual([{ data: 'base64-png', mimeType: 'image/png' }])
+  })
+
   it('nests the toolCallId under the parent so telemetry can rebuild the call tree', async () => {
     const execute = vi.fn().mockResolvedValue('ok')
     const reg = registryWith({ name: 'mcp__s1__t', tool: toolWith({ execute }) })

--- a/src/main/ai/tools/adapters/aiSdk/meta/exec/__tests__/runtime.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/exec/__tests__/runtime.test.ts
@@ -76,6 +76,82 @@ describe('runExec / handleToolCall', () => {
     expect(out.images).toEqual([{ data: 'base64-png', mimeType: 'image/png' }])
   })
 
+  it('keeps multiple forwarded and explicitly emitted images in order', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      content: [
+        { type: 'image', data: 'first', mimeType: 'image/png' },
+        { type: 'image', data: 'second', mimeType: 'image/jpeg' }
+      ]
+    })
+    const reg = registryWith({ name: 'mcp__s1__screenshot', tool: toolWith({ execute }) })
+
+    const out = await runExec(
+      "await tools.invoke('mcp__s1__screenshot', {}); emitImage({ data: 'third', mimeType: 'image/webp' }); return 'done'",
+      { registry: reg, parentOptions: makeOptions() }
+    )
+
+    expect(out.result).toBe('done')
+    expect(out.images).toEqual([
+      { data: 'first', mimeType: 'image/png' },
+      { data: 'second', mimeType: 'image/jpeg' },
+      { data: 'third', mimeType: 'image/webp' }
+    ])
+  })
+
+  it('fails explicitly when nested tools forward too many images', async () => {
+    const image = { type: 'image', data: 'base64-png', mimeType: 'image/png' }
+    const execute = vi.fn().mockResolvedValue({ content: Array.from({ length: 33 }, () => image) })
+    const reg = registryWith({ name: 'mcp__s1__screenshot', tool: toolWith({ execute }) })
+
+    const out = await runExec("try { await tools.invoke('mcp__s1__screenshot', {}) } catch {} return 'done'", {
+      registry: reg,
+      parentOptions: makeOptions()
+    })
+
+    expect(out.isError).toBe(true)
+    expect(out.error).toMatch(/image output.*32 images/)
+    expect(out.images).toBeUndefined()
+  })
+
+  it('fails explicitly when code emits too many images', async () => {
+    const reg = new ToolRegistry()
+    const out = await runExec(
+      "try { for (let i = 0; i < 33; i++) emitImage({ data: 'base64-png', mimeType: 'image/png' }) } catch {} return 'done'",
+      { registry: reg, parentOptions: makeOptions() }
+    )
+
+    expect(out.isError).toBe(true)
+    expect(out.error).toMatch(/image output.*32 images/)
+    expect(out.images).toBeUndefined()
+  })
+
+  it('shares one image budget between nested tools and explicit emits', async () => {
+    const image = { type: 'image', data: 'base64-png', mimeType: 'image/png' }
+    const execute = vi.fn().mockResolvedValue({ content: Array.from({ length: 32 }, () => image) })
+    const reg = registryWith({ name: 'mcp__s1__screenshot', tool: toolWith({ execute }) })
+
+    const out = await runExec(
+      "await tools.invoke('mcp__s1__screenshot', {}); try { emitImage({ data: 'extra', mimeType: 'image/png' }) } catch {} return 'done'",
+      { registry: reg, parentOptions: makeOptions() }
+    )
+
+    expect(out.isError).toBe(true)
+    expect(out.error).toMatch(/image output.*32 images/)
+    expect(out.images).toBeUndefined()
+  })
+
+  it('fails explicitly when one emitted image exceeds the data budget', async () => {
+    const reg = new ToolRegistry()
+    const out = await runExec(
+      "try { emitImage({ data: 'A'.repeat(64 * 1024 * 1024 + 1), mimeType: 'image/png' }) } catch {} return 'done'",
+      { registry: reg, parentOptions: makeOptions() }
+    )
+
+    expect(out.isError).toBe(true)
+    expect(out.error).toMatch(/image output.*64 MiB/)
+    expect(out.images).toBeUndefined()
+  })
+
   it('nests the toolCallId under the parent so telemetry can rebuild the call tree', async () => {
     const execute = vi.fn().mockResolvedValue('ok')
     const reg = registryWith({ name: 'mcp__s1__t', tool: toolWith({ execute }) })

--- a/src/main/ai/tools/adapters/aiSdk/meta/exec/runtime.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/exec/runtime.ts
@@ -1,5 +1,6 @@
 import type { ToolExecutionOptions } from '@ai-sdk/provider-utils'
 
+import type { McpCallToolResponse } from '@main/ai/mcp/types'
 import { type ExecResult, runExecCode } from '@main/ai/tools/codeMode/runtime'
 
 import { isApprovalGated } from '../../isApprovalGated'
@@ -34,13 +35,20 @@ export function runExec(code: string, ctx: ExecRuntimeContext): Promise<ExecResu
         throw new Error(`Tool ${name} requires user approval; call it directly instead of via tool_exec.`)
       }
 
-      return {
-        value: await execute(params, {
-          ...ctx.parentOptions,
-          toolCallId: `${ctx.parentOptions.toolCallId}::exec::${requestId}`,
-          abortSignal: signal
-        })
-      }
+      const value = await execute(params, {
+        ...ctx.parentOptions,
+        toolCallId: `${ctx.parentOptions.toolCallId}::exec::${requestId}`,
+        abortSignal: signal
+      })
+      const content = (value as Partial<McpCallToolResponse> | null)?.content
+      const images = Array.isArray(content)
+        ? content.flatMap((part) =>
+            part.type === 'image' && typeof part.data === 'string' && typeof part.mimeType === 'string'
+              ? [{ data: part.data, mimeType: part.mimeType }]
+              : []
+          )
+        : []
+      return { value, ...(images.length > 0 && { images }) }
     }
   })
 }

--- a/src/main/ai/tools/adapters/aiSdk/meta/exec/runtime.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/exec/runtime.ts
@@ -34,11 +34,13 @@ export function runExec(code: string, ctx: ExecRuntimeContext): Promise<ExecResu
         throw new Error(`Tool ${name} requires user approval; call it directly instead of via tool_exec.`)
       }
 
-      return execute(params, {
-        ...ctx.parentOptions,
-        toolCallId: `${ctx.parentOptions.toolCallId}::exec::${requestId}`,
-        abortSignal: signal
-      })
+      return {
+        value: await execute(params, {
+          ...ctx.parentOptions,
+          toolCallId: `${ctx.parentOptions.toolCallId}::exec::${requestId}`,
+          abortSignal: signal
+        })
+      }
     }
   })
 }

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolExec.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolExec.ts
@@ -18,8 +18,6 @@
 import { type Tool, tool } from 'ai'
 import * as z from 'zod'
 
-import type { McpCallToolResponse } from '@main/ai/mcp/types'
-
 import type { ToolRegistry } from '../registry'
 import { runExec } from './exec/runtime'
 
@@ -51,21 +49,25 @@ export function createToolExecTool(registry: ToolRegistry): Tool {
       const { images, ...textOutput } = output
       if (!images?.length) return { type: 'json', value: output }
 
-      const content = (output.result as Partial<McpCallToolResponse> | null)?.content
-      const modelOutput =
-        Array.isArray(content) && content.some((part) => part.type === 'image')
-          ? {
-              ...textOutput,
-              result: {
-                ...(output.result as McpCallToolResponse),
-                content: content.filter((part) => part.type !== 'image')
-              }
-            }
-          : textOutput
       return {
         type: 'content',
         value: [
-          { type: 'text', text: JSON.stringify(modelOutput) },
+          {
+            type: 'text',
+            text: JSON.stringify(textOutput, (key, value) =>
+              key === 'content' && Array.isArray(value)
+                ? value.filter(
+                    (part) =>
+                      !(
+                        part?.type === 'image' &&
+                        typeof part.data === 'string' &&
+                        typeof part.mimeType === 'string' &&
+                        images.some((image) => image.data === part.data && image.mimeType === part.mimeType)
+                      )
+                  )
+                : value
+            )
+          },
           ...images.map(({ data, mimeType }) => ({ type: 'image-data' as const, data, mediaType: mimeType }))
         ]
       }

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolExec.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolExec.ts
@@ -18,6 +18,8 @@
 import { type Tool, tool } from 'ai'
 import * as z from 'zod'
 
+import type { McpCallToolResponse } from '@main/ai/mcp/types'
+
 import type { ToolRegistry } from '../registry'
 import { runExec } from './exec/runtime'
 
@@ -41,7 +43,31 @@ export function createToolExecTool(registry: ToolRegistry): Tool {
         result: result.result,
         ...(result.logs && result.logs.length > 0 ? { logs: result.logs } : {}),
         ...(result.error ? { error: result.error } : {}),
-        ...(result.isError ? { isError: true } : {})
+        ...(result.isError ? { isError: true } : {}),
+        ...(result.images?.length ? { images: result.images } : {})
+      }
+    },
+    toModelOutput: ({ output }) => {
+      const { images, ...textOutput } = output
+      if (!images?.length) return { type: 'json', value: output }
+
+      const content = (output.result as Partial<McpCallToolResponse> | null)?.content
+      const modelOutput =
+        Array.isArray(content) && content.some((part) => part.type === 'image')
+          ? {
+              ...textOutput,
+              result: {
+                ...(output.result as McpCallToolResponse),
+                content: content.filter((part) => part.type !== 'image')
+              }
+            }
+          : textOutput
+      return {
+        type: 'content',
+        value: [
+          { type: 'text', text: JSON.stringify(modelOutput) },
+          ...images.map(({ data, mimeType }) => ({ type: 'image-data' as const, data, mediaType: mimeType }))
+        ]
       }
     }
   })

--- a/src/main/ai/tools/codeMode/runtime.ts
+++ b/src/main/ai/tools/codeMode/runtime.ts
@@ -2,7 +2,7 @@ import { Worker } from 'node:worker_threads'
 
 import { loggerService } from '@logger'
 
-import { execWorkerSource } from './worker'
+import { execWorkerSource, IMAGE_OUTPUT_LIMIT_ERROR, MAX_EXEC_IMAGE_DATA_LENGTH, MAX_EXEC_IMAGES } from './worker'
 
 const logger = loggerService.withContext('codeMode.runtime')
 
@@ -81,6 +81,8 @@ export function runExecCode(code: string, ctx: ExecCodeContext): Promise<ExecRes
     let timeoutStartedAt = 0
     let timeoutRemainingMs = EXECUTION_TIMEOUT_MS
     let timeoutPauseCount = 0
+    let forwardedImageCount = 0
+    let forwardedImageDataLength = 0
 
     const addLog = (entry: string) => {
       if (logs.length < MAX_LOGS) logs.push(entry)
@@ -180,11 +182,23 @@ export function runExecCode(code: string, ctx: ExecCodeContext): Promise<ExecRes
       try {
         const result = await ctx.executeTool(message.name, message.params ?? {}, message.requestId, childAbort.signal)
         if (finished || timedOut || terminating) return
+        const images = result.images ?? []
+        const nextImageCount = forwardedImageCount + images.length
+        const nextImageDataLength = images.reduce(
+          (length, image) => length + image.data.length,
+          forwardedImageDataLength
+        )
+        if (nextImageCount > MAX_EXEC_IMAGES || nextImageDataLength > MAX_EXEC_IMAGE_DATA_LENGTH) {
+          await terminateWithError(IMAGE_OUTPUT_LIMIT_ERROR)
+          return
+        }
+        forwardedImageCount = nextImageCount
+        forwardedImageDataLength = nextImageDataLength
         worker.postMessage({
           type: 'toolResult',
           requestId: message.requestId,
           result: result.value,
-          images: result.images
+          images
         })
       } catch (err) {
         if (finished || timedOut || terminating) return

--- a/src/main/ai/tools/codeMode/runtime.ts
+++ b/src/main/ai/tools/codeMode/runtime.ts
@@ -12,13 +12,30 @@ const EXECUTION_TIMEOUT_MS = 60_000
 export interface ExecResult {
   result: unknown
   logs?: string[]
+  images?: ExecImage[]
   error?: string
   isError?: boolean
 }
 
+export interface ExecImage {
+  data: string
+  mimeType: string
+}
+
+export interface ExecToolResult {
+  value: unknown
+  images?: ExecImage[]
+}
+
 export interface ExecCodeContext {
   abortSignal?: AbortSignal
-  executeTool(name: string, params: Record<string, unknown>, requestId: string, signal: AbortSignal): Promise<unknown>
+  facades?: Record<string, Record<string, string>>
+  executeTool(
+    name: string,
+    params: Record<string, unknown>,
+    requestId: string,
+    signal: AbortSignal
+  ): Promise<ExecToolResult>
   onExecutionStarted?: (controls: { pauseTimeout: () => void; resumeTimeout: () => void }) => void
 }
 
@@ -38,6 +55,7 @@ interface WorkerResultMessage {
   type: 'result'
   result: unknown
   logs?: string[]
+  images?: ExecImage[]
 }
 
 interface WorkerErrorMessage {
@@ -162,7 +180,12 @@ export function runExecCode(code: string, ctx: ExecCodeContext): Promise<ExecRes
       try {
         const result = await ctx.executeTool(message.name, message.params ?? {}, message.requestId, childAbort.signal)
         if (finished || timedOut || terminating) return
-        worker.postMessage({ type: 'toolResult', requestId: message.requestId, result })
+        worker.postMessage({
+          type: 'toolResult',
+          requestId: message.requestId,
+          result: result.value,
+          images: result.images
+        })
       } catch (err) {
         if (finished || timedOut || terminating) return
         const errorMessage = err instanceof Error ? err.message : String(err)
@@ -183,7 +206,11 @@ export function runExecCode(code: string, ctx: ExecCodeContext): Promise<ExecRes
           break
         case 'result': {
           const resolvedLogs = message.logs && message.logs.length > 0 ? message.logs : logs
-          void finalize({ result: message.result, logs: resolvedLogs.length > 0 ? resolvedLogs : undefined })
+          void finalize({
+            result: message.result,
+            logs: resolvedLogs.length > 0 ? resolvedLogs : undefined,
+            images: message.images
+          })
           break
         }
         case 'error': {
@@ -221,6 +248,6 @@ export function runExecCode(code: string, ctx: ExecCodeContext): Promise<ExecRes
       )
     })
 
-    worker.postMessage({ type: 'exec', code })
+    worker.postMessage({ type: 'exec', code, facades: ctx.facades })
   })
 }

--- a/src/main/ai/tools/codeMode/schemaToTypeScript.ts
+++ b/src/main/ai/tools/codeMode/schemaToTypeScript.ts
@@ -109,6 +109,10 @@ interface ToolTypeScriptInput {
   outputSchema?: unknown
 }
 
+interface ToolFacadeTypeScriptInput extends ToolTypeScriptInput {
+  methodName: string
+}
+
 function toolInvokeToTypeScript(tool: ToolTypeScriptInput, indent: string): string[] {
   const doc = docText(tool.description || tool.name)
   const output = tool.outputSchema ? jsonSchemaToTypeScript(tool.outputSchema) : 'McpToolResult'
@@ -128,6 +132,22 @@ export function toolsToTypeScript(tools: readonly ToolTypeScriptInput[]): string
     '',
     'declare const tools: {',
     ...tools.flatMap((tool) => toolInvokeToTypeScript(tool, '  ')),
+    '}'
+  ].join('\n')
+}
+
+/** Generate a typed object facade whose methods retain each tool's input and output schema. */
+export function toolFacadeToTypeScript(name: string, tools: readonly ToolFacadeTypeScriptInput[]): string {
+  return [
+    `declare const ${quotePropertyName(name)}: {`,
+    ...tools.flatMap((tool) => {
+      const doc = docText(tool.description || tool.methodName)
+      const output = tool.outputSchema ? jsonSchemaToTypeScript(tool.outputSchema) : 'McpToolResult'
+      return [
+        `  /** ${doc} */`,
+        `  ${quotePropertyName(tool.methodName)}(params: ${jsonSchemaToTypeScript(tool.inputSchema)}): Promise<${output}>`
+      ]
+    }),
     '}'
   ].join('\n')
 }

--- a/src/main/ai/tools/codeMode/worker.ts
+++ b/src/main/ai/tools/codeMode/worker.ts
@@ -5,6 +5,7 @@ const { parentPort } = require('node:worker_threads')
 const MAX_LOGS = 1000
 
 const logs = []
+const images = []
 const pendingCalls = new Map()
 const activeCalls = new Map()
 let isExecuting = false
@@ -72,9 +73,24 @@ const tools = {
   }
 }
 
-const buildContext = () => {
+const emitImage = (image) => {
+  if (!image || typeof image.data !== 'string' || typeof image.mimeType !== 'string') {
+    throw new Error('emitImage requires string data and mimeType')
+  }
+  images.push({ data: image.data, mimeType: image.mimeType })
+}
+
+const buildContext = (facades) => {
+  const generatedFacades = {}
+  for (const [facadeName, methods] of Object.entries(facades || {})) {
+    generatedFacades[facadeName] = Object.fromEntries(
+      Object.entries(methods).map(([methodName, toolName]) => [methodName, (params = {}) => invoke(toolName, params)])
+    )
+  }
   return {
     tools,
+    ...generatedFacades,
+    emitImage,
     parallel: (...promises) => Promise.all(promises),
     settle: (...promises) => Promise.allSettled(promises),
     console: capturedConsole
@@ -103,14 +119,14 @@ const drainActiveCalls = async () => {
   }
 }
 
-const handleExec = async (code) => {
+const handleExec = async (code, facades) => {
   if (isExecuting) {
     return
   }
   isExecuting = true
 
   try {
-    const context = buildContext()
+    const context = buildContext(facades)
     let result
     let codeError
     try {
@@ -120,7 +136,12 @@ const handleExec = async (code) => {
     }
     await drainActiveCalls()
     if (codeError) throw codeError
-    parentPort?.postMessage({ type: 'result', result, logs: logs.length > 0 ? logs : undefined })
+    parentPort?.postMessage({
+      type: 'result',
+      result,
+      logs: logs.length > 0 ? logs : undefined,
+      images: images.length > 0 ? images : undefined
+    })
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     parentPort?.postMessage({ type: 'error', error: errorMessage, logs: logs.length > 0 ? logs : undefined })
@@ -137,6 +158,7 @@ const handleToolResult = (message) => {
   }
   pendingCalls.delete(message.requestId)
   activeCalls.delete(message.requestId)
+  for (const image of message.images || []) emitImage(image)
   pending.resolve(message.result)
 }
 
@@ -156,7 +178,7 @@ parentPort?.on('message', (message) => {
   }
   switch (message.type) {
     case 'exec':
-      handleExec(message.code)
+      handleExec(message.code, message.facades)
       break
     case 'toolResult':
       handleToolResult(message)

--- a/src/main/ai/tools/codeMode/worker.ts
+++ b/src/main/ai/tools/codeMode/worker.ts
@@ -1,11 +1,21 @@
+// Bound retained image output across an entire exec batch, including repeated screenshots.
+export const MAX_EXEC_IMAGES = 32
+export const MAX_EXEC_IMAGE_DATA_LENGTH = 64 * 1024 * 1024
+export const IMAGE_OUTPUT_LIMIT_ERROR = 'tool_exec image output exceeds 32 images or 64 MiB of base64 data'
+
 export const execWorkerSource = `
 const crypto = require('node:crypto')
 const { parentPort } = require('node:worker_threads')
 
 const MAX_LOGS = 1000
+const MAX_IMAGES = ${MAX_EXEC_IMAGES}
+const MAX_IMAGE_DATA_LENGTH = ${MAX_EXEC_IMAGE_DATA_LENGTH}
+const IMAGE_OUTPUT_LIMIT_ERROR = ${JSON.stringify(IMAGE_OUTPUT_LIMIT_ERROR)}
 
 const logs = []
 const images = []
+let imageDataLength = 0
+let imageOutputError
 const pendingCalls = new Map()
 const activeCalls = new Map()
 let isExecuting = false
@@ -73,12 +83,27 @@ const tools = {
   }
 }
 
-const emitImage = (image) => {
-  if (!image || typeof image.data !== 'string' || typeof image.mimeType !== 'string') {
-    throw new Error('emitImage requires string data and mimeType')
+const appendImages = (incoming) => {
+  if (images.length + incoming.length > MAX_IMAGES) {
+    imageOutputError = new Error(IMAGE_OUTPUT_LIMIT_ERROR)
+    throw imageOutputError
   }
-  images.push({ data: image.data, mimeType: image.mimeType })
+  let nextLength = imageDataLength
+  for (const image of incoming) {
+    if (!image || typeof image.data !== 'string' || typeof image.mimeType !== 'string') {
+      throw new Error('emitImage requires string data and mimeType')
+    }
+    nextLength += image.data.length
+    if (nextLength > MAX_IMAGE_DATA_LENGTH) {
+      imageOutputError = new Error(IMAGE_OUTPUT_LIMIT_ERROR)
+      throw imageOutputError
+    }
+  }
+  images.push(...incoming.map(({ data, mimeType }) => ({ data, mimeType })))
+  imageDataLength = nextLength
 }
+
+const emitImage = (image) => appendImages([image])
 
 const buildContext = (facades) => {
   const generatedFacades = {}
@@ -135,6 +160,7 @@ const handleExec = async (code, facades) => {
       codeError = error
     }
     await drainActiveCalls()
+    if (imageOutputError) throw imageOutputError
     if (codeError) throw codeError
     parentPort?.postMessage({
       type: 'result',
@@ -158,7 +184,12 @@ const handleToolResult = (message) => {
   }
   pendingCalls.delete(message.requestId)
   activeCalls.delete(message.requestId)
-  for (const image of message.images || []) emitImage(image)
+  try {
+    appendImages(message.images || [])
+  } catch (error) {
+    pending.reject(error)
+    return
+  }
   pending.resolve(message.result)
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Pi Code Mode could call browser MCP tools only through flat `tools.invoke(...)` names, and image content returned by nested tools was dropped before `tool_exec` reached the model.

After this PR:

Pi Code Mode discovery exposes typed `browser.<method>(params)` declarations generated from the browser MCP catalog. The worker dispatches those aliases through the existing nested-tool authorization boundary and forwards returned images alongside the JSON result.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20336

### Why we need it and why it was done in this way

Browser work commonly requires several related actions and a final visual check. A typed facade makes those actions composable in one `tool_exec` call while preserving the flat MCP tool catalog for runtimes that do not use Code Mode.

The following tradeoffs were made:

The existing fresh worker per `tool_exec` call remains unchanged. Browser tab IDs and element refs are serializable strings that can be reacquired; retaining workers would add lifecycle and stale-state behavior outside this task.

The following alternatives were considered:

A separate persistent REPL or browser-specific execution server was rejected because the shared worker already provides the required orchestration boundary. Persistent context can be revisited if handle re-fetching becomes a measured cost.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20336#issuecomment-5645164460

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Automated coverage verifies typed facade dispatch, nested approval denial, alias collision handling, batching guidance, image forwarding, and explicit failure on over-budget image output. At code head 6e35632ec1d9055229a0786e6c6d14a72d0fe897, the image-accumulation and text-only MCP schema fallback findings have RED/GREEN regressions; 59 focused Main tests, `pnpm lint`, and `pnpm test:lint` pass. The docs-only follow-up at current head 3e259c31f81672d4a4e30a65dc8c58eed128cc79 records the 32-image / 64 MiB execution-wide budget and whole-execution failure; `pnpm docs:check` and `git diff --check` pass. Current-head CI is running. UI screenshot verification is pending: the tracked single Cherry Studio dev Electron instance in Nashville remains active for another workflow, so this PR has not used or replaced it. No new screenshot has been produced, and this PR is not UI-ready.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Pi agents can batch browser actions in Code Mode and receive screenshots from nested browser tools.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `tool_exec` orchestration, model output shape, and browser tool dispatch across Pi and AI SDK paths; bounded by image limits and extensive tests but affects agent tool behavior.
> 
> **Overview**
> Pi Code Mode now exposes a typed **`browser.<method>(params)`** facade alongside flat **`tools.invoke`**, driven by MCP tools whose logical server is **`@cherry/browser`**. Tool discovery appends a `declare const browser` block when method names are unique; colliding or disabled tools drop the alias while wire names stay callable. Facade calls still go through nested approval and disabled-tool policy, with prompt guidance to batch browser work and end with one snapshot/screenshot.
> 
> **`tool_exec`** now forwards nested MCP **image** parts (and worker **`emitImage`**) as separate image content for Pi and the AI SDK meta-tool, with a shared **32 image / 64 MiB** budget that fails the whole run on overflow. Schema-less nested results strip images from the JSON value to avoid duplicating base64; structured outputs can decode from text when `details` is null.
> 
> MCP bridging adds optional **`logicalName`** on agent servers so Pi tool definitions keep UUID wire namespaces but record stable **`source`** metadata for facade generation. Docs describe the new browser and image limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e259c31f81672d4a4e30a65dc8c58eed128cc79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->