### PR TITLE
fix(agent-runtime): align Claude Code timeout budgets

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/tools.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/tools.test.ts
@@ -209,4 +209,62 @@ describe('ClaudeCodeService runtime authorization wiring', () => {
     expect(session.allowed_tools).toEqual(['PowerShell', 'Bash'])
     expect(serviceMocks.updateSession).not.toHaveBeenCalled()
   })
+
+  it('uses extended idle timeout defaults for Claude Code sessions', async () => {
+    const { default: ClaudeCodeService } = await import('../index')
+    const service = new ClaudeCodeService()
+    const session = {
+      id: 'session-default-timeouts',
+      agent_id: 'agent-test',
+      agent_type: 'claude-code',
+      accessible_paths: ['/tmp/claude-tools-test'],
+      allowed_tools: [],
+      configuration: {},
+      instructions: '',
+      mcps: [],
+      model: 'anthropic:claude-test'
+    }
+
+    await service.invoke('hello', session as never, new AbortController())
+    await vi.waitFor(() => expect(serviceMocks.query).toHaveBeenCalledTimes(1))
+
+    expect(serviceMocks.query.mock.calls[0][0].options.env).toMatchObject({
+      API_TIMEOUT_MS: '1800000',
+      API_FORCE_IDLE_TIMEOUT: '0',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: '1800000'
+    })
+  })
+
+  it('preserves explicit Claude Code timeout controls', async () => {
+    const { default: ClaudeCodeService } = await import('../index')
+    const service = new ClaudeCodeService()
+    const session = {
+      id: 'session-explicit-timeouts',
+      agent_id: 'agent-test',
+      agent_type: 'claude-code',
+      accessible_paths: ['/tmp/claude-tools-test'],
+      allowed_tools: [],
+      configuration: {
+        env_vars: {
+          API_TIMEOUT_MS: '3600000',
+          API_FORCE_IDLE_TIMEOUT: '1',
+          CLAUDE_STREAM_IDLE_TIMEOUT_MS: '900000',
+          CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '600000'
+        }
+      },
+      instructions: '',
+      mcps: [],
+      model: 'anthropic:claude-test'
+    }
+
+    await service.invoke('hello', session as never, new AbortController())
+    await vi.waitFor(() => expect(serviceMocks.query).toHaveBeenCalledTimes(1))
+
+    expect(serviceMocks.query.mock.calls[0][0].options.env).toMatchObject({
+      API_TIMEOUT_MS: '3600000',
+      API_FORCE_IDLE_TIMEOUT: '1',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: '900000',
+      CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '600000'
+    })
+  })
 })

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -34,6 +34,7 @@ import {
   GLOBALLY_DISALLOWED_TOOLS,
   SOUL_MODE_DISALLOWED_TOOLS
 } from '@shared/agents/claudecode/constants'
+import { DEFAULT_TIMEOUT } from '@shared/config/constant'
 import { languageEnglishNameMap } from '@shared/config/languages'
 import { defaultAppHeaders, withoutTrailingApiVersion } from '@shared/utils'
 import { app } from 'electron'
@@ -225,6 +226,9 @@ class ClaudeCodeService implements AgentServiceInterface {
       ANTHROPIC_DEFAULT_SONNET_MODEL: sdkModelId,
       // TODO: support set small model in UI
       ANTHROPIC_DEFAULT_HAIKU_MODEL: sdkModelId,
+      API_TIMEOUT_MS: String(DEFAULT_TIMEOUT),
+      API_FORCE_IDLE_TIMEOUT: '0',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: String(DEFAULT_TIMEOUT),
       ELECTRON_RUN_AS_NODE: '1',
       ELECTRON_NO_ATTACH_CONSOLE: '1',
       // Set CLAUDE_CONFIG_DIR to app's userData directory to avoid path encoding issues


### PR DESCRIPTION
### What this PR does

Before this PR:
Claude Code sessions on the v1 branch did not set the SDK API and stream idle timeout environment variables. Slow local or gateway-backed responses could therefore inherit the SDK's short idle watchdog and terminate with an unclassified operation timeout.

After this PR:
Claude Code sessions default API and stream idle budgets to 30 minutes and disable the redundant body-idle timeout. Explicit timeout environment variables supplied by the session remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19923

### Why we need it and why it was done in this way

The timeout controls are part of the environment passed to the Claude Agent SDK, so the defaults belong beside the existing Claude Code environment construction. This keeps the change local to the v1 Claude Code service and preserves explicit session overrides.

The following tradeoffs were made:
A silent request may remain active until the 30-minute API or stream budget rather than failing after the previous short SDK idle window. Cherry Studio's existing outer timeout remains the boundary.

The following alternatives were considered:
Changing all Claude Code routes globally was rejected because this issue is specific to the v1 service environment. Changing only one SDK watchdog was insufficient because the API and stream idle timers are independent.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19923

### Breaking changes

None.

### Special notes for your reviewer

The focused Claude Code service test fails on the base revision because the three default controls are absent, then passes after the change. A second test verifies that explicit session timeout values continue to win. The full suite passed with 4,866 tests passed and 72 skipped; lint, format, typecheck, and diff checks also passed.

PR #20380 is currently open as a competing v1 backport of the equivalent main-branch fix in PR #20176; this candidate should be consolidated with that work rather than treated as novel. Recent comparable merged work is authored by SiinXu, c020627, and DeJeune.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, or behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix v1 Claude Code agent sessions disconnecting after about five minutes of silent generation when using slow local or gateway-backed models.
```