### PR TITLE
fix(screenshot): match scaled secondary displays

### DIFF
--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -914,11 +914,14 @@ function matchCapture(
       return result
     }
 
-    // 3. Windows HiDPI: the native side reports physical pixels in the primary
-    //    display's grid while Electron reports DIP, so normalize before comparing.
-    if (primaryScaleFactor !== 1) {
-      const normX = Math.round(monitorInfo.x / primaryScaleFactor)
-      const normY = Math.round(monitorInfo.y / primaryScaleFactor)
+    // 3. Windows HiDPI: native origins can follow either the primary or the
+    //    monitor's physical-pixel grid, so normalize against both scales.
+    const scaleFactors = [primaryScaleFactor]
+    if (isWin && monitorInfo.scaleFactor !== primaryScaleFactor) scaleFactors.push(monitorInfo.scaleFactor)
+    for (const scaleFactor of scaleFactors) {
+      if (scaleFactor === 1) continue
+      const normX = Math.round(monitorInfo.x / scaleFactor)
+      const normY = Math.round(monitorInfo.y / scaleFactor)
       if (Math.abs(normX - display.bounds.x) <= 1 && Math.abs(normY - display.bounds.y) <= 1) return result
     }
   }

--- a/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
+++ b/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
@@ -617,6 +617,27 @@ describe('ScreenshotOverlayService', () => {
       expect(container.openCalls.map((c) => c.id)).toEqual(['overlay-0-0', 'overlay-1920-0'])
     })
 
+    it('matches a mixed-DPI secondary display left of the Windows primary', async () => {
+      platform.isMac = false
+      platform.isWin = true
+      electron.displays = [makeDisplay(100, 0, 0, 1920, 1080, 1.5), makeDisplay(101, -1920, 0, 1920, 1080, 1.25)]
+      electron.cursorDisplay = electron.displays[0]
+      capture.captureAllMonitors.mockReturnValue(
+        new Map([
+          [10, makeCapture(2880, 1620)],
+          [11, makeCapture(2400, 1350)]
+        ])
+      )
+      capture.listMonitors.mockReturnValue([
+        { id: 10, name: 'M1', x: 0, y: 0, width: 2880, height: 1620, scaleFactor: 1.5, isPrimary: true },
+        { id: 11, name: 'M2', x: -2400, y: 0, width: 2400, height: 1350, scaleFactor: 1.25, isPrimary: false }
+      ])
+
+      await service.startCapture()
+
+      expect(container.openCalls.map((c) => c.id)).toEqual(['overlay-0-0', 'overlay--1920-0'])
+    })
+
     it('takes the reference scale factor from the primary display, not from a display at the origin', async () => {
       // Under DPI scaling Electron reports fractional bounds, so no display sits exactly
       // at (0,0); guessing then silently falls back to 1 and tier 3 stops matching.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

On Windows mixed-DPI layouts, a secondary display positioned left of the primary could receive no screenshot overlay when Electron and the native capture backend used unrelated display IDs.

After this PR:

Capture matching also normalizes native origins with the native monitor's own scale factor on Windows, while preserving the existing direct-ID, unscaled-origin, and primary-scale matching paths.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19922

### Why we need it and why it was done in this way

The native capture backend can report a negative secondary-monitor origin in that monitor's physical-pixel grid, while Electron reports the origin in DIP. Normalizing only with the primary display scale leaves those origins unmatched.

The following tradeoffs were made:

The fix adds one Windows-only coordinate candidate and leaves all existing matching tiers intact.

The following alternatives were considered:

Replacing primary-scale normalization was rejected because existing right-side layouts rely on it. Matching by ID alone is not sufficient because Electron and the native backend use unrelated ID spaces on Windows.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19922

### Breaking changes

None.

### Special notes for your reviewer

Verified with the complete screenshot service test directory (83 tests), `pnpm lint`, and `CI=1 pnpm test:lint` under Node 24.14.0. Screenshots were omitted at the user's request; this changes main-process display matching and adds no visual styling.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Windows screenshot capture on mixed-DPI multi-monitor layouts where a secondary display is positioned left of the primary display.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only, additive matching path in display-to-capture pairing; existing tiers unchanged and covered by expanded tests.
> 
> **Overview**
> Fixes missing screenshot overlays on **Windows mixed-DPI** setups when a secondary monitor sits **left of the primary**. Native capture can report that monitor’s origin in **its own physical-pixel grid** (e.g. negative x), while Electron uses **DIP**—tier-3 matching previously normalized only with the **primary** scale, so the secondary never paired with a capture.
> 
> **`matchCapture`** now tries HiDPI normalization with both the primary scale and, on Windows when it differs, each monitor’s **`scaleFactor`**, without changing direct ID match or unscaled origin matching. A regression test covers a left-of-primary mixed-DPI layout and expects overlays on both displays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1f5954095d4d4e57303338e0142213421a13af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->