### PR TITLE
fix(migration-v2-window): preserve portable relaunch path

### DIFF
--- a/src/main/data/migration/v2/window/MigrationWindowManager.ts
+++ b/src/main/data/migration/v2/window/MigrationWindowManager.ts
@@ -6,6 +6,7 @@ import { join } from 'path'
 
 import { app, BrowserWindow, dialog } from 'electron'
 
+import { application } from '@application'
 import { loggerService } from '@logger'
 import { isDev, isMac } from '@main/core/platform'
 import { MigrationIpcChannels, type MigrationStage } from '@shared/data/migration/v2/types'
@@ -284,8 +285,7 @@ export class MigrationWindowManager {
     } else {
       // Production mode - clean up first, then relaunch
       this.close()
-      app.relaunch()
-      app.exit(0)
+      application.relaunch()
     }
   }
 }

--- a/src/main/data/migration/v2/window/__tests__/MigrationWindowManager.test.ts
+++ b/src/main/data/migration/v2/window/__tests__/MigrationWindowManager.test.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { application } from '@application'
 import { MigrationIpcChannels, type MigrationStage } from '@shared/data/migration/v2/types'
 
 import { MigrationWindowManager } from '../MigrationWindowManager'
@@ -55,6 +56,7 @@ describe('MigrationWindowManager', () => {
     // The global electron mock's `app` has no `quit`; provide one to observe quit attempts.
     quitMock = vi.fn()
     ;(app as unknown as { quit: typeof quitMock }).quit = quitMock
+    ;(app as unknown as { isPackaged: boolean }).isPackaged = false
     manager = new MigrationWindowManager()
     manager.create()
   })
@@ -98,6 +100,18 @@ describe('MigrationWindowManager', () => {
 
     expect(fakeWindow.close).toHaveBeenCalledTimes(1)
     expect(quitMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes packaged restarts through the application relaunch policy', async () => {
+    const electronRelaunch = vi.fn()
+    const electronExit = vi.fn()
+    Object.assign(app, { isPackaged: true, relaunch: electronRelaunch, exit: electronExit })
+
+    await manager.restartApp()
+
+    expect(application.relaunch).toHaveBeenCalledOnce()
+    expect(electronRelaunch).not.toHaveBeenCalled()
+    expect(electronExit).not.toHaveBeenCalled()
   })
 
   // Regression: confirmQuit() during an in-flow stage must NOT re-trigger the in-flow


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Completing the v2 data migration relaunched Electron directly. In a Windows portable build, that can restart the extracted inner executable instead of the stable outer launcher. The portable launcher may then remove the temporary extraction tree while the relaunched process still resolves packaged resources from it.

After this PR:

The migration restart delegates to `application.relaunch()`. That centralized policy selects `PORTABLE_EXECUTABLE_FILE` for Windows portable builds, so the outer launcher establishes a fresh extraction and resource root before the application starts again. The regression test prevents migration code from bypassing that policy with raw Electron relaunch calls.

Refs #19990

### Why we need it and why it was done in this way

The following tradeoffs were made: this is limited to the migration completion path. The existing centralized relaunch behavior remains the single owner of Windows portable and Linux AppImage executable selection.

The following alternatives were considered: duplicating the portable executable checks in `MigrationWindowManager` was rejected because it would create a second platform policy that can drift from `Application.relaunch()`.

Links to places where the discussion took place: #19990, #20015

### Breaking changes

None.

### Special notes for your reviewer

PR #20015 fixed the protocol deep-link launch path. The 2.0.14 report on #19990 showed that a portable process could still retain an expired extraction path; this PR covers the remaining direct relaunch in the v2 migration window.

This PR intentionally references rather than closes #19990. It does not add the requested packaged-Windows scenario that deletes the extraction directory before error diagnosis, and it does not change the independent fallback behavior when optional AI diagnosis fails. A packaged Windows smoke test was not available from the macOS development host.

Verified locally on exact `main` base `041045ef52` with Node 24.14.0 and pnpm 12.3.4:

- `pnpm install`
- `pnpm exec vitest run --project main src/main/data/migration/v2/window/__tests__/MigrationWindowManager.test.ts` (15 passed)
- `pnpm lint`
- `CI=1 pnpm test:lint`

No screenshot is included because this is a non-visual main-process relaunch fix.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for this internal relaunch-path correction
- [x] Self-review: I reviewed the final two-file diff against exact `main`

### Release note

```release-note
Fix Windows portable builds reopening from an expired temporary resource directory after v2 data migration.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to the migration completion path that reuses existing centralized relaunch logic; dev/unpackaged behavior is unchanged.
> 
> **Overview**
> After v2 data migration finishes in packaged builds, production restarts no longer call Electron’s `app.relaunch()` / `app.exit(0)` directly. **`MigrationWindowManager.restartApp()`** now closes the migration window and invokes **`application.relaunch()`**, so Windows portable and Linux AppImage use the same executable-selection policy as the rest of the app (e.g. `PORTABLE_EXECUTABLE_FILE` on portable Windows).
> 
> A unit test asserts that when `app.isPackaged` is true, packaged restarts go through **`application.relaunch`** and do not call raw Electron relaunch/exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870d56d7ff966c4e4d8a6129c2e26f9e38635cb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->