### PR TITLE
fix(binary-manager): refresh dependency state after update checks

### DIFF
--- a/src/main/services/binaryManager/BinaryManager.ts
+++ b/src/main/services/binaryManager/BinaryManager.ts
@@ -490,15 +490,15 @@ export class BinaryManager extends BaseService {
     const installed: Record<string, MiseInstallEntry[]> = {}
     // Backend state is derived once and drives the independent application fact:
     // a missing backend is `backend_unavailable`, a failed/malformed query is
-    // `query_failed`. Neither may ever collapse a tool to `absent`.
-    let queryFailed = false
+    // `query_failed` with sanitized details. Neither may ever collapse a tool to `absent`.
+    let queryFailureMessage: string | null = null
     if (this.miseBin) {
       try {
         Object.assign(installed, await this.listMiseInstalls())
       } catch (err) {
-        queryFailed = true
+        queryFailureMessage = this.errorMessage(err)
         logger.warn('Failed to query installed versions via mise ls', {
-          error: err instanceof Error ? err.message : String(err)
+          error: queryFailureMessage
         })
       }
     }
@@ -533,8 +533,8 @@ export class BinaryManager extends BaseService {
     // recipe options, `applied` proves package identity, not optional capabilities.
     const backendUnknown: BinaryApplication | null = !this.miseBin
       ? { status: 'unknown', reason: 'backend_unavailable' }
-      : queryFailed
-        ? { status: 'unknown', reason: 'query_failed' }
+      : queryFailureMessage !== null
+        ? { status: 'unknown', reason: 'query_failed', message: queryFailureMessage }
         : null
 
     type DerivedTool = { application?: BinaryApplication; mise?: { path: string; version?: string } }

--- a/src/main/services/binaryManager/__tests__/BinaryManager.test.ts
+++ b/src/main/services/binaryManager/__tests__/BinaryManager.test.ts
@@ -1230,12 +1230,12 @@ describe('BinaryManager', () => {
         expect(snapshots.bun).toEqual({
           name: 'bun',
           availability: { source: 'bundled', path: '/mock/cherry.bin/bun', version: '1.2.3' },
-          application: { status: 'unknown', reason: 'query_failed' }
+          application: { status: 'unknown', reason: 'query_failed', message: 'mise ls boom' }
         })
         expect(snapshots.fd).toEqual({
           name: 'fd',
           availability: { source: 'system', path: '/usr/local/bin/fd' },
-          application: { status: 'unknown', reason: 'query_failed' }
+          application: { status: 'unknown', reason: 'query_failed', message: 'mise ls boom' }
         })
       })
 
@@ -1257,14 +1257,14 @@ describe('BinaryManager', () => {
         expect(snapshots.fd).toEqual({
           name: 'fd',
           availability: { source: 'mise', path: '/mock/feature.binary.data/shims/fd' },
-          application: { status: 'unknown', reason: 'query_failed' }
+          application: { status: 'unknown', reason: 'query_failed', message: 'mise ls boom' }
         })
       })
 
       it.each([
-        ['a non-object', JSON.stringify(['not', 'an', 'object'])],
-        ['invalid spec entries', JSON.stringify({ fd: {} })]
-      ])('treats %s mise ls shape as query_failed, not absent', async (_case, stdout) => {
+        ['a non-object', JSON.stringify(['not', 'an', 'object']), 'mise ls --json returned a non-object shape'],
+        ['invalid spec entries', JSON.stringify({ fd: {} }), 'mise ls --json returned invalid entries for fd']
+      ])('treats %s mise ls shape as query_failed, not absent', async (_case, stdout, message) => {
         const service = new BinaryManager()
         ;(service as any).miseBin = '/mock/mise'
         ;(service as any).isolatedEnv = { env: {}, usesDefaultChinaPipIndex: false }
@@ -1276,7 +1276,7 @@ describe('BinaryManager', () => {
         expect(snapshots.fd).toEqual({
           name: 'fd',
           availability: { source: 'none' },
-          application: { status: 'unknown', reason: 'query_failed' }
+          application: { status: 'unknown', reason: 'query_failed', message }
         })
       })
 

--- a/src/renderer/pages/settings/DependenciesSettings/EnvironmentDependencies.tsx
+++ b/src/renderer/pages/settings/DependenciesSettings/EnvironmentDependencies.tsx
@@ -154,7 +154,7 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
     }
   }, [])
 
-  const refreshState = useCallback(async () => {
+  const refreshState = useCallback(async (propagateError = false): Promise<void> => {
     const requestId = ++resolutionRequestIdRef.current
     try {
       const nextSnapshots = await ipcApi.request(
@@ -164,8 +164,15 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
       if (!mountedRef.current || requestId !== resolutionRequestIdRef.current) return
       setSnapshots(nextSnapshots)
       setResolutionsReady(true)
+      const queryFailure = Object.values(nextSnapshots).find(
+        (snapshot) => snapshot.application?.status === 'unknown' && snapshot.application.reason === 'query_failed'
+      )?.application
+      if (propagateError && queryFailure?.status === 'unknown') {
+        throw new Error(queryFailure.message ?? queryFailure.reason)
+      }
     } catch (error) {
       logger.error('Failed to refresh binary state', error as Error)
+      if (propagateError) throw error
     }
   }, [])
 
@@ -175,6 +182,7 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
       setCheckingUpdates(true)
       try {
         const versions = await ipcApi.request('binary.get_latest_versions', force)
+        if (force) await refreshState(true)
         if (mountedRef.current && requestId === latestRequestIdRef.current) {
           setLatestVersions(versions)
           // Only the manual refresh (force) gets a toast — the background check on
@@ -190,7 +198,7 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
         if (mountedRef.current && requestId === latestRequestIdRef.current) setCheckingUpdates(false)
       }
     },
-    [t]
+    [refreshState, t]
   )
 
   useEffect(() => {

--- a/src/renderer/pages/settings/DependenciesSettings/EnvironmentDependencies.tsx
+++ b/src/renderer/pages/settings/DependenciesSettings/EnvironmentDependencies.tsx
@@ -154,14 +154,14 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
     }
   }, [])
 
-  const refreshState = useCallback(async (propagateError = false): Promise<void> => {
+  const refreshState = useCallback(async (propagateError = false): Promise<boolean> => {
     const requestId = ++resolutionRequestIdRef.current
     try {
       const nextSnapshots = await ipcApi.request(
         'binary.get_tool_snapshots',
         PRESETS_BINARY_TOOLS.map((tool) => tool.name)
       )
-      if (!mountedRef.current || requestId !== resolutionRequestIdRef.current) return
+      if (!mountedRef.current || requestId !== resolutionRequestIdRef.current) return false
       setSnapshots(nextSnapshots)
       setResolutionsReady(true)
       const queryFailure = Object.values(nextSnapshots).find(
@@ -170,9 +170,11 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
       if (propagateError && queryFailure?.status === 'unknown') {
         throw new Error(queryFailure.message ?? queryFailure.reason)
       }
+      return true
     } catch (error) {
       logger.error('Failed to refresh binary state', error as Error)
       if (propagateError) throw error
+      return false
     }
   }, [])
 
@@ -182,12 +184,12 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
       setCheckingUpdates(true)
       try {
         const versions = await ipcApi.request('binary.get_latest_versions', force)
-        if (force) await refreshState(true)
+        const stateRefreshed = !force || (await refreshState(true))
         if (mountedRef.current && requestId === latestRequestIdRef.current) {
           setLatestVersions(versions)
           // Only the manual refresh (force) gets a toast — the background check on
           // mount must stay silent.
-          if (force) toast.success(t('settings.dependencies.updateCheckSuccess'))
+          if (force && stateRefreshed) toast.success(t('settings.dependencies.updateCheckSuccess'))
         }
         return versions
       } catch (error) {

--- a/src/renderer/pages/settings/DependenciesSettings/EnvironmentDependencies.tsx
+++ b/src/renderer/pages/settings/DependenciesSettings/EnvironmentDependencies.tsx
@@ -183,18 +183,24 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
       const requestId = ++latestRequestIdRef.current
       setCheckingUpdates(true)
       try {
-        const versions = await ipcApi.request('binary.get_latest_versions', force)
-        const stateRefreshed = !force || (await refreshState(true))
+        const [versionsResult, stateResult] = await Promise.allSettled([
+          ipcApi.request('binary.get_latest_versions', force),
+          force ? refreshState(true) : Promise.resolve(true)
+        ])
+        if (versionsResult.status === 'rejected') throw versionsResult.reason
+        if (stateResult.status === 'rejected') throw stateResult.reason
         if (mountedRef.current && requestId === latestRequestIdRef.current) {
-          setLatestVersions(versions)
+          setLatestVersions(versionsResult.value)
           // Only the manual refresh (force) gets a toast — the background check on
           // mount must stay silent.
-          if (force && stateRefreshed) toast.success(t('settings.dependencies.updateCheckSuccess'))
+          if (force && stateResult.value) toast.success(t('settings.dependencies.updateCheckSuccess'))
         }
-        return versions
+        return versionsResult.value
       } catch (error) {
         logger.error('Failed to fetch latest versions', error as Error)
-        if (force) toast.error(`${t('settings.dependencies.updateCheckFailed')}: ${formatErrorMessage(error)}`)
+        if (force && mountedRef.current && requestId === latestRequestIdRef.current) {
+          toast.error(`${t('settings.dependencies.updateCheckFailed')}: ${formatErrorMessage(error)}`)
+        }
         return null
       } finally {
         if (mountedRef.current && requestId === latestRequestIdRef.current) setCheckingUpdates(false)
@@ -215,7 +221,9 @@ const EnvironmentDependencies: FC<EnvironmentDependenciesProps> = ({ mini = fals
   }, [fetchLatestVersions, mini])
 
   useIpcOn('binary.availability_changed', () => {
+    latestRequestIdRef.current++
     setLatestVersions(null)
+    setCheckingUpdates(false)
     void refreshState()
   })
 

--- a/src/renderer/pages/settings/DependenciesSettings/__tests__/EnvironmentDependencies.test.tsx
+++ b/src/renderer/pages/settings/DependenciesSettings/__tests__/EnvironmentDependencies.test.tsx
@@ -618,6 +618,29 @@ describe('EnvironmentDependencies', () => {
     await waitFor(() => expect(within(card).queryByText('common.retry')).not.toBeInTheDocument())
   })
 
+  it('re-probes dependency state even when the version catalog request fails', async () => {
+    const user = userEvent.setup()
+    const unknown: BinaryToolSnapshot = {
+      name: 'uv',
+      application: { status: 'unknown', reason: 'query_failed' },
+      availability: { source: 'bundled', path: 'C:\\Cherry\\bin\\uv.exe', version: '0.9.0' }
+    }
+    ipcMocks.snapshots
+      .mockResolvedValueOnce({ uv: unknown })
+      .mockResolvedValue({ uv: { ...unknown, application: { status: 'absent' } } })
+    ipcMocks.latestVersions.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('catalog offline'))
+
+    render(<EnvironmentDependencies />)
+    const card = (await screen.findByText('uv')).closest('[role="listitem"]') as HTMLElement
+    expect(within(card).getByText('common.retry')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'settings.dependencies.checkUpdates' }))
+
+    await waitFor(() => expect(within(card).queryByText('common.retry')).not.toBeInTheDocument())
+    expect(toastMock.error).toHaveBeenCalledWith('settings.dependencies.updateCheckFailed: catalog offline')
+    expect(toastMock.success).not.toHaveBeenCalled()
+  })
+
   it('keeps Retry and reports the probe error when a manual re-probe returns query_failed', async () => {
     const user = userEvent.setup()
     const unknown: BinaryToolSnapshot = {
@@ -676,6 +699,27 @@ describe('EnvironmentDependencies', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'settings.dependencies.checkUpdates' })).toBeEnabled()
     )
+    expect(toastMock.success).not.toHaveBeenCalled()
+  })
+
+  it('does not restore stale version badges after an availability change', async () => {
+    const user = userEvent.setup()
+    setSnapshots({ uv: miseSnapshot('uv') })
+    let resolveCatalog: (versions: Record<string, string>) => void = () => undefined
+    const manualCatalog = new Promise<Record<string, string>>((resolve) => {
+      resolveCatalog = resolve
+    })
+    ipcMocks.latestVersions.mockResolvedValueOnce({}).mockReturnValueOnce(manualCatalog)
+
+    render(<EnvironmentDependencies />)
+    await screen.findByText('uv')
+    await user.click(screen.getByRole('button', { name: 'settings.dependencies.checkUpdates' }))
+    await waitFor(() => expect(ipcMocks.latestVersions).toHaveBeenCalledTimes(2))
+
+    act(() => ipcEventHandlers.get('binary.availability_changed')?.(undefined))
+    await act(async () => resolveCatalog({ uv: '9.0.0' }))
+
+    expect(screen.queryByText('v9.0.0')).not.toBeInTheDocument()
     expect(toastMock.success).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/pages/settings/DependenciesSettings/__tests__/EnvironmentDependencies.test.tsx
+++ b/src/renderer/pages/settings/DependenciesSettings/__tests__/EnvironmentDependencies.test.tsx
@@ -643,6 +643,42 @@ describe('EnvironmentDependencies', () => {
     expect(within(card).getByText('common.retry')).toBeInTheDocument()
   })
 
+  it('does not report success when a concurrent refresh supersedes the manual re-probe', async () => {
+    const user = userEvent.setup()
+    const unknown: BinaryToolSnapshot = {
+      name: 'uv',
+      application: { status: 'unknown', reason: 'query_failed', message: 'mise ls failed' },
+      availability: { source: 'bundled', path: 'C:\\Cherry\\bin\\uv.exe', version: '0.9.0' }
+    }
+    const recovered: BinaryToolSnapshot = {
+      name: 'uv',
+      application: { status: 'absent' },
+      availability: unknown.availability
+    }
+    let resolveManualProbe: (snapshots: Record<string, BinaryToolSnapshot>) => void = () => undefined
+    const manualProbe = new Promise<Record<string, BinaryToolSnapshot>>((resolve) => {
+      resolveManualProbe = resolve
+    })
+    ipcMocks.snapshots
+      .mockResolvedValueOnce({ uv: unknown })
+      .mockReturnValueOnce(manualProbe)
+      .mockResolvedValueOnce({ uv: unknown })
+
+    render(<EnvironmentDependencies />)
+    await screen.findByText('uv')
+
+    await user.click(screen.getByRole('button', { name: 'settings.dependencies.checkUpdates' }))
+    await waitFor(() => expect(ipcMocks.snapshots).toHaveBeenCalledTimes(2))
+    act(() => ipcEventHandlers.get('binary.availability_changed')?.(undefined))
+    await waitFor(() => expect(ipcMocks.snapshots).toHaveBeenCalledTimes(3))
+    act(() => resolveManualProbe({ uv: recovered }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'settings.dependencies.checkUpdates' })).toBeEnabled()
+    )
+    expect(toastMock.success).not.toHaveBeenCalled()
+  })
+
   it('hides the mini warning when bundled core dependencies are available', async () => {
     setSnapshots({
       uv: { name: 'uv', availability: { source: 'bundled', path: '/bundled/uv' } },

--- a/src/renderer/pages/settings/DependenciesSettings/__tests__/EnvironmentDependencies.test.tsx
+++ b/src/renderer/pages/settings/DependenciesSettings/__tests__/EnvironmentDependencies.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { gt as semverGt } from 'semver'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -25,6 +26,12 @@ const ipcMocks = vi.hoisted(() => ({
 }))
 const toastMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }))
 const ipcEventHandlers = vi.hoisted(() => new Map<string, (payload: unknown) => void>())
+const translationMock = vi.hoisted(() => ({
+  t: (key: string, options?: { details?: string; dependents?: string }) => {
+    const interpolation = options?.details ?? options?.dependents
+    return interpolation ? `${key} ${interpolation}` : key
+  }
+}))
 
 const setSnapshots = (records: Record<string, BinaryToolSnapshot>) => {
   snapshotRecords.value = records
@@ -74,12 +81,7 @@ vi.mock('@renderer/ipc/useIpcOn', () => ({ useIpcOn: vi.fn() }))
 vi.mock('@renderer/services/toast', () => ({ toast: toastMock }))
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: vi.fn() },
-  useTranslation: () => ({
-    t: (key: string, options?: { details?: string; dependents?: string }) => {
-      const interpolation = options?.details ?? options?.dependents
-      return interpolation ? `${key} ${interpolation}` : key
-    }
-  })
+  useTranslation: () => translationMock
 }))
 vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }))
 vi.mock('@data/hooks/usePreference', () => ({
@@ -591,6 +593,54 @@ describe('EnvironmentDependencies', () => {
     await waitFor(() => expect(ipcMocks.snapshots).toHaveBeenCalledTimes(1))
     act(() => ipcEventHandlers.get('binary.availability_changed')?.(undefined))
     await waitFor(() => expect(ipcMocks.snapshots).toHaveBeenCalledTimes(2))
+  })
+
+  it('re-probes dependency state after a manual update check recovers the backend', async () => {
+    const user = userEvent.setup()
+    const unknown: BinaryToolSnapshot = {
+      name: 'uv',
+      application: { status: 'unknown', reason: 'query_failed' },
+      availability: { source: 'bundled', path: 'C:\\Cherry\\bin\\uv.exe', version: '0.9.0' }
+    }
+    const recovered: BinaryToolSnapshot = {
+      name: 'uv',
+      application: { status: 'absent' },
+      availability: unknown.availability
+    }
+    ipcMocks.snapshots.mockResolvedValueOnce({ uv: unknown }).mockResolvedValue({ uv: recovered })
+
+    render(<EnvironmentDependencies />)
+    const card = (await screen.findByText('uv')).closest('[role="listitem"]') as HTMLElement
+    expect(within(card).getByText('common.retry')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'settings.dependencies.checkUpdates' }))
+
+    await waitFor(() => expect(within(card).queryByText('common.retry')).not.toBeInTheDocument())
+  })
+
+  it('keeps Retry and reports the probe error when a manual re-probe returns query_failed', async () => {
+    const user = userEvent.setup()
+    const unknown: BinaryToolSnapshot = {
+      name: 'uv',
+      application: { status: 'unknown', reason: 'query_failed' },
+      availability: { source: 'bundled', path: 'C:\\Cherry\\bin\\uv.exe', version: '0.9.0' }
+    }
+    const failedProbe: BinaryToolSnapshot = {
+      ...unknown,
+      application: { status: 'unknown', reason: 'query_failed', message: 'mise ls failed' }
+    }
+    ipcMocks.snapshots.mockResolvedValueOnce({ uv: unknown }).mockResolvedValueOnce({ uv: failedProbe })
+
+    render(<EnvironmentDependencies />)
+    const card = (await screen.findByText('uv')).closest('[role="listitem"]') as HTMLElement
+
+    await user.click(screen.getByRole('button', { name: 'settings.dependencies.checkUpdates' }))
+
+    await waitFor(() =>
+      expect(toastMock.error).toHaveBeenCalledWith('settings.dependencies.updateCheckFailed: mise ls failed')
+    )
+    expect(toastMock.success).not.toHaveBeenCalled()
+    expect(within(card).getByText('common.retry')).toBeInTheDocument()
   })
 
   it('hides the mini warning when bundled core dependencies are available', async () => {

--- a/src/shared/ipc/schemas/binary.ts
+++ b/src/shared/ipc/schemas/binary.ts
@@ -79,7 +79,11 @@ const binaryApplicationSchema: z.ZodType<BinaryApplication> = z.discriminatedUni
   z.object({ status: z.literal('broken'), version: z.string().optional() }),
   z.object({ status: z.literal('absent') }),
   z.object({ status: z.literal('conflict') }),
-  z.object({ status: z.literal('unknown'), reason: z.enum(['backend_unavailable', 'query_failed']) })
+  z.object({
+    status: z.literal('unknown'),
+    reason: z.enum(['backend_unavailable', 'query_failed']),
+    message: z.string().optional()
+  })
 ])
 
 const binaryOperationSchema: z.ZodType<BinaryOperation> = z.discriminatedUnion('status', [

--- a/src/shared/types/binary.ts
+++ b/src/shared/types/binary.ts
@@ -66,14 +66,14 @@ export type BinaryAvailability =
  * - `broken`   — the exact recipe has only inactive entries, no executable shim, or a shim that resolves outside the active entry's install.
  * - `absent`   — the exact recipe has no installed entries (and no live shim of its own).
  * - `conflict` — no exact entries, but a shim mise still resolves to a runnable target.
- * - `unknown`  — the mise backend was unavailable or its query failed/was malformed.
+ * - `unknown`  — the mise backend was unavailable or its query failed/was malformed; query failures carry a sanitized message.
  */
 export type BinaryApplication =
   | { status: 'applied'; version?: string }
   | { status: 'broken'; version?: string }
   | { status: 'absent' }
   | { status: 'conflict' }
-  | { status: 'unknown'; reason: 'backend_unavailable' | 'query_failed' }
+  | { status: 'unknown'; reason: 'backend_unavailable' | 'query_failed'; message?: string }
 
 /** Main-computed runtime facts for one binary. */
 export type BinaryToolSnapshot = {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Manual update checks only refreshed the latest-version catalog. A dependency card whose mise state probe had returned `query_failed` therefore kept showing Retry even if the backend had recovered, while a persistent probe failure exposed only the generic reason.

After this PR:

Manual update checks refresh dependency snapshots independently of the latest-version catalog, even when the catalog fails. A recovered probe clears stale Retry even if the catalog fails; a persistent probe failure keeps Retry visible and reports the sanitized error. Availability changes invalidate pending catalog results so stale version badges cannot return. The existing snapshot response carries that detail through an optional `query_failed.message` field.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20459

### Why we need it and why it was done in this way

The update-check action is already the user-facing recovery path, so it now refreshes both version metadata and current dependency state. Keeping the error detail on the existing snapshot outcome preserves one source of truth for dependency state without adding another IPC route.

The following tradeoffs were made:

The failure message is optional so existing snapshot producers and consumers remain compatible. Manual checks fail visibly when the refreshed snapshots still contain `query_failed`, while background checks remain silent.

The following alternatives were considered:

A separate probe-error endpoint was considered, but it would duplicate state already represented by `BinaryToolSnapshot` and could drift from the card state.

Links to places where the discussion took place: #20459

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Follow-up at da56f27ddf: EnvironmentDependencies renderer tests 64/64 passed; the earlier head passed 214 main/IPC tests.
- `pnpm lint` and `CI=1 pnpm test:lint` passed at da56f27ddf.
- Screenshots are omitted at the user's explicit request. This changes recovery behavior and error reporting, not layout or styling; the result states are covered by renderer tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Environment Dependencies update checks so recovered dependency state clears Retry and persistent probe failures show their actionable error.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is limited to dependency settings refresh and optional snapshot metadata; no auth or install-path changes beyond clearer probe errors.
> 
> **Overview**
> Manual **Check for updates** in Environment Dependencies now re-fetches tool snapshots alongside the version catalog, so a recovered mise backend can clear stale **Retry** state instead of leaving cards stuck after an earlier `query_failed`.
> 
> When `mise ls` (or malformed JSON) still fails, snapshots expose an optional **`message`** on `unknown` / `query_failed` application facts (types, Zod schema, and `BinaryManager` use sanitized errors). The settings UI propagates that message into failed update-check toasts; background refresh stays silent. **`binary.availability_changed`** now cancels in-flight manual catalog requests so stale version badges do not reappear after availability shifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da56f27ddff4eb0c3354fa510df5883c6f4555db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
