### PR TITLE
fix(agent): hide tool boundary markers

### DIFF
--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -27,6 +27,9 @@ import { composeHooks } from './params/composeHooks'
 type AppProviderKey = StringKeys<AppProviderSettingsMap>
 
 const MISSING_FINISH_REASON_MESSAGE = 'Response stream ended without a finish reason.'
+const LEADING_TOOL_BOUNDARY_MARKERS = /^[\u2050-\u2057\u2063]+/u
+const ONLY_TOOL_BOUNDARY_MARKERS = /^[\u2050-\u2057\u2063]+$/u
+const TRAILING_TOOL_BOUNDARY_MARKERS = /[\u2050-\u2057\u2063]+$/u
 
 class MissingFinishReasonError extends Error {
   readonly i18nKey = 'missing_finish_reason'
@@ -330,6 +333,61 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
       const reader = uiStream.getReader()
       let readFailure: { error: unknown } | undefined
       let pendingFinish: Extract<UIMessageChunk, { type: 'finish' }> | undefined
+      let pendingTrailingMarkers: Array<Extract<UIMessageChunk, { type: 'text-delta' }>> = []
+      let chunksAfterTrailingMarkers: UIMessageChunk[] = []
+      let followsToolBoundary = false
+      const flushTrailingMarkers = async (): Promise<void> => {
+        for (const chunk of pendingTrailingMarkers) await writer.write(chunk)
+        for (const chunk of chunksAfterTrailingMarkers) await writer.write(chunk)
+        pendingTrailingMarkers = []
+        chunksAfterTrailingMarkers = []
+      }
+      const writeUiChunk = async (chunk: UIMessageChunk): Promise<void> => {
+        const isToolChunk = chunk.type.startsWith('tool-')
+        if (isToolChunk) {
+          if (pendingTrailingMarkers.length > 0) {
+            pendingTrailingMarkers = []
+            for (const pendingChunk of chunksAfterTrailingMarkers) await writer.write(pendingChunk)
+            chunksAfterTrailingMarkers = []
+          }
+          followsToolBoundary = true
+          await writer.write(chunk)
+          return
+        }
+
+        if (chunk.type !== 'text-delta') {
+          if (pendingTrailingMarkers.length > 0) {
+            chunksAfterTrailingMarkers.push(chunk)
+            return
+          }
+          await writer.write(chunk)
+          return
+        }
+
+        if (pendingTrailingMarkers.length > 0) {
+          if (ONLY_TOOL_BOUNDARY_MARKERS.test(chunk.delta)) {
+            pendingTrailingMarkers.push(chunk)
+            return
+          }
+          await flushTrailingMarkers()
+        }
+        let delta = chunk.delta
+        if (followsToolBoundary) {
+          delta = delta.replace(LEADING_TOOL_BOUNDARY_MARKERS, '')
+          if (delta.length === 0) return
+          followsToolBoundary = false
+        }
+
+        const trailingMarkers = delta.match(TRAILING_TOOL_BOUNDARY_MARKERS)?.[0]
+        if (!trailingMarkers) {
+          await writer.write(delta === chunk.delta ? chunk : { ...chunk, delta })
+          return
+        }
+
+        const visibleDelta = delta.slice(0, -trailingMarkers.length)
+        if (visibleDelta) await writer.write({ ...chunk, delta: visibleDelta })
+        pendingTrailingMarkers.push({ ...chunk, delta: trailingMarkers })
+      }
       try {
         while (true) {
           const { done, value } = await reader.read()
@@ -345,6 +403,7 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
               ? capturedUiErrors.shift()
               : undefined
           if (value.type === 'error' && capturedError) {
+            await flushTrailingMarkers()
             await reader.cancel(capturedError.error).catch(() => {})
             throw capturedError.error
           }
@@ -356,8 +415,9 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
             pendingFinish = value
             continue
           }
-          await writer.write(value)
+          await writeUiChunk(value)
         }
+        if (!signal.aborted) await flushTrailingMarkers()
       } catch (error) {
         readFailure = { error }
       } finally {

--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -419,6 +419,7 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
         }
         if (!signal.aborted) await flushTrailingMarkers()
       } catch (error) {
+        if (!signal.aborted) await flushTrailingMarkers()
         readFailure = { error }
       } finally {
         reader.releaseLock()

--- a/src/main/ai/runtime/aiSdk/Agent.ts
+++ b/src/main/ai/runtime/aiSdk/Agent.ts
@@ -365,7 +365,7 @@ export class Agent<T extends AppProviderKey = AppProviderKey> {
         }
 
         if (pendingTrailingMarkers.length > 0) {
-          if (ONLY_TOOL_BOUNDARY_MARKERS.test(chunk.delta)) {
+          if (chunksAfterTrailingMarkers.length === 0 && ONLY_TOOL_BOUNDARY_MARKERS.test(chunk.delta)) {
             pendingTrailingMarkers.push(chunk)
             return
           }

--- a/src/main/ai/runtime/aiSdk/loop/__tests__/agentToolBoundaryMarkers.test.ts
+++ b/src/main/ai/runtime/aiSdk/loop/__tests__/agentToolBoundaryMarkers.test.ts
@@ -1,0 +1,191 @@
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { stepCountIs, tool, ToolLoopAgent, type UIMessageChunk } from 'ai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as z from 'zod'
+
+import type { AgentLoopParams } from '../types'
+
+const mockCreateAgent = vi.fn()
+const BOUNDARY_MARKERS = '\u2050\u2051\u2052\u2053\u2054\u2055\u2056\u2057\u2063'
+
+vi.mock('@cherrystudio/ai-core', () => ({
+  createAgent: (...args: unknown[]) => mockCreateAgent(...args)
+}))
+
+function event(type: string, data: unknown): string {
+  return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`
+}
+
+function messageStart(id: string): string {
+  return event('message_start', {
+    type: 'message_start',
+    message: {
+      id,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-test',
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 10, output_tokens: 0 }
+    }
+  })
+}
+
+function messageEnd(stopReason: 'tool_use' | 'end_turn', outputTokens: number): string {
+  return (
+    event('message_delta', {
+      type: 'message_delta',
+      delta: { stop_reason: stopReason, stop_sequence: null },
+      usage: { output_tokens: outputTokens }
+    }) + event('message_stop', { type: 'message_stop' })
+  )
+}
+
+async function makeAgent(overrides: Partial<AgentLoopParams> = {}) {
+  const { Agent } = await import('../../Agent')
+  return new Agent({
+    providerId: 'anthropic',
+    providerSettings: {},
+    modelId: 'claude-test',
+    ...overrides
+  })
+}
+
+describe('Agent tool-boundary text', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('hides leaked marker runs at tool boundaries without changing the same Unicode in prose', async () => {
+    const firstResponse =
+      messageStart('msg-1') +
+      event('content_block_start', {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text', text: '' }
+      }) +
+      event('content_block_delta', {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: `Before tool.${BOUNDARY_MARKERS.slice(0, 4)}` }
+      }) +
+      event('content_block_delta', {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: BOUNDARY_MARKERS.slice(4) }
+      }) +
+      event('content_block_stop', { type: 'content_block_stop', index: 0 }) +
+      event('content_block_start', {
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'tool_use', id: 'toolu-1', name: 'inspect', input: {} }
+      }) +
+      event('content_block_delta', {
+        type: 'content_block_delta',
+        index: 1,
+        delta: { type: 'input_json_delta', partial_json: '{"value":"ok"}' }
+      }) +
+      event('content_block_stop', { type: 'content_block_stop', index: 1 }) +
+      messageEnd('tool_use', 12)
+    const secondResponse =
+      messageStart('msg-2') +
+      event('content_block_start', {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text', text: '' }
+      }) +
+      event('content_block_delta', {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: BOUNDARY_MARKERS.slice(0, 4) }
+      }) +
+      event('content_block_delta', {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'text_delta',
+          text: `${BOUNDARY_MARKERS.slice(4)}After tool. Keep ${BOUNDARY_MARKERS} here.`
+        }
+      }) +
+      event('content_block_stop', { type: 'content_block_stop', index: 0 }) +
+      messageEnd('end_turn', 14)
+
+    let requestCount = 0
+    let toolExecutions = 0
+    const fetch = async (): Promise<Response> => {
+      const body = [firstResponse, secondResponse][requestCount++]
+      if (body === undefined) throw new Error(`Unexpected request ${requestCount}`)
+      return new Response(body, { headers: { 'content-type': 'text/event-stream' } })
+    }
+    const sdkAgent = new ToolLoopAgent({
+      model: createAnthropic({ apiKey: 'test-key', fetch })('claude-test'),
+      stopWhen: stepCountIs(3),
+      tools: {
+        inspect: tool({
+          description: 'Inspect a value',
+          inputSchema: z.object({ value: z.string() }),
+          execute: async ({ value }) => {
+            toolExecutions += 1
+            return { inspected: value }
+          }
+        })
+      }
+    })
+    mockCreateAgent.mockResolvedValue(sdkAgent)
+
+    const agent = await makeAgent()
+    const chunks: UIMessageChunk[] = []
+    const messages = [{ id: 'user-1', role: 'user' as const, parts: [{ type: 'text' as const, text: 'Inspect ok.' }] }]
+    for await (const chunk of agent.stream(messages, new AbortController().signal)) chunks.push(chunk)
+
+    const visibleText = chunks
+      .filter((chunk): chunk is Extract<UIMessageChunk, { type: 'text-delta' }> => chunk.type === 'text-delta')
+      .map((chunk) => chunk.delta)
+      .join('')
+    const toolChunkTypes = chunks.filter((chunk) => chunk.type.startsWith('tool-')).map((chunk) => chunk.type)
+
+    expect(requestCount).toBe(2)
+    expect(toolExecutions).toBe(1)
+    expect(toolChunkTypes).toEqual([
+      'tool-input-start',
+      'tool-input-delta',
+      'tool-input-available',
+      'tool-output-available'
+    ])
+    expect(visibleText).toBe(`Before tool.After tool. Keep ${BOUNDARY_MARKERS} here.`)
+  })
+
+  it('preserves a trailing marker run when the response ends without a tool call', async () => {
+    const sourceChunks: UIMessageChunk[] = [
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: `Keep this ${BOUNDARY_MARKERS.slice(0, 4)}` },
+      { type: 'text-delta', id: 'text-1', delta: BOUNDARY_MARKERS.slice(4) },
+      { type: 'text-end', id: 'text-1' },
+      { type: 'finish', finishReason: 'stop' }
+    ]
+    mockCreateAgent.mockResolvedValue({
+      stream: vi.fn().mockResolvedValue({
+        toUIMessageStream: () =>
+          new ReadableStream({
+            start(controller) {
+              for (const chunk of sourceChunks) controller.enqueue(chunk)
+              controller.close()
+            }
+          }),
+        steps: Promise.resolve([])
+      })
+    })
+
+    const agent = await makeAgent()
+    const messages = [{ id: 'user-1', role: 'user' as const, parts: [{ type: 'text' as const, text: 'Continue.' }] }]
+    const chunks: UIMessageChunk[] = []
+    for await (const chunk of agent.stream(messages, new AbortController().signal)) chunks.push(chunk)
+
+    const visibleText = chunks
+      .filter((chunk): chunk is Extract<UIMessageChunk, { type: 'text-delta' }> => chunk.type === 'text-delta')
+      .map((chunk) => chunk.delta)
+      .join('')
+    expect(visibleText).toBe(`Keep this ${BOUNDARY_MARKERS}`)
+  })
+})

--- a/src/main/ai/runtime/aiSdk/loop/__tests__/agentToolBoundaryMarkers.test.ts
+++ b/src/main/ai/runtime/aiSdk/loop/__tests__/agentToolBoundaryMarkers.test.ts
@@ -188,4 +188,36 @@ describe('Agent tool-boundary text', () => {
       .join('')
     expect(visibleText).toBe(`Keep this ${BOUNDARY_MARKERS}`)
   })
+
+  it('preserves text-part ordering when marker runs continue after structural chunks', async () => {
+    const sourceChunks: UIMessageChunk[] = [
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: 'First part' },
+      { type: 'text-delta', id: 'text-1', delta: BOUNDARY_MARKERS },
+      { type: 'text-end', id: 'text-1' },
+      { type: 'text-start', id: 'text-2' },
+      { type: 'text-delta', id: 'text-2', delta: BOUNDARY_MARKERS },
+      { type: 'text-end', id: 'text-2' },
+      { type: 'finish', finishReason: 'stop' }
+    ]
+    mockCreateAgent.mockResolvedValue({
+      stream: vi.fn().mockResolvedValue({
+        toUIMessageStream: () =>
+          new ReadableStream({
+            start(controller) {
+              for (const chunk of sourceChunks) controller.enqueue(chunk)
+              controller.close()
+            }
+          }),
+        steps: Promise.resolve([])
+      })
+    })
+
+    const agent = await makeAgent()
+    const messages = [{ id: 'user-1', role: 'user' as const, parts: [{ type: 'text' as const, text: 'Continue.' }] }]
+    const chunks: UIMessageChunk[] = []
+    for await (const chunk of agent.stream(messages, new AbortController().signal)) chunks.push(chunk)
+
+    expect(chunks).toEqual(sourceChunks)
+  })
 })

--- a/src/main/ai/runtime/aiSdk/loop/__tests__/agentToolBoundaryMarkers.test.ts
+++ b/src/main/ai/runtime/aiSdk/loop/__tests__/agentToolBoundaryMarkers.test.ts
@@ -220,4 +220,49 @@ describe('Agent tool-boundary text', () => {
 
     expect(chunks).toEqual(sourceChunks)
   })
+
+  it('flushes buffered chunks before propagating a UI stream error', async () => {
+    const streamError = new Error('UI stream failed')
+    const sourceChunks: UIMessageChunk[] = [
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: `Keep this ${BOUNDARY_MARKERS}` },
+      { type: 'text-end', id: 'text-1' }
+    ]
+    let sourceIndex = 0
+    mockCreateAgent.mockResolvedValue({
+      stream: vi.fn().mockResolvedValue({
+        toUIMessageStream: () =>
+          new ReadableStream({
+            pull(controller) {
+              const chunk = sourceChunks[sourceIndex++]
+              if (chunk) controller.enqueue(chunk)
+              else controller.error(streamError)
+            }
+          }),
+        steps: Promise.resolve([])
+      })
+    })
+
+    const agent = await makeAgent()
+    const messages = [{ id: 'user-1', role: 'user' as const, parts: [{ type: 'text' as const, text: 'Continue.' }] }]
+    const reader = agent.stream(messages, new AbortController().signal).getReader()
+    const chunks: UIMessageChunk[] = []
+
+    await expect(
+      (async () => {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) return
+          chunks.push(value)
+        }
+      })()
+    ).rejects.toBe(streamError)
+    expect(chunks.map((chunk) => chunk.type)).toEqual(['text-start', 'text-delta', 'text-delta', 'text-end'])
+    expect(
+      chunks
+        .filter((chunk): chunk is Extract<UIMessageChunk, { type: 'text-delta' }> => chunk.type === 'text-delta')
+        .map((chunk) => chunk.delta)
+        .join('')
+    ).toBe(`Keep this ${BOUNDARY_MARKERS}`)
+  })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Agent streams could render `U+2050`-`U+2057` and `U+2063` marker runs immediately before and after tool calls.

After this PR:

Agent streams buffer candidate marker runs until their structural context is known, remove them only at tool-call boundaries, and preserve the same Unicode in ordinary text.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20462

### Why we need it and why it was done in this way

Some Anthropic-compatible endpoints expose tool-boundary markers as text deltas. The AI SDK preserves those deltas, so Cherry Studio must distinguish boundary-only markers before forwarding visible UI chunks.

The following tradeoffs were made:

Only candidate marker runs and intervening structural chunks are buffered long enough to determine whether a tool boundary follows. All normal text and tool chunks retain their order, and trailing markers are flushed unchanged when no tool follows.

The following alternatives were considered:

Globally deleting these code points was rejected because they are valid Unicode and may be intentional model output. Provider-wide stripping was also rejected because the leak is contextual rather than intrinsic to every provider response.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... --> #20462

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- The regression replays valid Anthropic SSE through the real provider and `ToolLoopAgent`, including marker runs split across text deltas and a real local tool execution.
- Focused validation: `pnpm test:main src/main/ai/runtime/aiSdk/loop/__tests__` (41 tests passed).
- Gates: `pnpm lint` and `CI=1 pnpm test:lint` passed. Both report only the existing 11 Oxlint and 47 ESLint warnings outside this change.
- Screenshots are omitted at the user's explicit request. This changes stream filtering only; it adds no visual component or layout surface, and no Electron instance was launched.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent mode no longer shows Unicode separator markers around tool calls while preserving legitimate text.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stream transformation logic on all agent UI output could mis-handle edge cases in text-delta splitting, though scope is limited to specific Unicode ranges at tool boundaries.
> 
> **Overview**
> Fixes agent chat showing stray Unicode separator characters (U+2050–U+2057, U+2063) around tool calls from some Anthropic-compatible streams.
> 
> **Agent UI stream forwarding** now routes chunks through `writeUiChunk` instead of writing them directly. After a tool chunk, leading marker runs are stripped from the next text deltas. Trailing marker-only deltas are buffered until the stream proves a tool follows (then dropped) or normal text/structure arrives (then flushed unchanged). Buffered content is also flushed on stream end and before terminal UI errors so ordering and legitimate in-prose markers stay intact.
> 
> Adds **`agentToolBoundaryMarkers.test.ts`** with integration-style coverage (real SSE + tool loop), preservation when no tool follows, chunk ordering, and error-path flushing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ff53db9af37892039e6d50c557e2a7a8524f13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

