### PR TITLE
fix(chat): restore bottom-follow after sending

### DIFF
--- a/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
+++ b/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
@@ -211,6 +211,28 @@ describe('useChatRuntimeState', () => {
     expect(sent).toBe(false)
   })
 
+  it('returns the viewport to bottom-follow after opening a conversation turn', async () => {
+    const requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+    const scrollToBottom = vi.fn()
+    render(<RuntimeHost topicId="topic-1" />)
+    latestRuntime?.bindMessageListRuntime({
+      copyTopicImage: vi.fn(),
+      exportTopicImage: vi.fn(),
+      locateMessage: vi.fn(),
+      scrollToBottom
+    })
+
+    await act(async () => {
+      await latestRuntime?.sendMessage('follow this response')
+    })
+
+    expect(scrollToBottom).toHaveBeenCalledOnce()
+    requestAnimationFrame.mockRestore()
+  })
+
   it('keeps sendMessage stable across runtime rerenders', () => {
     const view = render(<RuntimeHost topicId="topic-1" />)
     const sendMessage = latestRuntime?.sendMessage

--- a/src/renderer/pages/home/useChatRuntimeState.ts
+++ b/src/renderer/pages/home/useChatRuntimeState.ts
@@ -458,13 +458,15 @@ export function useChatRuntimeState({
   const sendMessage = useCallback(
     async (text: string, options?: ChatTurnInput['options']) => {
       try {
-        return await send({ text, options })
+        const sent = await send({ text, options })
+        if (sent) scrollToBottom()
+        return sent
       } catch (err) {
         logger.warn('failed to open conversation turn', err as Error)
         throw err
       }
     },
-    [send]
+    [scrollToBottom, send]
   )
 
   return {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Opening a new conversation turn did not hand message-list ownership back to bottom-follow mode. After a user had scrolled through the conversation, the list could therefore hold its position while the new response streamed.

After this PR:

A successfully opened turn calls the bound message-list runtime's `scrollToBottom`, which re-enters following mode before subsequent streamed content grows. Failed or blocked sends do not move the viewport.

Refs #20490

### Why we need it and why it was done in this way

The send path already owns the boundary where a turn is confirmed open, while the message-list runtime owns the following/reading transition. Reusing that runtime action avoids duplicating scroll geometry or changing the virtualizer's state rules.

The following tradeoffs were made:

- This PR addresses only the reported bottom-follow regression. It does not claim to resolve the separately reported intermittent composer focus loss.
- The transition happens only after stream opening succeeds, so blocked or failed submissions preserve the current viewport.

The following alternatives were considered:

- Reintroducing a global `SEND_MESSAGE` listener was rejected because the home runtime already binds the list directly and its adapter intentionally avoids the old event coupling.
- Changing wheel or scroll thresholds was rejected because submission is the missing ownership handoff, not a geometry calculation.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/20490

### Breaking changes

None.

### Special notes for your reviewer

The new regression test covers the successful send-to-runtime handoff. The existing `chatVirtualizerRuntime` suite covers that `scrollToBottom` exits reading mode and resumes live-bottom following.

Validated with:

- `useChatRuntimeState` renderer tests (9 passed)
- `chatVirtualizerRuntime` renderer tests (78 passed)
- `pnpm typecheck` (node, web, and aicore passed)
- targeted oxfmt, oxlint, and eslint checks
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Chat] Restore automatic response scrolling after sending a message.
```
