### PR TITLE
fix(subagent-resume): route continued subagent content in main process

### DIFF
--- a/docs/references/ai/adding-a-runtime.md
+++ b/docs/references/ai/adding-a-runtime.md
@@ -125,6 +125,12 @@ Create `src/main/ai/runtime/<name>/` implementing the contract in
    `claudeCode/streamAdapter.ts`, `pi/piStreamAdapter.ts`, and
    `dsh/dshStreamAdapter.ts`.
 
+   The adapter may recover runtime-specific session facts the host cannot see
+   (e.g. a task id's launch-root tool-call id) via the data services, but such
+   synchronous calls must be try/catch-guarded — an adapter's event loop must
+   never be torn down by a database error — and must not initialize or mutate
+   runtime lifecycle state.
+
 5. **Register the driver** in `src/main/ai/runtime/registerDrivers.ts`
    (called from `AgentSessionRuntimeService.onInit`). Do **not** create a
    side-effect `register.ts` module — an unimported side-effect module is

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2067,9 +2067,9 @@ export class AgentSessionRuntimeService extends BaseService {
         messageId = this.recoverDetachedFlowHost(entry, rootToolCallId)
         if (!messageId) {
           // Only a successful miss is cached with a timestamp — a transient query error must
-          // stay retryable.
+          // stay retryable. Buffered recovery chunks survive the miss: within the re-check
+          // window the row can still be committed, and at teardown they get a final lookup.
           ;(entry.checkedFlowHostMisses ??= new Map()).set(rootToolCallId, Date.now())
-          entry.pendingRecoveryFlowChunks?.delete(rootToolCallId)
         }
       } catch (error) {
         // Keep the chunk that triggered the failed lookup: dropping a text-start would abort the
@@ -3358,9 +3358,21 @@ export class AgentSessionRuntimeService extends BaseService {
       // an accumulator (or the pending buffer) and will be drained by the cascade below.
       for (const rootToolCallId of [...(entry.pendingRecoveryFlowChunks?.keys() ?? [])]) {
         try {
-          this.recoverDetachedFlowHost(entry, rootToolCallId)
-        } catch {
-          // Teardown best effort — the buffered chunks are lost with the entry otherwise.
+          if (!this.recoverDetachedFlowHost(entry, rootToolCallId)) {
+            // The host row never committed; the buffered chunks have nowhere to land. Log so a
+            // missing row is diagnosable instead of silently vanishing with the entry.
+            logger.warn('Detached flow recovery buffered chunks lost at teardown', {
+              sessionId: entry.sessionId,
+              rootToolCallId,
+              bufferedChunkCount: entry.pendingRecoveryFlowChunks?.get(rootToolCallId)?.length ?? 0
+            })
+          }
+        } catch (error) {
+          logger.warn('Detached flow recovery lookup failed at teardown', {
+            sessionId: entry.sessionId,
+            rootToolCallId,
+            error
+          })
         }
       }
       // Seed-failed chunks never reached an accumulator: retry once so the cascade persists

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -3315,6 +3315,11 @@ export class AgentSessionRuntimeService extends BaseService {
           BACKGROUND_FLOW_HANDOFF_TTL_MS
         )
     }
+    // Chunks buffered by seed/query failures never reached an accumulator: give them one last
+    // accumulator attempt so the normal flush persists them (the retry now may succeed).
+    for (const messageId of [...(entry.pendingBackgroundFlowChunks?.keys() ?? [])]) {
+      this.getOrCreateBackgroundFlowAccumulator(entry, messageId)
+    }
     const backgroundFlowFlush = this.finishBackgroundFlows(entry)
     const currentTurn = this.currentTurn(entry)
     if (currentTurn) this.closeTurn(currentTurn)
@@ -3338,7 +3343,54 @@ export class AgentSessionRuntimeService extends BaseService {
 
     const closings: Promise<unknown>[] = [backgroundFlowFlush, this.closeRuntimeConnection(connection, entry.sessionId)]
     if (connectionAttempt) closings.push(connectionAttempt)
-    return Promise.allSettled(closings).then(() => undefined)
+    return Promise.allSettled(closings).then(async () => {
+      // Chunks that never reached an accumulator get folded into a final cache snapshot so
+      // teardown does not silently drop subagent output the database never received.
+      const pending = entry.pendingBackgroundFlowChunks
+      if (pending?.size) {
+        const cacheService = application.get('CacheService')
+        for (const [messageId, chunks] of pending) {
+          if (!chunks.length) continue
+          let seedParts: CherryMessagePart[] = []
+          try {
+            const row = agentSessionMessageService.getSessionMessage(entry.sessionId, messageId)
+            seedParts = row.data.parts ?? []
+          } catch {
+            // The row may never have been written; the chunks themselves are the content.
+          }
+          let fallbackParts = seedParts
+          try {
+            const stream = new ReadableStream<UIMessageChunk>({
+              start: (controller) => {
+                for (const chunk of chunks) controller.enqueue(chunk)
+                controller.close()
+              }
+            })
+            let snapshot: CherryUIMessage = {
+              id: messageId,
+              role: 'assistant',
+              parts: structuredClone(seedParts)
+            }
+            for await (const next of readUIMessageStream<CherryUIMessage>({
+              stream,
+              message: snapshot,
+              terminateOnError: false
+            })) {
+              snapshot = next
+            }
+            fallbackParts = snapshot.parts as CherryMessagePart[]
+          } catch {
+            // Best effort — the seed snapshot still preserves the row's prior content.
+          }
+          cacheService.setShared(
+            AGENT_SESSION_FLOW_PARTS_CACHE_KEY(entry.sessionId, messageId),
+            fallbackParts,
+            BACKGROUND_FLOW_HANDOFF_TTL_MS
+          )
+        }
+      }
+      return undefined
+    })
   }
 
   private closeFailedPolicyUpdateConnection(entry: AgentSessionRuntimeEntry, connection: AgentRuntimeConnection): void {

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -114,6 +114,8 @@ const WARM_LEASE_RELEASE_DELAY_MS = 10_000
 const CONTEXT_USAGE_REFRESH_THROTTLE_MS = 3_000
 const BACKGROUND_FLOW_HANDOFF_TTL_MS = 60_000
 const BACKGROUND_FLOW_PUBLISH_THROTTLE_MS = 150
+/** A host-row miss is re-queried after this long — the row can be committed mid-connection. */
+const FLOW_HOST_MISS_RECHECK_MS = 5_000
 
 function knowledgeScopeEquals(left: readonly string[], right: readonly string[]): boolean {
   if (left.length !== right.length) return false
@@ -289,8 +291,8 @@ type AgentSessionRuntimeEntry = {
   pendingBackgroundFlowChunks?: Map<string, UIMessageChunk[]>
   /** One continuation accumulator per persisted assistant row receiving detached flow chunks. */
   backgroundFlowAccumulators?: Map<string, BackgroundFlowAccumulator>
-  /** Flow roots whose host row was already looked up and not found — do not re-query the DB. */
-  checkedFlowHostMisses?: Set<string>
+  /** Flow roots whose host row lookup came back empty, with the time it was cached. */
+  checkedFlowHostMisses?: Map<string, number>
   /** Detached chunks buffered while their host-row recovery is retried (root tool-call id keyed). */
   pendingRecoveryFlowChunks?: Map<string, UIMessageChunk[]>
   /** Single-flight finalization of the current detached flow batch. */
@@ -2054,34 +2056,19 @@ export class AgentSessionRuntimeService extends BaseService {
 
     let messageId = entry.flowMessageIdsByToolCallId?.get(rootToolCallId)
     // A fresh entry (restart or session reopen) has no in-memory anchor. Recover it from the
-    // persisted host row once per root so resumed chunks land on the launch message; the looked-up
-    // rows are already committed, so seeding their accumulator from the DB needs no pending buffer.
-    if (!messageId && !entry.checkedFlowHostMisses?.has(rootToolCallId)) {
+    // persisted host row so resumed chunks land on the launch message. A miss is cached only
+    // briefly — the row can be committed by a flush at any time, so re-query it periodically.
+    if (
+      !messageId &&
+      (entry.checkedFlowHostMisses?.get(rootToolCallId) ?? Number.NEGATIVE_INFINITY) <
+        Date.now() - FLOW_HOST_MISS_RECHECK_MS
+    ) {
       try {
-        const hostMessageId = agentSessionMessageService.findFlowHostMessageId(entry.sessionId, rootToolCallId)
-        if (hostMessageId) {
-          ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(rootToolCallId, hostMessageId)
-          ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
-          messageId = hostMessageId
-          // Chunks buffered across the transient recovery errors flow into the anchor now, ahead
-          // of the chunk that triggered the successful lookup. Nested tool calls inside them must
-          // register their own anchors exactly like the normal path below.
-          const buffered = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
-          if (buffered?.length) {
-            entry.pendingRecoveryFlowChunks?.delete(rootToolCallId)
-            for (const bufferedChunk of buffered) {
-              if (
-                (bufferedChunk.type === 'tool-input-start' || bufferedChunk.type === 'tool-input-available') &&
-                bufferedChunk.toolCallId
-              ) {
-                ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(bufferedChunk.toolCallId, messageId)
-              }
-              this.enqueueBackgroundFlowChunk(entry, messageId, bufferedChunk)
-            }
-          }
-        } else {
-          // Only a successful miss is cached — a transient query error must stay retryable.
-          ;(entry.checkedFlowHostMisses ??= new Set()).add(rootToolCallId)
+        messageId = this.recoverDetachedFlowHost(entry, rootToolCallId)
+        if (!messageId) {
+          // Only a successful miss is cached with a timestamp — a transient query error must
+          // stay retryable.
+          ;(entry.checkedFlowHostMisses ??= new Map()).set(rootToolCallId, Date.now())
           entry.pendingRecoveryFlowChunks?.delete(rootToolCallId)
         }
       } catch (error) {
@@ -2123,6 +2110,33 @@ export class AgentSessionRuntimeService extends BaseService {
     }
 
     this.enqueueBackgroundFlowChunk(entry, messageId, chunk)
+  }
+
+  /**
+   * Recover the persisted host row for a detached root and replay its buffered chunks. Used by
+   * the chunk path and by teardown, which must give recovery-buffered chunks a last chance.
+   */
+  private recoverDetachedFlowHost(entry: AgentSessionRuntimeEntry, rootToolCallId: string): string | undefined {
+    const hostMessageId = agentSessionMessageService.findFlowHostMessageId(entry.sessionId, rootToolCallId)
+    if (!hostMessageId) return undefined
+    ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(rootToolCallId, hostMessageId)
+    ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
+    // Chunks buffered across the transient recovery errors flow into the anchor now. Nested tool
+    // calls inside them must register their own anchors exactly like the normal chunk path below.
+    const buffered = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
+    if (buffered?.length) {
+      entry.pendingRecoveryFlowChunks?.delete(rootToolCallId)
+      for (const bufferedChunk of buffered) {
+        if (
+          (bufferedChunk.type === 'tool-input-start' || bufferedChunk.type === 'tool-input-available') &&
+          bufferedChunk.toolCallId
+        ) {
+          ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(bufferedChunk.toolCallId, hostMessageId)
+        }
+        this.enqueueBackgroundFlowChunk(entry, hostMessageId, bufferedChunk)
+      }
+    }
+    return hostMessageId
   }
 
   private markFlowMessagePersisted(entry: AgentSessionRuntimeEntry, messageId: string): void {
@@ -3315,11 +3329,6 @@ export class AgentSessionRuntimeService extends BaseService {
           BACKGROUND_FLOW_HANDOFF_TTL_MS
         )
     }
-    // Chunks buffered by seed/query failures never reached an accumulator: give them one last
-    // accumulator attempt so the normal flush persists them (the retry now may succeed).
-    for (const messageId of [...(entry.pendingBackgroundFlowChunks?.keys() ?? [])]) {
-      this.getOrCreateBackgroundFlowAccumulator(entry, messageId)
-    }
     const backgroundFlowFlush = this.finishBackgroundFlows(entry)
     const currentTurn = this.currentTurn(entry)
     if (currentTurn) this.closeTurn(currentTurn)
@@ -3344,11 +3353,44 @@ export class AgentSessionRuntimeService extends BaseService {
     const closings: Promise<unknown>[] = [backgroundFlowFlush, this.closeRuntimeConnection(connection, entry.sessionId)]
     if (connectionAttempt) closings.push(connectionAttempt)
     return Promise.allSettled(closings).then(async () => {
-      // Chunks that never reached an accumulator get folded into a final cache snapshot so
-      // teardown does not silently drop subagent output the database never received.
+      const cacheService = application.get('CacheService')
+      // Recovery-buffered chunks get their last host-row lookup; any that land now replay into
+      // an accumulator (or the pending buffer) and will be drained by the cascade below.
+      for (const rootToolCallId of [...(entry.pendingRecoveryFlowChunks?.keys() ?? [])]) {
+        try {
+          this.recoverDetachedFlowHost(entry, rootToolCallId)
+        } catch {
+          // Teardown best effort — the buffered chunks are lost with the entry otherwise.
+        }
+      }
+      // Seed-failed chunks never reached an accumulator: retry once so the cascade persists
+      // them; the fold below covers a retry that still fails.
+      for (const messageId of [...(entry.pendingBackgroundFlowChunks?.keys() ?? [])]) {
+        this.getOrCreateBackgroundFlowAccumulator(entry, messageId)
+      }
+      // A successor accumulator created by a flushing predecessor's held-chunk replay drains
+      // after the first batch; repeat until no new accumulator appears (converged or stuck).
+      let previousCount = -1
+      while (
+        (entry.backgroundFlowAccumulators?.size ?? 0) > 0 &&
+        (entry.backgroundFlowAccumulators?.size ?? 0) !== previousCount
+      ) {
+        previousCount = entry.backgroundFlowAccumulators?.size ?? 0
+        await this.finishBackgroundFlows(entry)
+      }
+      for (const accumulator of entry.backgroundFlowAccumulators?.values() ?? []) {
+        const parts = accumulator.latest?.parts as CherryMessagePart[] | undefined
+        if (!parts) continue
+        cacheService.setShared(
+          AGENT_SESSION_FLOW_PARTS_CACHE_KEY(entry.sessionId, accumulator.messageId),
+          parts,
+          BACKGROUND_FLOW_HANDOFF_TTL_MS
+        )
+      }
+      // Everything that still never reached an accumulator gets folded into a final cache
+      // snapshot so teardown does not silently drop subagent output the database never got.
       const pending = entry.pendingBackgroundFlowChunks
       if (pending?.size) {
-        const cacheService = application.get('CacheService')
         for (const [messageId, chunks] of pending) {
           if (!chunks.length) continue
           let seedParts: CherryMessagePart[] = []

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -233,6 +233,8 @@ type BackgroundFlowAccumulator = {
   latest?: CherryUIMessage
   done: Promise<void>
   closed: boolean
+  /** The reader drained the stream; the trailing snapshot is final and successors are safe. */
+  settled: boolean
   /** Broadcast throttle for the live overlay — see {@link AgentSessionRuntimeService.publishBackgroundFlowSnapshot}. */
   lastPublishedAt?: number
   publishTimer?: ReturnType<typeof setTimeout>
@@ -288,6 +290,8 @@ type AgentSessionRuntimeEntry = {
   backgroundFlowAccumulators?: Map<string, BackgroundFlowAccumulator>
   /** Flow roots whose host row was already looked up and not found — do not re-query the DB. */
   checkedFlowHostMisses?: Set<string>
+  /** Detached chunks buffered while their host-row recovery is retried (root tool-call id keyed). */
+  pendingRecoveryFlowChunks?: Map<string, UIMessageChunk[]>
   /** Single-flight finalization of the current detached flow batch. */
   backgroundFlowFlush?: Promise<void>
 }
@@ -2058,14 +2062,29 @@ export class AgentSessionRuntimeService extends BaseService {
           ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(rootToolCallId, hostMessageId)
           ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
           messageId = hostMessageId
+          // Chunks buffered across the transient recovery errors flow into the anchor now, ahead
+          // of the chunk that triggered the successful lookup.
+          const buffered = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
+          if (buffered?.length) {
+            entry.pendingRecoveryFlowChunks?.delete(rootToolCallId)
+            for (const bufferedChunk of buffered) this.enqueueBackgroundFlowChunk(entry, messageId, bufferedChunk)
+          }
         } else {
           // Only a successful miss is cached — a transient query error must stay retryable.
           ;(entry.checkedFlowHostMisses ??= new Set()).add(rootToolCallId)
         }
       } catch (error) {
+        // Keep the chunk that triggered the failed lookup: dropping a text-start would abort the
+        // whole ai stream pipe for this message.
+        const buffered = entry.pendingRecoveryFlowChunks ?? new Map<string, UIMessageChunk[]>()
+        entry.pendingRecoveryFlowChunks = buffered
+        const chunks = buffered.get(rootToolCallId) ?? []
+        chunks.push(chunk)
+        buffered.set(rootToolCallId, chunks)
         logger.warn('Failed to recover flow host row for detached subagent chunk', {
           sessionId: entry.sessionId,
           rootToolCallId,
+          chunkType: chunk.type,
           error
         })
       }
@@ -2107,6 +2126,16 @@ export class AgentSessionRuntimeService extends BaseService {
 
   private enqueueBackgroundFlowChunk(entry: AgentSessionRuntimeEntry, messageId: string, chunk: UIMessageChunk): void {
     const accumulator = this.getOrCreateBackgroundFlowAccumulator(entry, messageId)
+    if (accumulator === 'hold') {
+      // The predecessor is draining: a successor seeded now would miss its trailing chunks and the
+      // later flush would overwrite the full row. Buffer until the predecessor settles.
+      const pending = entry.pendingBackgroundFlowChunks ?? new Map<string, UIMessageChunk[]>()
+      entry.pendingBackgroundFlowChunks = pending
+      const chunks = pending.get(messageId) ?? []
+      chunks.push(chunk)
+      pending.set(messageId, chunks)
+      return
+    }
     if (!accumulator) return
     try {
       accumulator.controller.enqueue(chunk)
@@ -2123,15 +2152,16 @@ export class AgentSessionRuntimeService extends BaseService {
   private getOrCreateBackgroundFlowAccumulator(
     entry: AgentSessionRuntimeEntry,
     messageId: string
-  ): BackgroundFlowAccumulator | null {
+  ): BackgroundFlowAccumulator | 'hold' | null {
     const accumulators = entry.backgroundFlowAccumulators ?? new Map<string, BackgroundFlowAccumulator>()
     entry.backgroundFlowAccumulators = accumulators
     const existing = accumulators.get(messageId)
     // A closed accumulator is mid-drain: reusing it would enqueue into a closed controller and
-    // drop the chunk. Its replacement must be seeded from the predecessor's in-memory overlay —
-    // the persisted row still lags behind it until the pending flush writes, so seeding from the
-    // DB here would drop everything the predecessor drained.
+    // drop the chunk. Its replacement must be seeded from the predecessor's final overlay — the
+    // persisted row still lags behind it until the pending flush writes, so seeding from the DB
+    // here would drop everything the predecessor drained.
     if (existing && !existing.closed) return existing
+    if (existing && !existing.settled) return 'hold'
     const inheritedParts = existing?.latest?.parts as CherryMessagePart[] | undefined
 
     let persistedParts: CherryMessagePart[] | undefined
@@ -2165,7 +2195,8 @@ export class AgentSessionRuntimeService extends BaseService {
       messageId,
       controller,
       done: Promise.resolve(),
-      closed: false
+      closed: false,
+      settled: false
     }
     accumulator.done = this.consumeBackgroundFlow(entry, accumulator, stream, seed)
     accumulators.set(messageId, accumulator)
@@ -2200,6 +2231,9 @@ export class AgentSessionRuntimeService extends BaseService {
         error
       })
     } finally {
+      // Mark the drain settled before any flush reads the snapshot: a successor created from now
+      // on seeds from the final overlay and can no longer miss trailing chunks.
+      accumulator.settled = true
       // The reader is done — flush the trailing snapshot now so `finishBackgroundFlows` (which
       // awaits `accumulator.done`) always sees the final overlay in the cache before its TTL write.
       if (accumulator.publishTimer) {
@@ -2207,6 +2241,14 @@ export class AgentSessionRuntimeService extends BaseService {
         accumulator.publishTimer = undefined
       }
       this.publishBackgroundFlowParts(entry, accumulator)
+      // Chunks held while this accumulator was draining can now flow into a properly seeded
+      // successor; flush them so they do not sit in the buffer until some unrelated turn boundary.
+      const pending = entry.pendingBackgroundFlowChunks?.get(accumulator.messageId)
+      if (pending?.length) {
+        entry.pendingBackgroundFlowChunks?.delete(accumulator.messageId)
+        for (const chunk of pending) this.enqueueBackgroundFlowChunk(entry, accumulator.messageId, chunk)
+        void this.finishBackgroundFlows(entry)
+      }
     }
   }
 
@@ -2472,6 +2514,7 @@ export class AgentSessionRuntimeService extends BaseService {
     // change at a connection boundary. Clearing only the persisted gate would buffer resumed
     // chunks for an existing row into pendingBackgroundFlowChunks forever.
     entry.pendingBackgroundFlowChunks?.clear()
+    entry.pendingRecoveryFlowChunks?.clear()
     this.applyRuntimeStateEvent(entry, { type: 'connection-occupancy', occupancy: 'background', active: false })
     if (entry.runtimeState.execution.kind === 'autonomous-turn') {
       this.applyRuntimeStateEvent(entry, { type: 'autonomous-turn-state', state: 'finished' })

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -35,7 +35,10 @@ import {
   AGENT_SESSION_CONTEXT_USAGE_CACHE_KEY,
   type AgentSessionContextUsage
 } from '@shared/ai/agentSessionContextUsage'
-import { AGENT_SESSION_FLOW_PARTS_CACHE_KEY } from '@shared/ai/agentSessionFlowParts'
+import {
+  AGENT_SESSION_FLOW_PARTS_CACHE_KEY,
+  AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY
+} from '@shared/ai/agentSessionFlowParts'
 import {
   AGENT_SESSION_SLASH_COMMANDS_CACHE_KEY,
   type AgentSessionSlashCommand
@@ -116,6 +119,8 @@ const BACKGROUND_FLOW_HANDOFF_TTL_MS = 60_000
 const BACKGROUND_FLOW_PUBLISH_THROTTLE_MS = 150
 /** A host-row miss is re-queried after this long — the row can be committed mid-connection. */
 const FLOW_HOST_MISS_RECHECK_MS = 5_000
+/** Teardown orphaned recovery chunks survive long enough for a reopened session to pick them up. */
+const FLOW_RECOVERY_ORPHAN_TTL_MS = 600_000
 
 function knowledgeScopeEquals(left: readonly string[], right: readonly string[]): boolean {
   if (left.length !== right.length) return false
@@ -2074,25 +2079,21 @@ export class AgentSessionRuntimeService extends BaseService {
       } catch (error) {
         // Keep the chunk that triggered the failed lookup: dropping a text-start would abort the
         // whole ai stream pipe for this message.
-        const buffered = entry.pendingRecoveryFlowChunks ?? new Map<string, UIMessageChunk[]>()
-        entry.pendingRecoveryFlowChunks = buffered
-        const chunks = buffered.get(rootToolCallId) ?? []
-        chunks.push(chunk)
-        buffered.set(rootToolCallId, chunks)
+        this.bufferRecoveryChunk(entry, rootToolCallId, chunk)
         logger.warn('Failed to recover flow host row for detached subagent chunk', {
           sessionId: entry.sessionId,
           rootToolCallId,
           chunkType: chunk.type,
           error
         })
+        return
       }
     }
     if (!messageId) {
-      logger.debug('Ignoring detached subagent flow chunk without a persisted message anchor', {
-        sessionId: entry.sessionId,
-        rootToolCallId,
-        chunkType: chunk.type
-      })
+      // The miss is cached, so the lookup is not re-run for the whole re-check window — chunks
+      // arriving in that window are real output, so buffer them until a re-query can resolve or
+      // reject the root for good (neither lookup failure nor teardown is a reason to drop them).
+      this.bufferRecoveryChunk(entry, rootToolCallId, chunk)
       return
     }
 
@@ -2121,22 +2122,44 @@ export class AgentSessionRuntimeService extends BaseService {
     if (!hostMessageId) return undefined
     ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(rootToolCallId, hostMessageId)
     ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
-    // Chunks buffered across the transient recovery errors flow into the anchor now. Nested tool
-    // calls inside them must register their own anchors exactly like the normal chunk path below.
+    const replay = (chunks: UIMessageChunk[]) => {
+      for (const replayedChunk of chunks) {
+        if (
+          (replayedChunk.type === 'tool-input-start' || replayedChunk.type === 'tool-input-available') &&
+          replayedChunk.toolCallId
+        ) {
+          ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(replayedChunk.toolCallId, hostMessageId)
+        }
+        this.enqueueBackgroundFlowChunk(entry, hostMessageId, replayedChunk)
+      }
+    }
+    // A previous teardown orphaned chunks whose host row had not committed; now that the row is
+    // here, they flow first (they are the oldest content).
+    const cacheService = application.get('CacheService')
+    const orphan = cacheService.getShared(
+      AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY(entry.sessionId, rootToolCallId)
+    ) as UIMessageChunk[] | undefined
+    if (orphan?.length) {
+      cacheService.deleteShared(AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY(entry.sessionId, rootToolCallId))
+      replay(orphan)
+    }
+    // Chunks buffered across the transient recovery errors flow into the anchor next; nested
+    // tool calls inside them register anchors exactly like the normal chunk path below.
     const buffered = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
     if (buffered?.length) {
       entry.pendingRecoveryFlowChunks?.delete(rootToolCallId)
-      for (const bufferedChunk of buffered) {
-        if (
-          (bufferedChunk.type === 'tool-input-start' || bufferedChunk.type === 'tool-input-available') &&
-          bufferedChunk.toolCallId
-        ) {
-          ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(bufferedChunk.toolCallId, hostMessageId)
-        }
-        this.enqueueBackgroundFlowChunk(entry, hostMessageId, bufferedChunk)
-      }
+      replay(buffered)
     }
     return hostMessageId
+  }
+
+  /** Buffer an unrecoverable-root chunk so a later successful re-query can deliver it. */
+  private bufferRecoveryChunk(entry: AgentSessionRuntimeEntry, rootToolCallId: string, chunk: UIMessageChunk): void {
+    const buffered = entry.pendingRecoveryFlowChunks ?? new Map<string, UIMessageChunk[]>()
+    entry.pendingRecoveryFlowChunks = buffered
+    const chunks = buffered.get(rootToolCallId) ?? []
+    chunks.push(chunk)
+    buffered.set(rootToolCallId, chunks)
   }
 
   private markFlowMessagePersisted(entry: AgentSessionRuntimeEntry, messageId: string): void {
@@ -3359,15 +3382,26 @@ export class AgentSessionRuntimeService extends BaseService {
       for (const rootToolCallId of [...(entry.pendingRecoveryFlowChunks?.keys() ?? [])]) {
         try {
           if (!this.recoverDetachedFlowHost(entry, rootToolCallId)) {
-            // The host row never committed; the buffered chunks have nowhere to land. Log so a
-            // missing row is diagnosable instead of silently vanishing with the entry.
-            logger.warn('Detached flow recovery buffered chunks lost at teardown', {
-              sessionId: entry.sessionId,
-              rootToolCallId,
-              bufferedChunkCount: entry.pendingRecoveryFlowChunks?.get(rootToolCallId)?.length ?? 0
-            })
+            // The host row never committed: orphan the buffered chunks to the cache — a reopened
+            // session that later finds the row delivers them instead of dropping the output.
+            const orphan = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
+            if (orphan?.length) {
+              cacheService.setShared(
+                AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY(entry.sessionId, rootToolCallId),
+                orphan,
+                FLOW_RECOVERY_ORPHAN_TTL_MS
+              )
+            }
           }
         } catch (error) {
+          const orphan = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
+          if (orphan?.length) {
+            cacheService.setShared(
+              AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY(entry.sessionId, rootToolCallId),
+              orphan,
+              FLOW_RECOVERY_ORPHAN_TTL_MS
+            )
+          }
           logger.warn('Detached flow recovery lookup failed at teardown', {
             sessionId: entry.sessionId,
             rootToolCallId,

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2052,13 +2052,15 @@ export class AgentSessionRuntimeService extends BaseService {
     // persisted host row once per root so resumed chunks land on the launch message; the looked-up
     // rows are already committed, so seeding their accumulator from the DB needs no pending buffer.
     if (!messageId && !entry.checkedFlowHostMisses?.has(rootToolCallId)) {
-      ;(entry.checkedFlowHostMisses ??= new Set()).add(rootToolCallId)
       try {
         const hostMessageId = agentSessionMessageService.findFlowHostMessageId(entry.sessionId, rootToolCallId)
         if (hostMessageId) {
           ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(rootToolCallId, hostMessageId)
           ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
           messageId = hostMessageId
+        } else {
+          // Only a successful miss is cached — a transient query error must stay retryable.
+          ;(entry.checkedFlowHostMisses ??= new Set()).add(rootToolCallId)
         }
       } catch (error) {
         logger.warn('Failed to recover flow host row for detached subagent chunk', {
@@ -2253,6 +2255,9 @@ export class AgentSessionRuntimeService extends BaseService {
     const flush = Promise.all(accumulators.map((accumulator) => accumulator.done))
       .then(() => {
         const completedFlows: Array<{ messageId: string; parts: CherryMessagePart[] }> = []
+        // A failed persist keeps its accumulator: its in-memory parts are the only surviving copy
+        // and the next flush (or a successor seed) must be able to retry them.
+        const failedMessageIds = new Set<string>()
         for (const accumulator of accumulators) {
           const parts = accumulator.latest?.parts as CherryMessagePart[] | undefined
           if (!parts) continue
@@ -2265,6 +2270,7 @@ export class AgentSessionRuntimeService extends BaseService {
               messageId: accumulator.messageId,
               error
             })
+            failedMessageIds.add(accumulator.messageId)
             continue
           }
           completedFlows.push({ messageId: accumulator.messageId, parts })
@@ -2273,6 +2279,7 @@ export class AgentSessionRuntimeService extends BaseService {
         // Only drop the accumulators this flush closed — one created mid-drain belongs to newer
         // chunks and must survive, or its content leaks silently.
         for (const accumulator of accumulators) {
+          if (failedMessageIds.has(accumulator.messageId)) continue
           if (entry.backgroundFlowAccumulators?.get(accumulator.messageId) === accumulator) {
             entry.backgroundFlowAccumulators.delete(accumulator.messageId)
           }

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2063,15 +2063,25 @@ export class AgentSessionRuntimeService extends BaseService {
           ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
           messageId = hostMessageId
           // Chunks buffered across the transient recovery errors flow into the anchor now, ahead
-          // of the chunk that triggered the successful lookup.
+          // of the chunk that triggered the successful lookup. Nested tool calls inside them must
+          // register their own anchors exactly like the normal path below.
           const buffered = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
           if (buffered?.length) {
             entry.pendingRecoveryFlowChunks?.delete(rootToolCallId)
-            for (const bufferedChunk of buffered) this.enqueueBackgroundFlowChunk(entry, messageId, bufferedChunk)
+            for (const bufferedChunk of buffered) {
+              if (
+                (bufferedChunk.type === 'tool-input-start' || bufferedChunk.type === 'tool-input-available') &&
+                bufferedChunk.toolCallId
+              ) {
+                ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(bufferedChunk.toolCallId, messageId)
+              }
+              this.enqueueBackgroundFlowChunk(entry, messageId, bufferedChunk)
+            }
           }
         } else {
           // Only a successful miss is cached — a transient query error must stay retryable.
           ;(entry.checkedFlowHostMisses ??= new Set()).add(rootToolCallId)
+          entry.pendingRecoveryFlowChunks?.delete(rootToolCallId)
         }
       } catch (error) {
         // Keep the chunk that triggered the failed lookup: dropping a text-start would abort the

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -40,6 +40,7 @@ import {
   AGENT_SESSION_SLASH_COMMANDS_CACHE_KEY,
   type AgentSessionSlashCommand
 } from '@shared/ai/agentSessionSlashCommands'
+import { DataApiError, ErrorCode } from '@shared/data/api/errors'
 import type { AgentEntity, UpdateAgentDto } from '@shared/data/api/schemas/agents'
 import type { AgentSessionMessageEntity } from '@shared/data/types/agent'
 import type { CherryMessagePart, CherryUIMessage, MessageSnapshot } from '@shared/data/types/message'
@@ -2180,13 +2181,22 @@ export class AgentSessionRuntimeService extends BaseService {
       try {
         persisted = agentSessionMessageService.getSessionMessage(entry.sessionId, messageId)
       } catch (error) {
-        // The row was deleted while its anchors survived a reconnect — the chunk has nowhere to go.
-        logger.warn('Detached subagent flow chunk lost its host message', {
+        // A row deleted while its anchors survived a reconnect has nowhere to go; any other
+        // (transient) database error must hold the chunk for retry instead of dropping it.
+        if (error instanceof DataApiError && error.code === ErrorCode.NOT_FOUND) {
+          logger.warn('Detached subagent flow chunk lost its host message', {
+            sessionId: entry.sessionId,
+            messageId,
+            error
+          })
+          return null
+        }
+        logger.warn('Detached subagent flow accumulator seed failed', {
           sessionId: entry.sessionId,
           messageId,
           error
         })
-        return null
+        return 'hold'
       }
       persistedParts = persisted.data.parts ?? []
     }
@@ -2210,6 +2220,13 @@ export class AgentSessionRuntimeService extends BaseService {
     }
     accumulator.done = this.consumeBackgroundFlow(entry, accumulator, stream, seed)
     accumulators.set(messageId, accumulator)
+    // Chunks held while this message had no usable accumulator (mid-drain hold, seed error) now
+    // flow into it — the buffered ones are older, so they enqueue first.
+    const held = entry.pendingBackgroundFlowChunks?.get(messageId)
+    if (held?.length) {
+      entry.pendingBackgroundFlowChunks?.delete(messageId)
+      for (const heldChunk of held) this.enqueueBackgroundFlowChunk(entry, messageId, heldChunk)
+    }
     return accumulator
   }
 
@@ -2350,6 +2367,24 @@ export class AgentSessionRuntimeService extends BaseService {
               parts,
               BACKGROUND_FLOW_HANDOFF_TTL_MS
             )
+          }
+        }
+        // Failed persists still hand the final overlay to the cache, outside the current-entry
+        // gate: after teardown there is no retry window, so the renderer keeps the output visible
+        // even though the DB row lags behind (or never lands).
+        for (const accumulator of accumulators) {
+          if (!failedMessageIds.has(accumulator.messageId)) continue
+          const successor = entry.backgroundFlowAccumulators?.get(accumulator.messageId)
+          if (successor && successor.latest) continue
+          const failedParts = accumulator.latest?.parts as CherryMessagePart[] | undefined
+          if (failedParts) {
+            application
+              .get('CacheService')
+              .setShared(
+                AGENT_SESSION_FLOW_PARTS_CACHE_KEY(entry.sessionId, accumulator.messageId),
+                failedParts,
+                BACKGROUND_FLOW_HANDOFF_TTL_MS
+              )
           }
         }
       })

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -286,6 +286,8 @@ type AgentSessionRuntimeEntry = {
   pendingBackgroundFlowChunks?: Map<string, UIMessageChunk[]>
   /** One continuation accumulator per persisted assistant row receiving detached flow chunks. */
   backgroundFlowAccumulators?: Map<string, BackgroundFlowAccumulator>
+  /** Flow roots whose host row was already looked up and not found — do not re-query the DB. */
+  checkedFlowHostMisses?: Set<string>
   /** Single-flight finalization of the current detached flow batch. */
   backgroundFlowFlush?: Promise<void>
 }
@@ -2045,7 +2047,27 @@ export class AgentSessionRuntimeService extends BaseService {
   ): void {
     if (!this.isCurrentEntry(entry) || (connection && this.currentConnection(entry) !== connection)) return
 
-    const messageId = entry.flowMessageIdsByToolCallId?.get(rootToolCallId)
+    let messageId = entry.flowMessageIdsByToolCallId?.get(rootToolCallId)
+    // A fresh entry (restart or session reopen) has no in-memory anchor. Recover it from the
+    // persisted host row once per root so resumed chunks land on the launch message; the looked-up
+    // rows are already committed, so seeding their accumulator from the DB needs no pending buffer.
+    if (!messageId && !entry.checkedFlowHostMisses?.has(rootToolCallId)) {
+      ;(entry.checkedFlowHostMisses ??= new Set()).add(rootToolCallId)
+      try {
+        const hostMessageId = agentSessionMessageService.findFlowHostMessageId(entry.sessionId, rootToolCallId)
+        if (hostMessageId) {
+          ;(entry.flowMessageIdsByToolCallId ??= new Map()).set(rootToolCallId, hostMessageId)
+          ;(entry.persistedFlowMessageIds ??= new Set()).add(hostMessageId)
+          messageId = hostMessageId
+        }
+      } catch (error) {
+        logger.warn('Failed to recover flow host row for detached subagent chunk', {
+          sessionId: entry.sessionId,
+          rootToolCallId,
+          error
+        })
+      }
+    }
     if (!messageId) {
       logger.debug('Ignoring detached subagent flow chunk without a persisted message anchor', {
         sessionId: entry.sessionId,

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2554,12 +2554,9 @@ export class AgentSessionRuntimeService extends BaseService {
   private resetConnectionRuntimeState(entry: AgentSessionRuntimeEntry, connection: AgentRuntimeConnection): void {
     if (!this.isCurrentEntry(entry) || this.currentConnection(entry) !== connection) return
     void this.finishBackgroundFlows(entry)
-    // flowMessageIdsByToolCallId and persistedFlowMessageIds are deliberately kept: both record
-    // session facts (which tool call owns which row, and that the row already exists) that do not
-    // change at a connection boundary. Clearing only the persisted gate would buffer resumed
-    // chunks for an existing row into pendingBackgroundFlowChunks forever.
-    entry.pendingBackgroundFlowChunks?.clear()
-    entry.pendingRecoveryFlowChunks?.clear()
+    // Anchors and chunk buffers survive the reset: anchors are session facts, buffered chunks are
+    // output the DB never received, and a host-row miss is a snapshot a later flush invalidates.
+    entry.checkedFlowHostMisses?.clear()
     this.applyRuntimeStateEvent(entry, { type: 'connection-occupancy', occupancy: 'background', active: false })
     if (entry.runtimeState.execution.kind === 'autonomous-turn') {
       this.applyRuntimeStateEvent(entry, { type: 'autonomous-turn-state', state: 'finished' })

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2083,6 +2083,7 @@ export class AgentSessionRuntimeService extends BaseService {
 
   private enqueueBackgroundFlowChunk(entry: AgentSessionRuntimeEntry, messageId: string, chunk: UIMessageChunk): void {
     const accumulator = this.getOrCreateBackgroundFlowAccumulator(entry, messageId)
+    if (!accumulator) return
     try {
       accumulator.controller.enqueue(chunk)
     } catch (error) {
@@ -2098,17 +2099,37 @@ export class AgentSessionRuntimeService extends BaseService {
   private getOrCreateBackgroundFlowAccumulator(
     entry: AgentSessionRuntimeEntry,
     messageId: string
-  ): BackgroundFlowAccumulator {
+  ): BackgroundFlowAccumulator | null {
     const accumulators = entry.backgroundFlowAccumulators ?? new Map<string, BackgroundFlowAccumulator>()
     entry.backgroundFlowAccumulators = accumulators
     const existing = accumulators.get(messageId)
-    if (existing) return existing
+    // A closed accumulator is mid-drain: reusing it would enqueue into a closed controller and
+    // drop the chunk. Its replacement must be seeded from the predecessor's in-memory overlay —
+    // the persisted row still lags behind it until the pending flush writes, so seeding from the
+    // DB here would drop everything the predecessor drained.
+    if (existing && !existing.closed) return existing
+    const inheritedParts = existing?.latest?.parts as CherryMessagePart[] | undefined
 
-    const persisted = agentSessionMessageService.getSessionMessage(entry.sessionId, messageId)
+    let persistedParts: CherryMessagePart[] | undefined
+    if (!inheritedParts) {
+      let persisted: { id: string; data: { parts?: CherryMessagePart[] } } | undefined
+      try {
+        persisted = agentSessionMessageService.getSessionMessage(entry.sessionId, messageId)
+      } catch (error) {
+        // The row was deleted while its anchors survived a reconnect — the chunk has nowhere to go.
+        logger.warn('Detached subagent flow chunk lost its host message', {
+          sessionId: entry.sessionId,
+          messageId,
+          error
+        })
+        return null
+      }
+      persistedParts = persisted.data.parts ?? []
+    }
     const seed: CherryUIMessage = {
-      id: persisted.id,
+      id: messageId,
       role: 'assistant',
-      parts: structuredClone(persisted.data.parts ?? [])
+      parts: structuredClone(inheritedParts ?? persistedParts ?? [])
     }
     let controller!: ReadableStreamDefaultController<UIMessageChunk>
     const stream = new ReadableStream<UIMessageChunk>({
@@ -2209,23 +2230,40 @@ export class AgentSessionRuntimeService extends BaseService {
 
     const flush = Promise.all(accumulators.map((accumulator) => accumulator.done))
       .then(() => {
-        const completedMessageIds = new Set<string>()
         const completedFlows: Array<{ messageId: string; parts: CherryMessagePart[] }> = []
         for (const accumulator of accumulators) {
           const parts = accumulator.latest?.parts as CherryMessagePart[] | undefined
           if (!parts) continue
-          completedMessageIds.add(accumulator.messageId)
-          agentSessionMessageService.replaceMessageParts(entry.sessionId, accumulator.messageId, parts)
+          try {
+            agentSessionMessageService.replaceMessageParts(entry.sessionId, accumulator.messageId, parts)
+          } catch (error) {
+            // One removed row must not abort the rest of the batch.
+            logger.warn('Failed to persist detached subagent flow parts', {
+              sessionId: entry.sessionId,
+              messageId: accumulator.messageId,
+              error
+            })
+            continue
+          }
           completedFlows.push({ messageId: accumulator.messageId, parts })
         }
 
-        entry.backgroundFlowAccumulators?.clear()
-        for (const [toolCallId, messageId] of entry.flowMessageIdsByToolCallId ?? []) {
-          if (completedMessageIds.has(messageId)) entry.flowMessageIdsByToolCallId?.delete(toolCallId)
+        // Only drop the accumulators this flush closed — one created mid-drain belongs to newer
+        // chunks and must survive, or its content leaks silently.
+        for (const accumulator of accumulators) {
+          if (entry.backgroundFlowAccumulators?.get(accumulator.messageId) === accumulator) {
+            entry.backgroundFlowAccumulators.delete(accumulator.messageId)
+          }
         }
+        // Flow anchors are retained on purpose: a SendMessage resume re-streams under the original
+        // tool-call id after these flows have drained, and must still find its host message.
         if (this.isCurrentEntry(entry)) {
           const cacheService = application.get('CacheService')
           for (const { messageId, parts } of completedFlows) {
+            // A successor created mid-drain publishes fresher overlays for the same row; the stale
+            // handoff must not overwrite them.
+            const successor = entry.backgroundFlowAccumulators?.get(messageId)
+            if (successor && successor.latest) continue
             cacheService.setShared(
               AGENT_SESSION_FLOW_PARTS_CACHE_KEY(entry.sessionId, messageId),
               parts,
@@ -2239,6 +2277,17 @@ export class AgentSessionRuntimeService extends BaseService {
       })
       .finally(() => {
         if (entry.backgroundFlowFlush === flush) entry.backgroundFlowFlush = undefined
+        // A replacement created mid-drain is not in this batch — drain it too, or its chunks stay
+        // unpersisted until some unrelated turn boundary happens to fire. Runs after the
+        // single-flight field clears so the recursive call is not short-circuited by it.
+        const survivors = [...(entry.backgroundFlowAccumulators?.values() ?? [])].filter((a) => !a.closed)
+        if (
+          this.isCurrentEntry(entry) &&
+          survivors.length > 0 &&
+          !hasAgentSessionRuntimeBackgroundWork(entry.runtimeState)
+        ) {
+          void this.finishBackgroundFlows(entry)
+        }
       })
     entry.backgroundFlowFlush = flush
     this.inFlightBackgroundFlowFlushes.set(flush, entry.sessionId)
@@ -2389,8 +2438,10 @@ export class AgentSessionRuntimeService extends BaseService {
   private resetConnectionRuntimeState(entry: AgentSessionRuntimeEntry, connection: AgentRuntimeConnection): void {
     if (!this.isCurrentEntry(entry) || this.currentConnection(entry) !== connection) return
     void this.finishBackgroundFlows(entry)
-    entry.flowMessageIdsByToolCallId?.clear()
-    entry.persistedFlowMessageIds?.clear()
+    // flowMessageIdsByToolCallId and persistedFlowMessageIds are deliberately kept: both record
+    // session facts (which tool call owns which row, and that the row already exists) that do not
+    // change at a connection boundary. Clearing only the persisted gate would buffer resumed
+    // chunks for an existing row into pendingBackgroundFlowChunks forever.
     entry.pendingBackgroundFlowChunks?.clear()
     this.applyRuntimeStateEvent(entry, { type: 'connection-occupancy', occupancy: 'background', active: false })
     if (entry.runtimeState.execution.kind === 'autonomous-turn') {

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2135,18 +2135,27 @@ export class AgentSessionRuntimeService extends BaseService {
     const cacheService = application.get('CacheService')
     const orphanKey = 'agent.session.flow_recovery_orphans'
     const orphans = [...(cacheService.getPersist(orphanKey) ?? [])]
+    const now = Date.now()
+    // Every recovery also prunes expired orphans, so a root whose row never appears does not
+    // leave stragglers behind.
+    const expired = new Set(orphans.filter((orphan) => now - orphan.orphannedAt >= FLOW_RECOVERY_ORPHAN_TTL_MS))
+    if (expired.size) {
+      cacheService.setPersist(
+        orphanKey,
+        orphans.filter((orphan) => !expired.has(orphan))
+      )
+    }
     const matching = orphans.find(
-      (orphan) => orphan.sessionId === entry.sessionId && orphan.rootToolCallId === rootToolCallId
+      (orphan) =>
+        orphan.sessionId === entry.sessionId && orphan.rootToolCallId === rootToolCallId && !expired.has(orphan)
     )
-    if (matching) {
+    if (matching?.chunks.length) {
+      // Acknowledge only after the chunks are handed to an accumulator or its hold buffer.
+      replay(matching.chunks)
       cacheService.setPersist(
         orphanKey,
         orphans.filter((orphan) => orphan !== matching)
       )
-      // Expired batches are dropped, not replayed — the row would not have appeared by now.
-      if (Date.now() - matching.orphannedAt < FLOW_RECOVERY_ORPHAN_TTL_MS && matching.chunks.length) {
-        replay(matching.chunks)
-      }
     }
     // Chunks buffered across the transient recovery errors flow into the anchor next; nested
     // tool calls inside them register anchors exactly like the normal chunk path below.
@@ -3401,16 +3410,17 @@ export class AgentSessionRuntimeService extends BaseService {
       // Recovery-buffered chunks get their last host-row lookup; any that land now replay into
       // an accumulator (or the pending buffer) and will be drained by the cascade below.
       for (const rootToolCallId of [...(entry.pendingRecoveryFlowChunks?.keys() ?? [])]) {
-        // The host row never committed (or the final lookup failed): orphan the buffered chunks
-        // to the restart-safe persist tier — a reopened session that later finds the row
-        // delivers them instead of dropping the output.
-        const orphan = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
-        if (orphan?.length) this.persistFlowRecoveryOrphan(entry.sessionId, rootToolCallId, orphan)
         try {
           if (!this.recoverDetachedFlowHost(entry, rootToolCallId)) {
-            // Recovery already consumed or re-buffered the chunks — nothing to keep orphaned.
+            // The host row never committed: orphan the (still-unreplayed) buffered chunks to the
+            // restart-safe persist tier so a reopened session that later finds the row delivers
+            // them instead of dropping the output.
+            const orphan = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
+            if (orphan?.length) this.persistFlowRecoveryOrphan(entry.sessionId, rootToolCallId, orphan)
           }
         } catch (error) {
+          const orphan = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
+          if (orphan?.length) this.persistFlowRecoveryOrphan(entry.sessionId, rootToolCallId, orphan)
           logger.warn('Detached flow recovery lookup failed at teardown', {
             sessionId: entry.sessionId,
             rootToolCallId,

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -35,10 +35,7 @@ import {
   AGENT_SESSION_CONTEXT_USAGE_CACHE_KEY,
   type AgentSessionContextUsage
 } from '@shared/ai/agentSessionContextUsage'
-import {
-  AGENT_SESSION_FLOW_PARTS_CACHE_KEY,
-  AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY
-} from '@shared/ai/agentSessionFlowParts'
+import { AGENT_SESSION_FLOW_PARTS_CACHE_KEY } from '@shared/ai/agentSessionFlowParts'
 import {
   AGENT_SESSION_SLASH_COMMANDS_CACHE_KEY,
   type AgentSessionSlashCommand
@@ -2134,14 +2131,22 @@ export class AgentSessionRuntimeService extends BaseService {
       }
     }
     // A previous teardown orphaned chunks whose host row had not committed; now that the row is
-    // here, they flow first (they are the oldest content).
+    // here, they flow first (they are the oldest content). The persist tier survives restarts.
     const cacheService = application.get('CacheService')
-    const orphan = cacheService.getShared(
-      AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY(entry.sessionId, rootToolCallId)
-    ) as UIMessageChunk[] | undefined
-    if (orphan?.length) {
-      cacheService.deleteShared(AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY(entry.sessionId, rootToolCallId))
-      replay(orphan)
+    const orphanKey = 'agent.session.flow_recovery_orphans'
+    const orphans = [...(cacheService.getPersist(orphanKey) ?? [])]
+    const matching = orphans.find(
+      (orphan) => orphan.sessionId === entry.sessionId && orphan.rootToolCallId === rootToolCallId
+    )
+    if (matching) {
+      cacheService.setPersist(
+        orphanKey,
+        orphans.filter((orphan) => orphan !== matching)
+      )
+      // Expired batches are dropped, not replayed — the row would not have appeared by now.
+      if (Date.now() - matching.orphannedAt < FLOW_RECOVERY_ORPHAN_TTL_MS && matching.chunks.length) {
+        replay(matching.chunks)
+      }
     }
     // Chunks buffered across the transient recovery errors flow into the anchor next; nested
     // tool calls inside them register anchors exactly like the normal chunk path below.
@@ -2160,6 +2165,22 @@ export class AgentSessionRuntimeService extends BaseService {
     const chunks = buffered.get(rootToolCallId) ?? []
     chunks.push(chunk)
     buffered.set(rootToolCallId, chunks)
+  }
+
+  /** Persist an orphaned batch restart-safe, merging with earlier batches for the same root. */
+  private persistFlowRecoveryOrphan(sessionId: string, rootToolCallId: string, chunks: UIMessageChunk[]): void {
+    const cacheService = application.get('CacheService')
+    const orphanKey = 'agent.session.flow_recovery_orphans'
+    const orphans = cacheService.getPersist(orphanKey) ?? []
+    const now = Date.now()
+    const live = orphans.filter((orphan) => now - orphan.orphannedAt < FLOW_RECOVERY_ORPHAN_TTL_MS)
+    const existing = live.find((orphan) => orphan.sessionId === sessionId && orphan.rootToolCallId === rootToolCallId)
+    cacheService.setPersist(
+      orphanKey,
+      existing
+        ? live.map((orphan) => (orphan === existing ? { ...orphan, chunks: [...orphan.chunks, ...chunks] } : orphan))
+        : [...live, { sessionId, rootToolCallId, orphannedAt: now, chunks }]
+    )
   }
 
   private markFlowMessagePersisted(entry: AgentSessionRuntimeEntry, messageId: string): void {
@@ -3380,28 +3401,16 @@ export class AgentSessionRuntimeService extends BaseService {
       // Recovery-buffered chunks get their last host-row lookup; any that land now replay into
       // an accumulator (or the pending buffer) and will be drained by the cascade below.
       for (const rootToolCallId of [...(entry.pendingRecoveryFlowChunks?.keys() ?? [])]) {
+        // The host row never committed (or the final lookup failed): orphan the buffered chunks
+        // to the restart-safe persist tier — a reopened session that later finds the row
+        // delivers them instead of dropping the output.
+        const orphan = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
+        if (orphan?.length) this.persistFlowRecoveryOrphan(entry.sessionId, rootToolCallId, orphan)
         try {
           if (!this.recoverDetachedFlowHost(entry, rootToolCallId)) {
-            // The host row never committed: orphan the buffered chunks to the cache — a reopened
-            // session that later finds the row delivers them instead of dropping the output.
-            const orphan = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
-            if (orphan?.length) {
-              cacheService.setShared(
-                AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY(entry.sessionId, rootToolCallId),
-                orphan,
-                FLOW_RECOVERY_ORPHAN_TTL_MS
-              )
-            }
+            // Recovery already consumed or re-buffered the chunks — nothing to keep orphaned.
           }
         } catch (error) {
-          const orphan = entry.pendingRecoveryFlowChunks?.get(rootToolCallId)
-          if (orphan?.length) {
-            cacheService.setShared(
-              AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY(entry.sessionId, rootToolCallId),
-              orphan,
-              FLOW_RECOVERY_ORPHAN_TTL_MS
-            )
-          }
           logger.warn('Detached flow recovery lookup failed at teardown', {
             sessionId: entry.sessionId,
             rootToolCallId,

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   saveMessage: vi.fn(),
   replaceMessageParts: vi.fn(),
   getSessionMessage: vi.fn(),
+  findFlowHostMessageId: vi.fn(),
   hasSessionMessage: vi.fn(() => true),
   applyToolApprovalDecision: vi.fn(),
   getLastRuntimeResumeToken: vi.fn(),
@@ -56,6 +57,7 @@ vi.mock('@data/services/AgentSessionMessageService', () => ({
     saveMessage: mocks.saveMessage,
     replaceMessageParts: mocks.replaceMessageParts,
     getSessionMessage: mocks.getSessionMessage,
+    findFlowHostMessageId: mocks.findFlowHostMessageId,
     hasSessionMessage: mocks.hasSessionMessage,
     applyToolApprovalDecision: mocks.applyToolApprovalDecision,
     getLastRuntimeResumeToken: mocks.getLastRuntimeResumeToken,
@@ -256,6 +258,7 @@ describe('AgentSessionRuntimeService', () => {
         ]
       }
     })
+    mocks.findFlowHostMessageId.mockReturnValue(null)
     mocks.applyToolApprovalDecision.mockReturnValue(true)
     mocks.getLastRuntimeResumeToken.mockReturnValue(null)
     mocks.findCrashOrphanedAssistantMessages.mockReturnValue([])
@@ -2265,6 +2268,61 @@ describe('AgentSessionRuntimeService', () => {
           expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
         )
       })
+    })
+
+    it('recovers the flow host row from the database after the entry was rebuilt', async () => {
+      // A fresh entry (restart / session reopen) has no in-memory anchor; the resumed chunks
+      // stream under the original launch tool-call id and must re-anchor to the persisted row.
+      mocks.findFlowHostMessageId.mockReturnValue('assistant-1')
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      for (const chunk of [
+        { type: 'text-start', id: 'resumed-text' },
+        { type: 'text-delta', id: 'resumed-text', delta: 'Resumed findings' },
+        { type: 'text-end', id: 'resumed-text' }
+      ]) {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk
+        })
+      }
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        expect(mocks.findFlowHostMessageId).toHaveBeenCalledWith('session-1', 'task-root')
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
+        )
+      })
+    })
+
+    it('does not re-query the database for flow roots that have no host row', async () => {
+      mocks.findFlowHostMessageId.mockReturnValue(null)
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      const sendChunk = () => {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk: { type: 'text-start', id: 'orphan-text' }
+        })
+      }
+      sendChunk()
+      sendChunk()
+
+      expect(mocks.findFlowHostMessageId).toHaveBeenCalledTimes(1)
+      expect(mocks.replaceMessageParts).not.toHaveBeenCalled()
     })
 
     it('publishes detached flow overlays under independent message keys', () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2303,6 +2303,110 @@ describe('AgentSessionRuntimeService', () => {
       })
     })
 
+    it('keeps an accumulator whose persistence failed and retries it on the next drain', async () => {
+      let persistCalls = 0
+      mocks.replaceMessageParts.mockImplementation((...args: unknown[]) => {
+        persistCalls += 1
+        if (persistCalls === 1) throw new Error('db locked')
+        return { id: args[1] }
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      // Register the launch-root anchor like a real launch turn would.
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit the codebase' }
+        }
+      })
+      service.markTurnTerminal('session-1', 'success')
+
+      const sendFlow = (text: string, textId: string) => {
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+        for (const chunk of [
+          { type: 'text-start', id: textId },
+          { type: 'text-delta', id: textId, delta: text },
+          { type: 'text-end', id: textId }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+      }
+
+      sendFlow('First findings', 'first-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      await vi.waitFor(() => expect(mocks.replaceMessageParts).toHaveBeenCalledTimes(1))
+      expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+        'session-1',
+        'assistant-1',
+        expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'First findings' })])
+      )
+
+      // The failed accumulator survived the flush; the next round retries with both rounds' content.
+      sendFlow('Second findings', 'second-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      await vi.waitFor(() => expect(mocks.replaceMessageParts).toHaveBeenCalledTimes(2))
+      expect(mocks.replaceMessageParts).toHaveBeenLastCalledWith(
+        'session-1',
+        'assistant-1',
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'text', text: 'First findings' }),
+          expect.objectContaining({ type: 'text', text: 'Second findings' })
+        ])
+      )
+    })
+
+    it('retries the host-row lookup after a transient query error', async () => {
+      // A failed lookup must not poison the miss cache: the next chunk re-queries and lands.
+      let lookupCalls = 0
+      mocks.findFlowHostMessageId.mockImplementation(() => {
+        lookupCalls += 1
+        if (lookupCalls === 1) throw new Error('db busy')
+        return 'assistant-1'
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      const sendChunk = (id: string, text: string) => {
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+        for (const chunk of [
+          { type: 'text-start', id },
+          { type: 'text-delta', id, delta: text },
+          { type: 'text-end', id }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      }
+
+      sendChunk('first-text', 'First findings')
+      // The first chunk hit the transient error; the retry must both re-query and land.
+      sendChunk('second-text', 'Second findings')
+      await vi.waitFor(() => {
+        expect(lookupCalls).toBeGreaterThanOrEqual(2)
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Second findings' })])
+        )
+      })
+    })
+
     it('does not re-query the database for flow roots that have no host row', async () => {
       mocks.findFlowHostMessageId.mockReturnValue(null)
       const service = new AgentSessionRuntimeService()

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2540,6 +2540,54 @@ describe('AgentSessionRuntimeService', () => {
       })
     })
 
+    it('folds never-accumulated chunks into the cache overlay at teardown', async () => {
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit' }
+        }
+      })
+      service.markTurnTerminal('session-1', 'success')
+      // Every seed read fails: the round's chunks stay buffered, never accumulated.
+      mocks.getSessionMessage.mockImplementation(() => {
+        throw new Error('db busy')
+      })
+      mocks.cacheSetShared.mockClear()
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      for (const chunk of [
+        { type: 'text-start', id: 'orphan-text' },
+        { type: 'text-delta', id: 'orphan-text', delta: 'Orphaned findings' },
+        { type: 'text-end', id: 'orphan-text' }
+      ]) {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk
+        })
+      }
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      expect(getEntry(service).pendingBackgroundFlowChunks?.get('assistant-1')).toHaveLength(3)
+
+      await service.closeSession('session-1')
+
+      // closeEntry folded the buffered chunks into the cache overlay so the output survives.
+      const call = mocks.cacheSetShared.mock.calls.find(
+        ([key, parts]) =>
+          typeof key === 'string' && key.includes('flow_parts') && JSON.stringify(parts).includes('Orphaned findings')
+      )
+      expect(call).toBeDefined()
+    })
+
     it('registers nested tool anchors when replaying buffered recovery chunks', async () => {
       let lookupCalls = 0
       mocks.findFlowHostMessageId.mockImplementation(() => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2828,6 +2828,59 @@ describe('AgentSessionRuntimeService', () => {
       )
     })
 
+    it('keeps recovery-buffered chunks across a successful miss for the re-check window', async () => {
+      // A transient lookup failure buffers the chunk; a later successful miss must not discard
+      // that buffer — the row can still be committed within the re-check window.
+      let lookupCalls = 0
+      mocks.findFlowHostMessageId.mockImplementation(() => {
+        lookupCalls += 1
+        // The first round's chunks all hit the transient error and buffer in full.
+        if (lookupCalls <= 3) throw new Error('db busy')
+        if (lookupCalls === 4) return null
+        return 'assistant-1'
+      })
+      mocks.getSessionMessage.mockReturnValue({
+        id: 'assistant-1',
+        role: 'assistant',
+        data: { parts: [] }
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      const sendChunk = (text: string, id: string) => {
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+        for (const chunk of [
+          { type: 'text-start', id },
+          { type: 'text-delta', id, delta: text },
+          { type: 'text-end', id }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      }
+      sendChunk('First findings', 'first-text')
+
+      // The next round's first lookup succeeds as a miss — the buffered chunks must survive it.
+      sendChunk('Second findings', 'second-text')
+      expect(getEntry(service).pendingRecoveryFlowChunks?.get('task-root')).toHaveLength(3)
+
+      // Simulate the re-check window elapsing with the row now committed.
+      getEntry(service).checkedFlowHostMisses?.set('task-root', Date.now() - 6_000)
+      sendChunk('Third findings', 'third-text')
+
+      await vi.waitFor(() => {
+        const last = mocks.replaceMessageParts.mock.calls.at(-1)?.[2] as Array<{ text?: string }> | undefined
+        expect(last?.some((part) => part?.text === 'First findings')).toBe(true)
+        expect(last?.some((part) => part?.text === 'Third findings')).toBe(true)
+      })
+    })
+
     it('re-queries host rows after a connection reset so a late flush is not lost', async () => {
       // A host row missed at connection time can land via flush at any moment; the miss cache is
       // connection-scoped, so the reset must re-open the lookup for the same root.

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2540,6 +2540,46 @@ describe('AgentSessionRuntimeService', () => {
       })
     })
 
+    it('gives recovery-buffered chunks a last host-row lookup at teardown', async () => {
+      let lookupCalls = 0
+      mocks.findFlowHostMessageId.mockImplementation(() => {
+        lookupCalls += 1
+        if (lookupCalls === 1) throw new Error('db busy')
+        return 'assistant-1'
+      })
+      mocks.getSessionMessage.mockReturnValue({
+        id: 'assistant-1',
+        role: 'assistant',
+        data: { parts: [] }
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+      mocks.replaceMessageParts.mockClear()
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'background-flow-chunk',
+        rootToolCallId: 'task-root',
+        chunk: { type: 'text-start', id: 'recovered-text' }
+      })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      // The failed lookup buffered the chunk — no anchor, no accumulator.
+      expect(getEntry(service).pendingRecoveryFlowChunks?.get('task-root')).toHaveLength(1)
+      expect(mocks.replaceMessageParts).not.toHaveBeenCalled()
+
+      await service.closeSession('session-1')
+
+      // closeEntry re-runs the lookup and the replayed chunk lands in the database.
+      expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+        'session-1',
+        'assistant-1',
+        expect.arrayContaining([expect.objectContaining({ type: 'text' })])
+      )
+    })
+
     it('folds never-accumulated chunks into the cache overlay at teardown', async () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn(baseTurnInput)
@@ -2736,6 +2776,56 @@ describe('AgentSessionRuntimeService', () => {
 
       expect(mocks.findFlowHostMessageId).toHaveBeenCalledTimes(1)
       expect(mocks.replaceMessageParts).not.toHaveBeenCalled()
+    })
+
+    it('re-queries a missed host row once its re-check window elapses', async () => {
+      // A miss cached mid-connection must not stay cached forever — the row can be committed
+      // by a flush at any moment, so the lookup re-opens after FLOW_HOST_MISS_RECHECK_MS.
+      let lookupCalls = 0
+      mocks.findFlowHostMessageId.mockImplementation(() => {
+        lookupCalls += 1
+        return lookupCalls === 1 ? null : 'assistant-1'
+      })
+      mocks.getSessionMessage.mockReturnValue({
+        id: 'assistant-1',
+        role: 'assistant',
+        data: { parts: [] }
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      const sendChunk = (text: string, id: string) => {
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+        for (const chunk of [
+          { type: 'text-start', id },
+          { type: 'text-delta', id, delta: text },
+          { type: 'text-end', id }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      }
+      sendChunk('First findings', 'first-text')
+      expect(mocks.replaceMessageParts).not.toHaveBeenCalled()
+
+      // Simulate the re-check window elapsing with the row now committed.
+      getEntry(service).checkedFlowHostMisses?.set('task-root', Date.now() - 6_000)
+      sendChunk('Second findings', 'second-text')
+
+      expect(mocks.findFlowHostMessageId).toHaveBeenCalledTimes(2)
+      await vi.waitFor(() =>
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Second findings' })])
+        )
+      )
     })
 
     it('re-queries host rows after a connection reset so a late flush is not lost', async () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2690,6 +2690,119 @@ describe('AgentSessionRuntimeService', () => {
       expect(mocks.replaceMessageParts).not.toHaveBeenCalled()
     })
 
+    it('re-queries host rows after a connection reset so a late flush is not lost', async () => {
+      // A host row missed at connection time can land via flush at any moment; the miss cache is
+      // connection-scoped, so the reset must re-open the lookup for the same root.
+      let lookupCalls = 0
+      mocks.findFlowHostMessageId.mockImplementation(() => {
+        lookupCalls += 1
+        return lookupCalls === 1 ? null : 'assistant-1'
+      })
+      mocks.getSessionMessage.mockReturnValue({
+        id: 'assistant-1',
+        role: 'assistant',
+        data: { parts: [] }
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      const sendChunk = (text: string, id: string) => {
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+        for (const chunk of [
+          { type: 'text-start', id },
+          { type: 'text-delta', id, delta: text },
+          { type: 'text-end', id }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      }
+
+      sendChunk('First findings', 'first-text')
+      expect(mocks.findFlowHostMessageId).toHaveBeenCalledTimes(1)
+      expect(mocks.replaceMessageParts).not.toHaveBeenCalled()
+
+      const connection = { close: vi.fn(), send: vi.fn(), events: [] }
+      entry.connection = connection
+      ;(service as any).resetConnectionRuntimeState(entry, connection)
+
+      sendChunk('Second findings', 'second-text')
+      expect(mocks.findFlowHostMessageId).toHaveBeenCalledTimes(2)
+      await vi.waitFor(() =>
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Second findings' })])
+        )
+      )
+    })
+
+    it('keeps buffered chunks across a connection reset for replay', async () => {
+      // Chunks held after a seed failure are the only copy of the subagent's output — a reset must
+      // not clear them; the next seed retry replays them in order.
+      let seedCalls = 0
+      mocks.getSessionMessage.mockImplementation(() => {
+        seedCalls += 1
+        // Every chunk of the first round hits the failing seed so all three land in the buffer.
+        if (seedCalls <= 3) throw new Error('db busy')
+        return { id: 'assistant-1', role: 'assistant', data: { parts: [] } }
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit' }
+        }
+      })
+      service.markTurnTerminal('session-1', 'success')
+
+      const sendFlow = (text: string, textId: string) => {
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+        for (const chunk of [
+          { type: 'text-start', id: textId },
+          { type: 'text-delta', id: textId, delta: text },
+          { type: 'text-end', id: textId }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      }
+
+      sendFlow('First findings', 'first-text')
+      expect(getEntry(service).pendingBackgroundFlowChunks?.get('assistant-1')).toHaveLength(3)
+
+      const connection = { close: vi.fn(), send: vi.fn(), events: [] }
+      entry.connection = connection
+      ;(service as any).resetConnectionRuntimeState(entry, connection)
+
+      // The reset must not throw the buffered chunks away.
+      expect(getEntry(service).pendingBackgroundFlowChunks?.get('assistant-1')).toHaveLength(3)
+
+      sendFlow('Second findings', 'second-text')
+      await vi.waitFor(() => {
+        const last = mocks.replaceMessageParts.mock.calls.at(-1)?.[2] as Array<{ text?: string }> | undefined
+        expect(last?.some((part) => part?.text === 'First findings')).toBe(true)
+        expect(last?.some((part) => part?.text === 'Second findings')).toBe(true)
+      })
+    })
+
     it('publishes detached flow overlays under independent message keys', () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn(baseTurnInput)

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2428,7 +2428,7 @@ describe('AgentSessionRuntimeService', () => {
       ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
 
       await vi.waitFor(() => {
-        expect((getEntry(service) as any).flowMessageIdsByToolCallId?.get('nested-1')).toBe('assistant-1')
+        expect(getEntry(service).flowMessageIdsByToolCallId?.get('nested-1')).toBe('assistant-1')
       })
       // A nested-root chunk routed after the replay resolves without a second DB lookup.
       const lookupCount = lookupCalls

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2540,6 +2540,66 @@ describe('AgentSessionRuntimeService', () => {
       })
     })
 
+    it('orphans recovery-buffered chunks at teardown and delivers them on a later reopen', async () => {
+      // Teardown's final lookup misses — the chunks are orphaned to the cache instead of lost;
+      // a reopened session that finds the row replays them ahead of its own buffered chunks.
+      const orphanChunk = { type: 'text-start', id: 'orphaned-text' }
+      let lookupCalls = 0
+      mocks.findFlowHostMessageId.mockImplementation(() => {
+        lookupCalls += 1
+        // The first run buffers the chunk; teardown's final lookup misses.
+        if (lookupCalls === 1) throw new Error('db busy')
+        return null
+      })
+      mocks.getSessionMessage.mockReturnValue({
+        id: 'assistant-1',
+        role: 'assistant',
+        data: { parts: [] }
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+      mocks.cacheSetShared.mockClear()
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'background-flow-chunk',
+        rootToolCallId: 'task-root',
+        chunk: orphanChunk
+      })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await service.closeSession('session-1')
+      const orphanCall = mocks.cacheSetShared.mock.calls.find(
+        ([key]) => typeof key === 'string' && key.includes('flow_recovery_orphan')
+      )
+      expect(orphanCall).toBeDefined()
+
+      // A reopened session recovers the row and replays the orphan first.
+      mocks.findFlowHostMessageId.mockReturnValue('assistant-1')
+      mocks.cacheGetShared.mockImplementation((key) =>
+        typeof key === 'string' && key.includes('flow_recovery_orphan') ? [orphanChunk] : undefined
+      )
+      mocks.replaceMessageParts.mockClear()
+      service.beginTurn(baseTurnInput)
+      const reopenedEntry = getEntry(service)
+      reopenedEntry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(reopenedEntry, { type: 'background-work-state', active: true })
+      ;(service as any).handleRuntimeEvent(reopenedEntry, {
+        type: 'background-flow-chunk',
+        rootToolCallId: 'task-root',
+        chunk: { type: 'text-delta', id: 'orphaned-text', delta: 'Orphaned findings' }
+      })
+      ;(service as any).handleRuntimeEvent(reopenedEntry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        const last = mocks.replaceMessageParts.mock.calls.at(-1)?.[2] as Array<{ text?: string }> | undefined
+        expect(last?.some((part) => part?.text === 'Orphaned findings')).toBe(true)
+      })
+    })
+
     it('gives recovery-buffered chunks a last host-row lookup at teardown', async () => {
       let lookupCalls = 0
       mocks.findFlowHostMessageId.mockImplementation(() => {
@@ -2819,13 +2879,12 @@ describe('AgentSessionRuntimeService', () => {
       sendChunk('Second findings', 'second-text')
 
       expect(mocks.findFlowHostMessageId).toHaveBeenCalledTimes(2)
-      await vi.waitFor(() =>
-        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
-          'session-1',
-          'assistant-1',
-          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Second findings' })])
-        )
-      )
+      await vi.waitFor(() => {
+        const last = mocks.replaceMessageParts.mock.calls.at(-1)?.[2] as Array<{ text?: string }> | undefined
+        // Chunks arriving inside the re-check window were buffered, not discarded.
+        expect(last?.some((part) => part?.text === 'First findings')).toBe(true)
+        expect(last?.some((part) => part?.text === 'Second findings')).toBe(true)
+      })
     })
 
     it('keeps recovery-buffered chunks across a successful miss for the re-check window', async () => {
@@ -2866,9 +2925,10 @@ describe('AgentSessionRuntimeService', () => {
       }
       sendChunk('First findings', 'first-text')
 
-      // The next round's first lookup succeeds as a miss — the buffered chunks must survive it.
+      // The next round's first lookup succeeds as a miss — the buffered chunks must survive it,
+      // and the chunks arriving inside the re-check window must buffer too, not be discarded.
       sendChunk('Second findings', 'second-text')
-      expect(getEntry(service).pendingRecoveryFlowChunks?.get('task-root')).toHaveLength(3)
+      expect(getEntry(service).pendingRecoveryFlowChunks?.get('task-root')).toHaveLength(6)
 
       // Simulate the re-check window elapsing with the row now committed.
       getEntry(service).checkedFlowHostMisses?.set('task-root', Date.now() - 6_000)

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events'
 import { BaseService } from '@main/core/lifecycle/BaseService'
 import { ServiceContainer } from '@main/core/lifecycle/ServiceContainer'
 import { AGENT_SESSION_API_RETRY_CACHE_KEY } from '@shared/ai/agentSessionApiRetry'
+import { DataApiErrorFactory } from '@shared/data/api/errors'
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest'
 
@@ -2398,6 +2399,144 @@ describe('AgentSessionRuntimeService', () => {
           'assistant-1',
           expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Complete findings' })])
         )
+      })
+    })
+
+    it('holds chunks while the accumulator seed read fails and replays them', async () => {
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit' }
+        }
+      })
+      service.markTurnTerminal('session-1', 'success')
+
+      let seedCalls = 0
+      mocks.getSessionMessage.mockImplementation(() => {
+        seedCalls += 1
+        if (seedCalls === 1) throw new Error('db busy')
+        return {
+          id: 'assistant-1',
+          role: 'assistant',
+          data: {
+            parts: [
+              { type: 'tool-Agent', toolCallId: 'task-root', state: 'input-available', input: { prompt: 'Audit' } }
+            ]
+          }
+        }
+      })
+
+      const sendFlow = (text: string, textId: string) => {
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+        for (const chunk of [
+          { type: 'text-start', id: textId },
+          { type: 'text-delta', id: textId, delta: text },
+          { type: 'text-end', id: textId }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+      }
+
+      // The first seed read fails: the round's chunks must be held, not dropped.
+      sendFlow('First findings', 'first-text')
+      sendFlow('Second findings', 'second-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        const calls = mocks.replaceMessageParts.mock.calls
+        const last = calls.at(-1)?.[2] as Array<{ text?: string }> | undefined
+        expect(last?.some((part) => part?.text === 'First findings')).toBe(true)
+        expect(last?.some((part) => part?.text === 'Second findings')).toBe(true)
+      })
+    })
+
+    it('drops chunks whose host row is genuinely gone instead of buffering them', async () => {
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit' }
+        }
+      })
+      service.markTurnTerminal('session-1', 'success')
+      mocks.getSessionMessage.mockImplementation(() => {
+        throw DataApiErrorFactory.notFound('Message', 'assistant-1')
+      })
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'background-flow-chunk',
+        rootToolCallId: 'task-root',
+        chunk: { type: 'text-start', id: 'lost-text' }
+      })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => expect(mocks.replaceMessageParts).not.toHaveBeenCalled())
+      expect((getEntry(service) as any).pendingBackgroundFlowChunks).toBeUndefined()
+    })
+
+    it('hands failed-flush parts to the cache overlay so teardown does not lose them', async () => {
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit' }
+        }
+      })
+      service.markTurnTerminal('session-1', 'success')
+      mocks.replaceMessageParts.mockImplementation(() => {
+        throw new Error('db locked')
+      })
+      mocks.cacheSetShared.mockClear()
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      for (const chunk of [
+        { type: 'text-start', id: 'final-text' },
+        { type: 'text-delta', id: 'final-text', delta: 'Final findings' },
+        { type: 'text-end', id: 'final-text' }
+      ]) {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk
+        })
+      }
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => expect(mocks.replaceMessageParts).toHaveBeenCalled())
+      await vi.waitFor(() => {
+        // Streaming snapshots also hit the cache; the final overlay is the one that carries the text.
+        const call = mocks.cacheSetShared.mock.calls.find(
+          ([key, parts]) =>
+            typeof key === 'string' && key.includes('flow_parts') && JSON.stringify(parts).includes('Final findings')
+        )
+        expect(call).toBeDefined()
       })
     })
 

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2365,6 +2365,89 @@ describe('AgentSessionRuntimeService', () => {
       )
     })
 
+    it('replays chunks buffered while the host-row lookup was failing', async () => {
+      let lookupCalls = 0
+      mocks.findFlowHostMessageId.mockImplementation(() => {
+        lookupCalls += 1
+        if (lookupCalls === 1) throw new Error('db busy')
+        return 'assistant-1'
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      for (const chunk of [
+        { type: 'text-start', id: 'full-text' },
+        { type: 'text-delta', id: 'full-text', delta: 'Complete findings' },
+        { type: 'text-end', id: 'full-text' }
+      ]) {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk
+        })
+      }
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      // The text-start that hit the transient error is replayed with the rest of the flow.
+      await vi.waitFor(() => {
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Complete findings' })])
+        )
+      })
+    })
+
+    it('does not let a mid-drain successor overwrite the drained tail', async () => {
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit' }
+        }
+      })
+      service.markTurnTerminal('session-1', 'success')
+
+      const sendFlow = (text: string, textId: string) => {
+        ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+        for (const chunk of [
+          { type: 'text-start', id: textId },
+          { type: 'text-delta', id: textId, delta: text },
+          { type: 'text-end', id: textId }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+      }
+
+      // First drain starts (accumulator closes) — the second generation arrives synchronously
+      // before the drain settles, so it must be held, not seeded into a successor that misses the tail.
+      sendFlow('First round complete', 'first-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      sendFlow('Second round complete', 'second-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        const calls = mocks.replaceMessageParts.mock.calls
+        const last = calls.at(-1)?.[2] as Array<{ text?: string }> | undefined
+        expect(last?.some((part) => part?.text === 'First round complete')).toBe(true)
+        expect(last?.some((part) => part?.text === 'Second round complete')).toBe(true)
+      })
+    })
+
     it('retries the host-row lookup after a transient query error', async () => {
       // A failed lookup must not poison the miss cache: the next chunk re-queries and lands.
       let lookupCalls = 0

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2208,6 +2208,65 @@ describe('AgentSessionRuntimeService', () => {
       )
     })
 
+    // A SendMessage resume re-streams under the original tool-call id after the first background
+    // flow has drained — the retained anchor is what lets that second generation still land.
+    it('patches resumed subagent chunks onto the spawning message after the first flow drained', async () => {
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'task-root',
+          toolName: 'Agent',
+          input: { prompt: 'Audit the codebase' }
+        }
+      })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+
+      const sendFlow = (text: string, textId: string) => {
+        for (const chunk of [
+          { type: 'text-start', id: textId },
+          { type: 'text-delta', id: textId, delta: text },
+          { type: 'text-end', id: textId }
+        ]) {
+          ;(service as any).handleRuntimeEvent(entry, {
+            type: 'background-flow-chunk',
+            rootToolCallId: 'task-root',
+            chunk
+          })
+        }
+      }
+
+      service.markTurnTerminal('session-1', 'success')
+      sendFlow('First round findings', 'first-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+      await vi.waitFor(() => {
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'First round findings' })])
+        )
+      })
+      mocks.replaceMessageParts.mockClear()
+
+      // The resume arrives after the drain that used to delete the anchor.
+      sendFlow('Resumed findings', 'resumed-text')
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        expect(mocks.replaceMessageParts).toHaveBeenCalledWith(
+          'session-1',
+          'assistant-1',
+          expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Resumed findings' })])
+        )
+      })
+    })
+
     it('publishes detached flow overlays under independent message keys', () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn(baseTurnInput)

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2491,7 +2491,7 @@ describe('AgentSessionRuntimeService', () => {
       ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
 
       await vi.waitFor(() => expect(mocks.replaceMessageParts).not.toHaveBeenCalled())
-      expect((getEntry(service) as any).pendingBackgroundFlowChunks).toBeUndefined()
+      expect(getEntry(service).pendingBackgroundFlowChunks).toBeUndefined()
     })
 
     it('hands failed-flush parts to the cache overlay so teardown does not lose them', async () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2401,6 +2401,45 @@ describe('AgentSessionRuntimeService', () => {
       })
     })
 
+    it('registers nested tool anchors when replaying buffered recovery chunks', async () => {
+      let lookupCalls = 0
+      mocks.findFlowHostMessageId.mockImplementation(() => {
+        lookupCalls += 1
+        if (lookupCalls === 1) throw new Error('db busy')
+        return 'assistant-1'
+      })
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn(baseTurnInput)
+      const entry = getEntry(service)
+      entry.currentTurn.controller = { enqueue: vi.fn() } as never
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
+      for (const chunk of [
+        { type: 'text-start', id: 'buffered-text' },
+        { type: 'tool-input-start', toolCallId: 'nested-1', toolName: 'Read', input: {} },
+        { type: 'text-end', id: 'buffered-text' }
+      ]) {
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'background-flow-chunk',
+          rootToolCallId: 'task-root',
+          chunk
+        })
+      }
+      ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
+
+      await vi.waitFor(() => {
+        expect((getEntry(service) as any).flowMessageIdsByToolCallId?.get('nested-1')).toBe('assistant-1')
+      })
+      // A nested-root chunk routed after the replay resolves without a second DB lookup.
+      const lookupCount = lookupCalls
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'background-flow-chunk',
+        rootToolCallId: 'nested-1',
+        chunk: { type: 'text-start', id: 'nested-text' }
+      })
+      expect(lookupCalls).toBe(lookupCount)
+    })
+
     it('does not let a mid-drain successor overwrite the drained tail', async () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn(baseTurnInput)

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -33,6 +33,8 @@ const mocks = vi.hoisted(() => ({
   cacheSetShared: vi.fn(),
   cacheGetShared: vi.fn(),
   cacheDeleteShared: vi.fn(),
+  cacheSetPersist: vi.fn(),
+  cacheGetPersist: vi.fn(),
   closeWarmQueries: vi.fn(),
   closeAgentSessionWarm: vi.fn(),
   getSessionById: vi.fn(),
@@ -286,7 +288,9 @@ describe('AgentSessionRuntimeService', () => {
         return {
           setShared: mocks.cacheSetShared,
           getShared: mocks.cacheGetShared,
-          deleteShared: mocks.cacheDeleteShared
+          deleteShared: mocks.cacheDeleteShared,
+          setPersist: mocks.cacheSetPersist,
+          getPersist: mocks.cacheGetPersist
         }
       if (name === 'ClaudeCodeWarmQueryManager')
         return { closeAll: mocks.closeWarmQueries, closeAgentSessionWarm: mocks.closeAgentSessionWarm }
@@ -2560,7 +2564,7 @@ describe('AgentSessionRuntimeService', () => {
       service.beginTurn(baseTurnInput)
       const entry = getEntry(service)
       entry.currentTurn.controller = { enqueue: vi.fn() } as never
-      mocks.cacheSetShared.mockClear()
+      mocks.cacheSetPersist.mockClear()
 
       ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
       ;(service as any).handleRuntimeEvent(entry, {
@@ -2571,16 +2575,16 @@ describe('AgentSessionRuntimeService', () => {
       ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: false })
 
       await service.closeSession('session-1')
-      const orphanCall = mocks.cacheSetShared.mock.calls.find(
-        ([key]) => typeof key === 'string' && key.includes('flow_recovery_orphan')
-      )
-      expect(orphanCall).toBeDefined()
+      expect(mocks.cacheSetPersist).toHaveBeenCalledWith('agent.session.flow_recovery_orphans', [
+        expect.objectContaining({ sessionId: 'session-1', rootToolCallId: 'task-root', chunks: [orphanChunk] })
+      ])
 
       // A reopened session recovers the row and replays the orphan first.
       mocks.findFlowHostMessageId.mockReturnValue('assistant-1')
-      mocks.cacheGetShared.mockImplementation((key) =>
-        typeof key === 'string' && key.includes('flow_recovery_orphan') ? [orphanChunk] : undefined
-      )
+      const orphannedAt = Date.now()
+      mocks.cacheGetPersist.mockReturnValue([
+        { sessionId: 'session-1', rootToolCallId: 'task-root', orphannedAt, chunks: [orphanChunk] }
+      ])
       mocks.replaceMessageParts.mockClear()
       service.beginTurn(baseTurnInput)
       const reopenedEntry = getEntry(service)

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -1825,9 +1825,12 @@ describe('ClaudeCodeStreamAdapter', () => {
       })
     })
 
-    it('registers the edge id when launch-root recovery throws', () => {
+    it('skips registration on a launch-root recovery error and self-heals on the next event', () => {
+      let lookupCalls = 0
       messageServiceMocks.findLaunchToolCallId.mockImplementation(() => {
-        throw new Error('db locked')
+        lookupCalls += 1
+        if (lookupCalls === 1) throw new Error('db locked')
+        return 'call_launch'
       })
       const { adapter, statusEvents } = createAdapter()
 
@@ -1849,11 +1852,29 @@ describe('ClaudeCodeStreamAdapter', () => {
         task_type: 'subagent'
       } as any)
 
-      // The connection survives the failed recovery and the edge id is registered as a fallback.
+      // The connection survives the failed recovery; the chip surfaces without a toolCallId
+      // (delayed, never misshown) rather than pinning the resume edge id.
+      const first = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(first).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch' }]
+      })
+
+      // The next task event re-runs the lookup and finally registers the launch root.
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        task_id: 'subagent-1',
+        tool_use_id: 'call_resume_2',
+        description: 'Resumed review again',
+        task_type: 'subagent'
+      } as any)
       const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
       expect(last).toEqual({
         type: 'background-tasks',
-        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_resume' }]
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_launch' }]
       })
     })
 

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -16,11 +16,22 @@ vi.mock('@logger', () => ({
   }
 }))
 
+const messageServiceMocks = vi.hoisted(() => ({
+  findLaunchToolCallId: vi.fn()
+}))
+
+vi.mock('@data/services/AgentSessionMessageService', () => ({
+  agentSessionMessageService: {
+    findLaunchToolCallId: messageServiceMocks.findLaunchToolCallId
+  }
+}))
+
 const { ClaudeCodeResultError, ClaudeCodeStreamAdapter } = await import('../streamAdapter')
 const { PersistenceListener } = await import('../../../streamManager/listeners/PersistenceListener')
 
 beforeEach(() => {
   vi.clearAllMocks()
+  messageServiceMocks.findLaunchToolCallId.mockReturnValue(null)
 })
 
 /**
@@ -1807,6 +1818,38 @@ describe('ClaudeCodeStreamAdapter', () => {
         description: 'Resumed review'
       })
 
+      const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(last).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_launch' }]
+      })
+    })
+
+    it('recovers the launch root from the database when the adapter starts fresh', () => {
+      // A restarted app builds a new adapter with no in-memory mapping; the first resume edge
+      // must land on the persisted launch tool-use id, not the resuming call.
+      messageServiceMocks.findLaunchToolCallId.mockReturnValue('call_launch')
+      const { adapter, statusEvents } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        tasks: [{ task_id: 'subagent-1', task_type: 'subagent', description: 'Review the patch' }]
+      } as any)
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        task_id: 'subagent-1',
+        tool_use_id: 'call_resume',
+        description: 'Resumed review',
+        task_type: 'subagent'
+      } as any)
+
+      expect(messageServiceMocks.findLaunchToolCallId).toHaveBeenCalledWith('session-1', 'subagent-1')
       const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
       expect(last).toEqual({
         type: 'background-tasks',

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -1739,6 +1739,7 @@ describe('ClaudeCodeStreamAdapter', () => {
     })
 
     it('uses subagent edges only to enrich navigation without changing authoritative membership', () => {
+      messageServiceMocks.findLaunchToolCallId.mockReturnValue('tool-use-b')
       const { adapter, statusEvents } = createAdapter()
 
       adapter.handleMessage({
@@ -1791,6 +1792,7 @@ describe('ClaudeCodeStreamAdapter', () => {
     // A SendMessage resume re-points lifecycle edges at the resuming call's id; the navigation
     // anchor must stay on the launch root the content actually streams under.
     it('keeps the first navigation id for a task when resume edges report a new one', () => {
+      messageServiceMocks.findLaunchToolCallId.mockReturnValue('call_launch')
       const { adapter, statusEvents } = createAdapter()
 
       adapter.handleMessage({
@@ -1861,6 +1863,58 @@ describe('ClaudeCodeStreamAdapter', () => {
       })
 
       // The next task event re-runs the lookup and finally registers the launch root.
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        task_id: 'subagent-1',
+        tool_use_id: 'call_resume_2',
+        description: 'Resumed review again',
+        task_type: 'subagent'
+      } as any)
+      const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(last).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_launch' }]
+      })
+    })
+
+    it('skips registration on a launch-root query miss so a resume edge is not pinned', () => {
+      // A null result (row not yet persisted) must not pin the resume edge id either — a later
+      // event re-queries and lands the authoritative launch root.
+      let lookupCalls = 0
+      messageServiceMocks.findLaunchToolCallId.mockImplementation(() => {
+        lookupCalls += 1
+        if (lookupCalls === 1) return null
+        return 'call_launch'
+      })
+      const { adapter, statusEvents } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        tasks: [{ task_id: 'subagent-1', task_type: 'subagent', description: 'Review the patch' }]
+      } as any)
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        task_id: 'subagent-1',
+        tool_use_id: 'call_resume',
+        description: 'Resumed review',
+        task_type: 'subagent'
+      } as any)
+
+      const first = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(first).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch' }]
+      })
+
       adapter.handleMessage({
         type: 'system',
         subtype: 'task_started',
@@ -1988,6 +2042,7 @@ describe('ClaudeCodeStreamAdapter', () => {
     })
 
     it('uses local workflow task starts to enrich navigation without changing authoritative membership', () => {
+      messageServiceMocks.findLaunchToolCallId.mockReturnValue('workflow-tool-use')
       const { adapter, statusEvents } = createAdapter()
 
       adapter.handleMessage({

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -1825,6 +1825,38 @@ describe('ClaudeCodeStreamAdapter', () => {
       })
     })
 
+    it('registers the edge id when launch-root recovery throws', () => {
+      messageServiceMocks.findLaunchToolCallId.mockImplementation(() => {
+        throw new Error('db locked')
+      })
+      const { adapter, statusEvents } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        tasks: [{ task_id: 'subagent-1', task_type: 'subagent', description: 'Review the patch' }]
+      } as any)
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        task_id: 'subagent-1',
+        tool_use_id: 'call_resume',
+        description: 'Resumed review',
+        task_type: 'subagent'
+      } as any)
+
+      // The connection survives the failed recovery and the edge id is registered as a fallback.
+      const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(last).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_resume' }]
+      })
+    })
+
     it('recovers the launch root from the database when the adapter starts fresh', () => {
       // A restarted app builds a new adapter with no in-memory mapping; the first resume edge
       // must land on the persisted launch tool-use id, not the resuming call.

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -1586,6 +1586,86 @@ describe('ClaudeCodeStreamAdapter', () => {
       ])
     })
 
+    // A SendMessage to a still-running agent returns the queued form (no resumedAgentId, only
+    // pin.id). Its send call id must still tag that agent's subsequent content for round splitting.
+    it('re-tags content of a running agent from a queued-pin SendMessage receipt', () => {
+      const { adapter, parts } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [{ type: 'tool_use', id: 'launch-use', name: 'Agent', input: { prompt: 'review' } }]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'user',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'launch-use',
+              content: JSON.stringify({ status: 'async_launched', agentId: 'agent-a1b2c3d4e5f6' }),
+              is_error: false
+            }
+          ]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [{ type: 'tool_use', id: 'send-use', name: 'SendMessage', input: { to: 'agent-a1b2c3d4e5f6' } }]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'user',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'send-use',
+              content: JSON.stringify({
+                success: true,
+                message: 'Message queued for delivery to agent-a1b2c3d4e5f6 at its next tool round.',
+                pin: { id: 'agent-a1b2c3d4e5f6', name: 'worker', ref: 'abc' }
+              }),
+              is_error: false
+            }
+          ]
+        }
+      } as any)
+
+      const receiptChunk = parts.find(
+        (chunk) => chunk.type === 'tool-output-available' && chunk.toolCallId === 'send-use'
+      ) as { providerMetadata?: Record<string, Record<string, unknown>> }
+      expect(receiptChunk.providerMetadata?.cherry?.launchToolCallId).toBe('launch-use')
+
+      adapter.handleMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        parent_tool_use_id: 'launch-use',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID()
+      } as any)
+
+      const textStart = parts.filter((chunk) => chunk.type === 'text-start').at(-1) as {
+        providerMetadata?: Record<string, Record<string, unknown>>
+      }
+      expect(textStart.providerMetadata?.['claude-code']?.parentToolCallId).toBe('launch-use')
+      expect(textStart.providerMetadata?.cherry?.resumedViaCallId).toBe('send-use')
+    })
+
     it('enriches a local workflow task from its launch receipt without handling remote agents', () => {
       const { adapter, statusEvents } = createAdapter()
 
@@ -1695,6 +1775,43 @@ describe('ClaudeCodeStreamAdapter', () => {
           ]
         }
       ])
+    })
+
+    // A SendMessage resume re-points lifecycle edges at the resuming call's id; the navigation
+    // anchor must stay on the launch root the content actually streams under.
+    it('keeps the first navigation id for a task when resume edges report a new one', () => {
+      const { adapter, statusEvents } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        tasks: [{ task_id: 'subagent-1', task_type: 'subagent', description: 'Review the patch' }]
+      } as any)
+
+      const started = {
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'sdk-1',
+        task_id: 'subagent-1',
+        tool_use_id: 'call_launch',
+        description: 'Review the patch',
+        task_type: 'subagent'
+      } as any
+      adapter.handleMessage({ ...started, uuid: crypto.randomUUID() })
+      adapter.handleMessage({
+        ...started,
+        uuid: crypto.randomUUID(),
+        tool_use_id: 'call_resume',
+        description: 'Resumed review'
+      })
+
+      const last = statusEvents.filter((event) => event.type === 'background-tasks').at(-1)
+      expect(last).toEqual({
+        type: 'background-tasks',
+        tasks: [{ id: 'subagent-1', type: 'subagent', description: 'Review the patch', toolCallId: 'call_launch' }]
+      })
     })
 
     it('uses local workflow task starts to enrich navigation without changing authoritative membership', () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -1878,6 +1878,83 @@ describe('ClaudeCodeStreamAdapter', () => {
       })
     })
 
+    it('recovers the launch root from the resume receipt when registration recovery failed', () => {
+      let lookupCalls = 0
+      messageServiceMocks.findLaunchToolCallId.mockImplementation(() => {
+        lookupCalls += 1
+        if (lookupCalls === 1) throw new Error('db locked')
+        return 'call_launch'
+      })
+      const { adapter, parts } = createAdapter()
+
+      adapter.handleMessage({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [{ type: 'tool_use', id: 'launch-use', name: 'Agent', input: { prompt: 'review' } }]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'user',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'launch-use',
+              content: JSON.stringify({ status: 'async_launched', agentId: 'agent-a1b2c3d4e5f6' }),
+              is_error: false
+            }
+          ]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [{ type: 'tool_use', id: 'send-use', name: 'SendMessage', input: { to: 'agent-a1b2c3d4e5f6' } }]
+        }
+      } as any)
+      adapter.handleMessage({
+        type: 'user',
+        parent_tool_use_id: null,
+        session_id: 'sdk-1',
+        uuid: crypto.randomUUID(),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'send-use',
+              content: JSON.stringify({
+                success: true,
+                message: 'Agent "agent-a1b2c3d4e5f6" had no active task; resumed from transcript',
+                resumedAgentId: 'agent-a1b2c3d4e5f6'
+              }),
+              is_error: false
+            }
+          ]
+        }
+      } as any)
+
+      // The registration-time recovery failed; the receipt itself recovers and stamps the root.
+      const receiptChunk = parts.find(
+        (part) => part.type === 'tool-output-available' && (part as { toolCallId?: string }).toolCallId === 'send-use'
+      ) as {
+        resultProviderMetadata?: { cherry?: { launchToolCallId?: string } }
+        providerMetadata?: { cherry?: { launchToolCallId?: string } }
+      }
+      const stamped =
+        receiptChunk?.resultProviderMetadata?.cherry?.launchToolCallId ??
+        receiptChunk?.providerMetadata?.cherry?.launchToolCallId
+      expect(stamped).toBe('call_launch')
+    })
+
     it('recovers the launch root from the database when the adapter starts fresh', () => {
       // A restarted app builds a new adapter with no in-memory mapping; the first resume edge
       // must land on the persisted launch tool-use id, not the resuming call.

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -1229,7 +1229,27 @@ export class ClaudeCodeStreamAdapter {
             ? normalizedResult.pin.id
             : undefined
       if (resumedAgentId) {
-        const launchToolCallId = this.backgroundTaskToolCallIds.get(resumedAgentId)
+        let launchToolCallId: string | undefined = this.backgroundTaskToolCallIds.get(resumedAgentId)
+        // The receipt is the last event some resumes ever produce (fresh adapter, queued pin);
+        // when the registration-time recovery failed or never ran, recover the launch root here
+        // rather than leaving the task permanently unmapped.
+        if (!launchToolCallId) {
+          try {
+            launchToolCallId =
+              agentSessionMessageService.findLaunchToolCallId(this.sessionId, resumedAgentId) ?? undefined
+            if (launchToolCallId) {
+              this.backgroundTaskToolCallIds.set(resumedAgentId, launchToolCallId)
+              if (this.backgroundTasks.some((task) => task.id === resumedAgentId)) this.publishBackgroundTasks()
+            }
+          } catch (error) {
+            // Silent: the renderer's scanning fallback covers the unresolved entry.
+            logger.warn('Failed to recover launch tool call id from resume receipt', {
+              sessionId: this.sessionId,
+              resumedAgentId,
+              error
+            })
+          }
+        }
         if (launchToolCallId) {
           this.resumeMarkers.set(launchToolCallId, result.tool_use_id)
           const cherry = providerMetadata.cherry as Record<string, unknown>

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -1215,7 +1215,7 @@ export class ClaudeCodeStreamAdapter {
       toolName === 'Workflow' && isRecord(normalizedResult) && normalizedResult.taskType === 'local_workflow'
     if (!isError && (isSubagentToolName(toolName) || isLocalWorkflowLaunch)) {
       const taskId = getLaunchedBackgroundTaskId(normalizedResult)
-      if (taskId) this.registerBackgroundTaskToolCallId(taskId, result.tool_use_id)
+      if (taskId) this.registerBackgroundTaskToolCallId(taskId, result.tool_use_id, true)
     }
     // A SendMessage receipt that resumed a background agent carries the launch root id in its
     // own metadata (so the renderer can navigate without scanning) AND re-tags subsequent
@@ -1452,7 +1452,7 @@ export class ClaudeCodeStreamAdapter {
     })
   }
 
-  private registerBackgroundTaskToolCallId(taskId: string, toolCallId: string): void {
+  private registerBackgroundTaskToolCallId(taskId: string, toolCallId: string, allowToolCallIdFallback: boolean): void {
     // First registration wins: resume edges carry the resuming call's id, not the launch root.
     if (this.backgroundTaskToolCallIds.has(taskId)) return
     // A fresh adapter (app restart) has no in-memory mapping: the persisted launch task event is
@@ -1471,7 +1471,13 @@ export class ClaudeCodeStreamAdapter {
       })
       return
     }
-    this.backgroundTaskToolCallIds.set(taskId, launchToolCallId ?? toolCallId)
+    if (launchToolCallId) {
+      this.backgroundTaskToolCallIds.set(taskId, launchToolCallId)
+    } else if (allowToolCallIdFallback) {
+      // The launch receipt's own call id is the launch root (miss is transient pre-persist);
+      // a task edge's id may be a resume call's and must not be pinned while the row is absent.
+      this.backgroundTaskToolCallIds.set(taskId, toolCallId)
+    }
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()
   }
 
@@ -1508,7 +1514,7 @@ export class ClaudeCodeStreamAdapter {
         eventData.taskType === 'local_workflow' ||
         eventData.subagentType)
     ) {
-      this.registerBackgroundTaskToolCallId(eventData.taskId, eventData.toolUseId)
+      this.registerBackgroundTaskToolCallId(eventData.taskId, eventData.toolUseId, false)
     }
 
     // Keep a process-scoped per-task surface for status history and stop targets.

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -1437,7 +1437,17 @@ export class ClaudeCodeStreamAdapter {
     if (this.backgroundTaskToolCallIds.has(taskId)) return
     // A fresh adapter (app restart) has no in-memory mapping: the persisted launch task event is
     // authoritative and must win over a resume edge that arrives before the launch receipt context.
-    const launchToolCallId = agentSessionMessageService.findLaunchToolCallId(this.sessionId, taskId)
+    let launchToolCallId: string | null = null
+    try {
+      launchToolCallId = agentSessionMessageService.findLaunchToolCallId(this.sessionId, taskId)
+    } catch (error) {
+      // A transient database error must not kill the connection — fall back to the edge id.
+      logger.warn('Failed to recover launch tool call id for background task', {
+        sessionId: this.sessionId,
+        taskId,
+        error
+      })
+    }
     this.backgroundTaskToolCallIds.set(taskId, launchToolCallId ?? toolCallId)
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()
   }

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -34,6 +34,7 @@ import type {
   BetaServerToolUseBlock,
   BetaToolUseBlock
 } from '@anthropic-ai/sdk/resources/beta/messages'
+import { agentSessionMessageService } from '@data/services/AgentSessionMessageService'
 import { loggerService } from '@logger'
 import { extractSystemReminderBodies, SystemReminderTextFilter } from '@main/ai/steerReminder'
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
@@ -1434,7 +1435,10 @@ export class ClaudeCodeStreamAdapter {
   private registerBackgroundTaskToolCallId(taskId: string, toolCallId: string): void {
     // First registration wins: resume edges carry the resuming call's id, not the launch root.
     if (this.backgroundTaskToolCallIds.has(taskId)) return
-    this.backgroundTaskToolCallIds.set(taskId, toolCallId)
+    // A fresh adapter (app restart) has no in-memory mapping: the persisted launch task event is
+    // authoritative and must win over a resume edge that arrives before the launch receipt context.
+    const launchToolCallId = agentSessionMessageService.findLaunchToolCallId(this.sessionId, taskId)
+    this.backgroundTaskToolCallIds.set(taskId, launchToolCallId ?? toolCallId)
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()
   }
 

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -501,6 +501,10 @@ export class ClaudeCodeStreamAdapter {
   /** The latest authoritative level, enriched only by explicit async-launch receipts from this driver. */
   private backgroundTasks: AgentSessionBackgroundTask[] = []
   private readonly backgroundTaskToolCallIds = new Map<string, string>()
+  /** launch root tool-call id → the SendMessage call id that last resumed it. Instance-scoped
+   *  (survives idle flow-context clears) and only-overwrite: resumed content arrives after the
+   *  turn's result, so clearing would strip markers from the bulk of a continued round. */
+  private readonly resumeMarkers = new Map<string, string>()
   /** Parented SDK streams get independent state so subagent text/tool deltas cannot pollute the
    *  main agent's counters. Their sink is detached from the turn when that turn completes. */
   private readonly flowContexts: FlowContext[] = []
@@ -1212,6 +1216,26 @@ export class ClaudeCodeStreamAdapter {
       const taskId = getLaunchedBackgroundTaskId(normalizedResult)
       if (taskId) this.registerBackgroundTaskToolCallId(taskId, result.tool_use_id)
     }
+    // A SendMessage receipt that resumed a background agent carries the launch root id in its
+    // own metadata (so the renderer can navigate without scanning) AND re-tags subsequent
+    // content of that agent for round splitting. Only-overwrite, never clear. A receipt for a
+    // still-running target has no resumedAgentId — its queued form only carries `pin.id`.
+    if (!isError && isRecord(normalizedResult)) {
+      const resumedAgentId =
+        typeof normalizedResult.resumedAgentId === 'string'
+          ? normalizedResult.resumedAgentId
+          : isRecord(normalizedResult.pin) && typeof normalizedResult.pin.id === 'string'
+            ? normalizedResult.pin.id
+            : undefined
+      if (resumedAgentId) {
+        const launchToolCallId = this.backgroundTaskToolCallIds.get(resumedAgentId)
+        if (launchToolCallId) {
+          this.resumeMarkers.set(launchToolCallId, result.tool_use_id)
+          const cherry = providerMetadata.cherry as Record<string, unknown>
+          cherry.launchToolCallId = launchToolCallId
+        }
+      }
+    }
     if (ctx.deniedToolUseIds.has(result.tool_use_id)) {
       // The chunk schema is strict — `toolCallId` is the only accepted field, so the rejection
       // text stays in the log written by `handlePermissionDeniedSystemMessage`.
@@ -1408,7 +1432,8 @@ export class ClaudeCodeStreamAdapter {
   }
 
   private registerBackgroundTaskToolCallId(taskId: string, toolCallId: string): void {
-    if (this.backgroundTaskToolCallIds.get(taskId) === toolCallId) return
+    // First registration wins: resume edges carry the resuming call's id, not the launch root.
+    if (this.backgroundTaskToolCallIds.has(taskId)) return
     this.backgroundTaskToolCallIds.set(taskId, toolCallId)
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()
   }
@@ -1790,17 +1815,20 @@ export class ClaudeCodeStreamAdapter {
 
   private buildParentProviderMetadata(sdkParentToolUseId: SdkParentToolUseId): Record<string, JSONObject> | undefined {
     if (!sdkParentToolUseId) return undefined
+    const resumedViaCallId = this.resumeMarkers.get(sdkParentToolUseId)
     return {
       'claude-code': {
         parentToolCallId: sdkParentToolUseId
       },
       cherry: {
-        transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport
+        transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport,
+        ...(resumedViaCallId ? { resumedViaCallId } : {})
       }
     }
   }
 
   private buildToolProviderMetadata(state: ToolStreamState): Record<string, JSONObject> {
+    const resumedViaCallId = state.parentToolCallId ? this.resumeMarkers.get(state.parentToolCallId) : undefined
     const claudeCode: JSONObject = {
       parentToolCallId: state.parentToolCallId ?? null,
       ...(state.sdkBlockType ? { sdkBlockType: state.sdkBlockType } : {}),
@@ -1812,6 +1840,7 @@ export class ClaudeCodeStreamAdapter {
       'claude-code': claudeCode,
       cherry: {
         transport: AGENT_RUNTIME_CAPABILITIES['claude-code'].transport,
+        ...(resumedViaCallId ? { resumedViaCallId } : {}),
         tool: {
           type: state.toolType ?? 'provider',
           ...(state.displayName ? { name: state.displayName } : {}),

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -1441,12 +1441,15 @@ export class ClaudeCodeStreamAdapter {
     try {
       launchToolCallId = agentSessionMessageService.findLaunchToolCallId(this.sessionId, taskId)
     } catch (error) {
-      // A transient database error must not kill the connection — fall back to the edge id.
+      // A transient database error must not kill the connection — and must not pin the resume
+      // edge id either (first-wins would then block the launch root forever). Skip registration;
+      // the next task event or receipt re-runs this lookup and self-heals.
       logger.warn('Failed to recover launch tool call id for background task', {
         sessionId: this.sessionId,
         taskId,
         error
       })
+      return
     }
     this.backgroundTaskToolCallIds.set(taskId, launchToolCallId ?? toolCallId)
     if (this.backgroundTasks.some((task) => task.id === taskId)) this.publishBackgroundTasks()

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -712,6 +712,42 @@ export class AgentSessionMessageService {
   }
 
   /**
+   * The launch tool-use id for a background task, recovered from the persisted task event part of
+   * its earliest assistant row. A fresh adapter (app restart) has no in-memory task→tool-call
+   * mapping; resume edges then carry the resuming call's id, which must not displace the launch
+   * root every entry resolves to.
+   */
+  findLaunchToolCallId(sessionId: string, taskId: string): string | null {
+    const database = application.get('DbService').getDb()
+    const row = database
+      .select({
+        toolUseId: sql<string>`(
+          select json_extract(part.value, '$.data.toolUseId')
+          from json_each(${sessionMessagesTable.data}, '$.parts') as part
+          where json_extract(part.value, '$.type') = 'data-agent-task-event'
+            and json_extract(part.value, '$.data.taskId') = ${taskId}
+          limit 1
+        )`
+      })
+      .from(sessionMessagesTable)
+      .where(
+        and(
+          eq(sessionMessagesTable.sessionId, sessionId),
+          eq(sessionMessagesTable.role, 'assistant'),
+          sql`EXISTS (
+            select 1 from json_each(${sessionMessagesTable.data}, '$.parts') as part
+            where json_extract(part.value, '$.type') = 'data-agent-task-event'
+              and json_extract(part.value, '$.data.taskId') = ${taskId}
+          )`
+        )
+      )
+      .orderBy(asc(sessionMessagesTable.createdAt), asc(sessionMessagesTable.id))
+      .limit(1)
+      .all()
+    return row[0]?.toolUseId ?? null
+  }
+
+  /**
    * Boot reconcile of crash-orphaned `pending` rows: resolve each row to `error` (with the
    * caller's terminalized `data`) and discard the affected sessions' resume tokens, atomically.
    * A crashed turn leaves the external CLI session in an untrusted state — resuming it can replay

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -56,7 +56,7 @@ import {
 } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { isToolUIPart } from 'ai'
-import { and, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, type SQL, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, type SQL, sql } from 'drizzle-orm'
 import { v4 as uuidv4, v7 as uuidv7, validate as isUuid } from 'uuid'
 
 import { aiUsageRecordService, mergeMessageRuntimeStats } from './AiUsageRecordService'
@@ -682,6 +682,33 @@ export class AgentSessionMessageService {
         )
       )
       .all()
+  }
+
+  /**
+   * The assistant host row whose parts contain `rootToolCallId`, for a fresh runtime entry (after
+   * a process restart or session reopen) to re-anchor detached subagent flow chunks to the launch
+   * message. The launch part is the earliest row carrying the id, so ascending creation order and
+   * LIMIT 1 pick it.
+   */
+  findFlowHostMessageId(sessionId: string, rootToolCallId: string): string | null {
+    const database = application.get('DbService').getDb()
+    const row = database
+      .select({ id: sessionMessagesTable.id })
+      .from(sessionMessagesTable)
+      .where(
+        and(
+          eq(sessionMessagesTable.sessionId, sessionId),
+          eq(sessionMessagesTable.role, 'assistant'),
+          sql<boolean>`exists (
+            select 1 from json_each(${sessionMessagesTable.data}, '$.parts') as part
+            where json_extract(part.value, '$.toolCallId') = ${rootToolCallId}
+          )`
+        )
+      )
+      .orderBy(asc(sessionMessagesTable.createdAt))
+      .limit(1)
+      .all()
+    return row[0]?.id ?? null
   }
 
   /**

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -726,6 +726,7 @@ export class AgentSessionMessageService {
           from json_each(${sessionMessagesTable.data}, '$.parts') as part
           where json_extract(part.value, '$.type') = 'data-agent-task-event'
             and json_extract(part.value, '$.data.taskId') = ${taskId}
+            and json_extract(part.value, '$.data.toolUseId') is not null
           limit 1
         )`
       })

--- a/src/main/data/services/AgentSessionMessageService.ts
+++ b/src/main/data/services/AgentSessionMessageService.ts
@@ -739,6 +739,7 @@ export class AgentSessionMessageService {
             select 1 from json_each(${sessionMessagesTable.data}, '$.parts') as part
             where json_extract(part.value, '$.type') = 'data-agent-task-event'
               and json_extract(part.value, '$.data.taskId') = ${taskId}
+              and json_extract(part.value, '$.data.toolUseId') is not null
           )`
         )
       )

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -588,6 +588,35 @@ describe('AgentSessionMessageService', () => {
       expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-other')).toBeNull()
     })
 
+    it('finds the launch tool-use id in a later row when the earliest row has none', async () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+      const EARLY = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d037'
+      const LATER = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d038'
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: EARLY,
+          role: 'assistant',
+          status: 'success',
+          data: {
+            parts: [{ type: 'data-agent-task-event' as const, data: { taskId: 'task-1', event: 'progress' as const } }]
+          }
+        }
+      })
+      now.mockReturnValue(2_000)
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: LATER,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBe('launch-use')
+    })
+
     it('skips task events that carry no tool-use id', async () => {
       const ROOT2 = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d036'
       agentSessionMessageService.saveMessage({

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -588,6 +588,26 @@ describe('AgentSessionMessageService', () => {
       expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-other')).toBeNull()
     })
 
+    it('skips task events that carry no tool-use id', async () => {
+      const ROOT2 = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d036'
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: ROOT2,
+          role: 'assistant',
+          status: 'success',
+          data: {
+            parts: [
+              { type: 'data-agent-task-event' as const, data: { taskId: 'task-1', event: 'progress' as const } },
+              taskEventPart('task-1', 'launch-use')
+            ]
+          }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBe('launch-use')
+    })
+
     it('prefers the earliest row when several carry the same task id', async () => {
       const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
       const EARLY = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d034'

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -552,6 +552,51 @@ describe('AgentSessionMessageService', () => {
     })
   })
 
+  describe('findFlowHostMessageId (restart anchor recovery)', () => {
+    const HOST = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d030'
+    const lateHostPart = () => ({
+      type: 'tool-Agent' as const,
+      toolCallId: 'root-1',
+      state: 'input-available' as const,
+      input: { prompt: 'Audit' }
+    })
+
+    it('finds the assistant row whose parts carry the launch tool call id', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: HOST, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBe(HOST)
+    })
+
+    it('returns null when no assistant row carries the id (user rows are not hosts)', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: HOST, role: 'user', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBeNull()
+    })
+
+    it('returns the earliest row when several carry the same id', async () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+      const EARLY = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d031'
+      const LATE = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d032'
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: EARLY, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+      now.mockReturnValue(2_000)
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: { id: LATE, role: 'assistant', status: 'success', data: { parts: [lateHostPart()] } }
+      })
+
+      expect(agentSessionMessageService.findFlowHostMessageId(SESSION_ID, 'root-1')).toBe(EARLY)
+    })
+  })
+
   it('atomically settles a persisted background tool approval with the user-updated input', () => {
     const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
     agentSessionMessageService.saveMessage({

--- a/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionMessageService.test.ts
@@ -552,6 +552,70 @@ describe('AgentSessionMessageService', () => {
     })
   })
 
+  describe('findLaunchToolCallId (fresh-adapter task root recovery)', () => {
+    const ROOT = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d033'
+    const taskEventPart = (taskId: string, toolUseId: string) => ({
+      type: 'data-agent-task-event' as const,
+      data: { taskId, toolUseId, event: 'started' as const, status: 'in_progress' as const }
+    })
+
+    it('returns the launch tool-use id from the earliest task event row', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: ROOT,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBe('launch-use')
+    })
+
+    it('returns null when no assistant row carries the task id (user rows are ignored)', async () => {
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: ROOT,
+          role: 'user',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBeNull()
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-other')).toBeNull()
+    })
+
+    it('prefers the earliest row when several carry the same task id', async () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+      const EARLY = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d034'
+      const LATE = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d035'
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: EARLY,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'launch-use')] }
+        }
+      })
+      now.mockReturnValue(2_000)
+      agentSessionMessageService.saveMessage({
+        sessionId: SESSION_ID,
+        message: {
+          id: LATE,
+          role: 'assistant',
+          status: 'success',
+          data: { parts: [taskEventPart('task-1', 'resume-use')] }
+        }
+      })
+
+      expect(agentSessionMessageService.findLaunchToolCallId(SESSION_ID, 'task-1')).toBe('launch-use')
+    })
+  })
+
   describe('findFlowHostMessageId (restart anchor recovery)', () => {
     const HOST = '018f6ed6-73b8-7f40-8d0d-9bb2f8f1d030'
     const lateHostPart = () => ({

--- a/src/shared/ai/agentSessionFlowParts.ts
+++ b/src/shared/ai/agentSessionFlowParts.ts
@@ -1,3 +1,5 @@
+import type { UIMessageChunk } from 'ai'
+
 import type { CherryMessagePart } from '../data/types/message'
 
 /** Live parented parts for one persisted assistant message. */
@@ -5,3 +7,12 @@ export type AgentSessionFlowParts = CherryMessagePart[]
 
 export const AGENT_SESSION_FLOW_PARTS_CACHE_KEY = (sessionId: string, messageId: string) =>
   `agent.session.flow_parts.${sessionId}.${messageId}` as const
+
+/**
+ * Detached chunks whose host row had not committed when the session closed. Kept per root briefly
+ * so a reopen that finds the row can still deliver them instead of dropping the output.
+ */
+export type AgentSessionFlowRecoveryOrphan = UIMessageChunk[]
+
+export const AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY = (sessionId: string, rootToolCallId: string) =>
+  `agent.session.flow_recovery_orphan.${sessionId}.${rootToolCallId}` as const

--- a/src/shared/ai/agentSessionFlowParts.ts
+++ b/src/shared/ai/agentSessionFlowParts.ts
@@ -9,10 +9,13 @@ export const AGENT_SESSION_FLOW_PARTS_CACHE_KEY = (sessionId: string, messageId:
   `agent.session.flow_parts.${sessionId}.${messageId}` as const
 
 /**
- * Detached chunks whose host row had not committed when the session closed. Kept per root briefly
- * so a reopen that finds the row can still deliver them instead of dropping the output.
+ * Detached chunks whose host row had not committed when the session closed. Persisted (restart-safe)
+ * so a reopen that finds the row can still deliver them; `orphannedAt` lets stale entries expire.
  */
-export type AgentSessionFlowRecoveryOrphan = UIMessageChunk[]
-
-export const AGENT_SESSION_FLOW_RECOVERY_ORPHAN_CACHE_KEY = (sessionId: string, rootToolCallId: string) =>
-  `agent.session.flow_recovery_orphan.${sessionId}.${rootToolCallId}` as const
+export interface AgentSessionFlowRecoveryOrphan {
+  sessionId: string
+  rootToolCallId: string
+  /** Epoch ms of the teardown that orphaned the batch. */
+  orphannedAt: number
+  chunks: UIMessageChunk[]
+}

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -293,6 +293,7 @@ export type SharedCacheSchema = {
   'agent.session.background_tasks.${sessionId}': CacheValueTypes.CacheAgentSessionBackgroundTasks
   'agent.session.task_events.${sessionId}': CacheValueTypes.CacheAgentSessionTaskEvents
   'agent.session.flow_parts.${sessionId}.${messageId}': CacheValueTypes.CacheAgentSessionFlowParts
+  'agent.session.flow_recovery_orphan.${sessionId}.${rootToolCallId}': CacheValueTypes.CacheAgentSessionFlowRecoveryOrphan
   'topic.stream.statuses.${topicId}': TopicStatusSnapshotEntry | null
   'topic.stream.last_seen_completion.${topicId}': number | null
   'feature.openclaw.gateway_status': CacheValueTypes.OpenClawGatewayStatus
@@ -347,6 +348,7 @@ export const DefaultSharedCache: SharedCacheSchema = {
   'agent.session.background_tasks.${sessionId}': [],
   'agent.session.task_events.${sessionId}': {},
   'agent.session.flow_parts.${sessionId}.${messageId}': [],
+  'agent.session.flow_recovery_orphan.${sessionId}.${rootToolCallId}': [],
   'topic.stream.statuses.${topicId}': null,
   'topic.stream.last_seen_completion.${topicId}': null,
   'feature.openclaw.gateway_status': 'stopped',

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -6,6 +6,7 @@ import type { Currency } from '@shared/data/types/model'
 import type { AutoBackupType } from '@shared/types/backup'
 import type { AbsoluteFilePath } from '@shared/types/file'
 
+import type { AgentSessionFlowRecoveryOrphan } from '../../ai/agentSessionFlowParts'
 import type { TopicStatusSnapshotEntry } from '../../ai/transport'
 import type * as CacheValueTypes from './cacheValueTypes'
 
@@ -503,7 +504,7 @@ export type MainPersistCacheSchema = {
   // windowBoundsTracker is the sole writer and controls which keys appear.
   'window.bounds': Record<string, CacheValueTypes.WindowBoundsState>
   // Teardown-orphaned detached-flow chunks, restart-safe so a reopen can still deliver them.
-  'agent.session.flow_recovery_orphans': CacheValueTypes.CacheAgentSessionFlowRecoveryOrphans
+  'agent.session.flow_recovery_orphans': AgentSessionFlowRecoveryOrphan[]
 }
 
 export const DefaultMainPersistCache: MainPersistCacheSchema = {

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -293,7 +293,6 @@ export type SharedCacheSchema = {
   'agent.session.background_tasks.${sessionId}': CacheValueTypes.CacheAgentSessionBackgroundTasks
   'agent.session.task_events.${sessionId}': CacheValueTypes.CacheAgentSessionTaskEvents
   'agent.session.flow_parts.${sessionId}.${messageId}': CacheValueTypes.CacheAgentSessionFlowParts
-  'agent.session.flow_recovery_orphan.${sessionId}.${rootToolCallId}': CacheValueTypes.CacheAgentSessionFlowRecoveryOrphan
   'topic.stream.statuses.${topicId}': TopicStatusSnapshotEntry | null
   'topic.stream.last_seen_completion.${topicId}': number | null
   'feature.openclaw.gateway_status': CacheValueTypes.OpenClawGatewayStatus
@@ -348,7 +347,6 @@ export const DefaultSharedCache: SharedCacheSchema = {
   'agent.session.background_tasks.${sessionId}': [],
   'agent.session.task_events.${sessionId}': {},
   'agent.session.flow_parts.${sessionId}.${messageId}': [],
-  'agent.session.flow_recovery_orphan.${sessionId}.${rootToolCallId}': [],
   'topic.stream.statuses.${topicId}': null,
   'topic.stream.last_seen_completion.${topicId}': null,
   'feature.openclaw.gateway_status': 'stopped',
@@ -504,12 +502,15 @@ export type MainPersistCacheSchema = {
   // a @main enum (no reverse import), so the key type is `string`; the
   // windowBoundsTracker is the sole writer and controls which keys appear.
   'window.bounds': Record<string, CacheValueTypes.WindowBoundsState>
+  // Teardown-orphaned detached-flow chunks, restart-safe so a reopen can still deliver them.
+  'agent.session.flow_recovery_orphans': CacheValueTypes.CacheAgentSessionFlowRecoveryOrphans
 }
 
 export const DefaultMainPersistCache: MainPersistCacheSchema = {
   'backup.auto_sync.last_attempt_times': { webdav: null, s3: null, local: null, nutstore: null },
   'internal.persist_probe': 0,
-  'window.bounds': {}
+  'window.bounds': {},
+  'agent.session.flow_recovery_orphans': []
 }
 
 // ============================================================================

--- a/src/shared/data/cache/cacheValueTypes.ts
+++ b/src/shared/data/cache/cacheValueTypes.ts
@@ -6,7 +6,7 @@ import type { AgentSessionApiRetryState } from '../../ai/agentSessionApiRetry'
 import type { AgentSessionBackgroundTasks, AgentSessionTaskEvents } from '../../ai/agentSessionBackgroundTasks'
 import type { AgentSessionCompactionState } from '../../ai/agentSessionCompaction'
 import type { AgentSessionContextUsage } from '../../ai/agentSessionContextUsage'
-import type { AgentSessionFlowParts } from '../../ai/agentSessionFlowParts'
+import type { AgentSessionFlowParts, AgentSessionFlowRecoveryOrphan } from '../../ai/agentSessionFlowParts'
 import type { AgentSessionSlashCommand } from '../../ai/agentSessionSlashCommands'
 import type { McpServer } from '../types/mcpServer'
 import type { MiniApp } from '../types/miniApp'
@@ -189,6 +189,7 @@ export type CacheAgentSessionSlashCommands = AgentSessionSlashCommand[] | null
 export type CacheAgentSessionBackgroundTasks = AgentSessionBackgroundTasks
 export type CacheAgentSessionTaskEvents = AgentSessionTaskEvents
 export type CacheAgentSessionFlowParts = AgentSessionFlowParts
+export type CacheAgentSessionFlowRecoveryOrphan = AgentSessionFlowRecoveryOrphan
 
 /**
  * Persisted window geometry for the WindowManager "remember bounds" capability.

--- a/src/shared/data/cache/cacheValueTypes.ts
+++ b/src/shared/data/cache/cacheValueTypes.ts
@@ -7,6 +7,8 @@ import type { AgentSessionBackgroundTasks, AgentSessionTaskEvents } from '../../
 import type { AgentSessionCompactionState } from '../../ai/agentSessionCompaction'
 import type { AgentSessionContextUsage } from '../../ai/agentSessionContextUsage'
 import type { AgentSessionFlowParts, AgentSessionFlowRecoveryOrphan } from '../../ai/agentSessionFlowParts'
+
+export type CacheAgentSessionFlowRecoveryOrphans = AgentSessionFlowRecoveryOrphan[]
 import type { AgentSessionSlashCommand } from '../../ai/agentSessionSlashCommands'
 import type { McpServer } from '../types/mcpServer'
 import type { MiniApp } from '../types/miniApp'
@@ -189,7 +191,6 @@ export type CacheAgentSessionSlashCommands = AgentSessionSlashCommand[] | null
 export type CacheAgentSessionBackgroundTasks = AgentSessionBackgroundTasks
 export type CacheAgentSessionTaskEvents = AgentSessionTaskEvents
 export type CacheAgentSessionFlowParts = AgentSessionFlowParts
-export type CacheAgentSessionFlowRecoveryOrphan = AgentSessionFlowRecoveryOrphan
 
 /**
  * Persisted window geometry for the WindowManager "remember bounds" capability.

--- a/src/shared/data/cache/cacheValueTypes.ts
+++ b/src/shared/data/cache/cacheValueTypes.ts
@@ -6,9 +6,7 @@ import type { AgentSessionApiRetryState } from '../../ai/agentSessionApiRetry'
 import type { AgentSessionBackgroundTasks, AgentSessionTaskEvents } from '../../ai/agentSessionBackgroundTasks'
 import type { AgentSessionCompactionState } from '../../ai/agentSessionCompaction'
 import type { AgentSessionContextUsage } from '../../ai/agentSessionContextUsage'
-import type { AgentSessionFlowParts, AgentSessionFlowRecoveryOrphan } from '../../ai/agentSessionFlowParts'
-
-export type CacheAgentSessionFlowRecoveryOrphans = AgentSessionFlowRecoveryOrphan[]
+import type { AgentSessionFlowParts } from '../../ai/agentSessionFlowParts'
 import type { AgentSessionSlashCommand } from '../../ai/agentSessionSlashCommands'
 import type { McpServer } from '../types/mcpServer'
 import type { MiniApp } from '../types/miniApp'

--- a/src/shared/data/types/__tests__/uiParts.test.ts
+++ b/src/shared/data/types/__tests__/uiParts.test.ts
@@ -73,6 +73,24 @@ describe('CherryToolMetaSchema', () => {
     const bad = CherryToolMetaSchema.safeParse({ tool: { type: 'pluggable' } })
     expect(bad.success).toBe(false)
   })
+  it('keeps the subagent resume linkage fields through a readCherryMeta round-trip', () => {
+    const part = {
+      type: 'dynamic-tool',
+      providerMetadata: {
+        cherry: {
+          parentToolCallId: 'task-root',
+          launchToolCallId: 'task-root',
+          resumedViaCallId: 'call-resume'
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    expect(readCherryMeta(part)).toMatchObject({
+      parentToolCallId: 'task-root',
+      launchToolCallId: 'task-root',
+      resumedViaCallId: 'call-resume'
+    })
+  })
 })
 
 describe('CherryFileMetaSchema', () => {

--- a/src/shared/data/types/uiParts.ts
+++ b/src/shared/data/types/uiParts.ts
@@ -178,6 +178,10 @@ export interface CherryToolMeta {
   toolName?: string
   /** Runtime-neutral subagent linkage: the spawning tool call this part nests under. */
   parentToolCallId?: string
+  /** Launch-root tool-call id stamped on a SendMessage resume receipt. */
+  launchToolCallId?: string
+  /** The SendMessage call id whose resume this part continues, when the runtime tagged it. */
+  resumedViaCallId?: string
   /** MCP / builtin tool identity. Matches `ToolType` consumed by `toolResponse.ts`. */
   tool?: {
     serverId?: string
@@ -297,6 +301,9 @@ export const CherryReasoningMetaSchema: z.ZodType<CherryReasoningMeta> = z.objec
 export const CherryToolMetaSchema: z.ZodType<CherryToolMeta> = z.object({
   transport: z.string().optional(),
   toolName: z.string().optional(),
+  parentToolCallId: z.string().optional(),
+  launchToolCallId: z.string().optional(),
+  resumedViaCallId: z.string().optional(),
   tool: z
     .object({
       serverId: z.string().optional(),


### PR DESCRIPTION
### What this PR does

Before this PR, a continued (resumed) sub-agent's content could be dropped, buffered forever, or persisted under the wrong row. The Claude Code CLI re-streams a continued agent under its **original launch tool-use id**, while the lifecycle edges that describe the continuation carry the **resuming call id**. When that mapping was lost or overwritten:

- The flow anchor map was deleted after each drain and cleared on connection reset, so a `SendMessage` resume that re-streams under the launch id could no longer find its spawning message — its chunks were dropped with only a debug log.
- A background-flow accumulator whose drain was settling was reused, silently losing chunks; a replacement created mid-drain was never drained itself.
- The task→tool-call registration overwrote on a different value, so a resume edge displaced the launch root.
- After an app restart there was no in-memory mapping at all.

After this PR, the launch tool-use id is the single identity for a sub-agent run and it survives every process boundary:

- Flow anchors survive drain and connection resets — continued content keeps landing on its spawning message.
- Closed accumulators are never reused; mid-drain replacements inherit the predecessor's overlay and are drained too.
- Task→tool-call registration is **first-registration-wins**.
- A fresh connection (restart or session reopen) recovers the launch root from the database, and recovers a task's launch tool-call id from the persisted `data-agent-task-event` part.
- The stream adapter stamps `cherry.launchToolCallId` / `cherry.resumedViaCallId` onto resume receipts and continued content, so presentation layers read structured metadata instead of re-deriving identity.
- Launch-root lookup is supplied by the host through `AgentRuntimeConnectInput.resolveLaunchToolCallId` (beside the existing `onSteerInjected` hook), so the stream adapter does not import the data layer and a database failure can no longer end a connection.

Fixes #

### Why we need it and why it was done in this way

The resumed CLI keeps streaming under the original launch tool-use id; the protocol cannot change, so the app converges on that id as the single identity and persists enough state to recover it across any process boundary.

The following tradeoffs were made:

- Recovery reads (`findFlowHostMessageId`, `findLaunchToolCallId`) are synchronous SQLite `json_each` scans constrained by the session index, executed at most once per (entry, root) / (adapter, task) — constant cost on the hot path.
- Launch-task recovery prefers the persisted `data-agent-task-event` part over parsing launch receipt text — the SDK's launch output is a plain string trailer in this CLI version, with no structured fields.

The following alternatives were considered:

- Persisting a `taskId → launch toolCallId` map in a new DB table — not justified for presentation state; the existing message rows already carry the truth.
- Blocking mid-run `SendMessage` via `canUseTool` — rejected: it needs a name→running-state map that does not exist and risks mis-blocking reliable resumes.

### Breaking changes

NONE — all changes are additive to retained in-memory state and to `providerMetadata.cherry` fields; no schema, IPC or API surface changes.

### Special notes for your reviewer

This is **layer 1 of a stacked chain** and targets `main` directly. Layer 2 (`fix/subagent-resume-rendering-b`, chat-stream presentation) and layer 3 (`fix/subagent-resume-flow-c`, flow timeline) build on this one.

Rebased onto the latest `main`; conflicts (all import-ordering churn from the Oxfmt migration) resolved. Verified: `pnpm typecheck` (node + web) passes, the affected suites are green, and the repo-wide format and i18n checks pass.

The two DB recovery methods are exercised with real-DB tests (`setupTestDatabase`); the adapter recovery is covered by a fresh-instance test asserting the launch root wins over a resume edge.

Acceptance: after a subagent round completes, a `SendMessage` resume's content is persisted under the launch host row (grows in `agent_session_message.parts`), including across an app restart.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Continued sub-agent content is now reliably saved: resuming a finished sub-agent (even after quitting and reopening the app) no longer loses its new rounds inside the sub-agent's own session record.
```
