### PR TITLE
fix(markdown): bound mixed multiline math fences

### DIFF
--- a/src/renderer/components/markdown/__tests__/remarkLatexMath.test.ts
+++ b/src/renderer/components/markdown/__tests__/remarkLatexMath.test.ts
@@ -213,6 +213,74 @@ describe('remarkLatexMath', () => {
     expect(container.textContent).toContain('link')
   })
 
+  it('bounds a multiline display fence whose opening line contains math', () => {
+    const source = [
+      "$$f(2h)=f(0)+f'(0)(2h)+\\frac{f''(0)}{2}(2h)^2+o(h^2)",
+      "=f(0)+2f'(0)h+2f''(0)h^2+o(h^2)$$",
+      '',
+      'Text after the formula with $x$.',
+      '',
+      '$$',
+      '\\begin{cases}',
+      'x+y=1\\\\',
+      'x+2y=0',
+      '\\end{cases}',
+      '$$',
+      '',
+      '# Heading',
+      '',
+      '[link](https://example.com)',
+      '',
+      '| a | b |',
+      '| - | - |',
+      '| 1 | 2 |',
+      '',
+      '<span>html</span>'
+    ].join('\n')
+    const tree = parse(source)
+
+    expect(mathNodes(source)).toMatchObject([
+      {
+        type: 'math',
+        meta: null,
+        value: expect.stringContaining("=f(0)+2f'(0)h+2f''(0)h^2+o(h^2)")
+      },
+      { type: 'inlineMath', value: 'x' },
+      { type: 'math', value: expect.stringContaining('\\begin{cases}') }
+    ])
+    expect(tree.children.slice(0, 5).map((child) => child.type)).toEqual([
+      'math',
+      'paragraph',
+      'math',
+      'heading',
+      'paragraph'
+    ])
+    expect(tree.children[1]).toMatchObject({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'Text after the formula with ' },
+        { type: 'inlineMath', value: 'x' },
+        { type: 'text', value: '.' }
+      ]
+    })
+    expect(textValue(tree)).toContain('link')
+    expect(textValue(tree)).toContain('| a | b |')
+    expect(textValue(tree)).toContain('html')
+  })
+
+  it.each([
+    ['$$x$$', 'inlineMath', 'x'],
+    ['$$\nx\n$$', 'math', 'x'],
+    ['$$x\ny$$', 'math', 'x\ny'],
+    ['$$x\r\ny$$', 'math', 'x\r\ny']
+  ])('keeps dollar math bounded for %s', (source, type, value) => {
+    const tree = parse(`${source}\n\nAfter formula.`)
+
+    expect(mathNodes(source)).toMatchObject([{ type, value }])
+    expect(tree.children.at(-1)).toMatchObject({ type: 'paragraph' })
+    expect(textValue(tree)).toContain('After formula.')
+  })
+
   it('preserves a leading tag in existing multiline display math', () => {
     const source = '$$\\tag{1}\nx=1\n$$'
 

--- a/src/renderer/components/markdown/__tests__/remarkLatexMath.test.ts
+++ b/src/renderer/components/markdown/__tests__/remarkLatexMath.test.ts
@@ -281,6 +281,27 @@ describe('remarkLatexMath', () => {
     expect(textValue(tree)).toContain('After formula.')
   })
 
+  it.each([
+    ['LF', '$$x$$\n\nText with $$y$$'],
+    ['CRLF', '$$x$$\r\n\r\nText with $$y$$'],
+    ['trailing spaces', '$$x$$  \n\nText with $$y$$']
+  ])('leaves a first-line closing fence to the existing parser (%s)', (_label, source) => {
+    const tree = parse(source)
+
+    expect(mathNodes(source)).toMatchObject([
+      { type: 'inlineMath', value: 'x' },
+      { type: 'inlineMath', value: 'y' }
+    ])
+    expect(tree.children.map((child) => child.type)).toEqual(['paragraph', 'paragraph'])
+    expect(tree.children[1]).toMatchObject({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'Text with ' },
+        { type: 'inlineMath', value: 'y' }
+      ]
+    })
+  })
+
   it('preserves a leading tag in existing multiline display math', () => {
     const source = '$$\\tag{1}\nx=1\n$$'
 

--- a/src/renderer/components/markdown/remarkLatexMath.ts
+++ b/src/renderer/components/markdown/remarkLatexMath.ts
@@ -305,6 +305,99 @@ const latexDirectMath: Construct = {
   } satisfies Tokenizer
 }
 
+const latexMultilineDollarMath: Construct = {
+  name: 'latexMultilineDollarMath',
+  concrete: true,
+  tokenize: function tokenizeLatexMultilineDollarMath(effects, ok, nok) {
+    let indentation = 0
+    let fenceSize = 0
+    let closingSize = 0
+    let contentSeenOnLine = false
+
+    return start
+
+    function start(code: number | null): State | undefined {
+      effects.enter('latexDirectMath')
+      return linePrefix(code)
+    }
+
+    function linePrefix(code: number | null): State | undefined {
+      if (code === SPACE && indentation < 3) {
+        indentation += 1
+        effects.consume(code)
+        return linePrefix
+      }
+      return openingFence(code)
+    }
+
+    function openingFence(code: number | null): State | undefined {
+      if (code === DOLLAR) {
+        fenceSize += 1
+        effects.consume(code)
+        return openingFence
+      }
+      if (fenceSize < 2 || code === null || code <= -3) return nok(code)
+      effects.enter('latexDirectMathData')
+      return firstLine(code)
+    }
+
+    function firstLine(code: number | null): State | undefined {
+      if (code === null) return nok(code)
+      if (code <= -3) {
+        effects.exit('latexDirectMathData')
+        return effects.attempt(latexNonLazyContinuation, contentStart, nok)(code)
+      }
+      effects.consume(code)
+      return firstLine
+    }
+
+    function contentStart(code: number | null): State | undefined {
+      if (code === null) return nok(code)
+      if (code <= -3) return effects.attempt(latexNonLazyContinuation, contentStart, nok)(code)
+      contentSeenOnLine = false
+      effects.enter('latexDirectMathData')
+      return content(code)
+    }
+
+    function content(code: number | null): State | undefined {
+      if (code === null) return nok(code)
+      if (code <= -3) {
+        effects.exit('latexDirectMathData')
+        return effects.attempt(latexNonLazyContinuation, contentStart, nok)(code)
+      }
+      if (code === DOLLAR) {
+        closingSize = 0
+        return closingFence(code)
+      }
+      if (code !== SPACE && code !== 9) contentSeenOnLine = true
+      effects.consume(code)
+      return content
+    }
+
+    function closingFence(code: number | null): State | undefined {
+      if (code === DOLLAR) {
+        closingSize += 1
+        effects.consume(code)
+        return closingFence
+      }
+      if (closingSize !== fenceSize) return content(code)
+      if (!contentSeenOnLine) return nok(code)
+      return closingTail(code)
+    }
+
+    function closingTail(code: number | null): State | undefined {
+      if (code === SPACE || code === 9) {
+        effects.consume(code)
+        return closingTail
+      }
+      if (code !== null && code > -3) return content(code)
+      effects.exit('latexDirectMathData')
+      effects.exit('latexDirectMath')
+      return ok(code)
+    }
+  } satisfies Tokenizer
+}
+
 const latexEnvironmentMath: Construct = {
   name: 'latexEnvironmentMath',
   previous(code) {
@@ -407,8 +500,8 @@ const latexEnvironmentMath: Construct = {
 
 const latexMathSyntax: MicromarkExtension = {
   flowInitial: {
-    [DOLLAR]: latexDirectMath,
-    [SPACE]: latexDirectMath
+    [DOLLAR]: [latexDirectMath, latexMultilineDollarMath],
+    [SPACE]: [latexDirectMath, latexMultilineDollarMath]
   },
   text: {
     [BACKSLASH]: [latexDelimitedMath, latexEnvironmentMath]

--- a/src/renderer/components/markdown/remarkLatexMath.ts
+++ b/src/renderer/components/markdown/remarkLatexMath.ts
@@ -347,8 +347,31 @@ const latexMultilineDollarMath: Construct = {
         effects.exit('latexDirectMathData')
         return effects.attempt(latexNonLazyContinuation, contentStart, nok)(code)
       }
+      if (code === DOLLAR) {
+        closingSize = 0
+        return firstLineClosingFence(code)
+      }
       effects.consume(code)
       return firstLine
+    }
+
+    function firstLineClosingFence(code: number | null): State | undefined {
+      if (code === DOLLAR) {
+        closingSize += 1
+        effects.consume(code)
+        return firstLineClosingFence
+      }
+      if (closingSize !== fenceSize) return firstLine(code)
+      return firstLineClosingTail(code)
+    }
+
+    function firstLineClosingTail(code: number | null): State | undefined {
+      if (code === SPACE || code === 9) {
+        effects.consume(code)
+        return firstLineClosingTail
+      }
+      if (code === null || code <= -3) return nok(code)
+      return firstLine(code)
     }
 
     function contentStart(code: number | null): State | undefined {


### PR DESCRIPTION
### What this PR does

Before this PR:

A display-math fence with content on its opening line and a closing fence on a later content line could be tokenized as math metadata, then consume unrelated Markdown after the formula.

After this PR:

The Markdown extension recognizes that mixed multiline fence as one bounded display-math node. Canonical inline, single-line, and standalone display fences continue through their existing parsers, and Markdown after the closing fence remains structurally independent.

Fixes #19576

### Why we need it and why it was done in this way

The flow tokenizer is the earliest point where the intended fence boundaries are still available. The new construct is deliberately narrow: the opening line must contain math, at least one physical line ending must follow, and an equal-length closing fence must end a later line that also contains math.

The following tradeoffs were made:

- Keep canonical `$$x$$` and standalone `$$` blocks on the established Streamdown/remark-math paths.
- Require a content-bearing closing line so standalone closing fences are not reinterpreted.
- Preserve CRLF and non-lazy continuation handling in the tokenizer.

The following alternatives were considered:

- Repairing the mdast after parsing was rejected because the incorrect flow token has already consumed later Markdown boundaries.
- Broad delimiter normalization was rejected because it would expand the behavior change and risk code/link handling.

Links to places where the discussion took place: #19576, #19726

### Breaking changes

None.

### Special notes for your reviewer

Validated with the real unified + remark + Streamdown math pipeline:

- `VITE_CONFIG_NATIVE_IGNORE_WARNING=true node_modules/.bin/vitest run src/renderer/components/markdown/__tests__/remarkLatexMath.test.ts --reporter=dot` — 38 passed
- ESLint on both changed files — passed
- `oxfmt --check` on both changed files — passed
- `git diff --check` — passed

The regression covers the reported mixed fence, following inline/display math, heading, link, table-like Markdown, HTML, single-line/standalone fences, and CRLF input.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [ ] Refactor: Not applicable
- [ ] Upgrade: Not applicable
- [ ] Documentation: Not required for this parser bug fix
- [x] Self-review: I reviewed the final diff and targeted regression coverage

### Release note

```release-note
Fix display math with multiline content and same-line dollar delimiters from breaking subsequent Markdown rendering.
```
