### PR TITLE
fix(chat): resolve managed image paths before rendering

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -60,7 +60,8 @@ const mocks = vi.hoisted(() => ({
   messageListActions: vi.fn(),
   messageListSelection: vi.fn(),
   messageListEditingId: vi.fn(),
-  messageListUiSelectors: vi.fn()
+  messageListUiSelectors: vi.fn(),
+  ipcRequest: vi.fn()
 }))
 
 vi.mock('@logger', () => ({
@@ -88,6 +89,8 @@ vi.mock('@data/hooks/usePreference', () => ({
 vi.mock('@renderer/components/HorizontalScrollContainer', () => ({
   default: mocks.HorizontalScrollContainer
 }))
+
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: mocks.ipcRequest } }))
 
 vi.mock('@renderer/utils/style', () => {
   const flattenClassNames = (value: unknown): string[] => {
@@ -296,6 +299,8 @@ const expectEveryMessageHeaderToShowModelIdentity = (expected: boolean) => {
 
 describe('MessageGroup', () => {
   beforeEach(() => {
+    mocks.ipcRequest.mockReset()
+    mocks.ipcRequest.mockResolvedValue({})
     vi.clearAllMocks()
     mocks.settings.mockReturnValue({
       multiModelMessageStyle: 'horizontal',
@@ -604,7 +609,7 @@ describe('MessageGroup', () => {
     expect(container.querySelector('#message-msg-1 .message-content-container')).not.toHaveAttribute('tabindex')
   })
 
-  it('renders sent attachments outside the user bubble', () => {
+  it('renders sent attachments outside the user bubble', async () => {
     mocks.settings.mockReturnValue({
       multiModelMessageStyle: 'fold',
       gridColumns: 2,
@@ -615,6 +620,7 @@ describe('MessageGroup', () => {
       showMessageOutline: false
     })
     const messages = [{ ...createMessage('msg-1', 0, 'vertical'), role: 'user' as const }]
+    mocks.ipcRequest.mockResolvedValue({ 'entry-photo': '/current/Data/Files/entry-photo.png' })
 
     const { container } = render(
       <MessageGroup
@@ -642,7 +648,13 @@ describe('MessageGroup', () => {
                 }
               }
             },
-            { type: 'file', url: 'file:///tmp/photo.png', mediaType: 'image/png', filename: 'photo.png' },
+            {
+              type: 'file',
+              url: 'file:///previous-machine/Data/Files/entry-photo.png',
+              mediaType: 'image/png',
+              filename: 'photo.png',
+              providerMetadata: { cherry: { fileEntryId: 'entry-photo' } }
+            },
             {
               type: 'file',
               url: 'file:///tmp/Application%20Support/report.pdf',
@@ -656,9 +668,12 @@ describe('MessageGroup', () => {
     )
 
     const bubble = container.querySelector('#message-msg-1 .message-content-container')
-    const imageBlock = screen.getByTestId('hoisted-image-block')
+    const imageBlock = await screen.findByTestId('hoisted-image-block')
     const attachment = screen.getByTestId('hoisted-attachment')
-    expect(imageBlock).toHaveAttribute('data-images', '["file:///tmp/photo.png"]')
+    await waitFor(() =>
+      expect(imageBlock).toHaveAttribute('data-images', '["file:///current/Data/Files/entry-photo.png"]')
+    )
+    expect(mocks.ipcRequest).toHaveBeenCalledWith('file.batch_get_physical_paths', { ids: ['entry-photo'] })
     expect(bubble?.contains(imageBlock)).toBe(false)
     expect(bubble?.contains(attachment)).toBe(false)
     // The card is handed a handle, never a path it assembled: Main resolves it, and the

--- a/src/renderer/components/chat/messages/blocks/MessageImageUrlsContext.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessageImageUrlsContext.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react'
+import { createContext, use, useEffect, useMemo, useState } from 'react'
+
+import { ipcApi } from '@renderer/ipc'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { readCherryMeta } from '@shared/data/types/uiParts'
+import { toFileUrl } from '@shared/utils/file'
+
+const MessageImageUrlsContext = createContext<ReadonlyMap<string, string> | null>(null)
+const EMPTY_RESOLVED_IMAGE_URLS: ReadonlyMap<string, string> = new Map()
+
+function managedImageEntryIds(parts: readonly CherryMessagePart[]): string[] {
+  const ids = new Set<string>()
+  for (const part of parts) {
+    if (part.type !== 'file' || !part.mediaType.startsWith('image/')) continue
+    const entryId = readCherryMeta(part)?.fileEntryId
+    if (entryId) ids.add(entryId)
+  }
+  return [...ids]
+}
+
+export function MessageImageUrlsProvider({ parts, children }: { parts: CherryMessagePart[]; children: ReactNode }) {
+  const entryIds = useMemo(() => managedImageEntryIds(parts), [parts])
+  const entryIdsKey = entryIds.join('\0')
+  const [resolved, setResolved] = useState<{ key: string; urls: ReadonlyMap<string, string> }>({
+    key: '',
+    urls: EMPTY_RESOLVED_IMAGE_URLS
+  })
+
+  useEffect(() => {
+    if (entryIds.length === 0) return
+
+    let active = true
+    void ipcApi
+      .request('file.batch_get_physical_paths', { ids: entryIds })
+      .then((paths) => {
+        if (!active) return
+        const urls = new Map<string, string>()
+        for (const entryId of entryIds) {
+          const path = paths[entryId]
+          if (path) urls.set(entryId, toFileUrl(path))
+        }
+        setResolved({ key: entryIdsKey, urls })
+      })
+      .catch(() => {
+        if (active) setResolved({ key: entryIdsKey, urls: EMPTY_RESOLVED_IMAGE_URLS })
+      })
+
+    return () => {
+      active = false
+    }
+  }, [entryIds, entryIdsKey])
+
+  const urls = entryIds.length === 0 || resolved.key !== entryIdsKey ? EMPTY_RESOLVED_IMAGE_URLS : resolved.urls
+  return <MessageImageUrlsContext value={urls}>{children}</MessageImageUrlsContext>
+}
+
+/**
+ * Replace managed image URLs with current FileManager-backed locations for rendering only.
+ * The stored message parts remain unchanged, and unmanaged external/data URLs pass through.
+ */
+export function useResolvedMessageImageParts(parts: CherryMessagePart[]): CherryMessagePart[] {
+  const urls = use(MessageImageUrlsContext)
+
+  return useMemo(() => {
+    if (urls === null) return parts
+
+    let changed = false
+    const resolvedParts = parts.map((part) => {
+      if (part.type !== 'file' || !part.mediaType.startsWith('image/')) return part
+      const entryId = readCherryMeta(part)?.fileEntryId
+      if (!entryId) return part
+
+      const url = urls.get(entryId) ?? ''
+      if (part.url === url) return part
+      changed = true
+      return { ...part, url }
+    })
+    return changed ? resolvedParts : parts
+  }, [parts, urls])
+}

--- a/src/renderer/components/chat/messages/blocks/MessagePartsContext.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsContext.tsx
@@ -10,6 +10,8 @@ import { createContext, use, useMemo } from 'react'
 
 import type { CherryMessagePart } from '@shared/data/types/message'
 
+import { MessageImageUrlsProvider } from './MessageImageUrlsContext'
+
 // ============================================================================
 // Refresh Context — allows deep components to trigger data refresh
 // ============================================================================
@@ -69,7 +71,9 @@ export function MessagePartsScopeProvider({
   const value = useMemo(() => ({ messageId, parts }), [messageId, parts])
   return (
     <MessageIdContext value={messageId}>
-      <MessagePartsScopeContext value={value}>{children}</MessagePartsScopeContext>
+      <MessagePartsScopeContext value={value}>
+        <MessageImageUrlsProvider parts={parts}>{children}</MessageImageUrlsProvider>
+      </MessagePartsScopeContext>
     </MessageIdContext>
   )
 }

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -71,6 +71,7 @@ import ConversationResetBlock from './ConversationResetBlock'
 import ErrorBlock from './ErrorBlock'
 import ImageBlock from './ImageBlock'
 import MainTextBlock, { buildUserMessagePreview } from './MainTextBlock'
+import { useResolvedMessageImageParts } from './MessageImageUrlsContext'
 import {
   findOpenTextTailIndex,
   isHiddenPart,
@@ -1621,7 +1622,8 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
 })
 
 const MessagePartsRenderer: React.FC<Props> = ({ message, hoistAttachments }) => {
-  const messageParts = useMessageParts(message.id)
+  const rawMessageParts = useMessageParts(message.id)
+  const messageParts = useResolvedMessageImageParts(rawMessageParts)
   const { isActiveTurnProcessing, isStreamLive } = useMessageListItemActivityState(message)
   const priorCitationParts = useMessagePriorCitationParts(message.id)
   const { collapseCompletedToolHistory } = useMessageRenderConfig()

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessageImageUrlsContext.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessageImageUrlsContext.test.tsx
@@ -1,0 +1,71 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CherryMessagePart } from '@shared/data/types/message'
+
+const ipcRequest = vi.hoisted(() => vi.fn())
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: ipcRequest } }))
+
+import { MessageImageUrlsProvider, useResolvedMessageImageParts } from '../MessageImageUrlsContext'
+
+function managedImage(entryId: string, url: string): CherryMessagePart {
+  return {
+    type: 'file',
+    url,
+    mediaType: 'image/png',
+    filename: `${entryId}.png`,
+    providerMetadata: { cherry: { fileEntryId: entryId } }
+  } as unknown as CherryMessagePart
+}
+
+function Probe({ parts }: { parts: CherryMessagePart[] }) {
+  const resolved = useResolvedMessageImageParts(parts)
+  const urls = resolved.flatMap((part) => (part.type === 'file' && part.url ? [part.url] : []))
+  return <output data-testid="urls">{JSON.stringify(urls)}</output>
+}
+
+function Harness({ parts }: { parts: CherryMessagePart[] }) {
+  return (
+    <MessageImageUrlsProvider parts={parts}>
+      <Probe parts={parts} />
+    </MessageImageUrlsProvider>
+  )
+}
+
+describe('MessageImageUrlsProvider', () => {
+  it('preserves unmanaged external and data URLs while hiding a missing managed entry', async () => {
+    ipcRequest.mockResolvedValue({})
+    const parts = [
+      managedImage('missing', 'file:///old/missing.png'),
+      { type: 'file', url: 'https://example.com/image.png', mediaType: 'image/png' },
+      { type: 'file', url: 'data:image/png;base64,AA==', mediaType: 'image/png' }
+    ] as CherryMessagePart[]
+
+    render(<Harness parts={parts} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('urls')).toHaveTextContent(
+        JSON.stringify(['https://example.com/image.png', 'data:image/png;base64,AA=='])
+      )
+    )
+  })
+
+  it('ignores an older lookup that resolves after the message parts change', async () => {
+    let resolveFirst!: (paths: Record<string, string>) => void
+    let resolveSecond!: (paths: Record<string, string>) => void
+    ipcRequest
+      .mockReturnValueOnce(new Promise((resolve) => (resolveFirst = resolve)))
+      .mockReturnValueOnce(new Promise((resolve) => (resolveSecond = resolve)))
+
+    const first = [managedImage('first', 'file:///old/first.png')]
+    const second = [managedImage('second', 'file:///old/second.png')]
+    const { rerender } = render(<Harness parts={first} />)
+    rerender(<Harness parts={second} />)
+
+    await act(async () => resolveSecond({ second: '/current/second.png' }))
+    expect(screen.getByTestId('urls')).toHaveTextContent('["file:///current/second.png"]')
+
+    await act(async () => resolveFirst({ first: '/current/first.png' }))
+    expect(screen.getByTestId('urls')).toHaveTextContent('["file:///current/second.png"]')
+  })
+})

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -17,6 +17,7 @@ const mockReadText = vi.hoisted(() => vi.fn())
 const mockUsePlaceholderElapsedMs = vi.hoisted(() => vi.fn(() => 1000))
 const mockToolBlockGroupRender = vi.hoisted(() => vi.fn())
 const mockMessageToolsRender = vi.hoisted(() => vi.fn())
+const mockIpcRequest = vi.hoisted(() => vi.fn())
 
 type MainTextBlockModule = {
   buildUserMessagePreview: (content: string) => { content: string; isTruncated: boolean }
@@ -27,6 +28,7 @@ vi.mock('@logger', () => ({
   loggerService: { withContext: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }) }
 }))
 vi.mock('@data/hooks/usePreference', () => ({ usePreference: vi.fn(() => [false, vi.fn()]) }))
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: mockIpcRequest } }))
 
 // Mocked as a real external store, so a renderer that re-subscribes to topic
 // stream state re-renders from this source alone — the #19716 fan-out.
@@ -389,6 +391,7 @@ vi.mock('../PlaceholderBlock', () => ({
   usePlaceholderElapsedMs: mockUsePlaceholderElapsedMs
 }))
 
+import { MessageImageUrlsProvider } from '../MessageImageUrlsContext'
 import MessagePartsRenderer from '../MessagePartsRenderer'
 
 const msg = (overrides: Partial<MessageListItem> = {}): MessageListItem => ({
@@ -516,6 +519,8 @@ function answeredAskUserQuestionPart(toolCallId: string, state = 'output-availab
 
 describe('MessagePartsRenderer', () => {
   beforeEach(() => {
+    mockIpcRequest.mockReset()
+    mockIpcRequest.mockResolvedValue({})
     activityStore = new KeyedMessageActivityStore()
     topicStreamStore.setStatus(undefined)
     mockThinkingBlockMounted.mockClear()
@@ -1177,6 +1182,29 @@ describe('MessagePartsRenderer', () => {
       )
 
       expect(screen.getByTestId('mock-image-block')).toHaveAttribute('data-images', '["file:///tmp/photo.png"]')
+    })
+
+    it('renders a managed image from its current file entry path', async () => {
+      mockIpcRequest.mockResolvedValue({ 'entry-photo': '/current/Data/Files/entry-photo.png' })
+
+      const parts = [
+        {
+          type: 'file',
+          url: 'file:///previous-machine/Data/Files/entry-photo.png',
+          mediaType: 'image/png',
+          filename: 'photo.png',
+          providerMetadata: { cherry: { fileEntryId: 'entry-photo' } }
+        } as unknown as CherryMessagePart
+      ]
+      render(<MessageImageUrlsProvider parts={parts}>{renderPartsTree(parts)}</MessageImageUrlsProvider>)
+
+      await waitFor(() =>
+        expect(screen.getByTestId('mock-image-block')).toHaveAttribute(
+          'data-images',
+          '["file:///current/Data/Files/entry-photo.png"]'
+        )
+      )
+      expect(mockIpcRequest).toHaveBeenCalledWith('file.batch_get_physical_paths', { ids: ['entry-photo'] })
     })
 
     it('renders non-image file attachments', () => {

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -13,6 +13,7 @@ import type { CherryMessagePart } from '@shared/data/types/message'
 import { createUniqueModelId, type Model } from '@shared/data/types/model'
 
 import ImageBlock from '../blocks/ImageBlock'
+import { useResolvedMessageImageParts } from '../blocks/MessageImageUrlsContext'
 import { MessagePartsScopeProvider, useMessageParts } from '../blocks/MessagePartsContext'
 import { getHoistedAttachments } from '../blocks/MessagePartsRenderer'
 import { useScrollRuntimeNavigation } from '../list/ScrollOwnershipContext'
@@ -358,7 +359,8 @@ const UserBubbleMessage = ({
   const openUserProfile = useCallback(() => {
     void actions.openUserProfile?.()
   }, [actions])
-  const messageParts = useMessageParts(message.id)
+  const rawMessageParts = useMessageParts(message.id)
+  const messageParts = useResolvedMessageImageParts(rawMessageParts)
   const attachments = getHoistedAttachments(messageParts, message)
 
   return (


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Managed image parts were rendered from their stored `file://` URL even when they carried a durable `fileEntryId`. After a restore or data-directory move, inline and hoisted message images could therefore keep pointing at the previous machine's path.

After this PR:

Message rendering batches managed image entry IDs through the existing file IPC and uses each entry's current physical path. This is a rendering-only projection: stored message data is unchanged, external and data URLs pass through, missing entries do not fall back to stale managed paths, and superseded asynchronous lookups are ignored.

Refs #20477

### Why we need it and why it was done in this way

The v2 migration already preserves image `fileEntryId` metadata, and non-image attachments use that durable identity. Resolving images at the shared message rendering scope applies the same contract to both inline images and user-bubble hoisted images without reconstructing application paths in the renderer or rerunning migration.

The following tradeoffs were made:

- Managed images remain hidden while their current path is unresolved or missing instead of briefly or permanently displaying a stale legacy path.
- The lookup is batched per message scope and only clones image parts for rendering, preserving the persisted message payload and editing inputs.

The following alternatives were considered:

- Rewriting migrated URLs in storage was rejected because existing migrated conversations should recover without another destructive migration.
- Reconstructing `{userData}/Data/Files` in the renderer was rejected in favor of the existing FileManager-backed IPC boundary.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20477

### Breaking changes

None.

### Special notes for your reviewer

This intentionally addresses only the managed-image path subset of #20477. It does not claim to fix or explain the reported text or Python attachment failures.

Validation on Node 24.12.0:

- `vitest run` for `MessageImageUrlsContext.test.tsx`, `MessagePartsRenderer.test.tsx`, and `MessageGroup.test.tsx` (126 tests passed)
- ESLint on the seven changed production and test files
- `oxfmt --check` on the seven changed production and test files
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/everything/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix migrated managed images that still point to an old data directory.
```
