### PR TITLE
fix(assistant-tools): expose prepare_diagnostic_report in default tool set

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/assistant.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/assistant.test.ts
@@ -440,7 +440,7 @@ describe('create_agent', () => {
 })
 
 describe('prepare_diagnostic_report', () => {
-  it('is exposed only by the explicit Cherry Support capability set', async () => {
+  it('is exposed to Cherry Assistant and Cherry Support', async () => {
     const assistantClient = await connectAssistantClient()
     const supportClient = await connectAssistantClient(SUPPORT_ASSISTANT_TOOL_NAMES)
 
@@ -449,7 +449,8 @@ describe('prepare_diagnostic_report', () => {
       'diagnose',
       'product_info',
       'apply_setting',
-      'create_agent'
+      'create_agent',
+      'prepare_diagnostic_report'
     ])
 
     const supportTools = (await supportClient.listTools()).tools

--- a/src/main/ai/toolApproval/assistantToolNames.ts
+++ b/src/main/ai/toolApproval/assistantToolNames.ts
@@ -12,7 +12,8 @@ export const DEFAULT_ASSISTANT_TOOL_NAMES = [
   'diagnose',
   'product_info',
   'apply_setting',
-  'create_agent'
+  'create_agent',
+  'prepare_diagnostic_report'
 ] as const
 
 const ASSISTANT_TOOL_NAMES = [...DEFAULT_ASSISTANT_TOOL_NAMES, 'prepare_diagnostic_report'] as const


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The built-in Cherry Assistant used the default assistant MCP tool list, which omitted `prepare_diagnostic_report`, so the model could not call the tool.

After this PR:

The default assistant tool list includes `prepare_diagnostic_report`, while the existing Cherry Support capability remains unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #20404

### Why we need it and why it was done in this way

The default MCP tool list is the source used when the Assistant capability does not provide an explicit subset. Adding the already-implemented diagnostic report tool there keeps model discovery consistent with the registered tool without introducing a runtime-specific override.

The following tradeoffs were made:

The built-in Assistant now exposes the same diagnostic draft capability already available through the explicit Support capability. The tool prepares editable draft data and does not submit a report.

The following alternatives were considered:

Adding a special-case override in the runtime or Assistant server would duplicate capability knowledge and leave the canonical default list incomplete.

Links to places where the discussion took place: #20404

### Breaking changes

None.

<!-- optional -->

### Special notes for your reviewer

The focused regression assertion checks the default MCP `ListTools` result for Cherry Assistant. It was not executable locally because dependency installation timed out while fetching registry packages.

Recent maintainers for comparable merged changes include @SiinXu, @kovsu, and @SuYao.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Built-in Assistant can now discover the diagnostic report draft tool.
```